### PR TITLE
Use std::list for command linked list

### DIFF
--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -381,7 +381,7 @@ short effect::act()
 			}
 			
 			// Are we performing some action?
-			if (stats->commandlist)
+			if (stats->has_commands())
 				temp = stats->do_command();
 			else
 			{

--- a/src/living.cpp
+++ b/src/living.cpp
@@ -283,7 +283,7 @@ short living::act()
 
 
 	// Are we performing some action?
-	if (stats->commandlist)
+	if (stats->has_commands())
 	{
 		Sint32 temp = stats->do_command();
 		if (temp)
@@ -484,7 +484,7 @@ bool living::walk(float x, float y)
 		//   other walkers call ACT.  This would cause control
 		//   to turn TWICE on the first call to walk, which is bad.
 		//   So we stop that behavior here.
-		if (this->query_act_type() != ACT_CONTROL || stats->commandlist)
+		if (this->query_act_type() != ACT_CONTROL || stats->has_commands())
 			turn(enddir);
 	}
 	return 1;

--- a/src/stats.h
+++ b/src/stats.h
@@ -20,6 +20,7 @@
 // Definition of STATS class
 
 #include "base.h"
+#include <list>
 
 //
 // Include file for the stats object
@@ -60,6 +61,7 @@ class statistics
 		void set_command(short whatcommand, short iterations, short info1, short info2);
 		void add_command(short whatcommand, short iterations, short info1, short info2);
 		void force_command(short whatcommand, short iterations, short info1, short info2);
+		bool has_commands();
 		void clear_command();
 		short do_command();
 		void hit_response(walker * who);
@@ -101,8 +103,7 @@ class statistics
 		unsigned short special_cost[NUM_SPECIALS];  // cost of our special ability
 		short weapon_cost;                          // cost of our weapon
 		walker  * controller;
-		command *commandlist; // head of command list
-		command *endlist;     // end of command list
+		std::list<command> commands;
 	private:
 		//       short com1, com2;        // parameters to command
 		Sint32 walkrounds; //number of rounds we've spent rightwalking
@@ -117,7 +118,6 @@ class command
 		short commandcount;
 		short com1;
 		short com2;
-		command *next;
 };
 
 #endif

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -836,7 +836,7 @@ short viewscreen::input(const SDL_Event& event)
 
 	// Movement, etc.
 	// Make sure we're not performing some queued action ..
-	if (!control->stats->commandlist)
+	if (control->stats->commands.empty())
 	{
 	    #ifdef USE_TOUCH_INPUT
 	    // Treat this as an action, not a modifier
@@ -984,7 +984,7 @@ short viewscreen::continuous_input()
 
 	// Movement, etc.
 	// Make sure we're not performing some queued action ..
-	if (!control->stats->commandlist)
+	if (control->stats->commands.empty())
 	{
         #ifndef USE_TOUCH_INPUT
         // We will handle this as an action in input() instead.

--- a/src/walker.cpp
+++ b/src/walker.cpp
@@ -1562,7 +1562,7 @@ short walker::act()
 
 
 	// Are we performing some action?
-	if (stats->commandlist)
+	if (stats->has_commands())
 	{
 		temp = stats->do_command();
 		if (temp)


### PR DESCRIPTION
valgrind kept complaining about commands not being freed after new commands were pushed onto the end of the list. Rather than trying to figure out where the pointer manipulation was going wrong, I just replaced it with std::list which made the code a lot nicer and easier to manage.