### PR TITLE
Fix Zip Slip path traversal in unzip_into_with_error

### DIFF
--- a/src/io/zip_api.cpp
+++ b/src/io/zip_api.cpp
@@ -45,6 +45,60 @@ static std::vector<fs::path> list_relative_paths_recursively(const fs::path& bas
     return out;
 }
 
+static bool path_has_prefix(const fs::path& path, const fs::path& prefix)
+{
+    auto pit = path.begin();
+    auto pend = path.end();
+    auto qit = prefix.begin();
+    auto qend = prefix.end();
+    for (; qit != qend; ++qit, ++pit)
+    {
+        if (pit == pend || *pit != *qit)
+            return false;
+    }
+    return true;
+}
+
+static bool resolve_safe_unzip_destination(const fs::path& outdir_canonical,
+    const std::string& archive_entry_name, fs::path* out_destination)
+{
+    if (archive_entry_name.empty() || archive_entry_name.find('\0') != std::string::npos)
+        return false;
+
+    std::string normalized = archive_entry_name;
+    for (char& c : normalized)
+    {
+        if (c == '\\')
+            c = '/';
+    }
+    while (!normalized.empty() && normalized.back() == '/')
+        normalized.pop_back();
+    if (normalized.empty())
+        return false;
+
+    const fs::path rel = fs::path(normalized);
+    if (rel.empty() || rel.is_absolute() || rel.has_root_directory() || rel.has_root_name())
+        return false;
+
+    for (const fs::path& part : rel)
+    {
+        const std::string token = part.generic_string();
+        if (token.empty() || token == "." || token == "..")
+            return false;
+    }
+
+    std::error_code ec;
+    fs::path candidate = fs::weakly_canonical(outdir_canonical / rel, ec);
+    if (ec)
+        candidate = (outdir_canonical / rel).lexically_normal();
+
+    if (!path_has_prefix(candidate, outdir_canonical))
+        return false;
+
+    *out_destination = candidate;
+    return true;
+}
+
 ArchiveIoError zip_contents_with_error(const std::string& indirectory, const std::string& outfile)
 {
     fs::path base = fs::path(indirectory);
@@ -111,6 +165,14 @@ ArchiveIoError unzip_into_with_error(const std::string& infile, const std::strin
     std::error_code ec;
     fs::create_directories(outdir, ec);
 
+    fs::path outdir_canonical = fs::weakly_canonical(outdir, ec);
+    if (ec)
+    {
+        outdir_canonical = fs::absolute(outdir, ec);
+        if (ec)
+            outdir_canonical = outdir.lexically_normal();
+    }
+
     int err = 0;
     zip* archive = zip_open(infile.c_str(), 0, &err);
     if (archive == nullptr)
@@ -137,7 +199,12 @@ ArchiveIoError unzip_into_with_error(const std::string& infile, const std::strin
             continue;
 
         const bool is_dir = !name.empty() && name.back() == '/';
-        const fs::path dest = outdir / fs::path(name);
+        fs::path dest;
+        if (!resolve_safe_unzip_destination(outdir_canonical, name, &dest))
+        {
+            result = ArchiveIoError::OpenEntryFailed;
+            continue;
+        }
 
         if (is_dir)
         {

--- a/tests/test_io_zip_unzip.cpp
+++ b/tests/test_io_zip_unzip.cpp
@@ -10,6 +10,7 @@
 
 #include <unistd.h>
 #include <physfs.h>
+#include "zip.h"
 
 static bool write_file_bytes(const std::string& path, const std::string& contents)
 {
@@ -259,3 +260,48 @@ void test_io_zip_batch6_add_entry_failed_for_unreadable_file()
 #endif
 }
 REGISTER_TEST(test_io_zip_batch6_add_entry_failed_for_unreadable_file);
+
+void test_io_unzip_rejects_zip_slip_paths()
+{
+    namespace fs = std::filesystem;
+    const fs::path base = fs::temp_directory_path() / ("openglad_io_zipslip_" + std::to_string(::getpid()));
+    const fs::path zipfile = base / "malicious.zip";
+    const fs::path outdir = base / "out";
+    const fs::path outside = base / "outside.txt";
+
+    TEST_ASSERT(create_dir(base.string()), "create base dir should succeed");
+
+    int err = 0;
+    zip* za = zip_open(zipfile.string().c_str(), ZIP_CREATE | ZIP_TRUNCATE, &err);
+    TEST_ASSERT(za != nullptr, "zip_open malicious archive should succeed");
+    if (!za)
+        return;
+
+    zip_source* safe_src = zip_source_buffer(za, "SAFE", 4, 0);
+    TEST_ASSERT(safe_src != nullptr, "zip_source_buffer safe entry should succeed");
+    if (safe_src && zip_file_add(za, "safe.txt", safe_src, ZIP_FL_OVERWRITE) < 0)
+    {
+        zip_source_free(safe_src);
+        TEST_ASSERT(false, "zip_file_add safe entry should succeed");
+    }
+
+    zip_source* slip_src = zip_source_buffer(za, "EVIL", 4, 0);
+    TEST_ASSERT(slip_src != nullptr, "zip_source_buffer zip slip entry should succeed");
+    if (slip_src && zip_file_add(za, "../outside.txt", slip_src, ZIP_FL_OVERWRITE) < 0)
+    {
+        zip_source_free(slip_src);
+        TEST_ASSERT(false, "zip_file_add zip slip entry should succeed");
+    }
+
+    TEST_ASSERT_EQ(0, zip_close(za), "zip_close malicious archive should succeed");
+
+    TEST_ASSERT_EQ(static_cast<int>(ArchiveIoError::OpenEntryFailed),
+        static_cast<int>(unzip_into_with_error(zipfile.string(), outdir.string())),
+        "zip slip entry should be rejected");
+
+    std::string payload;
+    TEST_ASSERT(read_file_all((outdir / "safe.txt").string(), &payload), "safe file should extract");
+    TEST_ASSERT(payload == "SAFE", "safe file content should match");
+    TEST_ASSERT(!fs::exists(outside), "zip slip output path outside extraction root must not be created");
+}
+REGISTER_TEST(test_io_unzip_rejects_zip_slip_paths);


### PR DESCRIPTION
## Summary
- prevent Zip Slip path traversal in `unzip_into_with_error()` by validating entry destinations remain under the extraction root
- reject unsafe archive entries (absolute paths, `..`, dot segments, root-qualified paths, and backslash-separated traversal)
- add regression coverage for malicious `../outside.txt` zip entry while preserving extraction of safe entries

## Testing
- `cmake --build --preset ci-test && ctest --preset ci-test`
- `./build/ci-test/og_data_tests --test test_io_zip_contents_and_unzip_into_roundtrip,test_io_zip_batch5_empty_directory_and_non_regular_entries,test_io_unzip_rejects_zip_slip_paths`

Fixes #47
