### PR TITLE
Fix duplicate XP/score crediting in walker::attack

### DIFF
--- a/src/entities/walker_combat.cpp
+++ b/src/entities/walker_combat.cpp
@@ -274,7 +274,7 @@ bool walker::attack(walker  *target)
     playerteam = 0;
 
     // Award base hit rewards once per successful enemy hit.
-    if (playerteam != target->team_num)
+    if (targetorder == Order::Living && playerteam != target->team_num)
     {
         if (headguy->myguy)
             headguy->myguy->exp += attack_exp;

--- a/tests/test_walker_combat.cpp
+++ b/tests/test_walker_combat.cpp
@@ -975,6 +975,7 @@ void test_walker_combat_attack_rewards_single_credit_weapon_hit()
     TEST_ASSERT(owner && target && weapon, "owner/target/weapon created");
     if (!(owner && target && weapon))
     {
+        myscreen->level_data.delete_objects();
         myscreen->save_data.allied_mode = saved_allied_mode;
         return;
     }
@@ -1028,6 +1029,7 @@ void test_walker_combat_attack_rewards_single_credit_melee_kill()
     TEST_ASSERT(attacker && target, "attacker/target created");
     if (!(attacker && target))
     {
+        myscreen->level_data.delete_objects();
         myscreen->save_data.allied_mode = saved_allied_mode;
         return;
     }


### PR DESCRIPTION
## Summary
- centralize base hit reward attribution in `walker::attack()` so attack XP/score are credited once per successful enemy hit
- keep kill rewards separate and award kill XP once on lethal hits (without re-adding base attack XP)
- remove duplicated reward branches that previously double-counted owner/weapon and kill paths

## Tests
- `cmake --build --preset ci-test`
- `ctest --preset ci-test` *(initial run identified `og_runtime_tests` failures in new regression setup; fixed and validated with targeted rerun)*
- `ctest --preset ci-test -R og_runtime_tests --output-on-failure`

Closes #73
