### PR TITLE
Fix v4/v5 scenario name OOB read on 12-byte names

### DIFF
--- a/src/runtime/level_data.cpp
+++ b/src/runtime/level_data.cpp
@@ -935,7 +935,7 @@ short load_version_4(og::io::OgFile& infile, LevelData* data)
 	char newgrid[9] = "grid";  // default grid (8-byte field, no implicit NUL)
 	char oneline[80] = {};
 	char numlines, tempwidth;
-	char tempname[12] = {};
+	char tempname[13] = {};
 
 
 	// Format of a scenario object list file version 4 is:
@@ -995,6 +995,7 @@ short load_version_4(og::io::OgFile& infile, LevelData* data)
 		    !rw_read_exact_or_log(infile, tempname, 12, 1) ||
 		    !rw_read_exact_or_log(infile, tempreserved, 10, 1))
 			return 0;
+		tempname[12] = '\0';
 		if (static_cast<Order>(temporder) == Order::Treasure)
 			//new_guy = data->add_ob(static_cast<Order>(temporder), tempfamily, 1); // add to top of list
 			new_guy = data->add_fx_ob(static_cast<Order>(temporder), tempfamily);
@@ -1081,7 +1082,7 @@ short load_version_5(og::io::OgFile& infile, LevelData* data)
 	char new_scen_type; // read the scenario type
 	char oneline[80] = {};
 	char numlines, tempwidth;
-	char tempname[12] = {};
+	char tempname[13] = {};
 
 	// Format of a scenario object list file version 5 is:
 	// 3-byte header: 'FSS'
@@ -1146,6 +1147,7 @@ short load_version_5(og::io::OgFile& infile, LevelData* data)
 		    !rw_read_exact_or_log(infile, tempname, 12, 1) ||
 		    !rw_read_exact_or_log(infile, tempreserved, 10, 1))
 			return 0;
+		tempname[12] = '\0';
 		if (static_cast<Order>(temporder) == Order::Treasure)
 			new_guy = data->add_fx_ob(static_cast<Order>(temporder), tempfamily);
 		else

--- a/tests/test_level_data_ops.cpp
+++ b/tests/test_level_data_ops.cpp
@@ -608,6 +608,63 @@ void test_level_data_save_description_serialization_bounds()
 }
 REGISTER_TEST(test_level_data_save_description_serialization_bounds);
 
+void test_level_data_load_version4_5_name_field_without_nul_is_bounded()
+{
+    auto make_blob = [](bool include_type_byte) {
+        std::vector<uint8_t> b;
+        push_bytes(b, "16grass1", 8); // grid
+        if (include_type_byte)
+            push_u8(b, 2); // scenario type
+
+        push_i16(b, 1); // listsize
+
+        push_u8(b, static_cast<uint8_t>(Order::Living));
+        push_u8(b, static_cast<uint8_t>(FAMILY_SOLDIER));
+        push_i16(b, 48);
+        push_i16(b, 64);
+        push_u8(b, 1); // team
+        push_u8(b, 0); // facing
+        push_u8(b, static_cast<uint8_t>(ACT_RANDOM)); // command
+        push_u8(b, 4); // level
+        push_bytes(b, "ABCDEFGHIJKL", 12); // no NUL terminator in fixed 12-byte field
+        push_bytes(b, "RRRRRRRRRR", 10);   // no NUL in reserved field either
+
+        push_u8(b, 1); // numlines
+        push_u8(b, 6); // width
+        push_bytes(b, "hello!", 6);
+        return b;
+    };
+
+    const std::string expected_name = "ABCDEFGHIJKL";
+
+    {
+        std::vector<uint8_t> blob4 = make_blob(false);
+        MemoryOgFile rw4(blob4.data(), blob4.size());
+        myscreen->level_data.delete_objects();
+        myscreen->level_data.description.clear();
+        short r4 = load_scenario_version(rw4, &myscreen->level_data, 4);
+        TEST_ASSERT_EQ(1, (int)r4, "v4 should load with full 12-byte non-NUL name");
+        TEST_ASSERT(!myscreen->level_data.oblist.empty(), "v4 should create an object");
+        TEST_ASSERT(myscreen->level_data.oblist.front()->stats()->name == expected_name,
+            "v4 name should be bounded to 12 bytes");
+    }
+
+    {
+        std::vector<uint8_t> blob5 = make_blob(true);
+        MemoryOgFile rw5(blob5.data(), blob5.size());
+        myscreen->level_data.delete_objects();
+        myscreen->level_data.description.clear();
+        short r5 = load_scenario_version(rw5, &myscreen->level_data, 5);
+        TEST_ASSERT_EQ(1, (int)r5, "v5 should load with full 12-byte non-NUL name");
+        TEST_ASSERT(!myscreen->level_data.oblist.empty(), "v5 should create an object");
+        TEST_ASSERT(myscreen->level_data.oblist.front()->stats()->name == expected_name,
+            "v5 name should be bounded to 12 bytes");
+    }
+
+    myscreen->level_data.delete_objects();
+}
+REGISTER_TEST(test_level_data_load_version4_5_name_field_without_nul_is_bounded);
+
 // ---------------------------------------------------------------------------
 // LevelData::resize_grid with objects - tests off-map cleanup
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure v4/v5 scenario object name buffers are explicitly NUL-terminated after reading fixed 12-byte fields
- keep string construction bounded to the intended name field
- add regression coverage for v4/v5 scenario loading when the 12-byte name has no embedded NUL

## Testing
- cmake --build --preset ci-test
- ctest --preset ci-test
- ./build/ci-test/og_data_tests level_data_load_version4_5_name_field_without_nul_is_bounded

Fixes #49