### PR TITLE
Fix uninitialized walker::current_special in walker_init_common

### DIFF
--- a/src/entities/walker.cpp
+++ b/src/entities/walker.cpp
@@ -93,6 +93,7 @@ void walker_init_common(walker* w)
 	w->skip_exit = 0;
 	w->weapons_left = 1;
 	w->myobmap = nullptr;
+	w->current_special = 0;
 	w->path_check_counter = 5 + rand()%10;
 	w->hurt_flash = false;
 	w->attack_lunge = 0.0f;


### PR DESCRIPTION
current_special was never zeroed during walker construction, leaving it as stack garbage. This was latent because typical memory layouts happened to produce 0, but any change to stack frame sizes (e.g. resizing arrays sized to NUM_FAMILIES) could expose incorrect special-switching behavior.