### PR TITLE
Fix walker::attack to account for armor

### DIFF
--- a/src/walker.cpp
+++ b/src/walker.cpp
@@ -1949,7 +1949,7 @@ short walker::attack(walker  *target)
 	if (tempdamage < 0)
 		tempdamage = 0;
     
-    do_combat_damage(attacker, target, damage);
+    do_combat_damage(attacker, target, tempdamage);
 
 
     // Base exp from attack damage


### PR DESCRIPTION
This commit fixes the do_combat_damage in walker::attack to properly account for damage reduction from armor.

Closes #18 