### PR TITLE
Make config directory configurable via OPENGLAD_CONFIG_DIR

### DIFF
--- a/src/sdl_client/io/platform_io.cpp
+++ b/src/sdl_client/io/platform_io.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdio>
+#include <cstdlib>
 #include <random>
 #include <stdexcept>
 #include <sys/stat.h>
@@ -93,6 +94,25 @@ int rwops_write_handler(void *data, unsigned char *buffer, size_t size)
 
 std::string get_user_path()
 {
+    auto normalize_dir = [](std::string path) {
+        while (path.size() > 1 && path.back() == '/') {
+            path.pop_back();
+        }
+        if (path.empty()) {
+            return std::string("./");
+        }
+        if (path.back() != '/') {
+            path.push_back('/');
+        }
+        return path;
+    };
+
+    if (const char* config_dir = std::getenv("OPENGLAD_CONFIG_DIR")) {
+        if (config_dir[0] != '\0') {
+            return normalize_dir(config_dir);
+        }
+    }
+
 #ifdef __EMSCRIPTEN__
     // Use IDBFS mount point for persistent storage in browser
     return "/persist/";
@@ -121,13 +141,15 @@ std::string get_user_path()
                 s[pos] = '/';
         } while(pos != std::string::npos);
 
-        return s + "/.openglad/";
+        return normalize_dir(s + "/.openglad");
     }
     return "";
 #else
-    std::string path = getenv("HOME");
-    path += "/.openglad/";
-    return path;
+    const char* home = std::getenv("HOME");
+    if (!home) {
+        return "./";
+    }
+    return normalize_dir(std::string(home) + "/.openglad");
 #endif
 }
 
@@ -614,4 +636,3 @@ bool create_new_scen_file(const std::string& scenfile, const std::string& gridna
 {
     return create_new_scen_file_with_error(scenfile, gridname) == NewFileIoError::None;
 }
-

--- a/src/text_client/platform_headless.cpp
+++ b/src/text_client/platform_headless.cpp
@@ -36,6 +36,25 @@ std::int32_t difficulty_level[DIFFICULTY_SETTINGS] = { 50, 100, 200 };
 
 std::string get_user_path()
 {
+    auto normalize_dir = [](std::string path) {
+        while (path.size() > 1 && path.back() == '/') {
+            path.pop_back();
+        }
+        if (path.empty()) {
+            return std::string("./");
+        }
+        if (path.back() != '/') {
+            path.push_back('/');
+        }
+        return path;
+    };
+
+    if (const char* config_dir = std::getenv("OPENGLAD_CONFIG_DIR")) {
+        if (config_dir[0] != '\0') {
+            return normalize_dir(config_dir);
+        }
+    }
+
 #ifdef _WIN32
     char path[MAX_PATH];
     HRESULT hr = SHGetFolderPath(0, CSIDL_LOCAL_APPDATA, 0, 0, path);
@@ -47,13 +66,13 @@ std::string get_user_path()
             if (pos != std::string::npos)
                 s[pos] = '/';
         } while (pos != std::string::npos);
-        return s + "/.openglad/";
+        return normalize_dir(s + "/.openglad");
     }
     return "";
 #else
     const char* home = std::getenv("HOME");
     if (!home) return "./";
-    return std::string(home) + "/.openglad/";
+    return normalize_dir(std::string(home) + "/.openglad");
 #endif
 }
 

--- a/tests/test_io_funcs.cpp
+++ b/tests/test_io_funcs.cpp
@@ -1,6 +1,43 @@
 #include <openglad/platform/io.h>
 #include "test_framework.h"
 
+#include <cstdlib>
+#include <string>
+
+namespace {
+class ScopedEnvVar {
+public:
+    explicit ScopedEnvVar(const char* name) : name_(name) {
+        const char* current = std::getenv(name_);
+        if (current) {
+            had_value_ = true;
+            old_value_ = current;
+        }
+    }
+
+    ~ScopedEnvVar() {
+        if (had_value_) {
+#ifdef _WIN32
+            _putenv_s(name_, old_value_.c_str());
+#else
+            setenv(name_, old_value_.c_str(), 1);
+#endif
+        } else {
+#ifdef _WIN32
+            _putenv_s(name_, "");
+#else
+            unsetenv(name_);
+#endif
+        }
+    }
+
+private:
+    const char* name_;
+    bool had_value_ = false;
+    std::string old_value_;
+};
+} // namespace
+
 // ---------------------------------------------------------------------------
 // explode() - string splitting utility
 // ---------------------------------------------------------------------------
@@ -59,6 +96,58 @@ void test_io_get_user_path_nonempty()
     TEST_ASSERT(path.size() > 1, "user path has content");
 }
 REGISTER_TEST(test_io_get_user_path_nonempty);
+
+void test_io_get_user_path_uses_openglad_config_dir_when_set()
+{
+    ScopedEnvVar scoped("OPENGLAD_CONFIG_DIR");
+#ifdef _WIN32
+    _putenv_s("OPENGLAD_CONFIG_DIR", "C:/tmp/openglad_test_cfg");
+    const char* expected = "C:/tmp/openglad_test_cfg/";
+#else
+    setenv("OPENGLAD_CONFIG_DIR", "/tmp/openglad_test_cfg", 1);
+    const char* expected = "/tmp/openglad_test_cfg/";
+#endif
+
+    std::string path = get_user_path();
+    TEST_ASSERT_STR_EQ(expected, path.c_str(),
+                       "OPENGLAD_CONFIG_DIR should override default user path");
+}
+REGISTER_TEST(test_io_get_user_path_uses_openglad_config_dir_when_set);
+
+void test_io_get_user_path_ignores_empty_openglad_config_dir()
+{
+    ScopedEnvVar scoped_cfg("OPENGLAD_CONFIG_DIR");
+#ifdef _WIN32
+    _putenv_s("OPENGLAD_CONFIG_DIR", "");
+    std::string path = get_user_path();
+    TEST_ASSERT(!path.empty(), "empty OPENGLAD_CONFIG_DIR should still produce a non-empty default path");
+#else
+    ScopedEnvVar scoped_home("HOME");
+    setenv("OPENGLAD_CONFIG_DIR", "", 1);
+    setenv("HOME", "/tmp/openglad_test_home", 1);
+    std::string path = get_user_path();
+    TEST_ASSERT_STR_EQ("/tmp/openglad_test_home/.openglad/", path.c_str(),
+                       "empty OPENGLAD_CONFIG_DIR should fall back to HOME/.openglad");
+#endif
+}
+REGISTER_TEST(test_io_get_user_path_ignores_empty_openglad_config_dir);
+
+void test_io_get_user_path_normalizes_trailing_slashes()
+{
+    ScopedEnvVar scoped("OPENGLAD_CONFIG_DIR");
+#ifdef _WIN32
+    _putenv_s("OPENGLAD_CONFIG_DIR", "C:/tmp/openglad_cfg///");
+    const char* expected = "C:/tmp/openglad_cfg/";
+#else
+    setenv("OPENGLAD_CONFIG_DIR", "/tmp/openglad_cfg///", 1);
+    const char* expected = "/tmp/openglad_cfg/";
+#endif
+
+    std::string path = get_user_path();
+    TEST_ASSERT_STR_EQ(expected, path.c_str(),
+                       "OPENGLAD_CONFIG_DIR should normalize repeated trailing slashes");
+}
+REGISTER_TEST(test_io_get_user_path_normalizes_trailing_slashes);
 
 // ---------------------------------------------------------------------------
 // list_files


### PR DESCRIPTION
## Summary
- add OPENGLAD_CONFIG_DIR support to OpenGLad config/user path resolution
- if OPENGLAD_CONFIG_DIR is set and non-empty, use it as the user/config directory
- if it is unset or empty, keep existing fallback behavior ($HOME/.openglad)
- normalize configured paths to a single trailing slash for consistent path joins

## Code Changes
- updated get_user_path() in SDL runtime: src/sdl_client/io/platform_io.cpp
- updated get_user_path() in headless runtime: src/text_client/platform_headless.cpp
- added test coverage for env override/fallback edge cases in tests/test_io_funcs.cpp

## Tests
- Ran: cmake --build --preset ci-test && ctest --preset ci-test
- Result: openglad_test is currently unstable in this environment (timeout/failure in existing test_family_behaviors); other test targets passed, including suites containing the new path tests.
