### PR TITLE
include POSIX header for getpid/close/dup

### DIFF
--- a/src/external/libzip/mkstemp.c
+++ b/src/external/libzip/mkstemp.c
@@ -31,6 +31,8 @@
  * SUCH DAMAGE.
  */
 
+#include "config.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 
@@ -43,6 +45,9 @@
 #endif
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 
 #ifndef O_BINARY
 #define O_BINARY 0

--- a/src/external/libzip/zip_fdopen.c
+++ b/src/external/libzip/zip_fdopen.c
@@ -31,11 +31,11 @@
   IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-
-
 #include "zipint.h"
 
-
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 
 ZIP_EXTERN struct zip *
 zip_fdopen(int fd_orig, int _flags, int *zep)


### PR DESCRIPTION
Something about the latest gcc on Arch Linux no longer compiles these files without these includes.