### PR TITLE
Fix SaveData::load negative team size validation

### DIFF
--- a/src/runtime/save_data.cpp
+++ b/src/runtime/save_data.cpp
@@ -273,7 +273,7 @@ bool SaveData::load(const std::string& filename)
 
 	// Get # of guys to read
 	READ_OR_FAIL(&listsize, 2, 1);
-    const bool invalid_team_size = listsize > MAX_TEAM_SIZE;
+    const bool invalid_team_size = (listsize < 0) || (listsize > MAX_TEAM_SIZE);
     if (invalid_team_size)
     {
         LogError("save_load_team_size_invalid file={} listsize={} max={}\n",

--- a/tests/test_save_data_versions.cpp
+++ b/tests/test_save_data_versions.cpp
@@ -342,6 +342,32 @@ void test_save_data_load_with_error_campaign_mount_failure()
 }
 REGISTER_TEST(test_save_data_load_with_error_campaign_mount_failure);
 
+void test_save_data_load_rejects_negative_team_size()
+{
+    write_save_file("ver9_negative_team_size",
+                    /*version=*/9,
+                    /*campaign_id=*/"org.openglad.gladiator",
+                    /*scen_num=*/1,
+                    /*cash=*/100,
+                    /*score=*/200,
+                    /*allied_mode=*/1,
+                    /*numplayers=*/1,
+                    /*guys=*/nullptr,
+                    /*listsize=*/-1,
+                    /*use_v8plus_campaigns=*/true,
+                    /*v5plus_levelstatus=*/true,
+                    /*levelstatus_500=*/nullptr,
+                    /*levelstatus_200=*/nullptr);
+
+    SaveData tmp;
+    TEST_ASSERT(!tmp.load("ver9_negative_team_size"),
+                "load should fail when team listsize is negative");
+    TEST_ASSERT_EQ(static_cast<int>(SaveDataIoError::ReadFailed),
+                   static_cast<int>(tmp.last_io_error()),
+                   "negative team listsize should report ReadFailed");
+}
+REGISTER_TEST(test_save_data_load_rejects_negative_team_size);
+
 void test_save_data_save_with_error_open_write_failed_for_missing_directory()
 {
     const std::string bad_subdir = "save/typed_save_missing_dir";


### PR DESCRIPTION
## Summary
- reject negative listsize values when loading save files
- keep existing upper-bound validation against MAX_TEAM_SIZE
- add a regression test covering a v9 save blob with listsize = -1

## Testing
- cmake --build --preset ci-test
- ctest --preset ci-test (known local flake in openglad_test/openglad_test_menu as noted in issue instructions)
- ctest --preset ci-test -R '^og_runtime_tests$' --output-on-failure
- ctest --preset ci-test -R '^og_data_tests$' --output-on-failure

Fixes #51
