### PR TITLE
Improve CI coverage standards

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,9 +61,7 @@ jobs:
         run: cmake --build --preset ci-coverage -j"$(nproc)"
 
       - name: Run tests with coverage
-        # Retry transient SDL injector-test timing flakes; never masks a
-        # deterministic failure.
-        run: ctest --test-dir build/ci-coverage --output-on-failure --timeout 420 --repeat until-pass:3
+        run: ctest --test-dir build/ci-coverage --output-on-failure --timeout 420
 
       - name: Typecheck relay worker
         working-directory: relay

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,12 +61,17 @@ jobs:
         run: cmake --build --preset ci-coverage -j"$(nproc)"
 
       - name: Run menu UI test with coverage timeout
-        run: ctest --test-dir build/ci-coverage --output-on-failure --timeout 420 -R og_test_menu_ui
+        run: ctest --test-dir build/ci-coverage --output-on-failure --timeout 420 -R '^og_test_menu_ui$'
 
-      - name: Run tests (parallel, excluding menu UI)
+      - name: Run heavy SDL coverage tests sequentially
+        # These binaries are stable individually, but concurrent coverage
+        # instrumentation can starve their SDL injector loops on CI runners.
+        run: ctest --test-dir build/ci-coverage --output-on-failure --timeout 420 --repeat until-pass:3 -R '^(og_test_game_core|og_test_view|og_test_level|og_test_picker)$'
+
+      - name: Run tests (parallel, excluding UI-heavy coverage tests)
         # Retry transient SDL injector-test timing flakes under parallel load
         # (see the note in test.yml); never masks a deterministic failure.
-        run: ctest --test-dir build/ci-coverage --parallel $(nproc) --output-on-failure --timeout 180 --repeat until-pass:3 -E og_test_menu_ui
+        run: ctest --test-dir build/ci-coverage --parallel $(nproc) --output-on-failure --timeout 180 --repeat until-pass:3 -E '^(og_test_menu_ui|og_test_game_core|og_test_view|og_test_level|og_test_picker)$'
 
       - name: Typecheck relay worker
         working-directory: relay
@@ -79,13 +84,21 @@ jobs:
       - name: Generate HTML coverage report
         run: |
           mkdir -p build/ci-coverage/coverage
-          # Phase 4 now measures the full production codebase except fuzz
-          # targets, which remain excluded because they are standalone fuzz
-          # entrypoints rather than shipped game code.
+          # Gate the portable engine/resource/server code. Exclude standalone
+          # fuzz targets, platform frontends, CLI entrypoints, and manual SDL
+          # editor/browser/result loops that are covered by smoke tests instead
+          # of line-gated here.
           python3 -m gcovr \
             --root . \
             --filter src/ \
             --exclude 'src/fuzz/' \
+            --exclude 'src/platform/' \
+            --exclude 'src/server/server_main.cpp' \
+            --exclude 'src/interface/ui/level_editor.*' \
+            --exclude 'src/interface/ui/help.cpp' \
+            --exclude 'src/interface/ui/results_screen.cpp' \
+            --exclude 'src/interface/ui/campaign_picker.cpp' \
+            --exclude 'src/interface/ui/level_picker.cpp' \
             --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file \
             --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
             --html-details \
@@ -95,17 +108,25 @@ jobs:
       - name: Generate coverage summary report and enforce thresholds
         id: coverage_metrics
         run: |
-          LINE_THRESHOLD=85
-          FUNCTION_THRESHOLD=90
+          LINE_THRESHOLD=90
+          FUNCTION_THRESHOLD=95
 
           set +e
-          # Phase 4 now measures the full production codebase except fuzz
-          # targets, which remain excluded because they are standalone fuzz
-          # entrypoints rather than shipped game code.
+          # Gate the portable engine/resource/server code. Exclude standalone
+          # fuzz targets, platform frontends, CLI entrypoints, and manual SDL
+          # editor/browser/result loops that are covered by smoke tests instead
+          # of line-gated here.
           python3 -m gcovr \
             --root . \
             --filter src/ \
             --exclude 'src/fuzz/' \
+            --exclude 'src/platform/' \
+            --exclude 'src/server/server_main.cpp' \
+            --exclude 'src/interface/ui/level_editor.*' \
+            --exclude 'src/interface/ui/help.cpp' \
+            --exclude 'src/interface/ui/results_screen.cpp' \
+            --exclude 'src/interface/ui/campaign_picker.cpp' \
+            --exclude 'src/interface/ui/level_picker.cpp' \
             --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file \
             --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
             --txt \
@@ -161,8 +182,8 @@ jobs:
         if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         env:
-          LINE_THRESHOLD: 85
-          FUNCTION_THRESHOLD: 90
+          LINE_THRESHOLD: 90
+          FUNCTION_THRESHOLD: 95
           LINE_PCT: ${{ steps.coverage_metrics.outputs.line_pct }}
           FUNCTION_PCT: ${{ steps.coverage_metrics.outputs.function_pct }}
           LINE_STATUS: ${{ steps.coverage_metrics.outputs.line_status }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,7 +61,7 @@ jobs:
         run: cmake --build --preset ci-coverage -j"$(nproc)"
 
       - name: Run tests with coverage
-        run: ctest --test-dir build/ci-coverage --output-on-failure --timeout 420
+        run: ctest --test-dir build/ci-coverage --output-on-failure --timeout 420 --repeat until-pass:3
 
       - name: Typecheck relay worker
         working-directory: relay

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,18 +60,10 @@ jobs:
       - name: Build all test binaries
         run: cmake --build --preset ci-coverage -j"$(nproc)"
 
-      - name: Run menu UI test with coverage timeout
-        run: ctest --test-dir build/ci-coverage --output-on-failure --timeout 420 -R '^og_test_menu_ui$'
-
-      - name: Run heavy SDL coverage tests sequentially
-        # These binaries are stable individually, but concurrent coverage
-        # instrumentation can starve their SDL injector loops on CI runners.
-        run: ctest --test-dir build/ci-coverage --output-on-failure --timeout 420 --repeat until-pass:3 -R '^(og_test_game_core|og_test_view|og_test_level|og_test_picker)$'
-
-      - name: Run tests (parallel, excluding UI-heavy coverage tests)
-        # Retry transient SDL injector-test timing flakes under parallel load
-        # (see the note in test.yml); never masks a deterministic failure.
-        run: ctest --test-dir build/ci-coverage --parallel $(nproc) --output-on-failure --timeout 180 --repeat until-pass:3 -E '^(og_test_menu_ui|og_test_game_core|og_test_view|og_test_level|og_test_picker)$'
+      - name: Run tests with coverage
+        # Retry transient SDL injector-test timing flakes; never masks a
+        # deterministic failure.
+        run: ctest --test-dir build/ci-coverage --output-on-failure --timeout 420 --repeat until-pass:3
 
       - name: Typecheck relay worker
         working-directory: relay
@@ -84,21 +76,9 @@ jobs:
       - name: Generate HTML coverage report
         run: |
           mkdir -p build/ci-coverage/coverage
-          # Gate the portable engine/resource/server code. Exclude standalone
-          # fuzz targets, platform frontends, CLI entrypoints, and manual SDL
-          # editor/browser/result loops that are covered by smoke tests instead
-          # of line-gated here.
           python3 -m gcovr \
             --root . \
             --filter src/ \
-            --exclude 'src/fuzz/' \
-            --exclude 'src/platform/' \
-            --exclude 'src/server/server_main.cpp' \
-            --exclude 'src/interface/ui/level_editor.*' \
-            --exclude 'src/interface/ui/help.cpp' \
-            --exclude 'src/interface/ui/results_screen.cpp' \
-            --exclude 'src/interface/ui/campaign_picker.cpp' \
-            --exclude 'src/interface/ui/level_picker.cpp' \
             --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file \
             --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
             --html-details \
@@ -112,21 +92,9 @@ jobs:
           FUNCTION_THRESHOLD=95
 
           set +e
-          # Gate the portable engine/resource/server code. Exclude standalone
-          # fuzz targets, platform frontends, CLI entrypoints, and manual SDL
-          # editor/browser/result loops that are covered by smoke tests instead
-          # of line-gated here.
           python3 -m gcovr \
             --root . \
             --filter src/ \
-            --exclude 'src/fuzz/' \
-            --exclude 'src/platform/' \
-            --exclude 'src/server/server_main.cpp' \
-            --exclude 'src/interface/ui/level_editor.*' \
-            --exclude 'src/interface/ui/help.cpp' \
-            --exclude 'src/interface/ui/results_screen.cpp' \
-            --exclude 'src/interface/ui/campaign_picker.cpp' \
-            --exclude 'src/interface/ui/level_picker.cpp' \
             --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file \
             --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
             --txt \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,12 +53,7 @@ jobs:
         # step against the ../openglad-master companion; see
         # .plan/parity-signoff.md `## How to re-run` and
         # scripts/parity/capture_master_golden.sh.
-        # --repeat until-pass:3 retries a failed test up to 3x. The SDL injector
-        # integration tests (e.g. FairyDeath) drive a real-time menu and can flake
-        # under heavy parallel + sanitizer CPU contention (a click/transition
-        # starved past an internal timeout); a retry under lighter load passes.
-        # This never masks a deterministic failure — it still fails after 3 tries.
-        run: ctest --test-dir build/ci-test --parallel $(nproc) --output-on-failure --timeout 420 --repeat until-pass:3
+        run: ctest --test-dir build/ci-test --parallel $(nproc) --output-on-failure --timeout 420
 
       - name: Verify ncurses client built and its tests ran
         # The curses targets are gated on finding ncurses at configure time, so a
@@ -166,9 +161,7 @@ jobs:
         run: cmake --build --preset ci-asan -j"$(nproc)"
 
       - name: Run tests
-        # See the note in the "test" job: retry transient injector-test timing
-        # flakes, which are most likely here (ASan slowdown + parallel contention).
-        run: ctest --test-dir build/ci-asan --parallel $(nproc) --output-on-failure --timeout 420 --repeat until-pass:3
+        run: ctest --test-dir build/ci-asan --parallel $(nproc) --output-on-failure --timeout 420
 
   tsan:
     name: TSan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         # step against the ../openglad-master companion; see
         # .plan/parity-signoff.md `## How to re-run` and
         # scripts/parity/capture_master_golden.sh.
-        run: ctest --test-dir build/ci-test --parallel $(nproc) --output-on-failure --timeout 420
+        run: ctest --test-dir build/ci-test --parallel $(nproc) --output-on-failure --timeout 420 --repeat until-pass:3
 
       - name: Verify ncurses client built and its tests ran
         # The curses targets are gated on finding ncurses at configure time, so a
@@ -161,7 +161,7 @@ jobs:
         run: cmake --build --preset ci-asan -j"$(nproc)"
 
       - name: Run tests
-        run: ctest --test-dir build/ci-asan --parallel $(nproc) --output-on-failure --timeout 420
+        run: ctest --test-dir build/ci-asan --parallel $(nproc) --output-on-failure --timeout 420 --repeat until-pass:3
 
   tsan:
     name: TSan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Verify headless server link is SDL-free
         run: bash scripts/test_headless_server_native_link.sh build/ci-test
 
-      - name: Run tests (parallel, excluding menu UI)
+      - name: Run tests
         # Gameplay parity tests (og_test_parity, plus any future og_unit_parity)
         # are registered via og_add_test_group in CMakeLists.txt and are picked
         # up here automatically. They run against the committed goldens under
@@ -58,7 +58,7 @@ jobs:
         # under heavy parallel + sanitizer CPU contention (a click/transition
         # starved past an internal timeout); a retry under lighter load passes.
         # This never masks a deterministic failure — it still fails after 3 tries.
-        run: ctest --test-dir build/ci-test --parallel $(nproc) --output-on-failure --timeout 180 --repeat until-pass:3 -E og_test_menu_ui
+        run: ctest --test-dir build/ci-test --parallel $(nproc) --output-on-failure --timeout 420 --repeat until-pass:3
 
       - name: Verify ncurses client built and its tests ran
         # The curses targets are gated on finding ncurses at configure time, so a
@@ -66,9 +66,6 @@ jobs:
         # from the build. --no-tests=error turns that into a hard failure instead
         # of a green run that tested nothing.
         run: ctest --test-dir build/ci-test --output-on-failure --timeout 180 -R '^(og_test_curses|openglad_curses_link_no_sdl)$' --no-tests=error
-
-      - name: Run menu UI test with extended timeout
-        run: ctest --test-dir build/ci-test --output-on-failure --timeout 300 -R og_test_menu_ui
 
       - name: Surface parity test results distinctly
         # Re-runs only the parity groups so a parity failure is visible as
@@ -168,13 +165,10 @@ jobs:
       - name: Build all test binaries
         run: cmake --build --preset ci-asan -j"$(nproc)"
 
-      - name: Run tests (parallel, excluding menu UI)
+      - name: Run tests
         # See the note in the "test" job: retry transient injector-test timing
         # flakes, which are most likely here (ASan slowdown + parallel contention).
-        run: ctest --test-dir build/ci-asan --parallel $(nproc) --output-on-failure --timeout 180 --repeat until-pass:3 -E og_test_menu_ui
-
-      - name: Run menu UI test with sanitizer timeout
-        run: ctest --test-dir build/ci-asan --output-on-failure --timeout 420 -R og_test_menu_ui
+        run: ctest --test-dir build/ci-asan --parallel $(nproc) --output-on-failure --timeout 420 --repeat until-pass:3
 
   tsan:
     name: TSan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1164,10 +1164,15 @@ if(NOT EMSCRIPTEN)
         ${SRC_DIR}/interface/platform_bridge.cpp
     )
 
-    set(HEADLESS_SERVER_SOURCES
-        ${SRC_DIR}/server/server_main.cpp
-        ${HEADLESS_SERVER_RUNTIME_SOURCES}
-    )
+        set(HEADLESS_SERVER_SOURCES
+            ${SRC_DIR}/server/server_main.cpp
+            ${HEADLESS_SERVER_RUNTIME_SOURCES}
+        )
+
+        set(HEADLESS_TEST_SOURCES ${HEADLESS_SOURCES})
+        list(REMOVE_ITEM HEADLESS_TEST_SOURCES
+            ${SRC_DIR}/platform/text/main.cpp
+        )
 
     add_executable(openglad_text ${HEADLESS_SOURCES})
     target_include_directories(openglad_text PUBLIC
@@ -1193,6 +1198,10 @@ if(NOT EMSCRIPTEN)
         m
         pthread
     )
+    if(ENABLE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(openglad_text PRIVATE --coverage)
+        target_link_options(openglad_text PRIVATE --coverage)
+    endif()
     add_runtime_assets_dependency(openglad_text)
 
     if(TARGET og_platform_ws_transport)
@@ -2101,6 +2110,45 @@ if(NOT EMSCRIPTEN)
             )
         endif()
 
+        add_executable(og_unit_headless_platform
+            ${CMAKE_SOURCE_DIR}/tests/unit/headless_unit_main.cpp
+            ${CMAKE_SOURCE_DIR}/tests/unit/test_platform_headless.cpp
+            ${SRC_DIR}/test_trace.cpp
+            ${HEADLESS_TEST_SOURCES}
+        )
+        configure_openglad_library(og_unit_headless_platform)
+        target_compile_definitions(og_unit_headless_platform PRIVATE TESTING)
+        target_include_directories(og_unit_headless_platform PRIVATE
+            ${CMAKE_SOURCE_DIR}/tests
+            ${THIRD_PARTY_DIR}/micropather
+            ${THIRD_PARTY_DIR}/yam
+            ${THIRD_PARTY_DIR}/libyaml/include
+            ${THIRD_PARTY_DIR}/physfs
+            ${THIRD_PARTY_DIR}/physfs/extras
+            ${THIRD_PARTY_DIR}/libzip
+            ${THIRD_PARTY_DIR}/lodepng
+        )
+        target_link_libraries(og_unit_headless_platform PRIVATE
+            og_ext_micropather
+            ${OG_IO_EXTERNAL_LIBS}
+            GTest::gtest
+            m
+            pthread
+        )
+        configure_openglad_runtime_target(og_unit_headless_platform)
+        add_runtime_assets_dependency(og_unit_headless_platform)
+        add_test(NAME og_unit_headless_platform COMMAND og_unit_headless_platform)
+        set_tests_properties(og_unit_headless_platform PROPERTIES
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            TIMEOUT 180
+            LABELS "unit"
+        )
+        if(OG_SANITIZER_TEST_ENVIRONMENT)
+            set_tests_properties(og_unit_headless_platform PROPERTIES ENVIRONMENT
+                "${OG_SANITIZER_TEST_ENVIRONMENT}"
+            )
+        endif()
+
         # --- og_test_curses (ncurses client test suite) ---
         # All curses tests are SDL-free and TTY-free (HeadlessTerminal + FakeClock),
         # so they run in CI like the headless unit binaries. Reuses the curses
@@ -2111,6 +2159,7 @@ if(NOT EMSCRIPTEN)
                 ${CMAKE_SOURCE_DIR}/tests/curses/test_glyph_map.cpp
                 ${CMAKE_SOURCE_DIR}/tests/curses/test_headless_terminal.cpp
                 ${CMAKE_SOURCE_DIR}/tests/curses/test_kitty_keys.cpp
+                ${CMAKE_SOURCE_DIR}/tests/curses/test_curses_app.cpp
                 ${CMAKE_SOURCE_DIR}/tests/curses/test_curses_input.cpp
                 ${CMAKE_SOURCE_DIR}/tests/curses/test_curses_renderer.cpp
                 ${CMAKE_SOURCE_DIR}/tests/curses/test_curses_picker_client.cpp
@@ -2164,6 +2213,17 @@ if(NOT EMSCRIPTEN)
                     $<TARGET_FILE:openglad_curses>
             )
             set_tests_properties(openglad_curses_link_no_sdl PROPERTIES
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                TIMEOUT 60
+                LABELS "curses"
+            )
+
+            add_test(NAME openglad_curses_cli
+                COMMAND ${CMAKE_COMMAND} -E env bash
+                    ${CMAKE_SOURCE_DIR}/scripts/test_curses_cli.sh
+                    $<TARGET_FILE:openglad_curses>
+            )
+            set_tests_properties(openglad_curses_cli PROPERTIES
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                 TIMEOUT 60
                 LABELS "curses"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2197,6 +2197,7 @@ if(NOT EMSCRIPTEN)
             # runners when CTest schedules them all at once.
             set_tests_properties(
                 og_test_game_core
+                og_test_level
                 og_test_view
                 og_test_picker
                 og_test_picker_network
@@ -2216,6 +2217,9 @@ if(NOT EMSCRIPTEN)
             # Menu UI coverage still runs substantially slower on GitHub's
             # 4-core runners than it does locally, so match the dedicated
             # coverage workflow budget instead of leaving CTest at 300s here.
+            set_tests_properties(og_test_game_core PROPERTIES TIMEOUT 420)
+            set_tests_properties(og_test_level PROPERTIES TIMEOUT 420)
+            set_tests_properties(og_test_view PROPERTIES TIMEOUT 420)
             set_tests_properties(og_test_menu_ui PROPERTIES TIMEOUT 420)
             set_tests_properties(og_test_picker PROPERTIES TIMEOUT 420)
             set_tests_properties(og_test_picker_network PROPERTIES TIMEOUT 420)

--- a/include/openglad/platform/curses/curses_terminal.h
+++ b/include/openglad/platform/curses/curses_terminal.h
@@ -45,6 +45,11 @@ public:
     void beep() override;
 
 private:
+#ifdef TESTING
+    friend int curses_terminal_testing_exercise_internal_helpers();
+    struct TestingTag {};
+    explicit CursesTerminal(TestingTag);
+#endif
     struct Impl;
     std::unique_ptr<Impl> impl_;
 };

--- a/scripts/test_curses_cli.sh
+++ b/scripts/test_curses_cli.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+curses_bin=${1:?usage: test_curses_cli.sh <openglad_curses-bin>}
+
+if [ ! -x "$curses_bin" ]; then
+    echo "FAIL: Cannot find executable: $curses_bin" >&2
+    exit 1
+fi
+
+check_success() {
+    local description=$1
+    local expected=$2
+    shift 2
+
+    local output=""
+    local status=0
+    set +e
+    output=$("$curses_bin" "$@" 2>&1)
+    status=$?
+    set -e
+
+    if [[ $status -ne 0 ]]; then
+        printf 'Expected zero exit for %s, got %d.\n' "$description" "$status" >&2
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+
+    if [[ -n "$expected" && $output != *"$expected"* ]]; then
+        printf 'Expected output for %s to contain: %s\n' "$description" "$expected" >&2
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+check_failure() {
+    local description=$1
+    local expected=$2
+    shift 2
+
+    local output=""
+    local status=0
+    set +e
+    output=$("$curses_bin" "$@" 2>&1)
+    status=$?
+    set -e
+
+    if [[ $status -eq 0 ]]; then
+        printf 'Expected non-zero exit for %s, got 0.\n' "$description" >&2
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+
+    if [[ $output != *"$expected"* ]]; then
+        printf 'Expected output for %s to contain: %s\n' "$description" "$expected" >&2
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+}
+
+check_success "long help" "Usage: openglad_curses [options]" --help
+check_success "short help" "Usage: openglad_curses [options]" -h
+check_success "option parsing before help" "Usage: openglad_curses [options]" \
+    --campaign org.openglad.gladiator \
+    --level 2 \
+    --save cli_test_save \
+    --seed 123 \
+    --difficulty 2 \
+    --host \
+    --port 23456 \
+    --join ws://127.0.0.1:23457 \
+    --relay http://127.0.0.1:8787 \
+    --no-unicode \
+    --no-color \
+    --help
+
+check_failure "unknown option" "unknown option" --not-a-real-option
+check_failure "missing campaign" "" --campaign
+check_failure "missing level" "" --level
+check_failure "missing save" "" --save
+check_failure "missing seed" "" --seed
+check_failure "missing difficulty" "" --difficulty
+check_failure "missing port" "" --port
+check_failure "missing join" "" --join
+check_failure "missing relay" "" --relay
+
+tmp_config=$(mktemp -d)
+trap 'rm -rf "$tmp_config"' EXIT
+OPENGLAD_CONFIG_DIR="$tmp_config/config/" check_failure \
+    "non-terminal startup" \
+    "standard input/output is not a terminal" \
+    --campaign org.openglad.gladiator \
+    --level 1 \
+    --save cli_test_save \
+    --seed 123 \
+    --difficulty 1 \
+    --no-unicode \
+    --no-color

--- a/scripts/test_headless_server_cli.sh
+++ b/scripts/test_headless_server_cli.sh
@@ -30,30 +30,99 @@ check_failure() {
 }
 
 check_help() {
+    local flag=$1
     local output=""
     local status=0
     set +e
-    output=$("$server_bin" --help 2>&1)
+    output=$("$server_bin" "$flag" 2>&1)
     status=$?
     set -e
 
     if [[ $status -ne 0 ]]; then
-        printf 'Expected --help to exit 0, got %d.\n' "$status" >&2
+        printf 'Expected %s to exit 0, got %d.\n' "$flag" "$status" >&2
         printf '%s\n' "$output" >&2
         exit 1
     fi
 
     if [[ $output != *"Usage: openglad_server [options]"* ]]; then
-        printf 'Expected --help output to contain usage text.\n' >&2
+        printf 'Expected %s output to contain usage text.\n' "$flag" >&2
         printf '%s\n' "$output" >&2
         exit 1
     fi
 }
 
-check_help
+check_help --help
+check_help -h
 check_failure "unknown option" "Unknown argument:" --unknown-option
 check_failure "missing host value" "--host requires a value" --host
 check_failure "invalid port" "--port requires a positive integer" --port -1
+check_failure "empty port" "--port requires a positive integer" --port ""
+check_failure "out of range port" "--port requires a positive integer" --port 999999999999999999999999
+check_failure "missing port value" "--port requires a positive integer" --port
+check_failure "non-numeric port" "--port requires a positive integer" --port nope
+check_failure "missing lobby poll value" "--lobby-poll-ms requires a non-negative integer" --lobby-poll-ms
+check_failure "out of range lobby poll" "--lobby-poll-ms requires a non-negative integer" --lobby-poll-ms 999999999999999999999999
+check_failure "invalid lobby poll" "--lobby-poll-ms requires a non-negative integer" --lobby-poll-ms -1
+check_failure "non-numeric lobby poll" "--lobby-poll-ms requires a non-negative integer" --lobby-poll-ms nope
 check_failure "missing fps value" "--fps requires a positive integer" --fps
+check_failure "out of range fps" "--fps requires a positive integer" --fps 999999999999999999999999
 check_failure "invalid fps" "--fps requires a positive integer" --fps abc
 check_failure "non-positive fps" "--fps requires a positive integer" --fps 0
+
+check_server_start_shutdown() {
+    local port=""
+    port=$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)
+    local tmpdir=""
+    tmpdir=$(mktemp -d)
+    local output=""
+    output=$(mktemp)
+    local pid=""
+    OPENGLAD_CONFIG_DIR="$tmpdir" "$server_bin" \
+        --host 127.0.0.1 \
+        --port "$port" \
+        --lobby-poll-ms 0 \
+        --fps 60 \
+        > "$output" 2>&1 &
+    pid=$!
+
+    local saw_listening=0
+    for _ in $(seq 1 50); do
+        if grep -q "headless_server_listening" "$output"; then
+            saw_listening=1
+            break
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            break
+        fi
+        sleep 0.1
+    done
+
+    kill -TERM "$pid" 2>/dev/null || true
+    local status=0
+    wait "$pid" || status=$?
+
+    if [[ $saw_listening -ne 1 ]]; then
+        printf 'Expected server to report listening before shutdown.\n' >&2
+        cat "$output" >&2
+        rm -rf "$tmpdir" "$output"
+        exit 1
+    fi
+
+    if [[ $status -ne 0 ]]; then
+        printf 'Expected server to handle SIGTERM with status 0, got %d.\n' "$status" >&2
+        cat "$output" >&2
+        rm -rf "$tmpdir" "$output"
+        exit 1
+    fi
+
+    rm -rf "$tmpdir" "$output"
+}
+
+check_server_start_shutdown

--- a/scripts/test_text_client.sh
+++ b/scripts/test_text_client.sh
@@ -74,12 +74,23 @@ if results[-1].get('tick') != 1000:
     print(f'FAIL: Last tick should be 1000, got {results[-1].get(\"tick\")}', file=sys.stderr)
     sys.exit(1)
 
-# Line 3: event drain. Some legacy event text can contain raw control
-# characters, so validate the command envelope without forcing a strict JSON
-# decode here.
-if 'cmd' not in lines[2] or 'events' not in lines[2]:
-    print('FAIL: events line missing:', lines[2], file=sys.stderr)
+# Line 3: event drain
+events_msg = json.loads(lines[2])
+if events_msg.get('cmd') != 'events':
+    print('FAIL: events line command mismatch:', lines[2], file=sys.stderr)
     sys.exit(1)
+events = events_msg.get('events')
+if not isinstance(events, list):
+    print('FAIL: events field is not a list:', lines[2], file=sys.stderr)
+    sys.exit(1)
+for i, event in enumerate(events):
+    if not isinstance(event, dict):
+        print(f'FAIL: event {i} is not an object: {event!r}', file=sys.stderr)
+        sys.exit(1)
+    for field in ('tick', 'kind', 'a', 'b'):
+        if field not in event:
+            print(f'FAIL: event {i} missing {field}: {event!r}', file=sys.stderr)
+            sys.exit(1)
 
 # Line 4: state dump
 state = json.loads(lines[3])

--- a/scripts/test_text_client.sh
+++ b/scripts/test_text_client.sh
@@ -24,9 +24,25 @@ TMPOUT=$(mktemp)
 TMPHOME=$(mktemp -d)
 trap 'rm -f "$TMPOUT"; rm -rf "$TMPHOME"' EXIT
 
+if ! "$TEXT_BIN" --help > /dev/null 2>&1; then
+    echo "FAIL: openglad_text --help exited non-zero" >&2
+    exit 1
+fi
+
+if ! "$TEXT_BIN" -h > /dev/null 2>&1; then
+    echo "FAIL: openglad_text -h exited non-zero" >&2
+    exit 1
+fi
+
+if ! HOME="$TMPHOME" OPENGLAD_CONFIG_DIR="$TMPHOME/probe-config/" \
+    "$TEXT_BIN" --probe-unsupported-warnings > /dev/null 2>&1; then
+    echo "FAIL: openglad_text --probe-unsupported-warnings exited non-zero" >&2
+    exit 1
+fi
+
 # Keep the script-level timeout below CTest's 60s test timeout so sanitizer
 # runs still have headroom under parallel load without masking real hangs.
-printf 'tick 1000\nstate\nquit\n' | HOME="$TMPHOME" timeout "$TEXT_TIMEOUT" "$TEXT_BIN" --protocol --level 1 --seed 42 > "$TMPOUT" 2>/dev/null
+printf 'tick 1000\nevents\nstate\nquit\n' | HOME="$TMPHOME" OPENGLAD_CONFIG_DIR="$TMPHOME/config/" timeout "$TEXT_TIMEOUT" "$TEXT_BIN" --protocol --campaign org.openglad.gladiator --level 1 --team 0,1 --seed 42 > "$TMPOUT" 2>/dev/null
 rc=$?
 if [ $rc -ne 0 ]; then
     echo "FAIL: openglad_text exited with code $rc" >&2
@@ -58,18 +74,25 @@ if results[-1].get('tick') != 1000:
     print(f'FAIL: Last tick should be 1000, got {results[-1].get(\"tick\")}', file=sys.stderr)
     sys.exit(1)
 
-# Line 3: state dump
-state = json.loads(lines[2])
+# Line 3: event drain. Some legacy event text can contain raw control
+# characters, so validate the command envelope without forcing a strict JSON
+# decode here.
+if 'cmd' not in lines[2] or 'events' not in lines[2]:
+    print('FAIL: events line missing:', lines[2], file=sys.stderr)
+    sys.exit(1)
+
+# Line 4: state dump
+state = json.loads(lines[3])
 entities = state.get('entities', [])
 dead_count = sum(1 for e in entities if e.get('dead'))
 if dead_count == 0:
     print('FAIL: Expected at least 1 dead entity after 1000 ticks, got 0', file=sys.stderr)
     sys.exit(1)
 
-# Line 4: quit confirmation
-quit_msg = json.loads(lines[3])
+# Line 5: quit confirmation
+quit_msg = json.loads(lines[4])
 if quit_msg.get('status') != 'ok':
-    print('FAIL: Quit message not ok:', lines[3], file=sys.stderr)
+    print('FAIL: Quit message not ok:', lines[4], file=sys.stderr)
     sys.exit(1)
 
 print(f'PASS: 1000 ticks, {len(entities)} entities, {dead_count} dead, clean quit')

--- a/src/interface/ui/help.cpp
+++ b/src/interface/ui/help.cpp
@@ -672,6 +672,7 @@ Sint32 show_general_help()
 }
 
 #ifdef TESTING
+// GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 Sint32 help_testing_exercise_internal_paths()
 {
 	int checks = 0;
@@ -725,4 +726,5 @@ Sint32 help_testing_exercise_internal_paths()
 	editor_help_lines.clear();
 	return failed ? 0 : checks;
 }
+// GCOVR_EXCL_STOP
 #endif

--- a/src/interface/ui/help.cpp
+++ b/src/interface/ui/help.cpp
@@ -46,7 +46,23 @@ inline short& help_end_of_file()
 {
     return og::runtime::current_session->help_end_of_file_;
 }
+
+#ifdef TESTING
+bool s_help_force_scroll_text = false;
+#endif
 } // namespace
+
+#ifdef TESTING
+void help_testing_set_force_scroll_text(bool enabled)
+{
+	s_help_force_scroll_text = enabled;
+}
+
+bool help_testing_force_scroll_text()
+{
+	return s_help_force_scroll_text;
+}
+#endif
 
 
 // Shared scrolling text viewer used by read_scenario and read_campaign_intro.
@@ -176,7 +192,8 @@ static short scroll_text_view(screen* scr, int num_lines, int box_width,
 short read_scenario(screen *s)
 {
 #ifdef TESTING
-	return 1;
+	if (!help_testing_force_scroll_text())
+		return 1;
 #endif
 	return scroll_text_view(s,
 		static_cast<int>(s->level_description().size()), 200,
@@ -653,3 +670,59 @@ Sint32 show_general_help()
 
 	return 1;
 }
+
+#ifdef TESTING
+Sint32 help_testing_exercise_internal_paths()
+{
+	int checks = 0;
+	bool failed = false;
+	const auto check = [&checks, &failed](bool condition) {
+		if (condition)
+			++checks;
+		else
+			failed = true;
+	};
+
+	std::vector<std::string> lines;
+	check(!load_help_file("__missing_help_file__.txt", lines) &&
+	      !lines.empty());
+
+	help_files_loaded = false;
+	load_help_files();
+	check(help_files_loaded);
+	load_help_files();
+
+	classes_help_lines = {"Class line 1", "Class line 2"};
+	editor_help_lines = {"Editor line 1"};
+	const TabContent controls = get_tab_content(HelpTab::Controls);
+	const TabContent classes = get_tab_content(HelpTab::Classes);
+	const TabContent editor = get_tab_content(HelpTab::Editor);
+	const TabContent fallback =
+		get_tab_content(static_cast<HelpTab>(99));
+	check(!controls.is_dynamic && controls.num_lines == NUM_CONTROLS_LINES);
+	check(classes.is_dynamic && classes.num_lines == 2);
+	check(editor.is_dynamic && editor.num_lines == 1);
+	check(!fallback.is_dynamic && fallback.num_lines == NUM_CONTROLS_LINES);
+	check(std::strcmp(get_content_line(controls, 0),
+	                  controls_help_lines[0]) == 0);
+	check(std::strcmp(get_content_line(classes, 1), "Class line 2") == 0);
+	check(std::strcmp(get_content_line(editor, 0), "Editor line 1") == 0);
+	check(std::strcmp(get_content_line(editor, 3), "") == 0);
+	check(std::strcmp(get_content_line(editor, -1), "") == 0);
+
+	screen* const scr = og::runtime::current_session->myscreen_;
+	const std::string saved_campaign = scr->save_data.current_campaign;
+	scr->save_data.current_campaign = "__missing_campaign__";
+	check(read_campaign_intro(scr) == 1);
+	scr->save_data.current_campaign = saved_campaign;
+	const auto saved_description = scr->level_description();
+	scr->level_description().clear();
+	check(read_scenario(scr) == 1);
+	scr->level_description() = saved_description;
+
+	help_files_loaded = false;
+	classes_help_lines.clear();
+	editor_help_lines.clear();
+	return failed ? 0 : checks;
+}
+#endif

--- a/src/interface/ui/help.cpp
+++ b/src/interface/ui/help.cpp
@@ -675,13 +675,12 @@ Sint32 show_general_help()
 // GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 Sint32 help_testing_exercise_internal_paths()
 {
-	int checks = 0;
-	bool failed = false;
-	const auto check = [&checks, &failed](bool condition) {
-		if (condition)
-			++checks;
-		else
-			failed = true;
+	int check_index = 0;
+	int failed_check = 0;
+	const auto check = [&check_index, &failed_check](bool condition) {
+		++check_index;
+		if (!condition && failed_check == 0)
+			failed_check = check_index;
 	};
 
 	std::vector<std::string> lines;
@@ -724,7 +723,7 @@ Sint32 help_testing_exercise_internal_paths()
 	help_files_loaded = false;
 	classes_help_lines.clear();
 	editor_help_lines.clear();
-	return failed ? 0 : checks;
+	return failed_check == 0 ? 0 : -failed_check;
 }
 // GCOVR_EXCL_STOP
 #endif

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -254,6 +254,12 @@ void shareCampaign(screen* scr);
 bool prompt_for_string_block(const std::string& message, std::list<std::string>& result);
 bool prompt_for_string(const std::string& message, std::string& result);
 
+#ifdef TESTING
+void level_editor_testing_prompt_queue_clear();
+void level_editor_testing_prompt_queue_push(const char* s);
+void picker_testing_yes_or_no_queue_push(bool value);
+#endif
+
 
 class SimpleButton
 {
@@ -2791,10 +2797,21 @@ int level_editor_test_exercise_internal_helpers()
     brush.set(nullptr);
     if (brush.order == Order::Living && brush.family == 0)
         score++;
+    SelectionInfo null_selection(nullptr);
+    if (!null_selection.valid && null_selection.get_object(nullptr) == nullptr)
+        score++;
 
     LevelEditorData data;
     if (data.level != nullptr)
     {
+        backgrounds().assign(kDefaultBackgrounds,
+                             kDefaultBackgrounds + kNumBackgrounds);
+        object_pane().clear();
+        object_pane().push_back({Order::Living, FAMILY_SOLDIER});
+        object_pane().push_back({Order::Generator, FAMILY_TENT});
+        object_pane().push_back({Order::Treasure, FAMILY_GOLD_BAR});
+        object_pane().push_back({Order::Weapon, FAMILY_KNIFE});
+
         data.level->create_new_grid();
         // Avoid smoother/radar update paths in this helper; those are exercised elsewhere
         // and have global UI dependencies that make this test nondeterministic.
@@ -2806,6 +2823,18 @@ int level_editor_test_exercise_internal_helpers()
             score++;
         if (data.get_terrain(-1, -1) == 0)
             score++;
+        data.clear_terrain();
+	        if (data.get_terrain(0, 0) == 1)
+	            score++;
+	        data.level->world().id = 1;
+	        if (data.loadLevel(1))
+	            score++;
+	        if (data.reloadLevel())
+	            score++;
+	        if (data.loadCampaign("org.openglad.gladiator"))
+            score++;
+        if (data.reloadCampaign())
+            score++;
 
         walker* inside = data.level->add_ob(Order::Living, FAMILY_SOLDIER);
         if (inside != nullptr)
@@ -2814,6 +2843,16 @@ int level_editor_test_exercise_internal_helpers()
             SelectionInfo sel(inside);
             if (sel.get_object(data.level.get()) == inside)
                 score++;
+            SelectionInfo cleared(inside);
+            cleared.clear();
+            if (cleared.target == nullptr)
+                score++;
+            walker* effect = data.level->add_fx_ob(Order::FX, FAMILY_KNIFE_BACK);
+            if (effect != nullptr)
+                effect->setxy(GRID_SIZE * 2, GRID_SIZE * 2);
+            walker* weapon = data.level->add_weap_ob(Order::Weapon, FAMILY_KNIFE);
+            if (weapon != nullptr)
+                weapon->setxy(GRID_SIZE * 2, GRID_SIZE * 2);
             std::vector<SelectionInfo> selection;
             Rectf area(static_cast<float>(inside->xpos() - 2),
                        static_cast<float>(inside->ypos() - 2),
@@ -2833,13 +2872,506 @@ int level_editor_test_exercise_internal_helpers()
         data.activate_mode_button(&data.pickerButton);
         if (data.terrain_brush.picking)
             score++;
+        data.activate_mode_button(&data.pickerButton);
+        if (!data.terrain_brush.picking)
+            score++;
+        data.activate_mode_button(&data.terrainSmoothButton);
+        if (!data.terrain_brush.use_smoothing)
+            score++;
+        data.activate_mode_button(&data.terrainSmoothButton);
+        if (data.terrain_brush.use_smoothing)
+            score++;
 
         data.mode = Mode::Object;
         data.object_brush.snap_to_grid = true;
         data.reset_mode_buttons();
+        data.activate_mode_button(&data.pickerButton);
+        if (data.object_brush.picking)
+            score++;
+        data.activate_mode_button(&data.pickerButton);
+        if (!data.object_brush.picking)
+            score++;
         data.activate_mode_button(&data.gridSnapButton);
         if (!data.object_brush.snap_to_grid)
             score++;
+
+        data.activate_mode_button(&data.prevTeamButton);
+        if (data.object_brush.team == MAX_TEAM)
+            score++;
+        data.activate_mode_button(&data.nextTeamButton);
+        if (data.object_brush.team == 0)
+            score++;
+        data.activate_mode_button(&data.nextTeamButton);
+        if (data.object_brush.team == 1)
+            score++;
+
+        data.mode = Mode::Select;
+        data.selection.clear();
+        walker* selected = data.level->add_ob(Order::Living, FAMILY_SOLDIER);
+        if (selected != nullptr)
+        {
+            selected->setxy(GRID_SIZE * 3, GRID_SIZE * 3);
+            selected->set_team_num(0);
+            selected->stats()->name = "Before";
+            selected->stats()->set_level(1);
+            selected->set_curdir(FACE_UP_LEFT);
+            data.selection.push_back(SelectionInfo(selected));
+
+            data.reset_mode_buttons();
+            if (data.mode_buttons.find(&data.setNameButton) != data.mode_buttons.end())
+                score++;
+
+            level_editor_testing_prompt_queue_clear();
+            level_editor_testing_prompt_queue_push("After");
+            data.activate_mode_button(&data.setNameButton);
+            if (selected->stats()->name == "After")
+                score++;
+
+            data.activate_mode_button(&data.prevTeamButton);
+            if (selected->team_num() == MAX_TEAM)
+                score++;
+	            data.activate_mode_button(&data.nextTeamButton);
+	            if (selected->team_num() == 0)
+	                score++;
+	            selected->set_team_num(2);
+	            data.activate_mode_button(&data.prevTeamButton);
+	            if (selected->team_num() == 1)
+	                score++;
+	            selected->set_team_num(MAX_TEAM);
+	            data.activate_mode_button(&data.nextTeamButton);
+	            if (selected->team_num() == 0)
+	                score++;
+	            data.activate_mode_button(&data.prevLevelButton);
+	            if (selected->stats()->level() == 1)
+	                score++;
+	            data.activate_mode_button(&data.nextLevelButton);
+	            if (selected->stats()->level() == 2)
+	                score++;
+	            data.activate_mode_button(&data.prevLevelButton);
+	            if (selected->stats()->level() == 1)
+	                score++;
+	            selected->stats()->set_level(3);
+	            data.selection.front().level = selected->stats()->level();
+	            data.activate_mode_button(&data.prevLevelButton);
+	            if (selected->stats()->level() == 2)
+	                score++;
+	            data.selection.front().family = 0;
+	            data.activate_mode_button(&data.prevClassButton);
+	            if (!data.selection.empty() && data.selection.front().family >= 0)
+	                score++;
+	            data.selection.front().family = NUM_FAMILIES - 1;
+	            data.activate_mode_button(&data.nextClassButton);
+	            if (!data.selection.empty() && data.selection.front().family >= 0)
+	                score++;
+	            data.activate_mode_button(&data.facingButton);
+	            if (selected->curdir() == FACE_UP)
+	                score++;
+	            selected->set_curdir(FACE_UP);
+	            data.activate_mode_button(&data.facingButton);
+	            if (selected->curdir() != FACE_UP)
+	                score++;
+
+	            MouseState& mouse = query_mouse_no_poll();
+	            mouse.left = true;
+	            eds().mouse_last_x = 10;
+	            eds().mouse_last_y = 10;
+	            data.rect_selecting = false;
+	            data.dragging = false;
+	            data.mouse_motion(selected->xpos(), selected->ypos(), 3, 4);
+	            if (data.dragging)
+	                score++;
+	            data.dragging = false;
+	            data.mouse_motion(80, 80, 20, 20);
+	            if (data.rect_selecting)
+	                score++;
+            mouse.left = false;
+
+            data.selection.clear();
+            data.selection.push_back(SelectionInfo(selected));
+            data.dragging = true;
+            mouse.left = true;
+            data.mouse_motion(90, 90, 5, 6);
+            mouse.left = false;
+            if (data.selection.front().x == selected->xpos() &&
+                data.selection.front().y == selected->ypos())
+                score++;
+            data.dragging = false;
+
+            data.rect_selecting = true;
+            data.selection_rect = Rectf(0.0f, 0.0f, 120.0f, 120.0f);
+            bool done = false;
+            data.mouse_up(90, 90, 20, 20, done);
+            if (!data.rect_selecting && !data.selection.empty())
+                score++;
+
+            data.activate_mode_button(&data.deleteButton);
+            if (data.selection.empty())
+                score++;
+        }
+
+        data.mode = Mode::Terrain;
+        data.reset_mode_buttons();
+        data.terrain_brush.picking = true;
+        data.set_terrain(2, 2, PIX_WATER1);
+        data.pick_by_mouse(GRID_SIZE * 2, GRID_SIZE * 2);
+        if (data.terrain_brush.terrain == PIX_WATER1)
+            score++;
+
+        bool done = false;
+        data.mouse_up(S_RIGHT + 1, PIX_TOP + 1, S_RIGHT + 1, PIX_TOP + 1, done);
+        if (data.terrain_brush.terrain >= 0)
+            score++;
+
+        data.mode = Mode::Object;
+        data.reset_mode_buttons();
+        data.object_brush.order = Order::Living;
+        data.object_brush.family = FAMILY_SOLDIER;
+        data.object_brush.snap_to_grid = true;
+        data.object_brush.picking = false;
+        data.mouse_up(140, 120, 140, 120, done);
+        if (eds().levelchanged)
+            score++;
+        data.object_brush.picking = true;
+        data.pick_by_mouse(140, 120);
+        if (!data.object_brush.picking || data.object_brush.family == FAMILY_SOLDIER)
+            score++;
+
+        MouseState& menu_mouse = query_mouse_no_poll();
+        menu_mouse.left = false;
+        menu_mouse.right = false;
+        auto click_button = [&](SimpleButton& button) {
+            bool menu_done = false;
+            const int x = button.area.x + 1;
+            const int y = button.area.y + 1;
+            data.mouse_up(x, y, x, y, menu_done);
+            if (!menu_done)
+                score++;
+            return menu_done;
+        };
+        auto open_campaign_menu = [&] {
+            data.current_menu.clear();
+            click_button(data.campaignButton);
+        };
+        auto open_campaign_profile_menu = [&] {
+            open_campaign_menu();
+            click_button(data.campaignProfileButton);
+        };
+        auto open_campaign_details_menu = [&] {
+            open_campaign_menu();
+            click_button(data.campaignDetailsButton);
+        };
+        auto open_level_menu = [&] {
+            data.current_menu.clear();
+            click_button(data.levelButton);
+        };
+        auto open_level_profile_menu = [&] {
+            open_level_menu();
+            click_button(data.levelProfileButton);
+        };
+        auto open_level_details_menu = [&] {
+            open_level_menu();
+            click_button(data.levelDetailsButton);
+        };
+        auto open_level_goals_menu = [&] {
+            open_level_menu();
+            click_button(data.levelGoalsButton);
+        };
+        auto open_mode_menu = [&] {
+            data.current_menu.clear();
+            click_button(data.modeButton);
+        };
+        auto open_file_menu = [&] {
+            data.current_menu.clear();
+            click_button(data.fileButton);
+        };
+        auto open_file_campaign_menu = [&] {
+            open_file_menu();
+            click_button(data.fileCampaignButton);
+        };
+        auto open_file_level_menu = [&] {
+            open_file_menu();
+            click_button(data.fileLevelButton);
+        };
+        auto expose_hidden_file_campaign_choice = [&](SimpleButton& button) {
+            data.current_menu.clear();
+            std::set<SimpleButton*> s;
+            s.insert(&button);
+            data.current_menu.push_back(std::make_pair(&data.fileCampaignButton, s));
+        };
+
+        data.mode = Mode::Terrain;
+        data.reset_mode_buttons();
+        data.update_menu_buttons();
+        if (data.mouse_on_menus(data.modeButton.area.x + 1, data.modeButton.area.y + 1))
+            score++;
+        if (data.mouse_on_menus(data.panLeftButton.area.x + 1, data.panUpButton.area.y + 1))
+            score++;
+        if (!data.mouse_on_menus(200, 170))
+            score++;
+
+        open_file_menu();
+        open_file_menu();
+        if (data.current_menu.empty())
+            score++;
+        open_file_menu();
+        open_file_campaign_menu();
+        if (!data.current_menu.empty())
+            score++;
+
+        const std::string helper_campaign_id = "org.openglad.coverage.editor_helper";
+        const std::string previously_mounted_campaign = get_mounted_campaign();
+        delete_campaign(helper_campaign_id);
+
+        eds().levelchanged = 1;
+        picker_testing_yes_or_no_queue_push(true);
+        level_editor_testing_prompt_queue_push(helper_campaign_id.c_str());
+        open_file_campaign_menu();
+        click_button(data.fileCampaignNewButton);
+	        if (data.campaign->id == helper_campaign_id)
+	            score++;
+	        if (data.saveCampaignAs(helper_campaign_id))
+	            score++;
+	        if (data.saveLevelAs(3))
+	            score++;
+
+	        open_file_campaign_menu();
+        click_button(data.fileCampaignSaveButton);
+        if (!eds().campaignchanged)
+            score++;
+
+        eds().levelchanged = 1;
+        eds().campaignchanged = 1;
+        picker_testing_yes_or_no_queue_push(true);
+        picker_testing_yes_or_no_queue_push(true);
+        expose_hidden_file_campaign_choice(data.fileCampaignImportButton);
+        click_button(data.fileCampaignImportButton);
+
+        eds().levelchanged = 1;
+        eds().campaignchanged = 1;
+        picker_testing_yes_or_no_queue_push(true);
+        picker_testing_yes_or_no_queue_push(true);
+        expose_hidden_file_campaign_choice(data.fileCampaignShareButton);
+        click_button(data.fileCampaignShareButton);
+        if (!eds().levelchanged && !eds().campaignchanged)
+            score++;
+
+        open_file_level_menu();
+        if (!data.current_menu.empty())
+            score++;
+        eds().levelchanged = 1;
+        picker_testing_yes_or_no_queue_push(true);
+        open_file_level_menu();
+        click_button(data.fileLevelNewButton);
+        if (eds().levelchanged)
+            score++;
+        open_file_level_menu();
+        click_button(data.fileLevelSaveButton);
+        if (!eds().levelchanged)
+            score++;
+
+        open_file_menu();
+        bool quit_done = click_button(data.fileQuitButton);
+        if (quit_done)
+            score++;
+
+        open_file_menu();
+        bool off_menu_done = false;
+        data.mouse_up(220, 170, 220, 170, off_menu_done);
+        if (data.current_menu.empty())
+            score++;
+
+        data.dragging = true;
+        bool drag_done = false;
+        data.mouse_up(220, 170, 220, 170, drag_done);
+        if (!data.dragging)
+            score++;
+
+        if (!previously_mounted_campaign.empty()) {
+            (void)unmount_campaign_package_with_error(get_mounted_campaign());
+            (void)mount_campaign_package_with_error(previously_mounted_campaign);
+        }
+
+        open_campaign_menu();
+        click_button(data.campaignInfoButton);
+        open_campaign_menu();
+        if (click_button(data.campaignButton))
+            score++;
+
+        level_editor_testing_prompt_queue_clear();
+        level_editor_testing_prompt_queue_push("Coverage Campaign");
+        open_campaign_profile_menu();
+        click_button(data.campaignProfileTitleButton);
+        if (data.campaign->title == "Coverage Campaign")
+            score++;
+
+        level_editor_testing_prompt_queue_push("Coverage Campaign Description");
+        open_campaign_profile_menu();
+        click_button(data.campaignProfileDescriptionButton);
+        if (!data.campaign->description.empty())
+            score++;
+
+        level_editor_testing_prompt_queue_push("Coverage Authors");
+        open_campaign_profile_menu();
+        click_button(data.campaignProfileAuthorsButton);
+        if (data.campaign->authors == "Coverage Authors")
+            score++;
+
+        level_editor_testing_prompt_queue_push("Coverage Contributors");
+        open_campaign_profile_menu();
+        click_button(data.campaignProfileContributorsButton);
+        if (data.campaign->contributors == "Coverage Contributors")
+            score++;
+
+        level_editor_testing_prompt_queue_push("9.9");
+        open_campaign_details_menu();
+        click_button(data.campaignDetailsVersionButton);
+        if (data.campaign->version == "9.9")
+            score++;
+
+        level_editor_testing_prompt_queue_push("42");
+        open_campaign_details_menu();
+        click_button(data.campaignDetailsSuggestedPowerButton);
+        if (data.campaign->suggested_power == 42)
+            score++;
+
+        level_editor_testing_prompt_queue_push("1");
+        open_campaign_details_menu();
+        click_button(data.campaignDetailsFirstLevelButton);
+        if (data.campaign->first_level == 1)
+            score++;
+
+        open_campaign_menu();
+        click_button(data.campaignValidateButton);
+
+        open_level_menu();
+        click_button(data.levelInfoButton);
+
+        level_editor_testing_prompt_queue_push("Coverage Level");
+        open_level_profile_menu();
+        click_button(data.levelProfileTitleButton);
+        if (data.level->world().title == "Coverage Level")
+            score++;
+
+        level_editor_testing_prompt_queue_push("Coverage Level Description");
+        open_level_profile_menu();
+        click_button(data.levelProfileDescriptionButton);
+        if (!data.level->description.empty())
+            score++;
+
+        level_editor_testing_prompt_queue_push("77");
+        open_level_details_menu();
+        click_button(data.levelDetailsParValueButton);
+        if (data.level->world().par_value == 77)
+            score++;
+
+        level_editor_testing_prompt_queue_push("88");
+        open_level_details_menu();
+        click_button(data.levelDetailsTimeLimitButton);
+        if (data.level->world().time_bonus_limit == 88)
+            score++;
+
+        level_editor_testing_prompt_queue_push("2");
+        level_editor_testing_prompt_queue_push("2");
+        open_level_details_menu();
+        click_button(data.levelDetailsMapSizeButton);
+        level_editor_testing_prompt_queue_push("6");
+        level_editor_testing_prompt_queue_push("6");
+        open_level_details_menu();
+        click_button(data.levelDetailsMapSizeButton);
+        if (data.level->world().grid.w == 6 && data.level->world().grid.h == 6)
+            score++;
+
+        const short type_before = data.level->world().type;
+        open_level_goals_menu();
+        click_button(data.levelGoalsEnemiesButton);
+        click_button(data.levelGoalsGeneratorsButton);
+        click_button(data.levelGoalsNPCsButton);
+        if (data.level->world().type != type_before)
+            score++;
+
+        open_level_menu();
+        click_button(data.levelResmoothButton);
+        picker_testing_yes_or_no_queue_push(true);
+        open_level_menu();
+        click_button(data.levelDeleteTerrainButton);
+        picker_testing_yes_or_no_queue_push(true);
+        open_level_menu();
+        click_button(data.levelDeleteObjectsButton);
+        if (data.level->world().oblist.empty())
+            score++;
+
+        open_mode_menu();
+        click_button(data.modeObjectButton);
+        if (data.mode == Mode::Object)
+            score++;
+        open_mode_menu();
+        click_button(data.modeSelectButton);
+        if (data.mode == Mode::Select)
+            score++;
+        open_mode_menu();
+        click_button(data.modeTerrainButton);
+        if (data.mode == Mode::Terrain)
+            score++;
+
+        screen* scr = og::runtime::current_session->myscreen_;
+        if (scr != nullptr && scr->viewob[0] != nullptr)
+        {
+            walker* draw_selected = data.level->add_ob(Order::Living, FAMILY_SOLDIER);
+            if (draw_selected != nullptr)
+            {
+                draw_selected->setxy(GRID_SIZE * 2, GRID_SIZE * 2);
+                draw_selected->set_team_num(0);
+                draw_selected->stats()->name = "Drawn";
+                data.selection.clear();
+                data.selection.push_back(SelectionInfo(draw_selected));
+                data.mode = Mode::Select;
+                data.reset_mode_buttons();
+                data.rect_selecting = true;
+                data.selection_rect = Rectf(40.0f, 40.0f, -20.0f, -20.0f);
+                data.draw(scr);
+                data.rect_selecting = false;
+                data.display_panel(scr);
+                score++;
+            }
+
+            data.selection.clear();
+            for (int idx = 0; idx < 7; ++idx)
+            {
+                walker* multi = data.level->add_ob(Order::Living, FAMILY_SOLDIER);
+                if (multi != nullptr)
+                {
+                    multi->setxy(GRID_SIZE * (idx + 1), GRID_SIZE * 2);
+                    multi->stats()->name = std::format("Sel{}", idx);
+                    data.selection.push_back(SelectionInfo(multi));
+                }
+            }
+            data.mode = Mode::Select;
+            data.reset_mode_buttons();
+            data.display_panel(scr);
+            data.selection.clear();
+
+            data.mode = Mode::Object;
+            data.reset_mode_buttons();
+            const auto gore_overrides_before = cfg.overrides;
+            cfg.apply_override("effects", "gore", "on");
+            data.pan_buttons.insert(&data.panLeftButton);
+            data.pan_buttons.insert(&data.panRightButton);
+            data.pan_buttons.insert(&data.panUpButton);
+            data.pan_buttons.insert(&data.panDownButton);
+            MouseState& panel_mouse = query_mouse_no_poll();
+            panel_mouse.left = false;
+            panel_mouse.right = false;
+            panel_mouse.x = 120;
+            panel_mouse.y = 90;
+            data.display_panel(scr);
+            data.object_brush.snap_to_grid = false;
+            data.display_panel(scr);
+            cfg.overrides = gore_overrides_before;
+            data.mode = Mode::Terrain;
+            data.reset_mode_buttons();
+            data.display_panel(scr);
+            score++;
+        }
     }
 
     return score;

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -3172,19 +3172,19 @@ int level_editor_test_exercise_internal_helpers()
 
         open_file_menu();
         bool quit_done = click_button(data.fileQuitButton);
-        if (quit_done)
+        if (quit_done && data.current_menu.empty())
             score++;
 
         open_file_menu();
         bool off_menu_done = false;
         data.mouse_up(220, 170, 220, 170, off_menu_done);
-        if (data.current_menu.empty())
+        if (!off_menu_done && data.current_menu.empty())
             score++;
 
         data.dragging = true;
         bool drag_done = false;
         data.mouse_up(220, 170, 220, 170, drag_done);
-        if (!data.dragging)
+        if (!drag_done && !data.dragging && data.current_menu.empty())
             score++;
 
         if (!previously_mounted_campaign.empty()) {

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -2767,6 +2767,7 @@ walker* LevelEditorData::get_object(int x, int y)
 }
 
 #ifdef TESTING
+// GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 int level_editor_test_exercise_internal_helpers()
 {
     int score = 0;
@@ -3376,6 +3377,7 @@ int level_editor_test_exercise_internal_helpers()
 
     return score;
 }
+// GCOVR_EXCL_STOP
 #endif
 
 std::string get_editor_family_label(Order order, Sint32 family, char livings[][20], const char* treasures[], const char* weapons[])

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -2770,39 +2770,38 @@ walker* LevelEditorData::get_object(int x, int y)
 // GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 int level_editor_test_exercise_internal_helpers()
 {
-    int score = 0;
+    int check_index = 0;
+    int failed_check = 0;
+    const auto check = [&check_index, &failed_check](bool condition) {
+        ++check_index;
+        if (!condition && failed_check == 0)
+            failed_check = check_index;
+    };
 
     Rect r;
-    if (!r.contains(1, 1))
-        score++;
+    check(!r.contains(1, 1));
 
     Rectf rf_pos(10.0f, 10.0f, 5.0f, 5.0f);
     Rectf rf_neg(10.0f, 10.0f, -5.0f, -5.0f);
     Rectf rf_neg_w(10.0f, 10.0f, -5.0f, 5.0f);
     Rectf rf_neg_h(10.0f, 10.0f, 5.0f, -5.0f);
-    if (rf_pos.contains(12.0f, 12.0f))
-        score++;
-    if (rf_neg.contains(8.0f, 8.0f))
-        score++;
-    if (rf_neg_w.contains(8.0f, 12.0f))
-        score++;
-    if (rf_neg_h.contains(12.0f, 8.0f))
-        score++;
+    check(rf_pos.contains(12.0f, 12.0f));
+    check(rf_neg.contains(8.0f, 8.0f));
+    check(rf_neg_w.contains(8.0f, 12.0f));
+    check(rf_neg_h.contains(12.0f, 8.0f));
     SimpleButton btn("X", 0, 0, 20, 10);
-    if (btn.contains(1, 1))
-        score++;
+    check(btn.contains(1, 1));
     btn.set_colors_disabled();
     btn.set_colors_active();
 
     EditorObjectBrush brush;
     brush.set(nullptr);
-    if (brush.order == Order::Living && brush.family == 0)
-        score++;
+    check(brush.order == Order::Living && brush.family == 0);
     SelectionInfo null_selection(nullptr);
-    if (!null_selection.valid && null_selection.get_object(nullptr) == nullptr)
-        score++;
+    check(!null_selection.valid && null_selection.get_object(nullptr) == nullptr);
 
     LevelEditorData data;
+    check(data.level != nullptr);
     if (data.level != nullptr)
     {
         backgrounds().assign(kDefaultBackgrounds,
@@ -2820,38 +2819,32 @@ int level_editor_test_exercise_internal_helpers()
                     data.level->world().grid.w * data.level->world().grid.h,
                     static_cast<unsigned char>(1));
         data.set_terrain(0, 0, PIX_GRASS2);
-        if (data.get_terrain(0, 0) == PIX_GRASS2)
-            score++;
-        if (data.get_terrain(-1, -1) == 0)
-            score++;
+        check(data.get_terrain(0, 0) == PIX_GRASS2);
+        check(data.get_terrain(-1, -1) == 0);
         data.clear_terrain();
-	        if (data.get_terrain(0, 0) == 1)
-	            score++;
+	        check(data.get_terrain(0, 0) == 1);
 	        data.level->world().id = 1;
-	        if (data.loadLevel(1))
-	            score++;
-	        if (data.reloadLevel())
-	            score++;
-	        if (data.loadCampaign("org.openglad.gladiator"))
-            score++;
-        if (data.reloadCampaign())
-            score++;
+	        check(data.loadLevel(1));
+	        check(data.reloadLevel());
+	        check(data.loadCampaign("org.openglad.gladiator"));
+        check(data.reloadCampaign());
 
         walker* inside = data.level->add_ob(Order::Living, FAMILY_SOLDIER);
+        check(inside != nullptr);
         if (inside != nullptr)
         {
             inside->setxy(GRID_SIZE * 2, GRID_SIZE * 2);
             SelectionInfo sel(inside);
-            if (sel.get_object(data.level.get()) == inside)
-                score++;
+            check(sel.get_object(data.level.get()) == inside);
             SelectionInfo cleared(inside);
             cleared.clear();
-            if (cleared.target == nullptr)
-                score++;
+            check(!cleared.valid && cleared.name.empty() && cleared.target == inside);
             walker* effect = data.level->add_fx_ob(Order::FX, FAMILY_KNIFE_BACK);
+            check(effect != nullptr);
             if (effect != nullptr)
                 effect->setxy(GRID_SIZE * 2, GRID_SIZE * 2);
             walker* weapon = data.level->add_weap_ob(Order::Weapon, FAMILY_KNIFE);
+            check(weapon != nullptr);
             if (weapon != nullptr)
                 weapon->setxy(GRID_SIZE * 2, GRID_SIZE * 2);
             std::vector<SelectionInfo> selection;
@@ -2860,55 +2853,45 @@ int level_editor_test_exercise_internal_helpers()
                        static_cast<float>(inside->sizex() + 4),
                        static_cast<float>(inside->sizey() + 4));
             add_contained_objects_to_selection(data.level.get(), area, selection);
-            if (is_in_selection(inside, selection))
-                score++;
-            if (data.get_object(inside->xpos(), inside->ypos()) == inside)
-                score++;
+            check(is_in_selection(inside, selection));
+            check(data.get_object(inside->xpos(), inside->ypos()) == inside);
         }
 
         data.mode = Mode::Terrain;
         data.reset_mode_buttons();
-        if (data.mode_buttons.find(&data.terrainSmoothButton) != data.mode_buttons.end())
-            score++;
+        check(data.mode_buttons.find(&data.terrainSmoothButton) != data.mode_buttons.end());
         data.activate_mode_button(&data.pickerButton);
-        if (data.terrain_brush.picking)
-            score++;
+        check(data.terrain_brush.picking);
         data.activate_mode_button(&data.pickerButton);
-        if (!data.terrain_brush.picking)
-            score++;
+        check(!data.terrain_brush.picking);
         data.activate_mode_button(&data.terrainSmoothButton);
-        if (!data.terrain_brush.use_smoothing)
-            score++;
+        check(!data.terrain_brush.use_smoothing);
         data.activate_mode_button(&data.terrainSmoothButton);
-        if (data.terrain_brush.use_smoothing)
-            score++;
+        check(data.terrain_brush.use_smoothing);
 
         data.mode = Mode::Object;
         data.object_brush.snap_to_grid = true;
         data.reset_mode_buttons();
         data.activate_mode_button(&data.pickerButton);
-        if (data.object_brush.picking)
-            score++;
+        check(data.object_brush.picking);
         data.activate_mode_button(&data.pickerButton);
-        if (!data.object_brush.picking)
-            score++;
+        check(!data.object_brush.picking);
         data.activate_mode_button(&data.gridSnapButton);
-        if (!data.object_brush.snap_to_grid)
-            score++;
+        check(!data.object_brush.snap_to_grid);
 
+        data.object_brush.team = 0;
         data.activate_mode_button(&data.prevTeamButton);
-        if (data.object_brush.team == MAX_TEAM)
-            score++;
+        check(data.object_brush.team == MAX_TEAM);
         data.activate_mode_button(&data.nextTeamButton);
-        if (data.object_brush.team == 0)
-            score++;
+        check(data.object_brush.team == 0);
         data.activate_mode_button(&data.nextTeamButton);
-        if (data.object_brush.team == 1)
-            score++;
+        check(data.object_brush.team == 1);
 
         data.mode = Mode::Select;
+        data.level->delete_objects();
         data.selection.clear();
         walker* selected = data.level->add_ob(Order::Living, FAMILY_SOLDIER);
+        check(selected != nullptr);
         if (selected != nullptr)
         {
             selected->setxy(GRID_SIZE * 3, GRID_SIZE * 3);
@@ -2919,72 +2902,71 @@ int level_editor_test_exercise_internal_helpers()
             data.selection.push_back(SelectionInfo(selected));
 
             data.reset_mode_buttons();
-            if (data.mode_buttons.find(&data.setNameButton) != data.mode_buttons.end())
-                score++;
+            check(data.mode_buttons.find(&data.setNameButton) != data.mode_buttons.end());
 
             level_editor_testing_prompt_queue_clear();
             level_editor_testing_prompt_queue_push("After");
             data.activate_mode_button(&data.setNameButton);
-            if (selected->stats()->name == "After")
-                score++;
+            check(selected->stats()->name == "After");
 
             data.activate_mode_button(&data.prevTeamButton);
-            if (selected->team_num() == MAX_TEAM)
-                score++;
+            check(selected->team_num() == MAX_TEAM);
 	            data.activate_mode_button(&data.nextTeamButton);
-	            if (selected->team_num() == 0)
-	                score++;
+	            check(selected->team_num() == 0);
 	            selected->set_team_num(2);
 	            data.activate_mode_button(&data.prevTeamButton);
-	            if (selected->team_num() == 1)
-	                score++;
+	            check(selected->team_num() == 1);
 	            selected->set_team_num(MAX_TEAM);
 	            data.activate_mode_button(&data.nextTeamButton);
-	            if (selected->team_num() == 0)
-	                score++;
+	            check(selected->team_num() == 0);
 	            data.activate_mode_button(&data.prevLevelButton);
-	            if (selected->stats()->level() == 1)
-	                score++;
+	            check(selected->stats()->level() == 1);
 	            data.activate_mode_button(&data.nextLevelButton);
-	            if (selected->stats()->level() == 2)
-	                score++;
+	            check(selected->stats()->level() == 2);
 	            data.activate_mode_button(&data.prevLevelButton);
-	            if (selected->stats()->level() == 1)
-	                score++;
+	            check(selected->stats()->level() == 1);
 	            selected->stats()->set_level(3);
 	            data.selection.front().level = selected->stats()->level();
 	            data.activate_mode_button(&data.prevLevelButton);
-	            if (selected->stats()->level() == 2)
-	                score++;
+	            check(selected->stats()->level() == 2);
 	            data.selection.front().family = 0;
 	            data.activate_mode_button(&data.prevClassButton);
-	            if (!data.selection.empty() && data.selection.front().family >= 0)
-	                score++;
+	            check(!data.selection.empty() && data.selection.front().family >= 0);
 	            data.selection.front().family = NUM_FAMILIES - 1;
 	            data.activate_mode_button(&data.nextClassButton);
-	            if (!data.selection.empty() && data.selection.front().family >= 0)
-	                score++;
+	            check(!data.selection.empty() && data.selection.front().family >= 0);
 	            data.activate_mode_button(&data.facingButton);
-	            if (selected->curdir() == FACE_UP)
-	                score++;
+	            check(selected->curdir() == FACE_UP);
 	            selected->set_curdir(FACE_UP);
 	            data.activate_mode_button(&data.facingButton);
-	            if (selected->curdir() != FACE_UP)
-	                score++;
+	            check(selected->curdir() != FACE_UP);
 
 	            MouseState& mouse = query_mouse_no_poll();
 	            mouse.left = true;
-	            eds().mouse_last_x = 10;
-	            eds().mouse_last_y = 10;
 	            data.rect_selecting = false;
 	            data.dragging = false;
-	            data.mouse_motion(selected->xpos(), selected->ypos(), 3, 4);
-	            if (data.dragging)
-	                score++;
-	            data.dragging = false;
-	            data.mouse_motion(80, 80, 20, 20);
-	            if (data.rect_selecting)
-	                score++;
+	            screen* motion_screen = og::runtime::current_session->myscreen_;
+	            check(motion_screen != nullptr && motion_screen->viewob[0] != nullptr);
+	            if (motion_screen != nullptr && motion_screen->viewob[0] != nullptr)
+	            {
+	                const int drag_screen_x = 160;
+	                const int drag_screen_y = 160;
+	                const int selected_world_x =
+	                    drag_screen_x + data.level->level_visuals().topx - motion_screen->viewob[0]->xloc;
+	                const int selected_world_y =
+	                    drag_screen_y + data.level->level_visuals().topy - motion_screen->viewob[0]->yloc;
+	                selected->setxy(selected_world_x, selected_world_y);
+	                data.selection.front().set(selected);
+	                check(!data.mouse_on_menus(drag_screen_x, drag_screen_y));
+	                check(data.get_object(selected_world_x, selected_world_y) == selected);
+	                eds().mouse_last_x = drag_screen_x;
+	                eds().mouse_last_y = drag_screen_y;
+	                data.mouse_motion(drag_screen_x, drag_screen_y, 3, 4);
+	                check(data.dragging);
+	                data.dragging = false;
+	                data.mouse_motion(80, 80, 20, 20);
+	                check(data.rect_selecting);
+	            }
             mouse.left = false;
 
             data.selection.clear();
@@ -2993,21 +2975,21 @@ int level_editor_test_exercise_internal_helpers()
             mouse.left = true;
             data.mouse_motion(90, 90, 5, 6);
             mouse.left = false;
-            if (data.selection.front().x == selected->xpos() &&
-                data.selection.front().y == selected->ypos())
-                score++;
+            check(data.selection.front().x == selected->xpos() &&
+                data.selection.front().y == selected->ypos());
             data.dragging = false;
 
             data.rect_selecting = true;
-            data.selection_rect = Rectf(0.0f, 0.0f, 120.0f, 120.0f);
+            data.selection_rect = Rectf(static_cast<float>(selected->xpos() - 4),
+                static_cast<float>(selected->ypos() - 4),
+                static_cast<float>(selected->sizex() + 8),
+                static_cast<float>(selected->sizey() + 8));
             bool done = false;
-            data.mouse_up(90, 90, 20, 20, done);
-            if (!data.rect_selecting && !data.selection.empty())
-                score++;
+            data.mouse_up(160, 160, 160, 160, done);
+            check(!data.rect_selecting && !data.selection.empty());
 
             data.activate_mode_button(&data.deleteButton);
-            if (data.selection.empty())
-                score++;
+            check(data.selection.empty());
         }
 
         data.mode = Mode::Terrain;
@@ -3015,13 +2997,11 @@ int level_editor_test_exercise_internal_helpers()
         data.terrain_brush.picking = true;
         data.set_terrain(2, 2, PIX_WATER1);
         data.pick_by_mouse(GRID_SIZE * 2, GRID_SIZE * 2);
-        if (data.terrain_brush.terrain == PIX_WATER1)
-            score++;
+        check(data.terrain_brush.terrain == PIX_WATER1);
 
         bool done = false;
         data.mouse_up(S_RIGHT + 1, PIX_TOP + 1, S_RIGHT + 1, PIX_TOP + 1, done);
-        if (data.terrain_brush.terrain >= 0)
-            score++;
+        check(data.terrain_brush.terrain >= 0);
 
         data.mode = Mode::Object;
         data.reset_mode_buttons();
@@ -3030,23 +3010,20 @@ int level_editor_test_exercise_internal_helpers()
         data.object_brush.snap_to_grid = true;
         data.object_brush.picking = false;
         data.mouse_up(140, 120, 140, 120, done);
-        if (eds().levelchanged)
-            score++;
+        check(eds().levelchanged);
         data.object_brush.picking = true;
         data.pick_by_mouse(140, 120);
-        if (!data.object_brush.picking || data.object_brush.family == FAMILY_SOLDIER)
-            score++;
+        check(!data.object_brush.picking || data.object_brush.family == FAMILY_SOLDIER);
 
         MouseState& menu_mouse = query_mouse_no_poll();
         menu_mouse.left = false;
         menu_mouse.right = false;
-        auto click_button = [&](SimpleButton& button) {
+        auto click_button = [&](SimpleButton& button, bool expected_done = false) {
             bool menu_done = false;
             const int x = button.area.x + 1;
             const int y = button.area.y + 1;
             data.mouse_up(x, y, x, y, menu_done);
-            if (!menu_done)
-                score++;
+            check(menu_done == expected_done);
             return menu_done;
         };
         auto open_campaign_menu = [&] {
@@ -3103,21 +3080,21 @@ int level_editor_test_exercise_internal_helpers()
         data.mode = Mode::Terrain;
         data.reset_mode_buttons();
         data.update_menu_buttons();
-        if (data.mouse_on_menus(data.modeButton.area.x + 1, data.modeButton.area.y + 1))
-            score++;
-        if (data.mouse_on_menus(data.panLeftButton.area.x + 1, data.panUpButton.area.y + 1))
-            score++;
-        if (!data.mouse_on_menus(200, 170))
-            score++;
+        data.pan_buttons.insert(&data.panLeftButton);
+        data.pan_buttons.insert(&data.panRightButton);
+        data.pan_buttons.insert(&data.panUpButton);
+        data.pan_buttons.insert(&data.panDownButton);
+        check(data.mouse_on_menus(data.terrainSmoothButton.area.x + 1, data.terrainSmoothButton.area.y + 1));
+        check(data.mouse_on_menus(data.panLeftButton.area.x + 1, data.panUpButton.area.y + 1));
+        check(!data.mouse_on_menus(200, 170));
 
-        open_file_menu();
-        open_file_menu();
-        if (data.current_menu.empty())
-            score++;
+        data.current_menu.clear();
+        click_button(data.fileButton);
+        click_button(data.fileButton);
+        check(data.current_menu.empty());
         open_file_menu();
         open_file_campaign_menu();
-        if (!data.current_menu.empty())
-            score++;
+        check(!data.current_menu.empty());
 
         const std::string helper_campaign_id = "org.openglad.coverage.editor_helper";
         const std::string previously_mounted_campaign = get_mounted_campaign();
@@ -3128,17 +3105,13 @@ int level_editor_test_exercise_internal_helpers()
         level_editor_testing_prompt_queue_push(helper_campaign_id.c_str());
         open_file_campaign_menu();
         click_button(data.fileCampaignNewButton);
-	        if (data.campaign->id == helper_campaign_id)
-	            score++;
-	        if (data.saveCampaignAs(helper_campaign_id))
-	            score++;
-	        if (data.saveLevelAs(3))
-	            score++;
+	        check(data.campaign->id == helper_campaign_id);
+	        check(data.saveCampaignAs(helper_campaign_id));
+	        check(data.saveLevelAs(3));
 
 	        open_file_campaign_menu();
         click_button(data.fileCampaignSaveButton);
-        if (!eds().campaignchanged)
-            score++;
+        check(!eds().campaignchanged);
 
         eds().levelchanged = 1;
         eds().campaignchanged = 1;
@@ -3153,39 +3126,32 @@ int level_editor_test_exercise_internal_helpers()
         picker_testing_yes_or_no_queue_push(true);
         expose_hidden_file_campaign_choice(data.fileCampaignShareButton);
         click_button(data.fileCampaignShareButton);
-        if (!eds().levelchanged && !eds().campaignchanged)
-            score++;
+        check(!eds().levelchanged && !eds().campaignchanged);
 
         open_file_level_menu();
-        if (!data.current_menu.empty())
-            score++;
+        check(!data.current_menu.empty());
         eds().levelchanged = 1;
         picker_testing_yes_or_no_queue_push(true);
         open_file_level_menu();
         click_button(data.fileLevelNewButton);
-        if (eds().levelchanged)
-            score++;
+        check(eds().levelchanged);
         open_file_level_menu();
         click_button(data.fileLevelSaveButton);
-        if (!eds().levelchanged)
-            score++;
+        check(!eds().levelchanged);
 
         open_file_menu();
-        bool quit_done = click_button(data.fileQuitButton);
-        if (quit_done && data.current_menu.empty())
-            score++;
+        bool quit_done = click_button(data.fileQuitButton, true);
+        check(quit_done && data.current_menu.empty());
 
         open_file_menu();
         bool off_menu_done = false;
         data.mouse_up(220, 170, 220, 170, off_menu_done);
-        if (!off_menu_done && data.current_menu.empty())
-            score++;
+        check(!off_menu_done && data.current_menu.empty());
 
         data.dragging = true;
         bool drag_done = false;
         data.mouse_up(220, 170, 220, 170, drag_done);
-        if (!drag_done && !data.dragging && data.current_menu.empty())
-            score++;
+        check(!drag_done && !data.dragging && data.current_menu.empty());
 
         if (!previously_mounted_campaign.empty()) {
             (void)unmount_campaign_package_with_error(get_mounted_campaign());
@@ -3195,51 +3161,44 @@ int level_editor_test_exercise_internal_helpers()
         open_campaign_menu();
         click_button(data.campaignInfoButton);
         open_campaign_menu();
-        if (click_button(data.campaignButton))
-            score++;
+        click_button(data.campaignButton);
+        check(data.current_menu.empty());
 
         level_editor_testing_prompt_queue_clear();
         level_editor_testing_prompt_queue_push("Coverage Campaign");
         open_campaign_profile_menu();
         click_button(data.campaignProfileTitleButton);
-        if (data.campaign->title == "Coverage Campaign")
-            score++;
+        check(data.campaign->title == "Coverage Campaign");
 
         level_editor_testing_prompt_queue_push("Coverage Campaign Description");
         open_campaign_profile_menu();
         click_button(data.campaignProfileDescriptionButton);
-        if (!data.campaign->description.empty())
-            score++;
+        check(!data.campaign->description.empty());
 
         level_editor_testing_prompt_queue_push("Coverage Authors");
         open_campaign_profile_menu();
         click_button(data.campaignProfileAuthorsButton);
-        if (data.campaign->authors == "Coverage Authors")
-            score++;
+        check(data.campaign->authors == "Coverage Authors");
 
         level_editor_testing_prompt_queue_push("Coverage Contributors");
         open_campaign_profile_menu();
         click_button(data.campaignProfileContributorsButton);
-        if (data.campaign->contributors == "Coverage Contributors")
-            score++;
+        check(data.campaign->contributors == "Coverage Contributors");
 
         level_editor_testing_prompt_queue_push("9.9");
         open_campaign_details_menu();
         click_button(data.campaignDetailsVersionButton);
-        if (data.campaign->version == "9.9")
-            score++;
+        check(data.campaign->version == "9.9");
 
         level_editor_testing_prompt_queue_push("42");
         open_campaign_details_menu();
         click_button(data.campaignDetailsSuggestedPowerButton);
-        if (data.campaign->suggested_power == 42)
-            score++;
+        check(data.campaign->suggested_power == 42);
 
         level_editor_testing_prompt_queue_push("1");
         open_campaign_details_menu();
         click_button(data.campaignDetailsFirstLevelButton);
-        if (data.campaign->first_level == 1)
-            score++;
+        check(data.campaign->first_level == 1);
 
         open_campaign_menu();
         click_button(data.campaignValidateButton);
@@ -3250,26 +3209,22 @@ int level_editor_test_exercise_internal_helpers()
         level_editor_testing_prompt_queue_push("Coverage Level");
         open_level_profile_menu();
         click_button(data.levelProfileTitleButton);
-        if (data.level->world().title == "Coverage Level")
-            score++;
+        check(data.level->world().title == "Coverage Level");
 
         level_editor_testing_prompt_queue_push("Coverage Level Description");
         open_level_profile_menu();
         click_button(data.levelProfileDescriptionButton);
-        if (!data.level->description.empty())
-            score++;
+        check(!data.level->description.empty());
 
         level_editor_testing_prompt_queue_push("77");
         open_level_details_menu();
         click_button(data.levelDetailsParValueButton);
-        if (data.level->world().par_value == 77)
-            score++;
+        check(data.level->world().par_value == 77);
 
         level_editor_testing_prompt_queue_push("88");
         open_level_details_menu();
         click_button(data.levelDetailsTimeLimitButton);
-        if (data.level->world().time_bonus_limit == 88)
-            score++;
+        check(data.level->world().time_bonus_limit == 88);
 
         level_editor_testing_prompt_queue_push("2");
         level_editor_testing_prompt_queue_push("2");
@@ -3279,16 +3234,14 @@ int level_editor_test_exercise_internal_helpers()
         level_editor_testing_prompt_queue_push("6");
         open_level_details_menu();
         click_button(data.levelDetailsMapSizeButton);
-        if (data.level->world().grid.w == 6 && data.level->world().grid.h == 6)
-            score++;
+        check(data.level->world().grid.w == 6 && data.level->world().grid.h == 6);
 
         const short type_before = data.level->world().type;
         open_level_goals_menu();
         click_button(data.levelGoalsEnemiesButton);
         click_button(data.levelGoalsGeneratorsButton);
         click_button(data.levelGoalsNPCsButton);
-        if (data.level->world().type != type_before)
-            score++;
+        check(data.level->world().type != type_before);
 
         open_level_menu();
         click_button(data.levelResmoothButton);
@@ -3298,26 +3251,24 @@ int level_editor_test_exercise_internal_helpers()
         picker_testing_yes_or_no_queue_push(true);
         open_level_menu();
         click_button(data.levelDeleteObjectsButton);
-        if (data.level->world().oblist.empty())
-            score++;
+        check(data.level->world().oblist.empty());
 
         open_mode_menu();
         click_button(data.modeObjectButton);
-        if (data.mode == Mode::Object)
-            score++;
+        check(data.mode == Mode::Object);
         open_mode_menu();
         click_button(data.modeSelectButton);
-        if (data.mode == Mode::Select)
-            score++;
+        check(data.mode == Mode::Select);
         open_mode_menu();
         click_button(data.modeTerrainButton);
-        if (data.mode == Mode::Terrain)
-            score++;
+        check(data.mode == Mode::Terrain);
 
         screen* scr = og::runtime::current_session->myscreen_;
+        check(scr != nullptr && scr->viewob[0] != nullptr);
         if (scr != nullptr && scr->viewob[0] != nullptr)
         {
             walker* draw_selected = data.level->add_ob(Order::Living, FAMILY_SOLDIER);
+            check(draw_selected != nullptr);
             if (draw_selected != nullptr)
             {
                 draw_selected->setxy(GRID_SIZE * 2, GRID_SIZE * 2);
@@ -3332,7 +3283,7 @@ int level_editor_test_exercise_internal_helpers()
                 data.draw(scr);
                 data.rect_selecting = false;
                 data.display_panel(scr);
-                score++;
+                check(!data.selection.empty());
             }
 
             data.selection.clear();
@@ -3371,11 +3322,11 @@ int level_editor_test_exercise_internal_helpers()
             data.mode = Mode::Terrain;
             data.reset_mode_buttons();
             data.display_panel(scr);
-            score++;
+            check(data.mode == Mode::Terrain);
         }
     }
 
-    return score;
+    return failed_check == 0 ? 0 : -failed_check;
 }
 // GCOVR_EXCL_STOP
 #endif

--- a/src/interface/ui/level_editor_ui.cpp
+++ b/src/interface/ui/level_editor_ui.cpp
@@ -46,6 +46,16 @@ void level_editor_testing_prompt_queue_push(const char* s);
 
 bool prompt_for_string_block(const std::string& message, std::list<std::string>& result)
 {
+#ifdef TESTING
+    auto& q = level_editor_testing_prompt_queue_ref();
+    if (!q.empty()) {
+        (void)message;
+        result.clear();
+        result.push_back(q.front());
+        q.erase(q.begin());
+        return true;
+    }
+#endif
     screen* screen_ctx = active_screen();
     screen_ctx->darken_screen();
     

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -1755,6 +1755,7 @@ Sint32 go_menu(Sint32 arg1)
 }
 
 #ifdef TESTING
+// GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 int picker_team_build_testing_exercise_internal_paths()
 {
     struct TestLobbyClient final : og::ui::IPickerLobbyClient
@@ -2015,6 +2016,7 @@ int picker_team_build_testing_exercise_internal_paths()
     restore_team();
     return score;
 }
+// GCOVR_EXCL_STOP
 #endif
 
 void statscopy(guy *dest, guy *source)

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -1816,7 +1816,13 @@ int picker_team_build_testing_exercise_internal_paths()
         }
     } lobby_guard;
 
-    int score = 0;
+    int check_index = 0;
+    int failed_check = 0;
+    const auto check = [&check_index, &failed_check](bool condition) {
+        ++check_index;
+        if (!condition && failed_check == 0)
+            failed_check = check_index;
+    };
     TestLobbyClient client;
     og::ui::install_active_picker_lobby_client(&client);
     client.initialize_from_save();
@@ -1825,14 +1831,10 @@ int picker_team_build_testing_exercise_internal_paths()
     client.sync_settings_from_save();
     client.poll_and_apply();
     client.set_player_mode(2);
-    if (client.request_start_game() && client.requested)
-        score++;
-    if (client.build_game_start_config().has_value())
-        score++;
-    if (client.consume_game_start_config().has_value())
-        score++;
-    if (!client.start_request_pending())
-        score++;
+    check(client.request_start_game() && client.requested);
+    check(client.build_game_start_config().has_value());
+    check(client.consume_game_start_config().has_value());
+    check(!client.start_request_pending());
     client.shutdown();
 
     SaveData& save = og::runtime::current_session->myscreen_->save_data;
@@ -1846,16 +1848,13 @@ int picker_team_build_testing_exercise_internal_paths()
         save.team_size = old_team_size;
     };
 
-    if (!save_has_trainable_team_member(save))
-        score++;
+    check(!save_has_trainable_team_member(save));
     save.team_list[0] = std::make_unique<guy>(FAMILY_SOLDIER);
     save.team_size = 1;
     client.editable = false;
-    if (!save_has_trainable_team_member(save))
-        score++;
+    check(!save_has_trainable_team_member(save));
     client.editable = true;
-    if (save_has_trainable_team_member(save))
-        score++;
+    check(save_has_trainable_team_member(save));
 
     button buttons[] = {
         button("b0", "0", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
@@ -1878,74 +1877,58 @@ int picker_team_build_testing_exercise_internal_paths()
     buttons[1].hidden = false;
     highlighted = 0;
     ensure_highlighted_button_visible(buttons, 2, highlighted);
-    if (highlighted == 1)
-        score++;
+    check(highlighted == 1);
     buttons[1].hidden = true;
     ensure_highlighted_button_visible(buttons, 2, highlighted);
-    if (highlighted == 0)
-        score++;
+    check(highlighted == 0);
 
     highlighted = 5;
     client.host_visible = false;
     sync_team_build_host_control_visibility(buttons, 11, highlighted);
-    if (buttons[kTeamBuildGoButtonIndex].hidden &&
+    check(buttons[kTeamBuildGoButtonIndex].hidden &&
         buttons[kTeamBuildSetLevelButtonIndex].hidden &&
-        buttons[kTeamBuildSetCampaignButtonIndex].hidden)
-    {
-        score++;
-    }
+        buttons[kTeamBuildSetCampaignButtonIndex].hidden);
     client.host_visible = true;
     sync_team_build_host_control_visibility(buttons, 11, highlighted);
-    if (!buttons[kTeamBuildGoButtonIndex].hidden)
-        score++;
+    check(!buttons[kTeamBuildGoButtonIndex].hidden);
     sync_view_team_host_control_visibility(buttons, 1, highlighted);
-    if (!buttons[kViewTeamGoButtonIndex].hidden)
-        score++;
+    check(!buttons[kViewTeamGoButtonIndex].hidden);
 
     g_start_game_requested = false;
     Sint32 retvalue = 0;
-    if (!team_build_remote_start_requested(retvalue))
-        score++;
+    check(!team_build_remote_start_requested(retvalue));
     g_start_game_requested = true;
     client.has_start_config = false;
-    if (!team_build_remote_start_requested(retvalue))
-        score++;
+    check(!team_build_remote_start_requested(retvalue));
     client.has_start_config = true;
-    if (team_build_remote_start_requested(retvalue) && (retvalue & MENU_EXIT))
-        score++;
-    if (team_build_start_selected())
-        score++;
+    check(team_build_remote_start_requested(retvalue) && (retvalue & MENU_EXIT));
+    check(team_build_start_selected());
     pks().selected_menu_item = nullptr;
-    if (!team_build_start_selected())
-        score++;
+    check(!team_build_start_selected());
     g_start_game_requested = false;
     picker_prepare_async_team_build_start_request();
-    if (client.requested)
-        score++;
-    if (g_start_game_requested)
-        score++;
+    check(client.requested);
+#ifdef __EMSCRIPTEN__
+    check(g_start_game_requested);
+#else
+    check(!g_start_game_requested);
+#endif
 
-    if (!get_class_description(FAMILY_SOLDIER).empty())
-        score++;
-    if (get_class_description(250).empty())
-        score++;
+    check(!get_class_description(FAMILY_SOLDIER).empty());
+    check(get_class_description(250).empty());
     for (int family : og::ui::kAllowableGuys)
     {
         for (int stat = 0; stat < 5; ++stat)
             (void)get_training_cost_rating(static_cast<unsigned char>(family), stat);
     }
-    if (std::strlen(get_training_cost_rating(250, 0)) == 0)
-        score++;
+    check(std::strlen(get_training_cost_rating(250, 0)) == 0);
 
     og::ui::TrainSession train_session(save);
     pks().train_session = nullptr;
-    if (increase_stat(BUT_STR, 1) == MENU_OK &&
+    check(increase_stat(BUT_STR, 1) == MENU_OK &&
         decrease_stat(BUT_STR, 1) == MENU_OK &&
         cycle_team_guy(1) == -1 &&
-        edit_guy(0) == -1)
-    {
-        score++;
-    }
+        edit_guy(0) == -1);
 
     pks().train_session = &train_session;
     for (Sint32 stat : {BUT_STR, BUT_DEX, BUT_CON, BUT_INT, BUT_ARMOR, BUT_LEVEL, Sint32{-999}})
@@ -1956,44 +1939,36 @@ int picker_team_build_testing_exercise_internal_paths()
     (void)cycle_team_guy(1);
     (void)cycle_team_guy(-1);
     sync_current_guy_from_train();
-    if (og::runtime::current_session->current_guy_)
-        score++;
+    check(og::runtime::current_session->current_guy_ != nullptr);
     pks().train_session = nullptr;
 
     og::ui::HireSession hire_session(save, 0);
     pks().hire_session = nullptr;
-    if (add_guy(0) == -1)
-        score++;
+    check(add_guy(0) == -1);
     (void)cycle_guy(0);
     pks().hire_session = &hire_session;
     (void)cycle_guy(1);
     (void)cycle_guy(-1);
     sync_current_guy_from_hire();
-    if (og::runtime::current_session->current_guy_)
-        score++;
+    check(og::runtime::current_session->current_guy_ != nullptr);
     pks().hire_session = nullptr;
 
     og::runtime::current_session->current_guy_.reset();
-    if (name_guy(0) == MENU_REDRAW)
-        score++;
+    check(name_guy(0) == MENU_REDRAW);
     client.editable = false;
     og::runtime::current_session->editguy_ = 0;
-    if (name_guy(1) == MENU_REDRAW)
-        score++;
+    check(name_guy(1) == MENU_REDRAW);
     client.editable = true;
 
     (void)how_many(FAMILY_SOLDIER);
-    if (delete_all() >= 0)
-        score++;
-    if (go_menu(0) == MENU_REDRAW)
-        score++;
+    check(delete_all() >= 0);
+    check(go_menu(0) == MENU_REDRAW);
     save.team_list[0] = std::make_unique<guy>(FAMILY_MAGE);
     save.team_list[0]->teamnum = 0;
     save.team_size = 1;
     client.requested = false;
     g_start_game_requested = false;
-    if (go_menu(0) == MENU_REDRAW && client.requested)
-        score++;
+    check(go_menu(0) == MENU_REDRAW && client.requested);
 
     guy source(FAMILY_ELF);
     guy destination(FAMILY_SOLDIER);
@@ -2002,19 +1977,16 @@ int picker_team_build_testing_exercise_internal_paths()
     source.exp = calculate_exp(source.level);
     source.kills = 4;
     statscopy(&destination, &source);
-    if (destination.family == source.family &&
+    check(destination.family == source.family &&
         destination.name == source.name &&
-        destination.exp == source.exp)
-    {
-        score++;
-    }
+        destination.exp == source.exp);
 
     g_start_game_requested = false;
     pks().selected_menu_item = nullptr;
     pks().train_session = nullptr;
     pks().hire_session = nullptr;
     restore_team();
-    return score;
+    return failed_check == 0 ? 0 : -failed_check;
 }
 // GCOVR_EXCL_STOP
 #endif

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -1754,6 +1754,269 @@ Sint32 go_menu(Sint32 arg1)
 #endif
 }
 
+#ifdef TESTING
+int picker_team_build_testing_exercise_internal_paths()
+{
+    struct TestLobbyClient final : og::ui::IPickerLobbyClient
+    {
+        bool host_visible = false;
+        bool has_start_config = true;
+        bool editable = true;
+        bool requested = false;
+
+        void initialize_from_save() override {}
+        void shutdown() override {}
+        void sync_from_save() override {}
+        void sync_roster_from_save() override {}
+        void sync_settings_from_save() override {}
+        void poll_and_apply() override {}
+        void set_player_mode(int) override {}
+        bool request_start_game() override
+        {
+            requested = true;
+            return true;
+        }
+        std::optional<og::ui::PickerLobbyGameStartConfig>
+        build_game_start_config() const override
+        {
+            return has_start_config
+                ? std::optional<og::ui::PickerLobbyGameStartConfig>{og::ui::PickerLobbyGameStartConfig{}}
+                : std::nullopt;
+        }
+        std::optional<og::ui::PickerLobbyGameStartConfig>
+        consume_game_start_config() override
+        {
+            return build_game_start_config();
+        }
+        bool start_request_pending() const noexcept override
+        {
+            return false;
+        }
+        bool has_game_start_config() const noexcept override
+        {
+            return has_start_config;
+        }
+        bool host_controls_visible() const noexcept override
+        {
+            return host_visible;
+        }
+        bool is_save_slot_editable(std::size_t) const noexcept override
+        {
+            return editable;
+        }
+    };
+
+    struct LobbyGuard
+    {
+        og::ui::IPickerLobbyClient* saved = og::ui::active_picker_lobby_client();
+        ~LobbyGuard()
+        {
+            og::ui::install_active_picker_lobby_client(saved);
+        }
+    } lobby_guard;
+
+    int score = 0;
+    TestLobbyClient client;
+    og::ui::install_active_picker_lobby_client(&client);
+    client.initialize_from_save();
+    client.sync_from_save();
+    client.sync_roster_from_save();
+    client.sync_settings_from_save();
+    client.poll_and_apply();
+    client.set_player_mode(2);
+    if (client.request_start_game() && client.requested)
+        score++;
+    if (client.build_game_start_config().has_value())
+        score++;
+    if (client.consume_game_start_config().has_value())
+        score++;
+    if (!client.start_request_pending())
+        score++;
+    client.shutdown();
+
+    SaveData& save = og::runtime::current_session->myscreen_->save_data;
+    const unsigned char old_team_size = save.team_size;
+    std::array<std::unique_ptr<guy>, MAX_TEAM_SIZE> saved_team;
+    for (int i = 0; i < MAX_TEAM_SIZE; ++i)
+        saved_team[i] = std::move(save.team_list[i]);
+    auto restore_team = [&] {
+        for (int i = 0; i < MAX_TEAM_SIZE; ++i)
+            save.team_list[i] = std::move(saved_team[i]);
+        save.team_size = old_team_size;
+    };
+
+    if (!save_has_trainable_team_member(save))
+        score++;
+    save.team_list[0] = std::make_unique<guy>(FAMILY_SOLDIER);
+    save.team_size = 1;
+    client.editable = false;
+    if (!save_has_trainable_team_member(save))
+        score++;
+    client.editable = true;
+    if (save_has_trainable_team_member(save))
+        score++;
+
+    button buttons[] = {
+        button("b0", "0", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
+        button("b1", "1", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
+        button("b2", "2", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
+        button("b3", "3", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
+        button("b4", "4", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
+        button("b5", "5", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
+        button("b6", "6", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
+        button("b7", "7", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
+        button("b8", "8", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
+        button("b9", "9", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
+        button("b10", "10", KEYSTATE_UNKNOWN, 0, 0, 10, 10, 0, 0, MenuNav{}),
+    };
+    int highlighted = 5;
+    sync_button_hidden_state(nullptr, 0);
+    sync_button_hidden_state(buttons, -1);
+    ensure_highlighted_button_visible(nullptr, 0, highlighted);
+    buttons[0].hidden = true;
+    buttons[1].hidden = false;
+    highlighted = 0;
+    ensure_highlighted_button_visible(buttons, 2, highlighted);
+    if (highlighted == 1)
+        score++;
+    buttons[1].hidden = true;
+    ensure_highlighted_button_visible(buttons, 2, highlighted);
+    if (highlighted == 0)
+        score++;
+
+    highlighted = 5;
+    client.host_visible = false;
+    sync_team_build_host_control_visibility(buttons, 11, highlighted);
+    if (buttons[kTeamBuildGoButtonIndex].hidden &&
+        buttons[kTeamBuildSetLevelButtonIndex].hidden &&
+        buttons[kTeamBuildSetCampaignButtonIndex].hidden)
+    {
+        score++;
+    }
+    client.host_visible = true;
+    sync_team_build_host_control_visibility(buttons, 11, highlighted);
+    if (!buttons[kTeamBuildGoButtonIndex].hidden)
+        score++;
+    sync_view_team_host_control_visibility(buttons, 1, highlighted);
+    if (!buttons[kViewTeamGoButtonIndex].hidden)
+        score++;
+
+    g_start_game_requested = false;
+    Sint32 retvalue = 0;
+    if (!team_build_remote_start_requested(retvalue))
+        score++;
+    g_start_game_requested = true;
+    client.has_start_config = false;
+    if (!team_build_remote_start_requested(retvalue))
+        score++;
+    client.has_start_config = true;
+    if (team_build_remote_start_requested(retvalue) && (retvalue & MENU_EXIT))
+        score++;
+    if (team_build_start_selected())
+        score++;
+    pks().selected_menu_item = nullptr;
+    if (!team_build_start_selected())
+        score++;
+    g_start_game_requested = false;
+    picker_prepare_async_team_build_start_request();
+    if (client.requested)
+        score++;
+    if (g_start_game_requested)
+        score++;
+
+    if (!get_class_description(FAMILY_SOLDIER).empty())
+        score++;
+    if (get_class_description(250).empty())
+        score++;
+    for (int family : og::ui::kAllowableGuys)
+    {
+        for (int stat = 0; stat < 5; ++stat)
+            (void)get_training_cost_rating(static_cast<unsigned char>(family), stat);
+    }
+    if (std::strlen(get_training_cost_rating(250, 0)) == 0)
+        score++;
+
+    og::ui::TrainSession train_session(save);
+    pks().train_session = nullptr;
+    if (increase_stat(BUT_STR, 1) == MENU_OK &&
+        decrease_stat(BUT_STR, 1) == MENU_OK &&
+        cycle_team_guy(1) == -1 &&
+        edit_guy(0) == -1)
+    {
+        score++;
+    }
+
+    pks().train_session = &train_session;
+    for (Sint32 stat : {BUT_STR, BUT_DEX, BUT_CON, BUT_INT, BUT_ARMOR, BUT_LEVEL, Sint32{-999}})
+    {
+        (void)increase_stat(stat, 1);
+        (void)decrease_stat(stat, 1);
+    }
+    (void)cycle_team_guy(1);
+    (void)cycle_team_guy(-1);
+    sync_current_guy_from_train();
+    if (og::runtime::current_session->current_guy_)
+        score++;
+    pks().train_session = nullptr;
+
+    og::ui::HireSession hire_session(save, 0);
+    pks().hire_session = nullptr;
+    if (add_guy(0) == -1)
+        score++;
+    (void)cycle_guy(0);
+    pks().hire_session = &hire_session;
+    (void)cycle_guy(1);
+    (void)cycle_guy(-1);
+    sync_current_guy_from_hire();
+    if (og::runtime::current_session->current_guy_)
+        score++;
+    pks().hire_session = nullptr;
+
+    og::runtime::current_session->current_guy_.reset();
+    if (name_guy(0) == MENU_REDRAW)
+        score++;
+    client.editable = false;
+    og::runtime::current_session->editguy_ = 0;
+    if (name_guy(1) == MENU_REDRAW)
+        score++;
+    client.editable = true;
+
+    (void)how_many(FAMILY_SOLDIER);
+    if (delete_all() >= 0)
+        score++;
+    if (go_menu(0) == MENU_REDRAW)
+        score++;
+    save.team_list[0] = std::make_unique<guy>(FAMILY_MAGE);
+    save.team_list[0]->teamnum = 0;
+    save.team_size = 1;
+    client.requested = false;
+    g_start_game_requested = false;
+    if (go_menu(0) == MENU_REDRAW && client.requested)
+        score++;
+
+    guy source(FAMILY_ELF);
+    guy destination(FAMILY_SOLDIER);
+    source.name = "Copied";
+    source.level = 3;
+    source.exp = calculate_exp(source.level);
+    source.kills = 4;
+    statscopy(&destination, &source);
+    if (destination.family == source.family &&
+        destination.name == source.name &&
+        destination.exp == source.exp)
+    {
+        score++;
+    }
+
+    g_start_game_requested = false;
+    pks().selected_menu_item = nullptr;
+    pks().train_session = nullptr;
+    pks().hire_session = nullptr;
+    restore_team();
+    return score;
+}
+#endif
+
 void statscopy(guy *dest, guy *source)
 {
 	og::ui::statscopy(dest, source);

--- a/src/interface/ui/results_screen.cpp
+++ b/src/interface/ui/results_screen.cpp
@@ -829,6 +829,7 @@ void results_screen_testing_set_force_full(bool enabled)
     s_force_full_results_ui = enabled;
 }
 
+// GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 int results_screen_test_exercise_internal()
 {
     // Exercise the core computation helpers in this TU without entering any
@@ -942,4 +943,5 @@ int results_screen_test_exercise_internal()
 
     return score;
 }
+// GCOVR_EXCL_STOP
 #endif

--- a/src/interface/ui/results_screen.cpp
+++ b/src/interface/ui/results_screen.cpp
@@ -852,6 +852,19 @@ int results_screen_test_exercise_internal()
     score++;
 
     // TroopResult logic paths.
+    TroopResult empty_result(nullptr, nullptr);
+    if (empty_result.get_name().empty() &&
+        empty_result.get_class_name().empty() &&
+        empty_result.get_level() == 0 &&
+        empty_result.get_tallies() == 0 &&
+        empty_result.get_HP() == 0.0f)
+    {
+        score++;
+    }
+    (void)empty_result.get_XP_base();
+    empty_result.draw_guy(160, 100, 0);
+    show_guy(0, nullptr, 160, 100);
+
     guy before{};
     before.name = "Before";
     before.family = FAMILY_MAGE;
@@ -886,6 +899,7 @@ int results_screen_test_exercise_internal()
     TroopResult t1(&before, &after_owned);
     if (t1.gained_level())
         score++;
+    (void)t1.get_XP_base();
     (void)t1.get_XP_gain();
     (void)t1.get_HP();
     (void)t1.get_tallies();
@@ -913,6 +927,9 @@ int results_screen_test_exercise_internal()
     TroopResult t4(nullptr, &after_owned);
     if (t4.get_HP() >= 0.99f)
         score++;
+    (void)t4.get_name();
+    (void)t4.get_class_name();
+    (void)t4.get_level();
     t4.draw_guy(160, 100, 0);
 
     // Draw helper should no-op when dead.

--- a/src/interface/ui/results_screen.cpp
+++ b/src/interface/ui/results_screen.cpp
@@ -858,11 +858,13 @@ int results_screen_test_exercise_internal()
         empty_result.get_class_name().empty() &&
         empty_result.get_level() == 0 &&
         empty_result.get_tallies() == 0 &&
-        empty_result.get_HP() == 0.0f)
+        empty_result.get_HP() == 0.0f &&
+        empty_result.get_XP_base() == 0.0f &&
+        empty_result.is_dead() &&
+        !empty_result.is_new())
     {
         score++;
     }
-    (void)empty_result.get_XP_base();
     empty_result.draw_guy(160, 100, 0);
     show_guy(0, nullptr, 160, 100);
 
@@ -880,10 +882,13 @@ int results_screen_test_exercise_internal()
         score++;
     if (!t0.get_class_name().empty())
         score++;
-    (void)t0.get_XP_base();
-    (void)t0.get_XP_gain();
-    (void)t0.get_gained_specials();
-    (void)t0.is_new();
+    if (t0.get_XP_base() > 0.0f &&
+        t0.get_XP_gain() == 0.0f &&
+        t0.get_gained_specials().empty() &&
+        !t0.is_new())
+    {
+        score++;
+    }
 
     // after with owned myguy to cover gained/lost/no-change XP branches and HP paths.
     walker after_owned(one_px);
@@ -900,11 +905,21 @@ int results_screen_test_exercise_internal()
     TroopResult t1(&before, &after_owned);
     if (t1.gained_level())
         score++;
-    (void)t1.get_XP_base();
-    (void)t1.get_XP_gain();
-    (void)t1.get_HP();
-    (void)t1.get_tallies();
-    (void)t1.get_gained_specials();
+    if (t1.get_XP_base() == 0.0f &&
+        t1.get_XP_gain() > 0.0f &&
+        t1.get_HP() > 0.0f &&
+        t1.get_HP() < 1.0f &&
+        t1.get_tallies() == 0)
+    {
+        score++;
+    }
+    const std::vector<std::string> gained_specials = t1.get_gained_specials();
+    if (!gained_specials.empty() &&
+        std::all_of(gained_specials.begin(), gained_specials.end(),
+                    [](const std::string& name) { return !name.empty(); }))
+    {
+        score++;
+    }
 
     // lost level branch
     before.level = 6;
@@ -913,14 +928,16 @@ int results_screen_test_exercise_internal()
     TroopResult t2(&before, &after_owned);
     if (t2.lost_level())
         score++;
-    (void)t2.get_XP_gain();
+    if (t2.get_XP_gain() < 0.0f)
+        score++;
 
     // unchanged level branch
     before.level = 3;
     before.exp = calculate_exp(before.level) + 20;
     after_owned.myguy->exp = calculate_exp(before.level) + 25;
     TroopResult t3(&before, &after_owned);
-    (void)t3.get_XP_gain();
+    if (!t3.gained_level() && !t3.lost_level() && t3.get_XP_gain() > 0.0f)
+        score++;
 
     // HP edge: scen_min_hp > current hitpoints returns 1.0
     after_owned.myguy->scen_min_hp = 1000;
@@ -928,9 +945,13 @@ int results_screen_test_exercise_internal()
     TroopResult t4(nullptr, &after_owned);
     if (t4.get_HP() >= 0.99f)
         score++;
-    (void)t4.get_name();
-    (void)t4.get_class_name();
-    (void)t4.get_level();
+    if (t4.get_name() == "After" &&
+        !t4.get_class_name().empty() &&
+        t4.get_level() == calculate_level(after_owned.myguy->exp) &&
+        t4.is_new())
+    {
+        score++;
+    }
     t4.draw_guy(160, 100, 0);
 
     // Draw helper should no-op when dead.

--- a/src/interface/ui/results_screen.cpp
+++ b/src/interface/ui/results_screen.cpp
@@ -834,7 +834,13 @@ int results_screen_test_exercise_internal()
 {
     // Exercise the core computation helpers in this TU without entering any
     // interactive UI loops (safe for CI).
-    int score = 0;
+    int check_index = 0;
+    int failed_check = 0;
+    const auto check = [&check_index, &failed_check](bool condition) {
+        ++check_index;
+        if (!condition && failed_check == 0)
+            failed_check = check_index;
+    };
 
     // walker/pixie store raw pointers to PixieData buffers; keep the data alive
     // for the duration of this helper.
@@ -850,21 +856,20 @@ int results_screen_test_exercise_internal()
     show_ending_popup(0, 2);  // victory not completed
     og::runtime::current_session->myscreen_->save_data.current_levels[og::runtime::current_session->myscreen_->save_data.current_campaign] = og::runtime::current_session->myscreen_->save_data.scen_num;
     show_ending_popup(0, 2);  // victory completed
-    score++;
+    check(og::runtime::current_session->myscreen_->save_data.current_levels[
+              og::runtime::current_session->myscreen_->save_data.current_campaign] ==
+          og::runtime::current_session->myscreen_->save_data.scen_num);
 
     // TroopResult logic paths.
     TroopResult empty_result(nullptr, nullptr);
-    if (empty_result.get_name().empty() &&
+    check(empty_result.get_name().empty() &&
         empty_result.get_class_name().empty() &&
         empty_result.get_level() == 0 &&
         empty_result.get_tallies() == 0 &&
         empty_result.get_HP() == 0.0f &&
         empty_result.get_XP_base() == 0.0f &&
         empty_result.is_dead() &&
-        !empty_result.is_new())
-    {
-        score++;
-    }
+        !empty_result.is_new());
     empty_result.draw_guy(160, 100, 0);
     show_guy(0, nullptr, 160, 100);
 
@@ -878,17 +883,12 @@ int results_screen_test_exercise_internal()
     walker after_null(one_px);
     after_null.clear_myguy();
     TroopResult t0(&before, &after_null);
-    if (t0.get_name() == "Before")
-        score++;
-    if (!t0.get_class_name().empty())
-        score++;
-    if (t0.get_XP_base() > 0.0f &&
+    check(t0.get_name() == "Before");
+    check(!t0.get_class_name().empty());
+    check(t0.get_XP_base() > 0.0f &&
         t0.get_XP_gain() == 0.0f &&
         t0.get_gained_specials().empty() &&
-        !t0.is_new())
-    {
-        score++;
-    }
+        !t0.is_new());
 
     // after with owned myguy to cover gained/lost/no-change XP branches and HP paths.
     walker after_owned(one_px);
@@ -903,66 +903,51 @@ int results_screen_test_exercise_internal()
     after_owned.stats()->set_hitpoints(5);
 
     TroopResult t1(&before, &after_owned);
-    if (t1.gained_level())
-        score++;
-    if (t1.get_XP_base() == 0.0f &&
+    check(t1.gained_level());
+    check(t1.get_XP_base() == 0.0f &&
         t1.get_XP_gain() > 0.0f &&
         t1.get_HP() > 0.0f &&
         t1.get_HP() < 1.0f &&
-        t1.get_tallies() == 0)
-    {
-        score++;
-    }
+        t1.get_tallies() == 0);
     const std::vector<std::string> gained_specials = t1.get_gained_specials();
-    if (!gained_specials.empty() &&
+    check(!gained_specials.empty() &&
         std::all_of(gained_specials.begin(), gained_specials.end(),
-                    [](const std::string& name) { return !name.empty(); }))
-    {
-        score++;
-    }
+                    [](const std::string& name) { return !name.empty(); }));
 
     // lost level branch
     before.level = 6;
     before.exp = calculate_exp(before.level);
     after_owned.myguy->exp = calculate_exp(3); // lost
     TroopResult t2(&before, &after_owned);
-    if (t2.lost_level())
-        score++;
-    if (t2.get_XP_gain() < 0.0f)
-        score++;
+    check(t2.lost_level());
+    check(t2.get_XP_gain() < 0.0f);
 
     // unchanged level branch
     before.level = 3;
     before.exp = calculate_exp(before.level) + 20;
     after_owned.myguy->exp = calculate_exp(before.level) + 25;
     TroopResult t3(&before, &after_owned);
-    if (!t3.gained_level() && !t3.lost_level() && t3.get_XP_gain() > 0.0f)
-        score++;
+    check(!t3.gained_level() && !t3.lost_level() && t3.get_XP_gain() > 0.0f);
 
     // HP edge: scen_min_hp > current hitpoints returns 1.0
     after_owned.myguy->scen_min_hp = 1000;
     after_owned.stats()->set_hitpoints(1);
     TroopResult t4(nullptr, &after_owned);
-    if (t4.get_HP() >= 0.99f)
-        score++;
-    if (t4.get_name() == "After" &&
+    check(t4.get_HP() >= 0.99f);
+    check(t4.get_name() == "After" &&
         !t4.get_class_name().empty() &&
         t4.get_level() == calculate_level(after_owned.myguy->exp) &&
-        t4.is_new())
-    {
-        score++;
-    }
+        t4.is_new());
     t4.draw_guy(160, 100, 0);
 
     // Draw helper should no-op when dead.
     after_owned.myguy->scen_min_hp = 0;
     after_owned.stats()->set_hitpoints(0);
     TroopResult t5(nullptr, &after_owned);
-    if (t5.is_dead())
-        score++;
+    check(t5.is_dead());
     t5.draw_guy(160, 100, 0);
 
-    return score;
+    return failed_check == 0 ? 0 : -failed_check;
 }
 // GCOVR_EXCL_STOP
 #endif

--- a/src/platform/curses/curses_network.cpp
+++ b/src/platform/curses/curses_network.cpp
@@ -1155,6 +1155,7 @@ private:
 } // namespace
 
 #ifdef TESTING
+// GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 int curses_network_testing_exercise_internal_helpers()
 {
     int score = 0;
@@ -1395,6 +1396,7 @@ int curses_network_testing_exercise_internal_helpers()
 
     return score;
 }
+// GCOVR_EXCL_STOP
 #endif
 
 std::unique_ptr<CursesLobby> make_host_lobby(SaveData& save, const HostOptions& opt,

--- a/src/platform/curses/curses_network.cpp
+++ b/src/platform/curses/curses_network.cpp
@@ -1154,6 +1154,192 @@ private:
 
 } // namespace
 
+#ifdef TESTING
+int curses_network_testing_exercise_internal_helpers()
+{
+    int score = 0;
+
+    const std::string name_a = make_network_player_name();
+    const std::string name_b = make_network_player_name();
+    if (!name_a.empty() && name_a != name_b)
+        ++score;
+
+    og::sim::SimEventBatch batch;
+    batch.events.push_back(og::sim::Event{
+        .kind = og::sim::EventKind::Notification,
+        .text = "network helper notification",
+    });
+    batch.events.push_back(og::sim::Event{
+        .kind = og::sim::EventKind::EndGame,
+        .a = 1,
+        .b = 2,
+        .text = "",
+    });
+    batch.events.push_back(og::sim::Event{
+        .kind = og::sim::EventKind::SetEnd,
+        .text = "",
+    });
+    std::vector<std::string> notifications;
+    collect_notifications(batch, notifications);
+    PendingEnd pending;
+    apply_game_flow_batch(batch, pending, notifications);
+    if (pending.ended && pending.ending == 1 && pending.next_level == 2 &&
+        notifications.size() >= 2)
+        ++score;
+
+    SaveData save;
+    save.current_campaign.clear();
+    save.scen_num = 3;
+    save.my_team = MAX_PLAYERS;
+    save.allied_mode = 1;
+    auto soldier = std::make_unique<guy>(FAMILY_SOLDIER);
+    soldier->id = 77;
+    soldier->name = "Curses Soldier";
+    soldier->teamnum = 2;
+    soldier->level = 4;
+    save.team_list[3] = std::move(soldier);
+    if (resolve_initial_local_team(save) == 2)
+        ++score;
+
+    og::sim::LobbyPlayer player =
+        build_local_lobby_player(save, "local-player", 2);
+    if (player.name == "local-player" && player.team == 2 &&
+        player.character_slots.size() == 1 &&
+        player.character_slots.front().character.name == "Curses Soldier")
+        ++score;
+
+    og::sim::LobbyMessage join_message =
+        make_join_message(save, "local-player", 2);
+    og::sim::LobbyMessage settings_message = make_settings_message(save, 5);
+    if (join_message.kind() == og::sim::LobbyMessageKind::Join &&
+        settings_message.kind() == og::sim::LobbyMessageKind::SettingsChange)
+        ++score;
+
+    og::sim::LobbyState state;
+    state.settings.campaign_id = "";
+    state.settings.scenario_id = 3;
+    state.host_player_id = 0;
+    player.player_index = 0;
+    player.is_host = true;
+    state.players.push_back(player);
+    if (find_local_player(state, "local-player") != nullptr &&
+        find_local_player(state, "missing") == nullptr)
+        ++score;
+
+    class RawTransport final : public og::sim::ITransport {
+    public:
+        explicit RawTransport(std::vector<og::sim::ReceivedMessage> messages)
+            : messages_(std::move(messages))
+        {
+        }
+
+        void send(og::sim::PeerId, const std::uint8_t*, std::size_t) override {}
+        std::vector<og::sim::ReceivedMessage> poll() override
+        {
+            return std::exchange(messages_, {});
+        }
+        void accept_connections() override {}
+        void disconnect(og::sim::PeerId) override {}
+        std::vector<og::sim::PeerId> connected_peers() const override { return {1}; }
+
+    private:
+        std::vector<og::sim::ReceivedMessage> messages_;
+    };
+
+    std::vector<std::uint8_t> unknown;
+    og::sim::append_transport_header(unknown, og::sim::kHeartbeatMessageType, 0);
+    RawTransport raw({
+        og::sim::ReceivedMessage{.peer_id = 1, .data = {0xff}},
+        og::sim::ReceivedMessage{.peer_id = 1, .data = og::sim::serialize_lobby_message(join_message)},
+        og::sim::ReceivedMessage{.peer_id = 1, .data = og::sim::serialize_lobby_state_message(state)},
+        og::sim::ReceivedMessage{.peer_id = 1, .data = unknown},
+    });
+    raw.accept_connections();
+    raw.disconnect(1);
+    raw.send(1, unknown.data(), unknown.size());
+    if (raw.connected_peers() == std::vector<og::sim::PeerId>{1})
+        ++score;
+    const std::vector<og::sim::TypedReceivedMessage> decoded =
+        poll_lobby_transport_messages(raw);
+    if (decoded.size() == 2 &&
+        decoded[0].kind == og::sim::TypedReceivedMessageKind::LobbyMessage &&
+        decoded[1].kind == og::sim::TypedReceivedMessageKind::LobbyState)
+        ++score;
+
+    auto server = og::sim::InProcessTransport::create_server();
+    server->accept_connections();
+    auto host_client = server->create_client_transport();
+    std::string err;
+    if (HostCursesSession::create({}, {}, 1, nullptr, host_client, 0, &err) ==
+            nullptr &&
+        !err.empty())
+        ++score;
+
+    og::sim::LobbySaveDataEquivalent equivalent;
+    equivalent.current_campaign = "org.openglad.gladiator";
+    equivalent.scen_num = 1;
+    equivalent.numplayers = 1;
+    equivalent.allied_mode = 0;
+    equivalent.team_list.push_back(og::sim::LobbyCharacterSlot{
+        .slot_index = 0,
+        .character = player.character_slots.front().character,
+    });
+    std::vector<og::sim::LobbyPlayerBinding> bindings{
+        og::sim::LobbyPlayerBinding{
+            .peer_id = host_client->local_peer_id(),
+            .player_index = 0,
+            .team = 2,
+        },
+    };
+    std::unique_ptr<HostCursesSession> host =
+        HostCursesSession::create(equivalent, bindings, 1, server, host_client,
+                                  0, &err);
+    if (host != nullptr) {
+        InputState input;
+        host->send_input(input);
+        host->advance();
+        (void)host->mirror_world();
+        (void)host->followed_entity_id();
+        (void)host->next_input_tick();
+        (void)host->ended();
+        (void)host->ending();
+        (void)host->next_level();
+        host->request_abort();
+        (void)host->drain_messages();
+        host->commit_result_to_save();
+        (void)host->server();
+        (void)host->client();
+        (void)host->server_world_ref();
+        ++score;
+    }
+
+    auto join_server = og::sim::InProcessTransport::create_server();
+    join_server->accept_connections();
+    auto join_client = join_server->create_client_transport();
+    std::unique_ptr<JoinCursesSession> join =
+        JoinCursesSession::create(equivalent, 1, join_client,
+                                  join_client->local_peer_id(), 0, &err);
+    if (join != nullptr) {
+        InputState input;
+        join->send_input(input);
+        join->advance();
+        (void)join->mirror_world();
+        (void)join->followed_entity_id();
+        (void)join->next_input_tick();
+        (void)join->ended();
+        (void)join->ending();
+        (void)join->next_level();
+        join->request_abort();
+        (void)join->drain_messages();
+        join->commit_result_to_save();
+        (void)join->client();
+        ++score;
+    }
+
+    return score;
+}
+#endif
+
 std::unique_ptr<CursesLobby> make_host_lobby(SaveData& save, const HostOptions& opt,
                                              std::string* error)
 {

--- a/src/platform/curses/curses_network.cpp
+++ b/src/platform/curses/curses_network.cpp
@@ -1233,17 +1233,40 @@ int curses_network_testing_exercise_internal_helpers()
         {
         }
 
-        void send(og::sim::PeerId, const std::uint8_t*, std::size_t) override {}
+        void send(og::sim::PeerId peer_id,
+                  const std::uint8_t* data,
+                  std::size_t len) override
+        {
+            sent_peer_id_ = peer_id;
+            sent_payload_.assign(data, data + len);
+        }
         std::vector<og::sim::ReceivedMessage> poll() override
         {
             return std::exchange(messages_, {});
         }
-        void accept_connections() override {}
-        void disconnect(og::sim::PeerId) override {}
+        void accept_connections() override { accepted_ = true; }
+        void disconnect(og::sim::PeerId peer_id) override
+        {
+            disconnected_peer_id_ = peer_id;
+        }
         std::vector<og::sim::PeerId> connected_peers() const override { return {1}; }
+        bool accepted() const { return accepted_; }
+        og::sim::PeerId disconnected_peer_id() const
+        {
+            return disconnected_peer_id_;
+        }
+        og::sim::PeerId sent_peer_id() const { return sent_peer_id_; }
+        const std::vector<std::uint8_t>& sent_payload() const
+        {
+            return sent_payload_;
+        }
 
     private:
         std::vector<og::sim::ReceivedMessage> messages_;
+        bool accepted_ = false;
+        og::sim::PeerId disconnected_peer_id_ = 0;
+        og::sim::PeerId sent_peer_id_ = 0;
+        std::vector<std::uint8_t> sent_payload_;
     };
 
     std::vector<std::uint8_t> unknown;
@@ -1257,7 +1280,11 @@ int curses_network_testing_exercise_internal_helpers()
     raw.accept_connections();
     raw.disconnect(1);
     raw.send(1, unknown.data(), unknown.size());
-    if (raw.connected_peers() == std::vector<og::sim::PeerId>{1})
+    if (raw.accepted() &&
+        raw.disconnected_peer_id() == 1 &&
+        raw.sent_peer_id() == 1 &&
+        raw.sent_payload() == unknown &&
+        raw.connected_peers() == std::vector<og::sim::PeerId>{1})
         ++score;
     const std::vector<og::sim::TypedReceivedMessage> decoded =
         poll_lobby_transport_messages(raw);
@@ -1295,22 +1322,44 @@ int curses_network_testing_exercise_internal_helpers()
         HostCursesSession::create(equivalent, bindings, 1, server, host_client,
                                   0, &err);
     if (host != nullptr) {
+        GameWorld& mirror = host->mirror_world();
+        GameWorld& authoritative = host->server_world_ref();
+        const std::uint32_t initial_tick = authoritative.tick_count_;
+        const std::uint32_t initial_next_input_tick = host->next_input_tick();
+        const bool initial_worlds_valid =
+            &mirror != &authoritative &&
+            !mirror.oblist.empty() &&
+            !authoritative.oblist.empty();
         InputState input;
         host->send_input(input);
         host->advance();
-        (void)host->mirror_world();
-        (void)host->followed_entity_id();
-        (void)host->next_input_tick();
-        (void)host->ended();
-        (void)host->ending();
-        (void)host->next_level();
-        host->request_abort();
+        const std::uint32_t advanced_tick = authoritative.tick_count_;
         (void)host->drain_messages();
+        const std::vector<std::string> second_drain = host->drain_messages();
         host->commit_result_to_save();
         (void)host->server();
         (void)host->client();
-        (void)host->server_world_ref();
-        ++score;
+        const bool stable_before_abort =
+            initial_worlds_valid &&
+            initial_tick > 0 &&
+            initial_next_input_tick == initial_tick + 1 &&
+            advanced_tick >= initial_tick &&
+            host->next_input_tick() == authoritative.tick_count_ + 1 &&
+            !host->ended() &&
+            host->ending() == 0 &&
+            host->next_level() <= 0 &&
+            second_drain.empty();
+        host->request_abort();
+        bool ended_after_abort = false;
+        for (int i = 0; i < 25; ++i) {
+            host->advance();
+            ended_after_abort = ended_after_abort || host->ended();
+        }
+        if (stable_before_abort &&
+            ended_after_abort &&
+            host->ended() &&
+            host->ending() != 0)
+            ++score;
     }
 
     auto join_server = og::sim::InProcessTransport::create_server();
@@ -1320,20 +1369,28 @@ int curses_network_testing_exercise_internal_helpers()
         JoinCursesSession::create(equivalent, 1, join_client,
                                   join_client->local_peer_id(), 0, &err);
     if (join != nullptr) {
+        GameWorld& mirror = join->mirror_world();
+        const std::uint32_t initial_tick = mirror.tick_count_;
+        const std::uint32_t initial_next_input_tick = join->next_input_tick();
         InputState input;
         join->send_input(input);
         join->advance();
-        (void)join->mirror_world();
-        (void)join->followed_entity_id();
-        (void)join->next_input_tick();
-        (void)join->ended();
-        (void)join->ending();
-        (void)join->next_level();
-        join->request_abort();
         (void)join->drain_messages();
+        const std::vector<std::string> second_drain = join->drain_messages();
         join->commit_result_to_save();
         (void)join->client();
-        ++score;
+        const bool stable_before_abort =
+            !mirror.oblist.empty() &&
+            initial_next_input_tick == initial_tick + 1 &&
+            join->next_input_tick() == mirror.tick_count_ + 1 &&
+            !join->ended() &&
+            join->ending() == 0 &&
+            join->next_level() <= 0 &&
+            second_drain.empty();
+        join->request_abort();
+        join->advance();
+        if (stable_before_abort && !join->ended())
+            ++score;
     }
 
     return score;

--- a/src/platform/curses/curses_network.cpp
+++ b/src/platform/curses/curses_network.cpp
@@ -1158,12 +1158,17 @@ private:
 // GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 int curses_network_testing_exercise_internal_helpers()
 {
-    int score = 0;
+    int check_index = 0;
+    int failed_check = 0;
+    const auto check = [&check_index, &failed_check](bool condition) {
+        ++check_index;
+        if (!condition && failed_check == 0)
+            failed_check = check_index;
+    };
 
     const std::string name_a = make_network_player_name();
     const std::string name_b = make_network_player_name();
-    if (!name_a.empty() && name_a != name_b)
-        ++score;
+    check(!name_a.empty() && name_a != name_b);
 
     og::sim::SimEventBatch batch;
     batch.events.push_back(og::sim::Event{
@@ -1184,9 +1189,8 @@ int curses_network_testing_exercise_internal_helpers()
     collect_notifications(batch, notifications);
     PendingEnd pending;
     apply_game_flow_batch(batch, pending, notifications);
-    if (pending.ended && pending.ending == 1 && pending.next_level == 2 &&
-        notifications.size() >= 2)
-        ++score;
+    check(pending.ended && pending.ending == 1 && pending.next_level == 2 &&
+        notifications.size() >= 2);
 
     SaveData save;
     save.current_campaign.clear();
@@ -1199,22 +1203,19 @@ int curses_network_testing_exercise_internal_helpers()
     soldier->teamnum = 2;
     soldier->level = 4;
     save.team_list[3] = std::move(soldier);
-    if (resolve_initial_local_team(save) == 2)
-        ++score;
+    check(resolve_initial_local_team(save) == 2);
 
     og::sim::LobbyPlayer player =
         build_local_lobby_player(save, "local-player", 2);
-    if (player.name == "local-player" && player.team == 2 &&
+    check(player.name == "local-player" && player.team == 2 &&
         player.character_slots.size() == 1 &&
-        player.character_slots.front().character.name == "Curses Soldier")
-        ++score;
+        player.character_slots.front().character.name == "Curses Soldier");
 
     og::sim::LobbyMessage join_message =
         make_join_message(save, "local-player", 2);
     og::sim::LobbyMessage settings_message = make_settings_message(save, 5);
-    if (join_message.kind() == og::sim::LobbyMessageKind::Join &&
-        settings_message.kind() == og::sim::LobbyMessageKind::SettingsChange)
-        ++score;
+    check(join_message.kind() == og::sim::LobbyMessageKind::Join &&
+        settings_message.kind() == og::sim::LobbyMessageKind::SettingsChange);
 
     og::sim::LobbyState state;
     state.settings.campaign_id = "";
@@ -1223,9 +1224,8 @@ int curses_network_testing_exercise_internal_helpers()
     player.player_index = 0;
     player.is_host = true;
     state.players.push_back(player);
-    if (find_local_player(state, "local-player") != nullptr &&
-        find_local_player(state, "missing") == nullptr)
-        ++score;
+    check(find_local_player(state, "local-player") != nullptr &&
+        find_local_player(state, "missing") == nullptr);
 
     class RawTransport final : public og::sim::ITransport {
     public:
@@ -1281,27 +1281,24 @@ int curses_network_testing_exercise_internal_helpers()
     raw.accept_connections();
     raw.disconnect(1);
     raw.send(1, unknown.data(), unknown.size());
-    if (raw.accepted() &&
+    check(raw.accepted() &&
         raw.disconnected_peer_id() == 1 &&
         raw.sent_peer_id() == 1 &&
         raw.sent_payload() == unknown &&
-        raw.connected_peers() == std::vector<og::sim::PeerId>{1})
-        ++score;
+        raw.connected_peers() == std::vector<og::sim::PeerId>{1});
     const std::vector<og::sim::TypedReceivedMessage> decoded =
         poll_lobby_transport_messages(raw);
-    if (decoded.size() == 2 &&
+    check(decoded.size() == 2 &&
         decoded[0].kind == og::sim::TypedReceivedMessageKind::LobbyMessage &&
-        decoded[1].kind == og::sim::TypedReceivedMessageKind::LobbyState)
-        ++score;
+        decoded[1].kind == og::sim::TypedReceivedMessageKind::LobbyState);
 
     auto server = og::sim::InProcessTransport::create_server();
     server->accept_connections();
     auto host_client = server->create_client_transport();
     std::string err;
-    if (HostCursesSession::create({}, {}, 1, nullptr, host_client, 0, &err) ==
+    check(HostCursesSession::create({}, {}, 1, nullptr, host_client, 0, &err) ==
             nullptr &&
-        !err.empty())
-        ++score;
+        !err.empty());
 
     og::sim::LobbySaveDataEquivalent equivalent;
     equivalent.current_campaign = "org.openglad.gladiator";
@@ -1322,6 +1319,7 @@ int curses_network_testing_exercise_internal_helpers()
     std::unique_ptr<HostCursesSession> host =
         HostCursesSession::create(equivalent, bindings, 1, server, host_client,
                                   0, &err);
+    check(host != nullptr);
     if (host != nullptr) {
         GameWorld& mirror = host->mirror_world();
         GameWorld& authoritative = host->server_world_ref();
@@ -1356,11 +1354,10 @@ int curses_network_testing_exercise_internal_helpers()
             host->advance();
             ended_after_abort = ended_after_abort || host->ended();
         }
-        if (stable_before_abort &&
+        check(stable_before_abort &&
             ended_after_abort &&
             host->ended() &&
-            host->ending() != 0)
-            ++score;
+            host->ending() != 0);
     }
 
     auto join_server = og::sim::InProcessTransport::create_server();
@@ -1369,6 +1366,7 @@ int curses_network_testing_exercise_internal_helpers()
     std::unique_ptr<JoinCursesSession> join =
         JoinCursesSession::create(equivalent, 1, join_client,
                                   join_client->local_peer_id(), 0, &err);
+    check(join != nullptr);
     if (join != nullptr) {
         GameWorld& mirror = join->mirror_world();
         const std::uint32_t initial_tick = mirror.tick_count_;
@@ -1390,11 +1388,10 @@ int curses_network_testing_exercise_internal_helpers()
             second_drain.empty();
         join->request_abort();
         join->advance();
-        if (stable_before_abort && !join->ended())
-            ++score;
+        check(stable_before_abort && !join->ended());
     }
 
-    return score;
+    return failed_check == 0 ? 0 : -failed_check;
 }
 // GCOVR_EXCL_STOP
 #endif

--- a/src/platform/curses/curses_terminal.cpp
+++ b/src/platform/curses/curses_terminal.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <csignal>
 #include <poll.h>
@@ -167,6 +168,10 @@ struct CursesTerminal::Impl {
 };
 
 CursesTerminal::CursesTerminal() : CursesTerminal(Options{}) {}
+
+#ifdef TESTING
+CursesTerminal::CursesTerminal(TestingTag) : impl_(std::make_unique<Impl>()) {}
+#endif
 
 CursesTerminal::CursesTerminal(Options opt) : impl_(std::make_unique<Impl>())
 {
@@ -323,5 +328,120 @@ void CursesTerminal::set_cursor_visible(bool visible)
 }
 
 void CursesTerminal::beep() { ::beep(); }
+
+#ifdef TESTING
+int curses_terminal_testing_exercise_internal_helpers()
+{
+    int score = 0;
+    try {
+        CursesTerminal terminal(CursesTerminal::Options{});
+        (void)terminal;
+    } catch (const std::runtime_error&) {
+        ++score;
+    }
+
+    restore_terminal();
+    on_sigwinch(SIGWINCH);
+    if (g_resize_pending) {
+        ++score;
+        g_resize_pending = 0;
+    }
+
+    {
+        CursesTerminal term(CursesTerminal::TestingTag{});
+        term.impl_->unicode = true;
+        term.impl_->color = false;
+        term.impl_->handle_resize();
+        if (term.supports_unicode())
+            ++score;
+        if (!term.supports_color())
+            ++score;
+        (void)term.rows();
+        (void)term.cols();
+
+        int in_pipe[2]{};
+        if (::pipe(in_pipe) == 0) {
+            term.impl_->in_fd = in_pipe[0];
+            write_all(in_pipe[1], "\x1b[113u");
+            const Key key = term.poll_key(false);
+            if (key.is_char(U'q'))
+                ++score;
+            ::close(in_pipe[1]);
+            ::close(in_pipe[0]);
+            term.impl_->in_fd = STDIN_FILENO;
+        }
+
+        int empty_pipe[2]{};
+        if (::pipe(empty_pipe) == 0) {
+            ::close(empty_pipe[1]);
+            term.impl_->in_fd = empty_pipe[0];
+            if (term.poll_key(false).is_none())
+                ++score;
+            ::close(empty_pipe[0]);
+            term.impl_->in_fd = STDIN_FILENO;
+        }
+    }
+
+    if (to_ncurses_color(Color::Black) == COLOR_BLACK)
+        ++score;
+    if (to_ncurses_color(Color::Red) == COLOR_RED)
+        ++score;
+    if (to_ncurses_color(Color::Green) == COLOR_GREEN)
+        ++score;
+    if (to_ncurses_color(Color::Yellow) == COLOR_YELLOW)
+        ++score;
+    if (to_ncurses_color(Color::Blue) == COLOR_BLUE)
+        ++score;
+    if (to_ncurses_color(Color::Magenta) == COLOR_MAGENTA)
+        ++score;
+    if (to_ncurses_color(Color::Cyan) == COLOR_CYAN)
+        ++score;
+    if (to_ncurses_color(Color::White) == COLOR_WHITE)
+        ++score;
+    if (to_ncurses_color(Color::Default) == -1)
+        ++score;
+    if (pair_id(Color::Red, Color::Blue) != pair_id(Color::Blue, Color::Red))
+        ++score;
+
+    int write_pipe[2]{};
+    if (::pipe(write_pipe) == 0) {
+        write_all(write_pipe[1], "terminal-write-test");
+        ::close(write_pipe[1]);
+        char buf[64]{};
+        const ssize_t n = ::read(write_pipe[0], buf, sizeof(buf));
+        if (n == 19 && std::string(buf, static_cast<std::size_t>(n)) == "terminal-write-test")
+            ++score;
+        ::close(write_pipe[0]);
+    }
+
+    auto probe = [&](std::string_view reply, bool expected) {
+        int in_pipe[2]{};
+        int out_pipe[2]{};
+        if (::pipe(in_pipe) != 0)
+            return;
+        if (::pipe(out_pipe) != 0) {
+            ::close(in_pipe[0]);
+            ::close(in_pipe[1]);
+            return;
+        }
+        write_all(in_pipe[1], reply);
+        ::close(in_pipe[1]);
+        const bool supported = detect_kitty_support(in_pipe[0], out_pipe[1]);
+        ::close(in_pipe[0]);
+        ::close(out_pipe[1]);
+        std::vector<char> written(kitty::kQuery.size());
+        const ssize_t n = ::read(out_pipe[0], written.data(), written.size());
+        ::close(out_pipe[0]);
+        if (supported == expected &&
+            n == static_cast<ssize_t>(kitty::kQuery.size()) &&
+            std::string_view(written.data(), written.size()) == kitty::kQuery)
+            ++score;
+    };
+    probe("\x1b[?11u\x1b[?62;1c", true);
+    probe("\x1b[?62;1c", false);
+
+    return score;
+}
+#endif
 
 } // namespace og::curses

--- a/src/platform/curses/curses_terminal.cpp
+++ b/src/platform/curses/curses_terminal.cpp
@@ -330,6 +330,7 @@ void CursesTerminal::set_cursor_visible(bool visible)
 void CursesTerminal::beep() { ::beep(); }
 
 #ifdef TESTING
+// GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 int curses_terminal_testing_exercise_internal_helpers()
 {
     int score = 0;
@@ -442,6 +443,7 @@ int curses_terminal_testing_exercise_internal_helpers()
 
     return score;
 }
+// GCOVR_EXCL_STOP
 #endif
 
 } // namespace og::curses

--- a/src/platform/curses/curses_terminal.cpp
+++ b/src/platform/curses/curses_terminal.cpp
@@ -333,18 +333,26 @@ void CursesTerminal::beep() { ::beep(); }
 // GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 int curses_terminal_testing_exercise_internal_helpers()
 {
-    int score = 0;
+    int check_index = 0;
+    int failed_check = 0;
+    const auto check = [&check_index, &failed_check](bool condition) {
+        ++check_index;
+        if (!condition && failed_check == 0)
+            failed_check = check_index;
+    };
+    bool default_constructor_failed = false;
     try {
         CursesTerminal terminal(CursesTerminal::Options{});
         (void)terminal;
     } catch (const std::runtime_error&) {
-        ++score;
+        default_constructor_failed = true;
     }
+    check(default_constructor_failed);
 
     restore_terminal();
     on_sigwinch(SIGWINCH);
+    check(g_resize_pending);
     if (g_resize_pending) {
-        ++score;
         g_resize_pending = 0;
     }
 
@@ -353,10 +361,8 @@ int curses_terminal_testing_exercise_internal_helpers()
         term.impl_->unicode = true;
         term.impl_->color = false;
         term.impl_->handle_resize();
-        if (term.supports_unicode())
-            ++score;
-        if (!term.supports_color())
-            ++score;
+        check(term.supports_unicode());
+        check(!term.supports_color());
         (void)term.rows();
         (void)term.cols();
 
@@ -365,8 +371,7 @@ int curses_terminal_testing_exercise_internal_helpers()
             term.impl_->in_fd = in_pipe[0];
             write_all(in_pipe[1], "\x1b[113u");
             const Key key = term.poll_key(false);
-            if (key.is_char(U'q'))
-                ++score;
+            check(key.is_char(U'q'));
             ::close(in_pipe[1]);
             ::close(in_pipe[0]);
             term.impl_->in_fd = STDIN_FILENO;
@@ -376,33 +381,22 @@ int curses_terminal_testing_exercise_internal_helpers()
         if (::pipe(empty_pipe) == 0) {
             ::close(empty_pipe[1]);
             term.impl_->in_fd = empty_pipe[0];
-            if (term.poll_key(false).is_none())
-                ++score;
+            check(term.poll_key(false).is_none());
             ::close(empty_pipe[0]);
             term.impl_->in_fd = STDIN_FILENO;
         }
     }
 
-    if (to_ncurses_color(Color::Black) == COLOR_BLACK)
-        ++score;
-    if (to_ncurses_color(Color::Red) == COLOR_RED)
-        ++score;
-    if (to_ncurses_color(Color::Green) == COLOR_GREEN)
-        ++score;
-    if (to_ncurses_color(Color::Yellow) == COLOR_YELLOW)
-        ++score;
-    if (to_ncurses_color(Color::Blue) == COLOR_BLUE)
-        ++score;
-    if (to_ncurses_color(Color::Magenta) == COLOR_MAGENTA)
-        ++score;
-    if (to_ncurses_color(Color::Cyan) == COLOR_CYAN)
-        ++score;
-    if (to_ncurses_color(Color::White) == COLOR_WHITE)
-        ++score;
-    if (to_ncurses_color(Color::Default) == -1)
-        ++score;
-    if (pair_id(Color::Red, Color::Blue) != pair_id(Color::Blue, Color::Red))
-        ++score;
+    check(to_ncurses_color(Color::Black) == COLOR_BLACK);
+    check(to_ncurses_color(Color::Red) == COLOR_RED);
+    check(to_ncurses_color(Color::Green) == COLOR_GREEN);
+    check(to_ncurses_color(Color::Yellow) == COLOR_YELLOW);
+    check(to_ncurses_color(Color::Blue) == COLOR_BLUE);
+    check(to_ncurses_color(Color::Magenta) == COLOR_MAGENTA);
+    check(to_ncurses_color(Color::Cyan) == COLOR_CYAN);
+    check(to_ncurses_color(Color::White) == COLOR_WHITE);
+    check(to_ncurses_color(Color::Default) == -1);
+    check(pair_id(Color::Red, Color::Blue) != pair_id(Color::Blue, Color::Red));
 
     int write_pipe[2]{};
     if (::pipe(write_pipe) == 0) {
@@ -410,8 +404,7 @@ int curses_terminal_testing_exercise_internal_helpers()
         ::close(write_pipe[1]);
         char buf[64]{};
         const ssize_t n = ::read(write_pipe[0], buf, sizeof(buf));
-        if (n == 19 && std::string(buf, static_cast<std::size_t>(n)) == "terminal-write-test")
-            ++score;
+        check(n == 19 && std::string(buf, static_cast<std::size_t>(n)) == "terminal-write-test");
         ::close(write_pipe[0]);
     }
 
@@ -433,15 +426,14 @@ int curses_terminal_testing_exercise_internal_helpers()
         std::vector<char> written(kitty::kQuery.size());
         const ssize_t n = ::read(out_pipe[0], written.data(), written.size());
         ::close(out_pipe[0]);
-        if (supported == expected &&
+        check(supported == expected &&
             n == static_cast<ssize_t>(kitty::kQuery.size()) &&
-            std::string_view(written.data(), written.size()) == kitty::kQuery)
-            ++score;
+            std::string_view(written.data(), written.size()) == kitty::kQuery);
     };
     probe("\x1b[?11u\x1b[?62;1c", true);
     probe("\x1b[?62;1c", false);
 
-    return score;
+    return failed_check == 0 ? 0 : -failed_check;
 }
 // GCOVR_EXCL_STOP
 #endif

--- a/src/platform/sdl/picker_lobby_network_client.cpp
+++ b/src/platform/sdl/picker_lobby_network_client.cpp
@@ -668,7 +668,7 @@ std::vector<std::string> split_top_level_json_objects(std::string_view text)
         const auto value_pos = find_json_field_value(trimmed, "rooms");
         if (!value_pos.has_value() || trimmed[*value_pos] != '[')
             return objects;
-        array_view = trimmed.substr(*value_pos);
+        array_view = std::string_view(trimmed).substr(*value_pos);
     }
 
     if (array_view.empty() || array_view.front() != '[')
@@ -1431,7 +1431,14 @@ int picker_lobby_network_testing_exercise_internal_helpers()
           relay_rooms[0].code == "ROOM-1" &&
           relay_rooms[0].player_count == 3 &&
           relay_rooms[0].created_at_ms == 55);
-    check(parse_relay_room_list(R"({"rooms":[{"code":"room-2"}]})").size() <= 1);
+    const auto wrapped_relay_rooms =
+        parse_relay_room_list(R"({"rooms":[{"code":"room-2"}]})");
+    check(wrapped_relay_rooms.size() == 1);
+    check(!wrapped_relay_rooms.empty() &&
+          wrapped_relay_rooms[0].code == "ROOM-2" &&
+          wrapped_relay_rooms[0].campaign_hash.empty() &&
+          wrapped_relay_rooms[0].player_count == 0 &&
+          wrapped_relay_rooms[0].created_at_ms == 0);
 
     SaveData save;
     save.current_campaign = "campaign-one";

--- a/src/platform/sdl/picker_lobby_network_client.cpp
+++ b/src/platform/sdl/picker_lobby_network_client.cpp
@@ -1682,7 +1682,7 @@ int picker_lobby_network_testing_exercise_internal_helpers()
     check(build_host_transport_failure_message("", "") ==
           "Unable to host a network lobby.");
 
-    return failed ? -failed_check : checks;
+    return failed ? -failed_check : 0;
 }
 // GCOVR_EXCL_STOP
 

--- a/src/platform/sdl/picker_lobby_network_client.cpp
+++ b/src/platform/sdl/picker_lobby_network_client.cpp
@@ -1338,6 +1338,7 @@ void clear_active_gameplay_shadow() noexcept
 #ifdef TESTING
 namespace og::ui::detail {
 
+// GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 int picker_lobby_network_testing_exercise_internal_helpers()
 {
     int checks = 0;
@@ -1683,6 +1684,7 @@ int picker_lobby_network_testing_exercise_internal_helpers()
 
     return failed ? -failed_check : checks;
 }
+// GCOVR_EXCL_STOP
 
 } // namespace og::ui::detail
 #endif

--- a/src/platform/sdl/picker_lobby_network_client.cpp
+++ b/src/platform/sdl/picker_lobby_network_client.cpp
@@ -1335,6 +1335,351 @@ void clear_active_gameplay_shadow() noexcept
 
 } // namespace
 
+#ifdef TESTING
+namespace og::ui::detail {
+
+int picker_lobby_network_testing_exercise_internal_helpers()
+{
+    int checks = 0;
+    int check_index = 0;
+    int failed_check = 0;
+    bool failed = false;
+    const auto check = [&checks, &check_index, &failed_check, &failed](bool condition) {
+        ++check_index;
+        if (condition)
+            ++checks;
+        else
+        {
+            failed = true;
+            if (failed_check == 0)
+                failed_check = check_index;
+        }
+    };
+
+    check(trim_copy(" \t host player \n ") == "host player");
+    check(trim_copy(" \t\n ") == "");
+    check(url_encode_component("a b+/~") == "a%20b%2B%2F~");
+    check(relay_api_base_url(" https://relay.example/api/// ") ==
+          "https://relay.example/api");
+    check(relay_api_base_url("https://relay.example/base") ==
+          "https://relay.example/base/api");
+    check(build_relay_room_websocket_url_impl(
+              "https://relay.example",
+              "ROOM-1",
+              "owner token") ==
+          "wss://relay.example/api/room/ROOM-1?owner_token=owner%20token");
+    check(build_relay_room_websocket_url_impl(
+              "http://relay.example/api",
+              "ROOM-2",
+              "") ==
+          "ws://relay.example/api/room/ROOM-2");
+    check(build_relay_room_create_url(
+              "wss://relay.example/",
+              "",
+              "Campaign One",
+              "Host+Name") ==
+          "https://relay.example/api/create?campaign_name=Campaign%20One&host=Host%2BName");
+    check(build_relay_room_list_url("ws://relay.example", "hash one") ==
+          "http://relay.example/api/rooms?campaign=hash%20one");
+
+    check(!find_json_field_value(R"({"code" "missing-colon"})", "code").has_value());
+    check(!find_json_field_value(R"({"other":1})", "code").has_value());
+    check(extract_json_string_field(R"({"text":"a\\b"})", "text").value_or("") ==
+          "a\\b");
+    check(!extract_json_string_field(R"({"text":123})", "text").has_value());
+    check(!extract_json_string_field(R"({"text":"unterminated})", "text").has_value());
+    check(extract_json_u32_field(R"({"count":42})", "count").value_or(0) == 42);
+    check(!extract_json_u32_field(R"({"count":"42"})", "count").has_value());
+    check(!extract_json_u32_field(
+              R"({"count":999999999999999999999999})",
+              "count").has_value());
+    check(extract_json_i64_field(R"({"created_at":123456})", "created_at").value_or(0) ==
+          123456);
+    check(!extract_json_i64_field(R"({"created_at":-1})", "created_at").has_value());
+
+    const auto created_from_code =
+        parse_relay_room_create_response_impl(
+            R"({"code":"ROOM-A","owner_token":"owner-a"})");
+    check(created_from_code.room_code == "ROOM-A" &&
+          created_from_code.owner_token == "owner-a");
+    const auto created_from_room_code =
+        parse_relay_room_create_response_impl(R"({"room_code":"ROOM-B"})");
+    check(created_from_room_code.room_code == "ROOM-B" &&
+          created_from_room_code.owner_token.empty());
+    const auto created_from_plain =
+        parse_relay_room_create_response_impl(" ROOM-C ");
+    check(created_from_plain.room_code == "ROOM-C");
+    try
+    {
+        (void)parse_relay_room_create_response_impl(" \n\t ");
+        failed = true;
+    }
+    catch (const std::runtime_error&)
+    {
+        ++checks;
+    }
+
+    check(split_top_level_json_objects("").empty());
+    check(split_top_level_json_objects(R"({"not_rooms":[]})").empty());
+    check(split_top_level_json_objects(R"(not-json)").empty());
+    const auto split_objects = split_top_level_json_objects(
+        R"([{"code":"A","note":"literal { brace }"},{"code":"B","note":"escaped \\ slash"}])");
+    check(split_objects.size() == 2);
+    const auto relay_rooms = parse_relay_room_list(
+        R"([{"campaign_hash":"skip"},{"code":" room-1 ","campaign_hash":"hash","campaign_name":"Campaign","host_name":"Host","player_count":3,"created_at":55}])");
+    check(relay_rooms.size() == 1 &&
+          relay_rooms[0].code == "ROOM-1" &&
+          relay_rooms[0].player_count == 3 &&
+          relay_rooms[0].created_at_ms == 55);
+    check(parse_relay_room_list(R"({"rooms":[{"code":"room-2"}]})").size() <= 1);
+
+    SaveData save;
+    save.current_campaign = "campaign-one";
+    save.scen_num = 4;
+    save.allied_mode = 1;
+    save.my_team = 2;
+    auto make_member = [](int family,
+                          const std::string& name,
+                          short team,
+                          int id) {
+        auto member = std::make_unique<guy>(family);
+        member->name = name;
+        member->teamnum = team;
+        member->id = id;
+        member->strength = static_cast<short>(10 + id);
+        member->dexterity = static_cast<short>(11 + id);
+        member->constitution = static_cast<short>(12 + id);
+        member->intelligence = static_cast<short>(13 + id);
+        member->armor = static_cast<short>(14 + id);
+        member->exp = static_cast<std::uint32_t>(100 + id);
+        member->kills = static_cast<short>(id);
+        member->level_kills = id + 1;
+        member->total_damage = id + 2;
+        member->total_hits = id + 3;
+        member->total_shots = id + 4;
+        member->scen_damage = static_cast<float>(id + 5);
+        member->scen_kills = static_cast<short>(id + 6);
+        member->scen_damage_taken = static_cast<float>(id + 7);
+        member->scen_min_hp = static_cast<float>(id + 8);
+        member->scen_shots = static_cast<short>(id + 9);
+        member->scen_hits = static_cast<short>(id + 10);
+        member->level = static_cast<short>(id + 11);
+        return member;
+    };
+    save.team_list[0] = make_member(0, "Local A", 2, 1);
+    save.team_list[2] = make_member(1, "Local B", 2, 2);
+    save.team_list[3] = make_member(2, "Other Team", 3, 3);
+    save.team_size = 3;
+    save.numplayers = 1;
+
+    check(resolve_initial_local_team(save) == 2);
+    save.my_team = 7;
+    check(resolve_initial_local_team(save) == 2);
+    SaveData empty_save;
+    check(resolve_initial_local_team(empty_save) == 0);
+    check(gameplay_start_team(0, 3) == 3);
+    check(gameplay_start_team(1, 3) == 0);
+
+    std::array<bool, MAX_TEAM_SIZE> excluded_slots{};
+    excluded_slots.fill(false);
+    excluded_slots[2] = true;
+    og::sim::LobbyPlayer local_player =
+        build_local_lobby_player(save, "local-player", 2, &excluded_slots);
+    check(local_player.name == "local-player" &&
+          local_player.character_slots.size() == 1 &&
+          local_player.character_slots[0].slot_index == 0);
+    og::sim::LobbyMessage join_message =
+        make_join_message(save, "local-player", 2, &excluded_slots);
+    check(join_message.kind() == og::sim::LobbyMessageKind::Join);
+    og::sim::LobbyMessage settings_message = make_settings_message(save);
+    check(settings_message.kind() == og::sim::LobbyMessageKind::SettingsChange);
+
+    og::sim::LobbyState state;
+    state.settings.campaign_id = "";
+    state.settings.scenario_id = 0;
+    state.settings.difficulty = 5;
+    state.settings.allied_mode = 1;
+    state.host_player_id = 1;
+    local_player.player_index = 1;
+    local_player.is_host = true;
+    og::sim::LobbyPlayer remote_player;
+    remote_player.player_index = 2;
+    remote_player.name = "remote-player";
+    remote_player.team = 3;
+    remote_player.character_slots.push_back(local_player.character_slots[0]);
+    remote_player.character_slots[0].slot_index = 5;
+    remote_player.character_slots[0].character.name = "Remote";
+    remote_player.character_slots[0].character.teamnum = 3;
+    state.players = {remote_player, local_player};
+
+    check(find_local_player(state, "local-player") != nullptr);
+    check(find_local_player(state, "missing") == nullptr);
+    check(local_player_is_host(state, "local-player"));
+    check(!local_player_is_host(state, "remote-player"));
+    const auto equivalent =
+        build_save_data_equivalent_from_state(state, false);
+    check(equivalent.current_campaign == std::string(kDefaultCampaignId) &&
+          equivalent.scen_num == 1 &&
+          equivalent.numplayers == 1 &&
+          equivalent.team_list.size() == 2 &&
+          equivalent.team_list[0].character.teamnum == 0);
+    check(build_save_data_equivalent_from_state(state, true).numplayers == 0);
+    const auto remote_slots =
+        build_remote_owned_slot_mask(state, "local-player");
+    check(remote_slots[1]);
+    SaveData applied_save;
+    apply_lobby_state_to_save(state, applied_save, true, 4);
+    check(applied_save.current_campaign == std::string(kDefaultCampaignId) &&
+          applied_save.scen_num == 1 &&
+          applied_save.numplayers == 0 &&
+          applied_save.my_team == 4 &&
+          applied_save.team_size == 2);
+
+    og::sim::LobbyState oversized_state = state;
+    oversized_state.players.clear();
+    oversized_state.players.push_back(remote_player);
+    oversized_state.players[0].character_slots.clear();
+    for (std::uint8_t slot = 0; slot < MAX_TEAM_SIZE + 1; ++slot)
+    {
+        og::sim::LobbyCharacterSlot lobby_slot = local_player.character_slots[0];
+        lobby_slot.slot_index = slot;
+        oversized_state.players[0].character_slots.push_back(lobby_slot);
+    }
+    apply_lobby_state_to_save(oversized_state, applied_save, false, 1);
+    check(applied_save.team_size == MAX_TEAM_SIZE);
+
+    class RawTransport final : public og::sim::ITransport {
+    public:
+        std::vector<og::sim::ReceivedMessage> incoming;
+        std::vector<std::vector<std::uint8_t>> sent;
+
+        void send(og::sim::PeerId,
+                  const std::uint8_t* data,
+                  std::size_t len) override
+        {
+            sent.emplace_back(data, data + len);
+        }
+
+        std::vector<og::sim::ReceivedMessage> poll() override
+        {
+            auto result = std::move(incoming);
+            incoming.clear();
+            return result;
+        }
+
+        void accept_connections() override {}
+        void disconnect(og::sim::PeerId) override {}
+        std::vector<og::sim::PeerId> connected_peers() const override
+        {
+            return {7};
+        }
+    };
+
+    RawTransport raw_transport;
+    raw_transport.incoming.push_back({1, {0}});
+    std::vector<std::uint8_t> unknown_message;
+    og::sim::append_transport_header(unknown_message, 99, 0);
+    raw_transport.incoming.push_back({2, unknown_message});
+    std::vector<std::uint8_t> malformed_lobby;
+    og::sim::append_transport_header(
+        malformed_lobby,
+        og::sim::kLobbyMessageType,
+        0);
+    raw_transport.incoming.push_back({3, malformed_lobby});
+    raw_transport.incoming.push_back(
+        {4, og::sim::serialize_lobby_message(join_message)});
+    raw_transport.incoming.push_back(
+        {5, og::sim::serialize_lobby_state_message(state)});
+    const auto typed_from_raw = poll_lobby_transport_messages(raw_transport);
+    check(typed_from_raw.size() == 2 &&
+          typed_from_raw[0].kind == og::sim::TypedReceivedMessageKind::LobbyMessage &&
+          typed_from_raw[1].kind == og::sim::TypedReceivedMessageKind::LobbyState);
+    send_lobby_message(raw_transport, 9, std::move(join_message));
+    check(!raw_transport.sent.empty());
+
+    class TypedTransport final : public og::sim::ITransport {
+    public:
+        std::vector<og::sim::TypedReceivedMessage> typed;
+
+        bool supports_typed_messages() const noexcept override
+        {
+            return true;
+        }
+
+        std::vector<og::sim::TypedReceivedMessage> poll_typed() override
+        {
+            return std::move(typed);
+        }
+
+        void send(og::sim::PeerId,
+                  const std::uint8_t*,
+                  std::size_t) override {}
+        std::vector<og::sim::ReceivedMessage> poll() override
+        {
+            return {};
+        }
+        void accept_connections() override {}
+        void disconnect(og::sim::PeerId) override {}
+        std::vector<og::sim::PeerId> connected_peers() const override
+        {
+            return {};
+        }
+    };
+
+    TypedTransport typed_transport;
+    og::sim::TypedReceivedMessage typed_message;
+    typed_message.peer_id = 1;
+    typed_message.kind = og::sim::TypedReceivedMessageKind::LobbyState;
+    typed_message.lobby_state = std::make_shared<og::sim::LobbyState>(state);
+    typed_transport.typed.push_back(std::move(typed_message));
+    check(poll_lobby_transport_messages(typed_transport).size() == 1);
+
+    check(resolve_pending_local_team(state, -1, "local-player") == 0);
+    og::sim::LobbyState full_state;
+    for (short team = 0; team < MAX_PLAYERS; ++team)
+    {
+        og::sim::LobbyPlayer player;
+        player.name = std::format("player-{}", team);
+        player.team = team;
+        full_state.players.push_back(std::move(player));
+    }
+    check(resolve_pending_local_team(full_state, 3, "local-player") == 3);
+    og::sim::LobbyPlayer empty_pending;
+    check(build_pending_local_lobby_state(
+              state,
+              empty_pending,
+              1,
+              "pending-player").state.players.size() == state.players.size());
+    og::sim::LobbyPlayer pending_player = local_player;
+    pending_player.name = "pending-player";
+    const auto pending_state = build_pending_local_lobby_state(
+        state,
+        pending_player,
+        3,
+        "pending-player");
+    check(pending_state.state.players.size() == state.players.size() + 1 &&
+          pending_state.local_team == 0);
+    check(build_pending_local_lobby_state(
+              state,
+              pending_player,
+              3,
+              "local-player").state.players.size() == state.players.size());
+
+    check(build_host_transport_failure_message("direct failed", "relay failed") ==
+          "Direct: direct failed\nRelay: relay failed");
+    check(build_host_transport_failure_message("direct failed", "") ==
+          "direct failed");
+    check(build_host_transport_failure_message("", "relay failed") ==
+          "relay failed");
+    check(build_host_transport_failure_message("", "") ==
+          "Unable to host a network lobby.");
+
+    return failed ? -failed_check : checks;
+}
+
+} // namespace og::ui::detail
+#endif
+
 namespace og::ui {
 
 std::vector<std::string> build_host_picker_status_lines(

--- a/src/platform/text/text_picker.cpp
+++ b/src/platform/text/text_picker.cpp
@@ -558,6 +558,132 @@ private:
     bool show_new_game_team_build_notice_ = false;
 };
 
+#ifdef TESTING
+class ScopedCinRedirect
+{
+public:
+    explicit ScopedCinRedirect(std::string input)
+        : input_(std::move(input))
+        , saved_(std::cin.rdbuf(input_.rdbuf()))
+    {
+    }
+
+    ~ScopedCinRedirect()
+    {
+        std::cin.rdbuf(saved_);
+    }
+
+    ScopedCinRedirect(const ScopedCinRedirect&) = delete;
+    ScopedCinRedirect& operator=(const ScopedCinRedirect&) = delete;
+
+private:
+    std::istringstream input_;
+    std::streambuf* saved_;
+};
+
+int text_picker_testing_exercise_internal_paths()
+{
+    TextPickerConfig config;
+    config.team_families = {FAMILY_SOLDIER};
+    config.save_name = "missing-text-picker-save";
+    TextPickerError error;
+    TextPickerClient client(config, &error);
+
+    client.show_help();
+    const bool networking = client.configure_networking();
+    const bool loaded = client.load_game();
+    int score = (!networking ? 1 : 0) + (!loaded ? 1 : 0) +
+        (error.code == TextPickerErrorCode::LoadIoError ? 1 : 0);
+
+    {
+        ScopedCinRedirect input("bad\n1\n");
+        if (client.present_menu(PickerMenuId::Main) != nullptr)
+            ++score;
+    }
+    {
+        ScopedCinRedirect input("");
+        const PickerMenuItem* item = client.present_menu(PickerMenuId::TeamBuild);
+        if (item != nullptr && item->command == PickerMenuCommand::Back)
+            ++score;
+    }
+    {
+        ScopedCinRedirect input("");
+        const PickerMenuItem* item = client.present_menu(PickerMenuId::Main);
+        if (item != nullptr && item->command == PickerMenuCommand::Quit)
+            ++score;
+    }
+
+    if (client.prepare_new_game())
+        ++score;
+    if (client.screen_after_game() == PickerScreen::TeamBuild)
+        ++score;
+
+    if (const PickerMenuItem* item =
+            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::SetDifficulty))
+        client.handle_menu_item(PickerMenuId::Main, *item);
+    if (const PickerMenuItem* item =
+            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::SetPlayerMode, 2))
+        client.handle_menu_item(PickerMenuId::Main, *item);
+    if (const PickerMenuItem* item =
+            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::ToggleAlliedMode))
+        client.handle_menu_item(PickerMenuId::Main, *item);
+    if (const PickerMenuItem* item =
+            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::LevelEdit))
+        client.handle_menu_item(PickerMenuId::Main, *item);
+    const PickerMenuItem default_main{"helper-default", "Helper Default",
+                                      PickerMenuCommand::BeginNewGame, 0};
+    client.handle_menu_item(PickerMenuId::Main, default_main);
+    const PickerMenuItem default_team{"helper-default", "Helper Default",
+                                      PickerMenuCommand::Back, 0};
+    client.handle_menu_item(PickerMenuId::TeamBuild, default_team);
+
+    auto handle_team_item = [&](PickerMenuCommand command, std::string input_text) {
+        if (const PickerMenuItem* item =
+                find_picker_menu_item(PickerMenuId::TeamBuild, command))
+        {
+            ScopedCinRedirect input(std::move(input_text));
+            client.handle_menu_item(PickerMenuId::TeamBuild, *item);
+            ++score;
+        }
+    };
+
+    handle_team_item(PickerMenuCommand::ViewTeam, "\n");
+    handle_team_item(PickerMenuCommand::TrainTeam, "n\np\n1\n-1\n6\na\nb\n");
+    handle_team_item(PickerMenuCommand::HireTroops, "n\np\nh\nb\n");
+    handle_team_item(PickerMenuCommand::ShowProgress, "");
+    handle_team_item(PickerMenuCommand::Networking, "");
+    handle_team_item(PickerMenuCommand::SetLevel, "0\n");
+    handle_team_item(PickerMenuCommand::SetLevel, "5\n");
+    handle_team_item(PickerMenuCommand::SetCampaign, "999\n");
+    handle_team_item(PickerMenuCommand::SetCampaign, "\n");
+
+    const PickerMenuItem zero_players{"helper-zero", "Zero Players",
+                                      PickerMenuCommand::SetPlayerMode, 0};
+    client.handle_menu_item(PickerMenuId::Main, zero_players);
+    handle_team_item(PickerMenuCommand::ViewTeam, "\n");
+    handle_team_item(PickerMenuCommand::TrainTeam, "b\n");
+    (void)client.prepare_new_game();
+
+    {
+        ScopedCinRedirect input("helper-slot\nbad-seed\n");
+        client.show_options();
+        ++score;
+    }
+    {
+        ScopedCinRedirect input("\n123\n");
+        client.show_options();
+        if (config.seed == 123u)
+            ++score;
+    }
+    if (client.save_game())
+        ++score;
+    if (client.load_game())
+        ++score;
+
+    return score;
+}
+#endif
+
 void run_text_picker(TextPickerConfig& config, TextPickerError* error)
 {
     if (config.team_families.empty())

--- a/src/platform/text/text_picker.cpp
+++ b/src/platform/text/text_picker.cpp
@@ -211,6 +211,13 @@ public:
         return PickerScreen::TeamBuild;
     }
 
+#ifdef TESTING
+    const SaveData& testing_save_data() const
+    {
+        return save_data_;
+    }
+#endif
+
     bool load_game() override
     {
         const SaveDataIoError io = save_data_.load_with_error(config_.save_name);
@@ -588,99 +595,186 @@ int text_picker_testing_exercise_internal_paths()
     config.save_name = "missing-text-picker-save";
     TextPickerError error;
     TextPickerClient client(config, &error);
+    const SaveData& save = client.testing_save_data();
+
+    int checks = 0;
+    int check_index = 0;
+    int failed_check = 0;
+    bool failed = false;
+    const auto check = [&checks, &check_index, &failed_check, &failed](bool condition) {
+        ++check_index;
+        if (condition)
+            ++checks;
+        else {
+            failed = true;
+            if (failed_check == 0)
+                failed_check = check_index;
+        }
+    };
 
     client.show_help();
     const bool networking = client.configure_networking();
     const bool loaded = client.load_game();
-    int score = (!networking ? 1 : 0) + (!loaded ? 1 : 0) +
-        (error.code == TextPickerErrorCode::LoadIoError ? 1 : 0);
+    check(!networking);
+    check(!loaded);
+    check(error.code == TextPickerErrorCode::LoadIoError &&
+          !error.detail.empty());
 
     {
         ScopedCinRedirect input("bad\n1\n");
-        if (client.present_menu(PickerMenuId::Main) != nullptr)
-            ++score;
+        const PickerMenuItem* item = client.present_menu(PickerMenuId::Main);
+        check(item != nullptr &&
+              item->command == PickerMenuCommand::BeginNewGame);
     }
     {
         ScopedCinRedirect input("");
         const PickerMenuItem* item = client.present_menu(PickerMenuId::TeamBuild);
-        if (item != nullptr && item->command == PickerMenuCommand::Back)
-            ++score;
+        check(item != nullptr && item->command == PickerMenuCommand::Back);
     }
     {
         ScopedCinRedirect input("");
         const PickerMenuItem* item = client.present_menu(PickerMenuId::Main);
-        if (item != nullptr && item->command == PickerMenuCommand::Quit)
-            ++score;
+        check(item != nullptr && item->command == PickerMenuCommand::Quit);
     }
 
-    if (client.prepare_new_game())
-        ++score;
-    if (client.screen_after_game() == PickerScreen::TeamBuild)
-        ++score;
+    check(client.prepare_new_game() &&
+          save.team_size == 1 &&
+          save.team_list[0] != nullptr &&
+          save.team_list[0]->family == FAMILY_SOLDIER);
+    check(client.screen_after_game() == PickerScreen::TeamBuild);
 
     if (const PickerMenuItem* item =
-            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::SetDifficulty))
+            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::SetDifficulty)) {
+        const int previous = og::runtime::current_session->current_difficulty_;
         client.handle_menu_item(PickerMenuId::Main, *item);
+        check(og::runtime::current_session->current_difficulty_ ==
+              cycle_difficulty(previous));
+    } else {
+        check(false);
+    }
     if (const PickerMenuItem* item =
-            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::SetPlayerMode, 2))
+            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::SetPlayerMode, 2)) {
         client.handle_menu_item(PickerMenuId::Main, *item);
+        check(save.numplayers == 2);
+    } else {
+        check(false);
+    }
     if (const PickerMenuItem* item =
-            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::ToggleAlliedMode))
+            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::ToggleAlliedMode)) {
+        const bool previous = is_allied_mode(save);
         client.handle_menu_item(PickerMenuId::Main, *item);
+        check(is_allied_mode(save) != previous);
+    } else {
+        check(false);
+    }
     if (const PickerMenuItem* item =
-            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::LevelEdit))
+            find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::LevelEdit)) {
+        const int previous_level = config.level;
+        const TextPickerErrorCode previous_error = error.code;
         client.handle_menu_item(PickerMenuId::Main, *item);
+        check(config.level == previous_level && error.code == previous_error);
+    } else {
+        check(false);
+    }
     const PickerMenuItem default_main{"helper-default", "Helper Default",
                                       PickerMenuCommand::BeginNewGame, 0};
+    const unsigned char previous_players = save.numplayers;
     client.handle_menu_item(PickerMenuId::Main, default_main);
+    check(save.numplayers == previous_players);
     const PickerMenuItem default_team{"helper-default", "Helper Default",
                                       PickerMenuCommand::Back, 0};
+    int previous_level = config.level;
     client.handle_menu_item(PickerMenuId::TeamBuild, default_team);
+    check(config.level == previous_level);
 
-    auto handle_team_item = [&](PickerMenuCommand command, std::string input_text) {
+    auto handle_team_item = [&](PickerMenuCommand command,
+                                std::string input_text,
+                                const auto& predicate) {
         if (const PickerMenuItem* item =
                 find_picker_menu_item(PickerMenuId::TeamBuild, command))
         {
             ScopedCinRedirect input(std::move(input_text));
             client.handle_menu_item(PickerMenuId::TeamBuild, *item);
-            ++score;
+            check(predicate());
+        } else {
+            check(false);
         }
     };
 
-    handle_team_item(PickerMenuCommand::ViewTeam, "\n");
-    handle_team_item(PickerMenuCommand::TrainTeam, "n\np\n1\n-1\n6\na\nb\n");
-    handle_team_item(PickerMenuCommand::HireTroops, "n\np\nh\nb\n");
-    handle_team_item(PickerMenuCommand::ShowProgress, "");
-    handle_team_item(PickerMenuCommand::Networking, "");
-    handle_team_item(PickerMenuCommand::SetLevel, "0\n");
-    handle_team_item(PickerMenuCommand::SetLevel, "5\n");
-    handle_team_item(PickerMenuCommand::SetCampaign, "999\n");
-    handle_team_item(PickerMenuCommand::SetCampaign, "\n");
+    unsigned char previous_team_size = save.team_size;
+    handle_team_item(PickerMenuCommand::ViewTeam, "\n", [&] {
+        return save.team_size == previous_team_size;
+    });
+    previous_team_size = save.team_size;
+    handle_team_item(PickerMenuCommand::TrainTeam, "n\np\n1\n-1\n6\na\nb\n", [&] {
+        return save.team_size == previous_team_size &&
+               !config.team_families.empty();
+    });
+    previous_team_size = save.team_size;
+    handle_team_item(PickerMenuCommand::HireTroops, "n\np\nh\nb\n", [&] {
+        return save.team_size == static_cast<unsigned char>(previous_team_size + 1) &&
+               config.team_families.size() == save.team_size;
+    });
+    previous_level = config.level;
+    handle_team_item(PickerMenuCommand::ShowProgress, "", [&] {
+        return config.level == previous_level;
+    });
+    const TextPickerErrorCode error_before_networking = error.code;
+    handle_team_item(PickerMenuCommand::Networking, "", [&] {
+        return error.code == error_before_networking;
+    });
+    previous_level = config.level;
+    handle_team_item(PickerMenuCommand::SetLevel, "0\n", [&] {
+        return config.level == previous_level &&
+               save.scen_num == previous_level;
+    });
+    handle_team_item(PickerMenuCommand::SetLevel, "5\n", [&] {
+        return config.level == 5 && save.scen_num == 5;
+    });
+    const std::string previous_campaign = config.campaign;
+    handle_team_item(PickerMenuCommand::SetCampaign, "999\n", [&] {
+        return config.campaign == previous_campaign &&
+               save.current_campaign == previous_campaign;
+    });
+    handle_team_item(PickerMenuCommand::SetCampaign, "\n", [&] {
+        return config.campaign == previous_campaign &&
+               save.current_campaign == previous_campaign;
+    });
 
     const PickerMenuItem zero_players{"helper-zero", "Zero Players",
                                       PickerMenuCommand::SetPlayerMode, 0};
     client.handle_menu_item(PickerMenuId::Main, zero_players);
-    handle_team_item(PickerMenuCommand::ViewTeam, "\n");
-    handle_team_item(PickerMenuCommand::TrainTeam, "b\n");
-    (void)client.prepare_new_game();
+    check(save.numplayers == 0);
+    previous_team_size = save.team_size;
+    handle_team_item(PickerMenuCommand::ViewTeam, "\n", [&] {
+        return save.team_size == previous_team_size;
+    });
+    handle_team_item(PickerMenuCommand::TrainTeam, "b\n", [&] {
+        return save.team_size == previous_team_size &&
+               save.numplayers == 0;
+    });
+    check(client.prepare_new_game() &&
+          save.team_size >= 1 &&
+          !config.team_families.empty());
 
     {
+        const std::uint32_t previous_seed = config.seed;
         ScopedCinRedirect input("helper-slot\nbad-seed\n");
         client.show_options();
-        ++score;
+        check(config.save_name == "helper-slot" &&
+              config.seed == previous_seed);
     }
     {
         ScopedCinRedirect input("\n123\n");
         client.show_options();
-        if (config.seed == 123u)
-            ++score;
+        check(config.save_name == "helper-slot" && config.seed == 123u);
     }
-    if (client.save_game())
-        ++score;
-    if (client.load_game())
-        ++score;
+    check(client.save_game() && error.code == TextPickerErrorCode::None);
+    check(client.load_game() &&
+          error.code == TextPickerErrorCode::None &&
+          !config.team_families.empty());
 
-    return score;
+    return failed ? -failed_check : checks;
 }
 #endif
 

--- a/src/platform/text/text_picker.cpp
+++ b/src/platform/text/text_picker.cpp
@@ -777,7 +777,7 @@ int text_picker_testing_exercise_internal_paths()
           error.code == TextPickerErrorCode::None &&
           !config.team_families.empty());
 
-    return failed ? -failed_check : checks;
+    return failed ? -failed_check : 0;
 }
 // GCOVR_EXCL_STOP
 #endif

--- a/src/platform/text/text_picker.cpp
+++ b/src/platform/text/text_picker.cpp
@@ -212,10 +212,12 @@ public:
     }
 
 #ifdef TESTING
+    // GCOVR_EXCL_START -- test-only accessor in src/, not shipped code.
     const SaveData& testing_save_data() const
     {
         return save_data_;
     }
+    // GCOVR_EXCL_STOP
 #endif
 
     bool load_game() override
@@ -566,6 +568,7 @@ private:
 };
 
 #ifdef TESTING
+// GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 class ScopedCinRedirect
 {
 public:
@@ -588,7 +591,6 @@ private:
     std::streambuf* saved_;
 };
 
-// GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 int text_picker_testing_exercise_internal_paths()
 {
     TextPickerConfig config;

--- a/src/platform/text/text_picker.cpp
+++ b/src/platform/text/text_picker.cpp
@@ -588,6 +588,7 @@ private:
     std::streambuf* saved_;
 };
 
+// GCOVR_EXCL_START -- test-only coverage harness in src/, not shipped code.
 int text_picker_testing_exercise_internal_paths()
 {
     TextPickerConfig config;
@@ -776,6 +777,7 @@ int text_picker_testing_exercise_internal_paths()
 
     return failed ? -failed_check : checks;
 }
+// GCOVR_EXCL_STOP
 #endif
 
 void run_text_picker(TextPickerConfig& config, TextPickerError* error)

--- a/src/platform/text/text_protocol.cpp
+++ b/src/platform/text/text_protocol.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include <openglad/resources/gparser.h> // cfg_store, ::cfg
 
@@ -45,6 +46,46 @@ static void json_entity(std::ostream& os, const walker* w, int index)
        << "}";
 }
 
+static void json_string(std::ostream& os, std::string_view value)
+{
+    static constexpr char kHex[] = "0123456789abcdef";
+
+    os << '"';
+    for (unsigned char c : value) {
+        switch (c) {
+        case '"':
+            os << "\\\"";
+            break;
+        case '\\':
+            os << "\\\\";
+            break;
+        case '\b':
+            os << "\\b";
+            break;
+        case '\f':
+            os << "\\f";
+            break;
+        case '\n':
+            os << "\\n";
+            break;
+        case '\r':
+            os << "\\r";
+            break;
+        case '\t':
+            os << "\\t";
+            break;
+        default:
+            if (c < 0x20) {
+                os << "\\u00" << kHex[c >> 4] << kHex[c & 0x0f];
+            } else {
+                os << static_cast<char>(c);
+            }
+            break;
+        }
+    }
+    os << '"';
+}
+
 static void json_event(std::ostream& os, const og::sim::Event& ev)
 {
     os << "{\"tick\":" << ev.tick
@@ -52,13 +93,8 @@ static void json_event(std::ostream& os, const og::sim::Event& ev)
        << ",\"a\":" << ev.a
        << ",\"b\":" << ev.b;
     if (!ev.text.empty()) {
-        os << ",\"text\":\"";
-        for (char c : ev.text) {
-            if (c == '"') os << "\\\"";
-            else if (c == '\\') os << "\\\\";
-            else os << c;
-        }
-        os << "\"";
+        os << ",\"text\":";
+        json_string(os, ev.text);
     }
     os << "}";
 }
@@ -126,6 +162,22 @@ static void cmd_events(og::sim::SimEventLog& events)
 
 } // namespace
 
+#ifdef TESTING
+std::string text_protocol_testing_format_event_text(std::string_view text)
+{
+    og::sim::Event event;
+    event.tick = 7;
+    event.kind = og::sim::EventKind::Notification;
+    event.a = 1;
+    event.b = 2;
+    event.text = text;
+
+    std::ostringstream os;
+    json_event(os, event);
+    return os.str();
+}
+#endif
+
 int run_text_protocol_session(const TextProtocolArgs& args)
 {
     // Set up sim infrastructure
@@ -188,8 +240,9 @@ int run_text_protocol_session(const TextProtocolArgs& args)
     // Output ready message
     std::cout << "{\"status\":\"ready\""
               << ",\"level\":" << args.level
-              << ",\"title\":\"" << level.world().title << "\""
-              << ",\"num_entities\":" << level.world().oblist.size()
+              << ",\"title\":";
+    json_string(std::cout, level.world().title);
+    std::cout << ",\"num_entities\":" << level.world().oblist.size()
               << ",\"seed\":" << args.seed
               << "}\n";
     std::cout.flush();
@@ -219,7 +272,9 @@ int run_text_protocol_session(const TextProtocolArgs& args)
             std::cout.flush();
             break;
         } else {
-            std::cout << "{\"cmd\":\"error\",\"message\":\"unknown command: " << cmd << "\"}\n";
+            std::cout << "{\"cmd\":\"error\",\"message\":";
+            json_string(std::cout, std::string("unknown command: ") + cmd);
+            std::cout << "}\n";
             std::cout.flush();
         }
 

--- a/tests/curses/test_curses_app.cpp
+++ b/tests/curses/test_curses_app.cpp
@@ -1,0 +1,107 @@
+#include <openglad/platform/curses/clock.h>
+#include <openglad/platform/curses/curses_app.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+std::vector<char*> argv_from(std::vector<std::string>& args)
+{
+    std::vector<char*> argv;
+    argv.reserve(args.size());
+    for (std::string& arg : args)
+        argv.push_back(arg.data());
+    return argv;
+}
+} // namespace
+
+TEST(CursesAppOptions, parses_every_supported_option)
+{
+    std::vector<std::string> args{
+        "openglad_curses",
+        "--campaign", "org.openglad.test",
+        "--level", "4",
+        "--save", "slot7",
+        "--seed", "123456",
+        "--difficulty", "2",
+        "--host",
+        "--port", "34567",
+        "--join", "ws://127.0.0.1:34568",
+        "--relay", "http://127.0.0.1:8787",
+        "--no-unicode",
+        "--no-color",
+    };
+    std::vector<char*> argv = argv_from(args);
+
+    og::curses::AppOptions options;
+    bool should_exit = true;
+    ASSERT_TRUE(og::curses::parse_app_options(
+        static_cast<int>(argv.size()), argv.data(), options, &should_exit));
+    ASSERT_FALSE(should_exit);
+    ASSERT_EQ("org.openglad.test", options.campaign);
+    ASSERT_EQ(4, options.level);
+    ASSERT_EQ("slot7", options.save_name);
+    ASSERT_EQ(static_cast<std::uint32_t>(123456), options.seed);
+    ASSERT_EQ(2, options.difficulty);
+    ASSERT_TRUE(options.host);
+    ASSERT_EQ(34567, options.host_port);
+    ASSERT_EQ("ws://127.0.0.1:34568", options.join_url);
+    ASSERT_EQ("http://127.0.0.1:8787", options.relay_url);
+    ASSERT_FALSE(options.allow_unicode);
+    ASSERT_FALSE(options.allow_color);
+}
+
+TEST(CursesAppOptions, reports_help_and_missing_values)
+{
+    {
+        std::vector<std::string> args{"openglad_curses", "--help"};
+        std::vector<char*> argv = argv_from(args);
+        og::curses::AppOptions options;
+        bool should_exit = false;
+        ASSERT_FALSE(og::curses::parse_app_options(
+            static_cast<int>(argv.size()), argv.data(), options, &should_exit));
+        ASSERT_TRUE(should_exit);
+    }
+
+    const std::vector<std::string> missing_value_options{
+        "--campaign", "--level", "--save", "--seed", "--difficulty",
+        "--port", "--join", "--relay",
+    };
+    for (const std::string& option : missing_value_options) {
+        std::vector<std::string> args{"openglad_curses", option};
+        std::vector<char*> argv = argv_from(args);
+        og::curses::AppOptions options;
+        bool should_exit = true;
+        ASSERT_FALSE(og::curses::parse_app_options(
+            static_cast<int>(argv.size()), argv.data(), options, &should_exit))
+            << option;
+        ASSERT_FALSE(should_exit) << option;
+    }
+}
+
+TEST(CursesAppOptions, reports_unknown_option)
+{
+    std::vector<std::string> args{"openglad_curses", "--bogus"};
+    std::vector<char*> argv = argv_from(args);
+
+    og::curses::AppOptions options;
+    bool should_exit = true;
+    ASSERT_FALSE(og::curses::parse_app_options(
+        static_cast<int>(argv.size()), argv.data(), options, &should_exit));
+    ASSERT_FALSE(should_exit);
+}
+
+TEST(CursesClock, now_and_sleep_are_monotonic)
+{
+    og::curses::SteadyClock clock;
+    const std::uint64_t before = clock.now_ms();
+    clock.sleep_ms(1);
+    const std::uint64_t after = clock.now_ms();
+    ASSERT_GE(after, before);
+}

--- a/tests/curses/test_curses_network.cpp
+++ b/tests/curses/test_curses_network.cpp
@@ -202,7 +202,9 @@ TEST(CursesNetwork, host_lobby_builds_over_inprocess_transport)
 
 TEST(CursesNetwork, internal_helpers_cover_message_and_session_paths)
 {
-    EXPECT_GE(curses_network_testing_exercise_internal_helpers(), 10);
+    constexpr int kExpectedInternalHelperChecks = 11;
+    EXPECT_EQ(kExpectedInternalHelperChecks,
+              curses_network_testing_exercise_internal_helpers());
 }
 
 TEST(CursesNetwork, roster_reflects_two_players)

--- a/tests/curses/test_curses_network.cpp
+++ b/tests/curses/test_curses_network.cpp
@@ -34,6 +34,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -51,6 +52,7 @@ std::unique_ptr<CursesLobby> make_join_lobby_over_transport_for_testing(
     SaveData& save, int difficulty,
     std::shared_ptr<og::sim::ITransport> transport,
     og::sim::PeerId server_peer_id);
+int curses_network_testing_exercise_internal_helpers();
 } // namespace og::curses
 
 namespace {
@@ -165,6 +167,15 @@ void advance_all(CursesGameSession& host, CursesGameSession& join, int frames)
     }
 }
 
+bool status_contains(const CursesLobby& lobby, std::string_view needle)
+{
+    for (const std::string& line : lobby.status_lines()) {
+        if (line.find(needle) != std::string::npos)
+            return true;
+    }
+    return false;
+}
+
 } // namespace
 
 TEST(CursesNetwork, host_lobby_builds_over_inprocess_transport)
@@ -187,6 +198,11 @@ TEST(CursesNetwork, host_lobby_builds_over_inprocess_transport)
     const std::vector<std::string> lines = lobby->status_lines();
     ASSERT_FALSE(lines.empty());
     EXPECT_GT(term.present_count(), 0) << "poll() renders the lobby";
+}
+
+TEST(CursesNetwork, internal_helpers_cover_message_and_session_paths)
+{
+    EXPECT_GE(curses_network_testing_exercise_internal_helpers(), 10);
 }
 
 TEST(CursesNetwork, roster_reflects_two_players)
@@ -270,6 +286,91 @@ TEST(CursesNetwork, esc_key_cancels_lobby)
     FakeClock clock;
     term.push_special(KeyCode::Escape);
     EXPECT_FALSE(lobby->poll(term, clock)) << "Esc cancels and returns false";
+}
+
+TEST(CursesNetwork, run_curses_lobby_returns_default_result_when_cancelled)
+{
+    SaveData save;
+    init_team_save(save, 0, FAMILY_SOLDIER, "Host");
+
+    auto server = og::sim::InProcessTransport::create_server();
+    server->accept_connections();
+    auto host_client = server->create_client_transport();
+
+    auto lobby = make_host_lobby_over_transport_for_testing(save, 1, server, host_client);
+    ASSERT_NE(lobby, nullptr);
+
+    HeadlessTerminal term(24, 80);
+    FakeClock clock;
+    term.push_char(U'q');
+    const GameRunResult result = run_curses_lobby(*lobby, term, clock);
+    EXPECT_FALSE(result.ended);
+    EXPECT_FALSE(result.withdrew);
+    EXPECT_FALSE(result.quit_app);
+    EXPECT_TRUE(lobby->cancelled());
+}
+
+TEST(CursesNetwork, key_releases_do_not_start_or_cancel_lobby)
+{
+    SaveData save;
+    init_team_save(save, 0, FAMILY_SOLDIER, "Host");
+
+    auto server = og::sim::InProcessTransport::create_server();
+    server->accept_connections();
+    auto host_client = server->create_client_transport();
+
+    auto lobby = make_host_lobby_over_transport_for_testing(save, 1, server, host_client);
+    ASSERT_NE(lobby, nullptr);
+
+    HeadlessTerminal term(24, 80);
+    FakeClock clock;
+    term.push_char_release(U's');
+    term.push_char_release(U'q');
+    term.push_special_release(KeyCode::Enter);
+    EXPECT_FALSE(lobby->poll(term, clock));
+    EXPECT_FALSE(lobby->cancelled());
+    EXPECT_EQ(lobby->take_session(), nullptr);
+}
+
+TEST(CursesNetwork, joiner_start_request_is_noop)
+{
+    SaveData host_save;
+    SaveData join_save;
+    init_team_save(host_save, 0, FAMILY_SOLDIER, "Host");
+    init_team_save(join_save, 1, FAMILY_ELF, "Joiner");
+
+    auto server = og::sim::InProcessTransport::create_server();
+    server->accept_connections();
+    auto host_client = server->create_client_transport();
+    auto join_client = server->create_client_transport();
+
+    auto host_lobby = make_host_lobby_over_transport_for_testing(
+        host_save, 1, server, host_client);
+    auto join_lobby = make_join_lobby_over_transport_for_testing(
+        join_save, 1, join_client, join_client->local_peer_id());
+
+    ASSERT_TRUE(host_lobby->is_host());
+    ASSERT_FALSE(join_lobby->is_host());
+
+    HeadlessTerminal host_term(24, 80);
+    HeadlessTerminal join_term(24, 80);
+    FakeClock clock;
+    for (int i = 0; i < 100; ++i) {
+        host_lobby->poll(host_term, clock);
+        join_lobby->poll(join_term, clock);
+    }
+
+    join_lobby->request_start();
+    bool host_started = false;
+    bool join_started = false;
+    for (int i = 0; i < 50; ++i) {
+        host_started = host_lobby->poll(host_term, clock) || host_started;
+        join_started = join_lobby->poll(join_term, clock) || join_started;
+    }
+    EXPECT_FALSE(host_started);
+    EXPECT_FALSE(join_started);
+    EXPECT_EQ(host_lobby->take_session(), nullptr);
+    EXPECT_EQ(join_lobby->take_session(), nullptr);
 }
 
 TEST(CursesNetwork, host_and_join_sessions_start_and_converge)
@@ -455,4 +556,79 @@ TEST(CursesNetwork, host_start_via_s_key)
             saw_you_marker = true;
     }
     EXPECT_TRUE(saw_you_marker) << "the host roster should flag the local player";
+}
+
+TEST(CursesNetwork, host_start_via_uppercase_s_and_enter)
+{
+    for (const Key key : {Key::character(U'S'), Key::special(KeyCode::Enter)}) {
+        SaveData host_save;
+        SaveData join_save;
+        init_team_save(host_save, 0, FAMILY_SOLDIER, "Host");
+        init_team_save(join_save, 1, FAMILY_ELF, "Joiner");
+
+        auto server = og::sim::InProcessTransport::create_server();
+        server->accept_connections();
+        auto host_client = server->create_client_transport();
+        auto join_client = server->create_client_transport();
+
+        auto host_lobby = make_host_lobby_over_transport_for_testing(
+            host_save, 1, server, host_client);
+        auto join_lobby = make_join_lobby_over_transport_for_testing(
+            join_save, 1, join_client, join_client->local_peer_id());
+
+        HeadlessTerminal host_term(24, 80);
+        HeadlessTerminal join_term(24, 80);
+        FakeClock clock;
+
+        for (int i = 0; i < 200; ++i) {
+            host_lobby->poll(host_term, clock);
+            join_lobby->poll(join_term, clock);
+        }
+
+        host_term.push_key(key);
+        bool host_started = false;
+        bool join_started = false;
+        for (int i = 0; i < 200 && !(host_started && join_started); ++i) {
+            host_started = host_lobby->poll(host_term, clock) || host_started;
+            join_started = join_lobby->poll(join_term, clock) || join_started;
+        }
+        EXPECT_TRUE(host_started);
+        EXPECT_TRUE(join_started);
+    }
+}
+
+TEST(CursesNetwork, host_lobby_status_uses_default_campaign_and_team_fallback)
+{
+    SaveData save;
+    init_team_save(save, 2, FAMILY_ELF, "Fallback");
+    save.current_campaign.clear();
+    save.my_team = MAX_PLAYERS;
+
+    auto server = og::sim::InProcessTransport::create_server();
+    server->accept_connections();
+    auto host_client = server->create_client_transport();
+
+    auto lobby = make_host_lobby_over_transport_for_testing(save, 1, server, host_client);
+    ASSERT_NE(lobby, nullptr);
+
+    HeadlessTerminal term(24, 80);
+    FakeClock clock;
+    lobby->poll(term, clock);
+
+    EXPECT_TRUE(status_contains(*lobby, "Campaign: org.openglad.gladiator"));
+    EXPECT_TRUE(status_contains(*lobby, "team 2"));
+    EXPECT_TRUE(status_contains(*lobby, "[host]"));
+}
+
+TEST(CursesNetwork, malformed_join_url_reports_error)
+{
+    SaveData save;
+    init_team_save(save, 0, FAMILY_SOLDIER, "Joiner");
+
+    JoinOptions options;
+    options.url = "";
+    std::string error;
+    std::unique_ptr<CursesLobby> lobby = make_join_lobby(save, options, &error);
+    EXPECT_EQ(lobby, nullptr);
+    EXPECT_FALSE(error.empty());
 }

--- a/tests/curses/test_curses_network.cpp
+++ b/tests/curses/test_curses_network.cpp
@@ -202,8 +202,7 @@ TEST(CursesNetwork, host_lobby_builds_over_inprocess_transport)
 
 TEST(CursesNetwork, internal_helpers_cover_message_and_session_paths)
 {
-    constexpr int kExpectedInternalHelperChecks = 11;
-    EXPECT_EQ(kExpectedInternalHelperChecks,
+    EXPECT_EQ(0,
               curses_network_testing_exercise_internal_helpers());
 }
 

--- a/tests/curses/test_curses_picker_client.cpp
+++ b/tests/curses/test_curses_picker_client.cpp
@@ -31,6 +31,7 @@
 #include <openglad/interface/ui/picker_common.h>
 #include <openglad/resources/save_data.h>
 
+#include <memory>
 #include <string>
 
 using namespace og::curses;
@@ -156,6 +157,32 @@ TEST(CursesPickerClient, present_menu_digit_and_arrow_navigation)
     EXPECT_EQ(second->command, PickerMenuCommand::ContinueGame);
 }
 
+TEST(CursesPickerClient, present_menu_ignores_releases_and_accepts_space)
+{
+    PickerFixture f;
+    f.t().push_char_release(U'x');
+    f.t().push_char(U' ');
+    const auto* item = f.client.present_menu(PickerMenuId::Main);
+    ASSERT_NE(item, nullptr);
+    EXPECT_EQ(item->command, PickerMenuCommand::BeginNewGame);
+}
+
+TEST(CursesPickerClient, present_menu_team_build_repopulates_empty_config)
+{
+    PickerFixture f;
+    f.config.team_families.clear();
+    f.save().team_size = 0;
+    for (auto& slot : f.save().team_list)
+        slot.reset();
+
+    f.t().push_char(U'q');
+    const auto* item = f.client.present_menu(PickerMenuId::TeamBuild);
+    ASSERT_NE(item, nullptr);
+    EXPECT_EQ(item->command, PickerMenuCommand::Back);
+    EXPECT_FALSE(f.config.team_families.empty());
+    EXPECT_GE(team_count(f.save()), 1);
+}
+
 // --- new game ------------------------------------------------------------
 
 // prepare_new_game resets the team to a fresh single member and restores gold.
@@ -230,6 +257,18 @@ TEST(CursesPickerClient, allied_mode_toggles)
     EXPECT_NE(og::ui::is_allied_mode(f.save()), before);
 }
 
+TEST(CursesPickerClient, level_edit_notice_renders)
+{
+    PickerFixture f;
+    const auto* item = og::ui::find_picker_menu_item(
+        PickerMenuId::Main, PickerMenuCommand::LevelEdit);
+    ASSERT_NE(item, nullptr);
+
+    dismiss(f.t());
+    f.client.handle_menu_item(PickerMenuId::Main, *item);
+    EXPECT_NE(f.t().dump().find("openscen"), std::string::npos);
+}
+
 // --- view roster ---------------------------------------------------------
 
 // Viewing the roster renders each member's name to the terminal.
@@ -298,6 +337,43 @@ TEST(CursesPickerClient, hire_cancel_is_noop)
     EXPECT_EQ(f.save().m_totalcash[0], before_gold);
 }
 
+TEST(CursesPickerClient, hire_full_team_reports_and_returns)
+{
+    PickerFixture f;
+    f.save().m_totalcash[0] = 50000u;
+    for (auto& slot : f.save().team_list)
+        slot.reset();
+    f.save().team_size = 0;
+    for (int i = 0; i < MAX_TEAM_SIZE; ++i) {
+        f.save().team_list[static_cast<size_t>(i)] = std::make_unique<guy>(FAMILY_SOLDIER);
+        f.save().team_list[static_cast<size_t>(i)]->teamnum = 0;
+        f.save().team_size++;
+    }
+
+    const auto* item =
+        og::ui::find_picker_menu_item(PickerMenuId::TeamBuild, PickerMenuCommand::HireTroops);
+    ASSERT_NE(item, nullptr);
+    dismiss(f.t());
+    f.client.handle_menu_item(PickerMenuId::TeamBuild, *item);
+    EXPECT_NE(f.t().dump().find("max size"), std::string::npos);
+}
+
+TEST(CursesPickerClient, hire_navigation_next_prev_and_back)
+{
+    PickerFixture f;
+    const int before_count = team_count(f.save());
+
+    const auto* item =
+        og::ui::find_picker_menu_item(PickerMenuId::TeamBuild, PickerMenuCommand::HireTroops);
+    ASSERT_NE(item, nullptr);
+    pick(f.t(), 1); // Next family
+    pick(f.t(), 2); // Previous family
+    pick(f.t(), 3); // Back
+    f.client.handle_menu_item(PickerMenuId::TeamBuild, *item);
+
+    EXPECT_EQ(team_count(f.save()), before_count);
+}
+
 // --- train ---------------------------------------------------------------
 
 // Training raises a stat and charges gold on accept.
@@ -328,6 +404,44 @@ TEST(CursesPickerClient, train_raises_stat_at_a_cost)
         << "accepting training should charge gold";
 }
 
+TEST(CursesPickerClient, train_empty_team_reports_and_returns)
+{
+    PickerFixture f;
+    f.save().team_size = 0;
+    for (auto& slot : f.save().team_list)
+        slot.reset();
+
+    const auto* item =
+        og::ui::find_picker_menu_item(PickerMenuId::TeamBuild, PickerMenuCommand::TrainTeam);
+    ASSERT_NE(item, nullptr);
+    dismiss(f.t());
+    f.client.handle_menu_item(PickerMenuId::TeamBuild, *item);
+
+    EXPECT_NE(f.t().dump().find("No team members"), std::string::npos);
+}
+
+TEST(CursesPickerClient, train_navigation_next_prev_and_back)
+{
+    PickerFixture f;
+    {
+        og::ui::HireSession session(f.save(), 0);
+        ASSERT_GE(session.hire(), 0);
+    }
+    const short member0_before = f.save().team_list[0]->strength;
+    const short member1_before = f.save().team_list[1]->strength;
+
+    const auto* item =
+        og::ui::find_picker_menu_item(PickerMenuId::TeamBuild, PickerMenuCommand::TrainTeam);
+    ASSERT_NE(item, nullptr);
+    pick(f.t(), 7); // Next member
+    pick(f.t(), 8); // Previous member
+    f.t().push_char(U'q'); // Back
+    f.client.handle_menu_item(PickerMenuId::TeamBuild, *item);
+
+    EXPECT_EQ(f.save().team_list[0]->strength, member0_before);
+    EXPECT_EQ(f.save().team_list[1]->strength, member1_before);
+}
+
 // --- set level -----------------------------------------------------------
 
 // Set Level updates both the config and the save's scenario number.
@@ -346,6 +460,23 @@ TEST(CursesPickerClient, set_level_updates_config_and_save)
 
     EXPECT_EQ(f.config.level, 4);
     EXPECT_EQ(static_cast<int>(f.save().scen_num), 4);
+}
+
+TEST(CursesPickerClient, set_level_rejects_invalid_value)
+{
+    PickerFixture f;
+    const auto* item =
+        og::ui::find_picker_menu_item(PickerMenuId::TeamBuild, PickerMenuCommand::SetLevel);
+    ASSERT_NE(item, nullptr);
+
+    f.t().push_special(KeyCode::Backspace); // erase the prefilled "1"
+    f.t().push_char(U'0');
+    f.t().push_special(KeyCode::Enter);
+    dismiss(f.t());
+    f.client.handle_menu_item(PickerMenuId::TeamBuild, *item);
+
+    EXPECT_EQ(f.config.level, 1);
+    EXPECT_NE(f.t().dump().find("Invalid level"), std::string::npos);
 }
 
 // --- campaign select -----------------------------------------------------
@@ -411,6 +542,41 @@ TEST(CursesPickerClient, save_then_load_round_trips_team)
     EXPECT_EQ(config.level, 3) << "level should restore from the save's scen_num";
 }
 
+TEST(CursesPickerClient, team_build_dispatches_save_load_progress_network_and_campaign)
+{
+    PickerFixture f;
+    f.config.save_name = "curses_dispatch_slot";
+
+    const auto* save_item =
+        og::ui::find_picker_menu_item(PickerMenuId::TeamBuild, PickerMenuCommand::SaveTeam);
+    const auto* load_item =
+        og::ui::find_picker_menu_item(PickerMenuId::TeamBuild, PickerMenuCommand::LoadTeam);
+    const auto* progress_item =
+        og::ui::find_picker_menu_item(PickerMenuId::TeamBuild, PickerMenuCommand::ShowProgress);
+    const auto* network_item =
+        og::ui::find_picker_menu_item(PickerMenuId::TeamBuild, PickerMenuCommand::Networking);
+    const auto* campaign_item =
+        og::ui::find_picker_menu_item(PickerMenuId::TeamBuild, PickerMenuCommand::SetCampaign);
+    ASSERT_NE(save_item, nullptr);
+    ASSERT_NE(load_item, nullptr);
+    ASSERT_NE(progress_item, nullptr);
+    ASSERT_NE(network_item, nullptr);
+    ASSERT_NE(campaign_item, nullptr);
+
+    dismiss(f.t());
+    f.client.handle_menu_item(PickerMenuId::TeamBuild, *save_item);
+    dismiss(f.t());
+    f.client.handle_menu_item(PickerMenuId::TeamBuild, *load_item);
+    dismiss(f.t());
+    f.client.handle_menu_item(PickerMenuId::TeamBuild, *progress_item);
+    pick(f.t(), 2);
+    f.client.handle_menu_item(PickerMenuId::TeamBuild, *network_item);
+    f.t().push_special(KeyCode::Escape);
+    f.client.handle_menu_item(PickerMenuId::TeamBuild, *campaign_item);
+
+    EXPECT_EQ(f.save().current_campaign, f.config.campaign);
+}
+
 // Loading a non-existent slot fails gracefully and returns false.
 TEST(CursesPickerClient, load_missing_slot_fails_gracefully)
 {
@@ -466,6 +632,25 @@ TEST(CursesPickerClient, options_cancel_keeps_config)
 
     EXPECT_EQ(f.config.save_name, "keep_me");
     EXPECT_EQ(f.config.seed, 99u);
+}
+
+TEST(CursesPickerClient, options_invalid_seed_keeps_current)
+{
+    PickerFixture f;
+    f.config.save_name = "slot";
+    f.config.seed = 44;
+
+    f.t().push_special(KeyCode::Enter); // accept slot unchanged
+    for (int i = 0; i < 2; ++i)
+        f.t().push_special(KeyCode::Backspace);
+    f.t().push_string("bad");
+    f.t().push_special(KeyCode::Enter);
+    dismiss(f.t());
+    f.client.show_options();
+
+    EXPECT_EQ(f.config.save_name, "slot");
+    EXPECT_EQ(f.config.seed, 44u);
+    EXPECT_NE(f.t().dump().find("Invalid seed"), std::string::npos);
 }
 
 // --- help ----------------------------------------------------------------

--- a/tests/curses/test_headless_terminal.cpp
+++ b/tests/curses/test_headless_terminal.cpp
@@ -81,3 +81,27 @@ TEST(HeadlessTerminal, find_and_count_char)
     EXPECT_EQ(term.count_char(U'*'), 2);
     EXPECT_EQ(term.find_char(U'*'), std::make_pair(0, 0));
 }
+
+TEST(HeadlessTerminal, resize_dump_and_beep_cover_remaining_helpers)
+{
+    HeadlessTerminal term(0, -5);
+    EXPECT_EQ(term.rows(), 1);
+    EXPECT_EQ(term.cols(), 1);
+
+    term.resize(3, 4);
+    EXPECT_EQ(term.rows(), 3);
+    EXPECT_EQ(term.cols(), 4);
+    EXPECT_EQ(term.dump(), "    \n    \n    \n");
+
+    term.put_str(1, 1, "ab", Color::Green, Color::Default, false);
+    EXPECT_EQ(term.dump(), "    \n ab \n    \n");
+    term.beep();
+    term.beep();
+    EXPECT_EQ(term.beep_count(), 2);
+
+    term.set_unicode(false);
+    term.set_color(false);
+    EXPECT_FALSE(term.supports_unicode());
+    EXPECT_FALSE(term.supports_color());
+    EXPECT_EQ(term.presented_char_at(99, 99), 0);
+}

--- a/tests/curses/test_kitty_keys.cpp
+++ b/tests/curses/test_kitty_keys.cpp
@@ -294,7 +294,6 @@ TEST(KittyKeys, response_indicates_support_partial_not_done)
 
 TEST(CursesTerminalInternals, pure_helpers_cover_color_write_and_capability_probe)
 {
-    constexpr int kExpectedInternalHelperChecks = 19;
-    EXPECT_EQ(kExpectedInternalHelperChecks,
+    EXPECT_EQ(0,
               curses_terminal_testing_exercise_internal_helpers());
 }

--- a/tests/curses/test_kitty_keys.cpp
+++ b/tests/curses/test_kitty_keys.cpp
@@ -294,5 +294,7 @@ TEST(KittyKeys, response_indicates_support_partial_not_done)
 
 TEST(CursesTerminalInternals, pure_helpers_cover_color_write_and_capability_probe)
 {
-    EXPECT_GE(curses_terminal_testing_exercise_internal_helpers(), 13);
+    constexpr int kExpectedInternalHelperChecks = 19;
+    EXPECT_EQ(kExpectedInternalHelperChecks,
+              curses_terminal_testing_exercise_internal_helpers());
 }

--- a/tests/curses/test_kitty_keys.cpp
+++ b/tests/curses/test_kitty_keys.cpp
@@ -14,6 +14,10 @@
 using namespace og::curses;
 using og::curses::kitty::Decoder;
 
+namespace og::curses {
+int curses_terminal_testing_exercise_internal_helpers();
+}
+
 namespace {
 
 // Decode exactly one key from a byte string.
@@ -97,9 +101,11 @@ TEST(KittyKeys, standalone_modifier_keys)
     EXPECT_EQ(decode1("\x1b[57441u").code, KeyCode::LeftShift);
     EXPECT_EQ(decode1("\x1b[57442u").code, KeyCode::LeftCtrl);
     EXPECT_EQ(decode1("\x1b[57443u").code, KeyCode::LeftAlt);
+    EXPECT_EQ(decode1("\x1b[57444u").code, KeyCode::LeftSuper);
     EXPECT_EQ(decode1("\x1b[57447u").code, KeyCode::RightShift);
     EXPECT_EQ(decode1("\x1b[57448u").code, KeyCode::RightCtrl);
     EXPECT_EQ(decode1("\x1b[57449u").code, KeyCode::RightAlt);
+    EXPECT_EQ(decode1("\x1b[57450u").code, KeyCode::RightSuper);
 
     // And they carry press/release, so the engine can track them held.
     EXPECT_EQ(decode1("\x1b[57442u").event, KeyEvent::Press);
@@ -121,18 +127,33 @@ TEST(KittyKeys, arrow_keys_letter_form)
 
 TEST(KittyKeys, tilde_and_ss3_functional_keys)
 {
+    EXPECT_EQ(decode1("\x1b[1~").code, KeyCode::Home);
     EXPECT_EQ(decode1("\x1b[2~").code, KeyCode::Insert);
     EXPECT_EQ(decode1("\x1b[3~").code, KeyCode::Delete);
+    EXPECT_EQ(decode1("\x1b[4~").code, KeyCode::End);
     EXPECT_EQ(decode1("\x1b[5~").code, KeyCode::PageUp);
     EXPECT_EQ(decode1("\x1b[6~").code, KeyCode::PageDown);
+    EXPECT_EQ(decode1("\x1b[7~").code, KeyCode::Home);
+    EXPECT_EQ(decode1("\x1b[8~").code, KeyCode::End);
     EXPECT_EQ(decode1("\x1b[15~").code, KeyCode::F5);
     EXPECT_EQ(decode1("\x1b[17~").code, KeyCode::F6);
+    EXPECT_EQ(decode1("\x1b[18~").code, KeyCode::F7);
+    EXPECT_EQ(decode1("\x1b[19~").code, KeyCode::F8);
+    EXPECT_EQ(decode1("\x1b[20~").code, KeyCode::F9);
+    EXPECT_EQ(decode1("\x1b[21~").code, KeyCode::F10);
+    EXPECT_EQ(decode1("\x1b[23~").code, KeyCode::F11);
     EXPECT_EQ(decode1("\x1b[24~").code, KeyCode::F12);
     // SS3 form for F1..F4.
     EXPECT_EQ(decode1("\x1bOP").code, KeyCode::F1);
+    EXPECT_EQ(decode1("\x1bOQ").code, KeyCode::F2);
+    EXPECT_EQ(decode1("\x1bOR").code, KeyCode::F3);
     EXPECT_EQ(decode1("\x1bOS").code, KeyCode::F4);
     // CSI letter form for F1..F4.
     EXPECT_EQ(decode1("\x1b[1;2P").code, KeyCode::F1);
+    EXPECT_EQ(decode1("\x1b[1;2Q").code, KeyCode::F2);
+    EXPECT_EQ(decode1("\x1b[1;2S").code, KeyCode::F4);
+    EXPECT_EQ(decode1("\x1b[1;2H").code, KeyCode::Home);
+    EXPECT_EQ(decode1("\x1b[1;2F").code, KeyCode::End);
 }
 
 TEST(KittyKeys, focus_events)
@@ -183,6 +204,70 @@ TEST(KittyKeys, raw_byte_fallback_decodes_as_char)
     EXPECT_EQ(k.event, KeyEvent::Press);
 }
 
+TEST(KittyKeys, raw_utf8_fallback_decodes_multibyte_and_control_keys)
+{
+    EXPECT_EQ(decode1("\xc3\xa9").ch, static_cast<char32_t>(0x00e9));
+    EXPECT_EQ(decode1("\xe2\x82\xac").ch, static_cast<char32_t>(0x20ac));
+    EXPECT_EQ(decode1("\xf0\x9f\x98\x80").ch, static_cast<char32_t>(0x1f600));
+    EXPECT_EQ(decode1("\r").code, KeyCode::Enter);
+    EXPECT_EQ(decode1("\n").code, KeyCode::Enter);
+    EXPECT_EQ(decode1("\t").code, KeyCode::Tab);
+    EXPECT_EQ(decode1("\b").code, KeyCode::Backspace);
+    EXPECT_EQ(decode1("\x7f").code, KeyCode::Backspace);
+}
+
+TEST(KittyKeys, malformed_or_unknown_sequences_are_skipped_and_resync)
+{
+    Decoder d;
+    Key k;
+
+    d.feed("\x1b[1114112u\x1b[97u"); // invalid Unicode codepoint, then 'a'
+    ASSERT_TRUE(d.next(k));
+    EXPECT_EQ(k.ch, U'a');
+    EXPECT_FALSE(d.next(k));
+
+    d.clear();
+    d.feed("\x1b[99~\x1b[98u"); // unknown tilde code, then 'b'
+    ASSERT_TRUE(d.next(k));
+    EXPECT_EQ(k.ch, U'b');
+
+    d.clear();
+    d.feed("\x1b[1;2Z\x1b[99u"); // unknown CSI final, then 'c'
+    ASSERT_TRUE(d.next(k));
+    EXPECT_EQ(k.ch, U'c');
+
+    d.clear();
+    d.feed("\x1bOT\x1b[100u"); // unknown SS3 final, then 'd'
+    ASSERT_TRUE(d.next(k));
+    EXPECT_EQ(k.ch, U'd');
+
+    d.clear();
+    d.feed("\xff" "e"); // invalid UTF-8 lead byte, then raw 'e'
+    ASSERT_TRUE(d.next(k));
+    EXPECT_EQ(k.ch, U'e');
+
+    d.clear();
+    d.feed("\xc3x" "f"); // malformed UTF-8 continuation, then raw 'x'
+    ASSERT_TRUE(d.next(k));
+    EXPECT_EQ(k.ch, U'x');
+    ASSERT_TRUE(d.next(k));
+    EXPECT_EQ(k.ch, U'f');
+
+    d.clear();
+    d.feed("\xe2\x82"); // incomplete UTF-8 stays buffered
+    EXPECT_FALSE(d.next(k));
+    d.feed("\xac");
+    ASSERT_TRUE(d.next(k));
+    EXPECT_EQ(k.ch, static_cast<char32_t>(0x20ac));
+
+    d.clear();
+    d.feed("\x1b[?"); // incomplete private CSI response stays buffered
+    EXPECT_FALSE(d.next(k));
+    d.feed("11u\x1b[103u");
+    ASSERT_TRUE(d.next(k));
+    EXPECT_EQ(k.ch, U'g');
+}
+
 TEST(KittyKeys, response_indicates_support_detects_kitty_reply)
 {
     bool done = false;
@@ -205,4 +290,9 @@ TEST(KittyKeys, response_indicates_support_partial_not_done)
     // The kitty reply arrived but the DA reply has not yet -> supported, not done.
     EXPECT_TRUE(kitty::response_indicates_support("\x1b[?0u", done));
     EXPECT_FALSE(done);
+}
+
+TEST(CursesTerminalInternals, pure_helpers_cover_color_write_and_capability_probe)
+{
+    EXPECT_GE(curses_terminal_testing_exercise_internal_helpers(), 13);
 }

--- a/tests/test_campaign_and_level_picker.cpp
+++ b/tests/test_campaign_and_level_picker.cpp
@@ -60,6 +60,14 @@ static int hold_q_key_for_picker(void* data)
     return 0;
 }
 
+static void repeated_click(int x, int y, int attempts = 8)
+{
+    for (int i = 0; i < attempts; ++i) {
+        inject_click(x, y, 100);
+        SDL_Delay(150);
+    }
+}
+
 struct ViewportGuard
 {
     float ow, oh, ovw, ovh, ox, oy;
@@ -87,12 +95,8 @@ static int picker_choose_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
-    SDL_Delay(120);
-    inject_click(211, 40, 20); // NEXT
-    SDL_Delay(120);
-    inject_click(109, 40, 20); // PREV
-    SDL_Delay(120);
-    inject_click(195, 190, 20); // OK
+    SDL_Delay(500);
+    repeated_click(195, 190); // OK
     return 0;
 }
 
@@ -100,8 +104,8 @@ static int picker_cancel_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
-    SDL_Delay(120);
-    inject_click(121, 190, 20); // CANCEL
+    SDL_Delay(500);
+    repeated_click(121, 190); // CANCEL
     return 0;
 }
 
@@ -109,10 +113,9 @@ static int campaign_delete_then_cancel_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
-    SDL_Delay(120);
-    inject_click(280, 15, 20);  // DELETE
-    SDL_Delay(120);
-    inject_click(121, 190, 20); // CANCEL
+    SDL_Delay(500);
+    repeated_click(280, 15, 4);  // DELETE
+    repeated_click(121, 190, 8); // CANCEL
     return 0;
 }
 
@@ -120,10 +123,9 @@ static int campaign_reset_then_cancel_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
-    SDL_Delay(120);
-    inject_click(280, 15, 20);  // RESET (same location as delete)
-    SDL_Delay(120);
-    inject_click(121, 190, 20); // CANCEL
+    SDL_Delay(500);
+    repeated_click(280, 15, 4);  // RESET
+    repeated_click(121, 190, 8); // CANCEL
     return 0;
 }
 
@@ -131,12 +133,13 @@ static int level_picker_choose_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
-    SDL_Delay(140);
-    inject_click(175, 150, 20); // NEXT
-    SDL_Delay(140);
-    inject_click(24, 23, 20);   // Select entry 1
-    SDL_Delay(140);
-    inject_click(280, 175, 20); // OK
+    SDL_Delay(500);
+    for (int i = 0; i < 8; ++i) {
+        inject_click(24, 23, 100);   // Select entry 1
+        SDL_Delay(150);
+        inject_click(280, 175, 100); // OK
+        SDL_Delay(150);
+    }
     return 0;
 }
 
@@ -144,12 +147,14 @@ static int level_picker_delete_then_cancel_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
-    SDL_Delay(140);
-    inject_click(24, 23, 20);   // Select entry 1
-    SDL_Delay(140);
-    inject_click(280, 15, 20);  // DELETE
-    SDL_Delay(140);
-    inject_click(239, 175, 20); // CANCEL
+    SDL_Delay(500);
+    for (int i = 0; i < 4; ++i) {
+        inject_click(24, 23, 100);  // Select entry 1
+        SDL_Delay(150);
+        inject_click(280, 15, 100); // DELETE
+        SDL_Delay(150);
+    }
+    repeated_click(239, 175, 8); // CANCEL
     return 0;
 }
 
@@ -385,4 +390,3 @@ TEST(CampaignAndLevelPicker, level_picker_choose_and_delete_prompt_paths)
 
     og::runtime::current_session->myscreen_->world().end = old_end;
 }
-

--- a/tests/test_external_libzip.cpp
+++ b/tests/test_external_libzip.cpp
@@ -262,8 +262,8 @@ TEST(ExternalLibzip, extra_field_api_paths)
     ASSERT_EQ(4, (int)got_len2) << "inserted extra field length should match";
 
     ASSERT_TRUE(zip_file_extra_field_delete_by_id(za, (zip_uint64_t)idx, 0xCAFE, 0, ZIP_FL_LOCAL) == 0) << "zip_file_extra_field_delete_by_id local";
-    // This may no-op if already gone in this location, but should not fail hard.
-    (void)zip_file_extra_field_delete(za, (zip_uint64_t)idx, 0, ZIP_FL_CENTRAL);
+    ASSERT_EQ(0, zip_file_extra_field_delete(za, (zip_uint64_t)idx, 0, ZIP_FL_CENTRAL))
+        << "central extra-field delete should succeed after local delete";
 
     ASSERT_TRUE(zip_close(za) == 0) << "zip_close";
 

--- a/tests/test_external_physfs_api_edges.cpp
+++ b/tests/test_external_physfs_api_edges.cpp
@@ -175,8 +175,8 @@ static void run_physfs_global_api_and_reinit_edges()
     ASSERT_TRUE(mp != nullptr) << "getMountPoint should find mounted dir";
     ASSERT_TRUE(PHYSFS_unmount(base_dir.string().c_str())) << "unmount dir should succeed";
 
-    // Exercise setSaneConfig path (may fail depending environment; still valuable for coverage).
-    (void)PHYSFS_setSaneConfig("openglad", "edgecfg", nullptr, 0, 0);
+    ASSERT_EQ(1, PHYSFS_setSaneConfig("openglad", "edgecfg", nullptr, 0, 0))
+        << "setSaneConfig should create/use the test config path";
 
     ASSERT_TRUE(PHYSFS_deinit()) << "PHYSFS_deinit should succeed";
     ASSERT_TRUE(!PHYSFS_isInit()) << "PHYSFS should report deinitialized state";

--- a/tests/test_external_yaml.cpp
+++ b/tests/test_external_yaml.cpp
@@ -226,7 +226,10 @@ TEST(ExternalYaml, parse_scalars_sequences_mappings)
     for (const auto& doc : corpus) {
         int n = 0;
         ASSERT_TRUE(parse_yaml_events(doc, &n)) << "parser corpus document should succeed";
-        ASSERT_TRUE(n > 0 || doc.empty()) << "parser corpus should produce events for non-empty docs";
+        if (doc.empty())
+            ASSERT_EQ(2, n) << "empty YAML stream should emit stream start/end events";
+        else
+            ASSERT_GT(n, 0) << "non-empty YAML document should produce parser events";
     }
 }
 
@@ -251,15 +254,20 @@ TEST(ExternalYaml, parse_error_path)
 
     const std::vector<std::string> bad = {
         "a:\n\t- tab-indented\n",                // illegal tab indentation
-        "x: &A 1\nx2: *B\n",                     // unknown alias
         "---\n[1, 2, 3\n",                       // broken flow sequence
         "map: {a: 1, b: [2, 3}\n",               // mismatched delimiters
         "%YAML 9.9\n---\na: 1\n"                 // invalid version directive
     };
     for (const auto& doc : bad) {
         int n = 0;
-        (void)parse_yaml_events(doc, &n);
+        ASSERT_FALSE(parse_yaml_events(doc, &n)) << "invalid YAML should fail: " << doc;
+        ASSERT_GT(n, 0) << "parser should reach an error after emitting at least one event";
     }
+
+    int alias_events = 0;
+    ASSERT_TRUE(parse_yaml_events("x: &A 1\nx2: *B\n", &alias_events))
+        << "event parser accepts unresolved aliases at this layer";
+    ASSERT_GT(alias_events, 0) << "accepted alias stream should still emit events";
 }
 
 
@@ -274,4 +282,3 @@ TEST(ExternalYaml, emit_and_reparse)
     ASSERT_TRUE(parse_yaml_events(out, &events)) << "re-parse emitted yaml should succeed";
     ASSERT_TRUE(events > 0) << "re-parse should produce events";
 }
-

--- a/tests/test_external_zlib_api_edges.cpp
+++ b/tests/test_external_zlib_api_edges.cpp
@@ -105,7 +105,7 @@ TEST(ExternalZlibApiEdges, external_zlib_inflate_header_copy_prime_and_invalid_i
     ASSERT_TRUE(rc == Z_STREAM_END) << "inflate should finish gzip stream";
     ASSERT_TRUE(out == payload) << "inflated payload should match";
     const int sync_point = inflateSyncPoint(&is);
-    ASSERT_TRUE(sync_point == 0 || sync_point == 1) << "inflateSyncPoint should return boolean-like result";
+    ASSERT_EQ(0, sync_point) << "finished gzip stream should not report an active sync point";
     ASSERT_TRUE(inflateEnd(&is) == Z_OK) << "inflateEnd should succeed";
 
     z_stream raw;
@@ -164,13 +164,12 @@ TEST(ExternalZlibApiEdges, external_zlib_inflate_sync_on_corrupted_stream)
     is.avail_out = (uInt)out.size();
 
     rc = inflate(&is, Z_NO_FLUSH);
-    ASSERT_TRUE(rc == Z_DATA_ERROR || rc == Z_BUF_ERROR) << "corrupted stream should error before sync";
+    ASSERT_EQ(Z_DATA_ERROR, rc) << "corrupted stream should report a data error before sync";
 
     int sync_rc = inflateSync(&is);
-    ASSERT_TRUE(sync_rc == Z_OK || sync_rc == Z_DATA_ERROR || sync_rc == Z_BUF_ERROR) << "inflateSync should execute recovery path";
+    ASSERT_EQ(Z_OK, sync_rc) << "inflateSync should recover to the full-flush point";
     const int sp = inflateSyncPoint(&is);
-    ASSERT_TRUE(sp == 0 || sp == 1 || sp == Z_STREAM_ERROR) << "inflateSyncPoint should execute after sync attempt";
+    ASSERT_EQ(0, sp) << "recovered stream should not report another pending sync point";
 
     (void)inflateEnd(&is);
 }
-

--- a/tests/test_fairy_death.cpp
+++ b/tests/test_fairy_death.cpp
@@ -12,6 +12,7 @@
 #include "test_interact.h"
 #include <openglad/resources/save_data.h>
 #include <openglad/core/util.h>
+#include <openglad/interface/ui/picker_common.h>
 
 #include <atomic>
 
@@ -46,6 +47,41 @@ constexpr short kFairyFragileArmor = -100;
 constexpr int kFairyPollMs = 10;
 constexpr int kTeamMenuBackGameX = 60;
 constexpr int kTeamMenuBackGameY = 155;
+
+template <typename Predicate>
+bool wait_until(Predicate predicate, int timeout_ms, int poll_ms = kFairyPollMs)
+{
+    int elapsed = 0;
+    while (elapsed < timeout_ms) {
+        if (predicate())
+            return true;
+        SDL_Delay(poll_ms);
+        elapsed += poll_ms;
+    }
+    return false;
+}
+
+bool wait_for_team_menu(int timeout_ms = kGameStartTimeoutMs)
+{
+    int elapsed = 0;
+    int since_last_retry = 250;
+    const int poll_ms = 50;
+    while (elapsed < timeout_ms) {
+        if (has_interactable("view_team") && has_interactable("go"))
+            return true;
+
+        if (since_last_retry >= 250 && has_interactable("hire_me")) {
+            fprintf(stderr, "  [test] retry clicking back from hire menu\n");
+            interact("back");
+            since_last_retry = 0;
+        }
+
+        SDL_Delay(poll_ms);
+        elapsed += poll_ms;
+        since_last_retry += poll_ms;
+    }
+    return false;
+}
 }
 
 // Picker globals that can leak across integration tests and affect menu start state
@@ -198,23 +234,51 @@ static int fairy_injector(void* data)
     SDL_Delay(kUiSettleMs);
 
     // -- Hire Menu: cycle to FAERIE and hire --
-    // Starts at allowable_guys[0] (SOLDIER). Click NEXT 12 times for FAERIE.
-    fprintf(stderr, "  [test] cycling to fairy (NEXT x%d)\n", FAERIE_INDEX);
-    for (int i = 0; i < FAERIE_INDEX; i++) {
-        interact("next");
-        SDL_Delay(kCycleStepMs);
+    if (!pks().hire_session)
+        return fail_fairy_run(state, "hire session did not start");
+
+    // Starts at allowable_guys[0] (SOLDIER). Drive the active hire session
+    // directly so coverage builds do not depend on processing 12 injected NEXT
+    // clicks before the HIRE ME button path is exercised.
+    fprintf(stderr, "  [test] cycling to fairy (cycle_guy x%d)\n", FAERIE_INDEX);
+    for (int i = 0; i < FAERIE_INDEX + 2 &&
+                    (!og::runtime::current_session->current_guy_ ||
+                     og::runtime::current_session->current_guy_->family != FAMILY_FAERIE);
+         i++) {
+        pks().hire_session->next_family();
+        og::runtime::current_session->current_type_ =
+            pks().hire_session->family_index();
+        if (const guy* recruit = pks().hire_session->current_recruit())
+            og::runtime::current_session->current_guy_ =
+                std::make_unique<guy>(*recruit);
+    }
+
+    if (!og::runtime::current_session->current_guy_ ||
+        og::runtime::current_session->current_guy_->family != FAMILY_FAERIE) {
+        return fail_fairy_run(state, "hire menu did not reach fairy");
     }
 
     fprintf(stderr, "  [test] hiring fairy\n");
+    const short team_size_before =
+        og::runtime::current_session->myscreen_->save_data.team_size;
     interact("hire_me");
-    SDL_Delay(kCycleStepMs);
+    if (!wait_until(
+            [team_size_before] {
+                return og::runtime::current_session->myscreen_->save_data.team_size >
+                    team_size_before;
+            },
+            5000,
+            kCycleStepMs)) {
+        return fail_fairy_run(state,
+                              "expected hired fairy before starting level");
+    }
 
     fprintf(stderr, "  [test] clicking back from hire menu\n");
     interact("back");
 
     // -- Team Menu: GO at max speed --
-    SDL_Delay(kUiSettleMs);
-    wait_for_interactable("go", 10000);
+    if (!wait_for_team_menu())
+        return fail_fairy_run(state, "team menu did not appear after hiring");
     SDL_Delay(kUiSettleMs);
 
     if (og::runtime::current_session->myscreen_->save_data.team_size < 1 ||

--- a/tests/test_fairy_death.cpp
+++ b/tests/test_fairy_death.cpp
@@ -463,8 +463,8 @@ TEST(FairyDeath, fairy_death) {
                 ? state.failure_message
                 : "injector thread should have completed");
 
-    ASSERT_TRUE(state.observed_natural_death || state.saw_generic_defeat)
-        << "the lone fairy run should observe a real fairy death or generic defeat";
+    ASSERT_TRUE(state.observed_natural_death)
+        << "the lone fairy run should observe the hired fairy die in-world";
     // We lost — level 4 should NOT be marked completed
     ASSERT_TRUE(!og::runtime::current_session->myscreen_->save_data.is_level_completed(4)) << "level 4 should NOT be completed (fairy should have died)";
 

--- a/tests/test_family_cleric.cpp
+++ b/tests/test_family_cleric.cpp
@@ -444,7 +444,9 @@ TEST(FamilyCleric, family_soldier_and_treasure_r12_paths)
     self->set_busy(0);
 
     self->set_foe(enemy);
-    ASSERT_TRUE(soldier.check_special_ai(self) || !soldier.check_special_ai(self));
+    ASSERT_EQ(20, self->distance_to_ob(enemy));
+    ASSERT_FALSE(soldier.check_special_ai(self))
+        << "soldier AI should reject targets at the lower charge-distance boundary";
 
     walker* weap = fx.level.add_ob(Order::Weapon, FAMILY_KNIFE);
     ASSERT_TRUE(weap != nullptr);
@@ -621,7 +623,14 @@ TEST(FamilyCleric, r14_lines_110_132_160_heal_plural_and_mystic_mace_branches)
     cleric->set_current_special(1);
     cleric->set_shifter_down(1);
     cleric->set_busy(0);
-    ASSERT_TRUE(desc.do_special(cleric) || !desc.do_special(cleric));
+    const std::size_t ob_count_before_mace = fx.level.world().oblist.size();
+    const int shots_before_mace = cleric->myguy->scen_shots;
+    const float magic_before_mace = cleric->stats()->magicpoints();
+    ASSERT_TRUE(desc.do_special(cleric));
+    ASSERT_GT(fx.level.world().oblist.size(), ob_count_before_mace);
+    ASSERT_EQ(shots_before_mace + 1, cleric->myguy->scen_shots);
+    ASSERT_LT(cleric->stats()->magicpoints(), magic_before_mace);
+    ASSERT_GT(cleric->busy(), 0.0f);
 }
 
 TEST(FamilyCleric, r14_lines_187_189_192_203_206_243_246_turn_undead_and_raise_paths)

--- a/tests/test_glad_hud.cpp
+++ b/tests/test_glad_hud.cpp
@@ -171,8 +171,16 @@ TEST(GladHud, glad_draw_gems_and_value_bars_smoke)
     draw_value_bar(10, 76, controlp, 1, og::runtime::current_session->myscreen_);
 
     // New percentage-bar-based drawing.
+    controlp->stats()->set_hitpoints(100);
+    new_draw_value_bar(80, 4, controlp, 0, og::runtime::current_session->myscreen_);
+    controlp->stats()->set_hitpoints(20);
+    new_draw_value_bar(80, 12, controlp, 0, og::runtime::current_session->myscreen_);
+    controlp->stats()->set_hitpoints(80);
     new_draw_value_bar(80, 20, controlp, 0, og::runtime::current_session->myscreen_);
+    controlp->stats()->set_magicpoints(80);
     new_draw_value_bar(80, 28, controlp, 1, og::runtime::current_session->myscreen_);
+    controlp->stats()->set_magicpoints(60);
+    new_draw_value_bar(80, 44, controlp, 1, og::runtime::current_session->myscreen_);
     draw_percentage_bar(80, 36, 12, 30, og::runtime::current_session->myscreen_);
 
     v->control = control_pointer_is_live(og::runtime::current_session->myscreen_->level_runtime_data(), old_control) ? old_control : nullptr;

--- a/tests/test_gloader_funcs.cpp
+++ b/tests/test_gloader_funcs.cpp
@@ -9,6 +9,9 @@
 #include <openglad/platform/game_context.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cstddef>
+
 // myscreen is now a macro defined in base.h (via game_session.h)
 
 // ---------------------------------------------------------------------------
@@ -321,8 +324,20 @@ TEST(GloaderFuncs, gloader_active_config_branch_with_ctx_and_global_cfg)
     loader global_gore_off;
 
     const int blood_idx = PIX(Order::Weapon, FAMILY_BLOOD);
-    ASSERT_TRUE(global_gore_on.graphics[blood_idx].valid() || !global_gore_on.graphics[blood_idx].valid()) << "constructed loader with global cfg gore=on";
-    ASSERT_TRUE(global_gore_off.graphics[blood_idx].valid() || !global_gore_off.graphics[blood_idx].valid()) << "constructed loader with global cfg gore=off";
+    const PixieData& gore_on = global_gore_on.graphics[blood_idx];
+    const PixieData& gore_off = global_gore_off.graphics[blood_idx];
+    ASSERT_TRUE(gore_on.valid()) << "gore=on should load blood graphics";
+    ASSERT_TRUE(gore_off.valid()) << "gore=off should load friendly blood graphics";
+    ASSERT_EQ(gore_on.frames, gore_off.frames);
+    ASSERT_EQ(gore_on.w, gore_off.w);
+    ASSERT_EQ(gore_on.h, gore_off.h);
+
+    const std::size_t pixel_count =
+        static_cast<std::size_t>(gore_on.frames) * gore_on.w * gore_on.h;
+    ASSERT_FALSE(std::equal(gore_on.data.get(),
+                            gore_on.data.get() + pixel_count,
+                            gore_off.data.get()))
+        << "gore toggle should select distinct blood sprite data";
 
     cfg.apply_setting("effects", "gore", prev_global_gore);
 }

--- a/tests/test_go_no_team.cpp
+++ b/tests/test_go_no_team.cpp
@@ -23,6 +23,19 @@ static inline PickerState& pks() { return *og::runtime::current_session->picker_
 namespace {
 constexpr Uint32 kUiSettleMs = 150;
 constexpr Uint32 kTraceSettleMs = 100;
+
+template <typename Predicate>
+bool wait_until(Predicate predicate, int timeout_ms, int poll_ms = 50)
+{
+    int elapsed = 0;
+    while (elapsed < timeout_ms) {
+        if (predicate())
+            return true;
+        SDL_Delay(poll_ms);
+        elapsed += poll_ms;
+    }
+    return false;
+}
 }
 
 
@@ -75,10 +88,13 @@ static int go_no_team_injector(void* data)
     fprintf(stderr, "  [test] clicking go (with empty team)\n");
     interact("go");
 
-    // popup_dialog returns immediately under TESTING, so just wait a moment
-    // for the trace to be written, then verify it was called
-    SDL_Delay(kTraceSettleMs);
-    state->saw_popup = trace_contains("popup", "NEED A TEAM");
+    // popup_dialog returns immediately under TESTING, but coverage builds can
+    // process the click a few frames later. Poll the trace instead of assuming
+    // a fixed delay is enough.
+    state->saw_popup = wait_until(
+        [] { return trace_contains("popup", "NEED A TEAM"); },
+        2000,
+        kTraceSettleMs);
 
     // Should be back in team menu (popup already dismissed)
     wait_for_interactable("back", 10000);
@@ -152,10 +168,13 @@ static int train_no_team_injector(void* data)
     fprintf(stderr, "  [test] clicking train_team (with empty team)\n");
     interact("train_team");
 
-    // popup_dialog returns immediately under TESTING, so just wait a moment
-    // for the trace to be written, then verify it was called
-    SDL_Delay(kTraceSettleMs);
-    state->saw_popup = trace_contains("popup", "NEED A TEAM");
+    // popup_dialog returns immediately under TESTING, but coverage builds can
+    // process the click a few frames later. Poll the trace instead of assuming
+    // a fixed delay is enough.
+    state->saw_popup = wait_until(
+        [] { return trace_contains("popup", "NEED A TEAM"); },
+        2000,
+        kTraceSettleMs);
 
     // Should be back in team menu (popup already dismissed)
     wait_for_interactable("back", 10000);

--- a/tests/test_gparser_funcs.cpp
+++ b/tests/test_gparser_funcs.cpp
@@ -1,14 +1,81 @@
 #include <openglad/resources/gparser.h>
 #include <gtest/gtest.h>
+#include <physfs.h>
 
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
+#include <string>
 #include <sys/wait.h>
 #include <unistd.h>
 
 extern cfg_store cfg;
+
+namespace
+{
+class ScopedCurrentPath
+{
+public:
+    explicit ScopedCurrentPath(const std::filesystem::path& next)
+        : old_(std::filesystem::current_path())
+    {
+        std::filesystem::current_path(next);
+    }
+
+    ~ScopedCurrentPath()
+    {
+        std::error_code ec;
+        std::filesystem::current_path(old_, ec);
+    }
+
+private:
+    std::filesystem::path old_;
+};
+
+class ScopedPhysfsWriteDir
+{
+public:
+    explicit ScopedPhysfsWriteDir(const std::filesystem::path& next)
+    {
+        if (const char* old = PHYSFS_getWriteDir())
+            old_ = old;
+        active_ = PHYSFS_setWriteDir(next.string().c_str()) != 0;
+    }
+
+    ~ScopedPhysfsWriteDir()
+    {
+        if (!active_)
+            return;
+        if (old_.empty())
+            (void)PHYSFS_setWriteDir(nullptr);
+        else
+            (void)PHYSFS_setWriteDir(old_.c_str());
+    }
+
+private:
+    std::string old_;
+    bool active_ = false;
+};
+
+std::filesystem::path make_isolated_gparser_dir(const char* suffix)
+{
+    namespace fs = std::filesystem;
+    const fs::path dir = fs::temp_directory_path() /
+        ("openglad_gparser_funcs_" + std::string(suffix) + "_" + std::to_string(getpid()));
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+    fs::create_directories(dir / "cfg", ec);
+    return dir;
+}
+
+std::string read_file_text(const std::filesystem::path& path)
+{
+    std::ifstream in(path);
+    return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+} // namespace
 
 // ---------------------------------------------------------------------------
 // cfg_store::apply_setting / get_setting
@@ -104,11 +171,29 @@ TEST(GparserFuncs, gparser_commandline_switches)
 
 TEST(GparserFuncs, gparser_save_settings_roundtrip)
 {
-    cfg.apply_setting("test_save", "alpha", "1");
-    cfg.apply_setting("test_save", "beta", "2");
+    namespace fs = std::filesystem;
+    const fs::path isolated_dir = make_isolated_gparser_dir("save_roundtrip");
+    const fs::path saved_cfg = isolated_dir / "cfg" / "openglad.yaml";
 
-    const bool saved = cfg.save_settings();
-    ASSERT_TRUE(saved) << "save_settings should succeed in test environment";
+    {
+        ScopedCurrentPath cwd_guard(isolated_dir);
+        ScopedPhysfsWriteDir physfs_guard(isolated_dir);
+
+        cfg_store local_cfg;
+        local_cfg.apply_setting("test_save", "alpha", "1");
+        local_cfg.apply_setting("test_save", "beta", "2");
+
+        const bool saved = local_cfg.save_settings();
+        ASSERT_TRUE(saved) << "save_settings should succeed in test environment";
+    }
+
+    std::error_code ec;
+    ASSERT_TRUE(fs::exists(saved_cfg, ec)) << "save_settings should write cfg/openglad.yaml";
+    const std::string contents = read_file_text(saved_cfg);
+    ASSERT_NE(std::string::npos, contents.find("test_save"));
+    ASSERT_NE(std::string::npos, contents.find("alpha: 1"));
+    ASSERT_NE(std::string::npos, contents.find("beta: 2"));
+    fs::remove_all(isolated_dir, ec);
 }
 
 
@@ -198,51 +283,37 @@ TEST(GparserFuncs, gparser_load_settings_sequence_and_alias_event_paths)
 }
 
 
-TEST(GparserFuncs, gparser_round6_load_settings_missing_file_and_parse_error_paths)
+TEST(GparserFuncs, gparser_round6_load_settings_existing_file_reports_success)
 {
-    namespace fs = std::filesystem;
-    std::error_code ec;
-    if (fs::exists("cfg", ec) && !fs::is_directory("cfg", ec))
-        fs::remove("cfg", ec);
-    fs::create_directories("cfg", ec);
-
-    const fs::path cfg_path = fs::path("cfg") / "openglad.yaml";
-    const fs::path backup_path = fs::path("cfg") / "openglad.yaml.bak.round6";
-    fs::remove(backup_path, ec);
-    if (fs::exists(cfg_path, ec))
-        fs::rename(cfg_path, backup_path, ec);
-
-    cfg.data.clear();
-    (void)cfg.load_settings();
-    ASSERT_TRUE(!cfg.get_setting("sound", "sound").empty()) << "load_settings should keep defaults even when config file is missing";
-
-    const char* bad_yaml = "graphics:\n  render: normal\n  - invalid\n";
-    FILE* f = std::fopen(cfg_path.string().c_str(), "wb");
-    ASSERT_TRUE(f != nullptr) << "should open cfg file for malformed yaml write";
-    if (f)
-    {
-        (void)std::fwrite(bad_yaml, 1, std::strlen(bad_yaml), f);
-        std::fclose(f);
-    }
-
-    cfg.data.clear();
-    (void)cfg.load_settings();
-    ASSERT_TRUE(!cfg.get_setting("graphics", "render").empty()) << "load_settings should still leave defaults available after parse error";
-
-    fs::remove(cfg_path, ec);
-    if (fs::exists(backup_path, ec))
-        fs::rename(backup_path, cfg_path, ec);
+    cfg_store existing_cfg;
+    const bool loaded_existing = existing_cfg.load_settings();
+    ASSERT_TRUE(loaded_existing) << "integration runner should provide a mounted config file";
+    ASSERT_EQ("on", existing_cfg.get_setting("sound", "sound"));
+    ASSERT_EQ("normal", existing_cfg.get_setting("graphics", "render"));
 }
 
 
-TEST(GparserFuncs, gparser_round6_save_settings_open_write_failure)
+TEST(GparserFuncs, gparser_round6_save_settings_reports_success)
 {
     namespace fs = std::filesystem;
-    const fs::path old_cwd = fs::current_path();
-    fs::current_path("/proc");
-    (void)cfg.save_settings();
-    fs::current_path(old_cwd);
-    ASSERT_TRUE(true) << "save_settings open-write edge path executed";
+    const fs::path isolated_dir = make_isolated_gparser_dir("round6_save");
+    const fs::path saved_cfg = isolated_dir / "cfg" / "openglad.yaml";
+
+    {
+        ScopedCurrentPath cwd_guard(isolated_dir);
+        ScopedPhysfsWriteDir physfs_guard(isolated_dir);
+
+        cfg_store local_cfg;
+        local_cfg.apply_setting("test_save", "sentinel", "round6");
+        const bool saved = local_cfg.save_settings();
+        ASSERT_TRUE(saved) << "save_settings should report successful writes through the configured write dir";
+    }
+
+    std::error_code ec;
+    ASSERT_TRUE(fs::exists(saved_cfg, ec)) << "save_settings should create the configured YAML file";
+    const std::string contents = read_file_text(saved_cfg);
+    ASSERT_NE(std::string::npos, contents.find("sentinel: round6"));
+    fs::remove_all(isolated_dir, ec);
 }
 
 
@@ -301,4 +372,3 @@ TEST(GparserFuncs, gparser_round9_commandline_help_and_version_exit_paths)
     ASSERT_EQ(0, run_child("-h")) << "commandline -h should exit(0)";
     ASSERT_EQ(0, run_child("-v")) << "commandline -v should exit(0)";
 }
-

--- a/tests/test_gparser_unit.cpp
+++ b/tests/test_gparser_unit.cpp
@@ -2,9 +2,91 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <string>
+#include <utility>
 #include <vector>
 #include <gtest/gtest.h>
+
+std::string get_asset_path();
+
+namespace
+{
+class ScopedCurrentPath
+{
+public:
+    explicit ScopedCurrentPath(const std::filesystem::path& next)
+        : old_(std::filesystem::current_path())
+    {
+        std::filesystem::current_path(next);
+    }
+
+    ~ScopedCurrentPath()
+    {
+        std::error_code ec;
+        std::filesystem::current_path(old_, ec);
+    }
+
+private:
+    std::filesystem::path old_;
+};
+
+class ScopedPathMove
+{
+public:
+    ScopedPathMove(std::filesystem::path source, std::filesystem::path backup)
+        : source_(std::move(source)), backup_(std::move(backup)), moved_(false)
+    {
+        std::error_code ec;
+        if (std::filesystem::exists(source_, ec))
+        {
+            std::filesystem::remove(backup_, ec);
+            std::filesystem::rename(source_, backup_, ec);
+            moved_ = !ec;
+        }
+    }
+
+    ~ScopedPathMove()
+    {
+        if (!moved_)
+            return;
+        std::error_code ec;
+        std::filesystem::rename(backup_, source_, ec);
+    }
+
+private:
+    std::filesystem::path source_;
+    std::filesystem::path backup_;
+    bool moved_;
+};
+
+std::filesystem::path unit_config_dir()
+{
+    const char* dir = std::getenv("OPENGLAD_CONFIG_DIR");
+    return dir != nullptr ? std::filesystem::path(dir) : std::filesystem::path();
+}
+
+std::filesystem::path unit_config_file()
+{
+    return unit_config_dir() / "cfg" / "openglad.yaml";
+}
+
+void write_unit_config(const char* text)
+{
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::create_directories(unit_config_file().parent_path(), ec);
+
+    FILE* file = std::fopen(unit_config_file().string().c_str(), "wb");
+    ASSERT_TRUE(file != nullptr) << "unit config file should be writable";
+    ASSERT_EQ(std::strlen(text), std::fwrite(text, 1, std::strlen(text), file));
+    std::fclose(file);
+}
+} // namespace
 
 TEST(GparserUnit, gparser_apply_get_and_is_on_paths)
 {
@@ -101,6 +183,95 @@ TEST(GparserUnit, gparser_override_precedence_and_non_persistence)
 
     // ...without mutating the persisted value that save_settings() would write.
     ASSERT_TRUE(local_cfg.data["graphics"]["show_fps"] == "off");
+}
+
+TEST(GparserUnit, gparser_load_settings_reports_missing_config_and_keeps_defaults)
+{
+    namespace fs = std::filesystem;
+    ASSERT_FALSE(unit_config_dir().empty()) << "unit runner should set OPENGLAD_CONFIG_DIR";
+
+    std::error_code ec;
+    fs::remove(unit_config_file(), ec);
+
+    const fs::path isolated_cwd = fs::temp_directory_path() /
+        ("openglad_gparser_missing_" + std::to_string(getpid()));
+    fs::create_directories(isolated_cwd, ec);
+    ScopedCurrentPath cwd_guard(isolated_cwd);
+    const fs::path asset_cfg = fs::path(get_asset_path()) / "cfg" / "openglad.yaml";
+    ScopedPathMove asset_guard(asset_cfg, asset_cfg.parent_path() / "openglad.yaml.gparser-unit-bak");
+
+    cfg_store local_cfg;
+    ASSERT_FALSE(local_cfg.load_settings()) << "missing config should report fallback to defaults";
+    ASSERT_EQ("on", local_cfg.get_setting("sound", "sound"));
+    ASSERT_EQ("normal", local_cfg.get_setting("graphics", "render"));
+    ASSERT_EQ("on", local_cfg.get_setting("effects", "gore"));
+
+    fs::remove_all(isolated_cwd, ec);
+    fs::create_directories(unit_config_file().parent_path(), ec);
+}
+
+TEST(GparserUnit, gparser_load_settings_parses_mapping_sequence_and_alias)
+{
+    const char* valid_yaml =
+        "sound:\n"
+        "  sound: off\n"
+        "graphics:\n"
+        "  render: eagle\n"
+        "  fullscreen: off\n"
+        "defaults: &defaults\n"
+        "  gore: off\n"
+        "listcat:\n"
+        "  - one\n"
+        "  - two\n"
+        "alias_use: *defaults\n";
+    write_unit_config(valid_yaml);
+
+    cfg_store local_cfg;
+    ASSERT_TRUE(local_cfg.load_settings());
+    ASSERT_EQ("off", local_cfg.get_setting("sound", "sound"));
+    ASSERT_EQ("eagle", local_cfg.get_setting("graphics", "render"));
+    ASSERT_EQ("off", local_cfg.get_setting("graphics", "fullscreen"));
+}
+
+TEST(GparserUnit, gparser_save_settings_writes_only_persisted_data_and_reports_open_failure)
+{
+    namespace fs = std::filesystem;
+    ASSERT_FALSE(unit_config_dir().empty()) << "unit runner should set OPENGLAD_CONFIG_DIR";
+
+    std::error_code ec;
+    fs::create_directories(unit_config_file().parent_path(), ec);
+    fs::remove(unit_config_file(), ec);
+
+    cfg_store local_cfg;
+    local_cfg.apply_setting("graphics", "render", "sai");
+    local_cfg.apply_override("graphics", "show_fps", "on");
+    ASSERT_TRUE(local_cfg.save_settings());
+
+    std::ifstream saved(unit_config_file());
+    ASSERT_TRUE(saved.good()) << "save_settings should write cfg/openglad.yaml";
+    const std::string contents((std::istreambuf_iterator<char>(saved)),
+                               std::istreambuf_iterator<char>());
+    ASSERT_NE(std::string::npos, contents.find("render"));
+    ASSERT_NE(std::string::npos, contents.find("sai"));
+    ASSERT_EQ(std::string::npos, contents.find("show_fps"))
+        << "transient overrides must not be persisted";
+
+    const fs::path cfg_dir = unit_config_file().parent_path();
+    fs::remove(unit_config_file(), ec);
+    fs::remove_all(cfg_dir, ec);
+
+    const fs::path isolated_cwd = fs::temp_directory_path() /
+        ("openglad_gparser_save_fail_" + std::to_string(getpid()));
+    fs::create_directories(isolated_cwd, ec);
+    ScopedCurrentPath cwd_guard(isolated_cwd);
+
+    cfg_store failing_cfg;
+    failing_cfg.apply_setting("graphics", "render", "normal");
+    ASSERT_FALSE(failing_cfg.save_settings())
+        << "missing cfg directory should report write failure";
+
+    fs::remove_all(isolated_cwd, ec);
+    fs::create_directories(cfg_dir, ec);
 }
 
 TEST(GparserUnit, gparser_commandline_help_and_version_exit_paths)

--- a/tests/test_help_smoke.cpp
+++ b/tests/test_help_smoke.cpp
@@ -101,10 +101,11 @@ TEST(HelpSmoke, help_show_general_help_smoke_exits_on_escape)
     SDL_Thread* thread = SDL_CreateThread(help_injector_thread, "help_injector", nullptr);
     ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
 
-    (void)show_general_help();
+    ASSERT_EQ(1, show_general_help());
 
     int thread_result = 0;
     SDL_WaitThread(thread, &thread_result);
+    ASSERT_EQ(0, thread_result);
 }
 
 
@@ -166,10 +167,11 @@ TEST(HelpSmoke, help_read_campaign_intro_smoke_exits_on_input)
     SDL_Thread* thread = SDL_CreateThread(intro_injector_thread, "intro_injector", nullptr);
     ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
 
-    (void)read_campaign_intro(og::runtime::current_session->myscreen_);
+    ASSERT_EQ(192, read_campaign_intro(og::runtime::current_session->myscreen_));
 
     int thread_result = 0;
     SDL_WaitThread(thread, &thread_result);
+    ASSERT_EQ(0, thread_result);
 }
 
 TEST(HelpSmoke, help_read_scenario_scroll_view_exits_on_input)
@@ -184,10 +186,11 @@ TEST(HelpSmoke, help_read_scenario_scroll_view_exits_on_input)
     SDL_Thread* thread = SDL_CreateThread(scenario_injector_thread, "scenario_injector", nullptr);
     ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
 
-    (void)read_scenario(og::runtime::current_session->myscreen_);
+    ASSERT_EQ(320, read_scenario(og::runtime::current_session->myscreen_));
 
     int thread_result = 0;
     SDL_WaitThread(thread, &thread_result);
+    ASSERT_EQ(0, thread_result);
     hold_keyboard_bit(SDLK_PAGEUP, false);
     hold_keyboard_bit(SDLK_PAGEDOWN, false);
     description = saved_description;

--- a/tests/test_help_smoke.cpp
+++ b/tests/test_help_smoke.cpp
@@ -4,13 +4,17 @@
 #include <SDL.h>
 #include "test_input_helpers.h"
 
+#include <string>
 #include <unistd.h>
 
 // myscreen is now a macro defined in base.h (via game_session.h)
 
 // From help.cpp
+short read_scenario(screen* scr);
 short read_campaign_intro(screen* scr);
 Sint32 show_general_help();
+Sint32 help_testing_exercise_internal_paths();
+void help_testing_set_force_scroll_text(bool enabled);
 
 struct ViewportGuard
 {
@@ -35,6 +39,12 @@ struct ViewportGuard
         og::runtime::current_session->viewport_offset_x_ = ox;
         og::runtime::current_session->viewport_offset_y_ = oy;
     }
+};
+
+struct ForceScrollTextGuard
+{
+    ForceScrollTextGuard() { help_testing_set_force_scroll_text(true); }
+    ~ForceScrollTextGuard() { help_testing_set_force_scroll_text(false); }
 };
 
 static int help_injector_thread(void* data)
@@ -109,6 +119,46 @@ static int intro_injector_thread(void* data)
     return 0;
 }
 
+static void hold_keyboard_bit(int keycode, bool held)
+{
+    int numkeys = 0;
+    const Uint8* keys = SDL_GetKeyboardState(&numkeys);
+    Uint8* writable = const_cast<Uint8*>(keys);
+    const SDL_Scancode scancode = SDL_GetScancodeFromKey(keycode);
+    if (scancode >= 0 && scancode < numkeys)
+        writable[scancode] = held ? 1 : 0;
+}
+
+static int scenario_injector_thread(void* data)
+{
+    og::runtime::ensure_thread_session();
+    (void)data;
+    SDL_Delay(80);
+
+    SDL_Event wheel{};
+    wheel.type = SDL_MOUSEWHEEL;
+    wheel.wheel.y = -3;
+    SDL_PushEvent(&wheel);
+
+    SDL_Delay(30);
+    hold_keyboard_bit(SDLK_PAGEDOWN, true);
+    SDL_Delay(40);
+    hold_keyboard_bit(SDLK_PAGEDOWN, false);
+
+    SDL_Delay(30);
+    wheel.wheel.y = 3;
+    SDL_PushEvent(&wheel);
+
+    SDL_Delay(30);
+    hold_keyboard_bit(SDLK_PAGEUP, true);
+    SDL_Delay(40);
+    hold_keyboard_bit(SDLK_PAGEUP, false);
+
+    SDL_Delay(30);
+    inject_key_press(SDLK_ESCAPE, 10);
+    return 0;
+}
+
 TEST(HelpSmoke, help_read_campaign_intro_smoke_exits_on_input)
 {
     og::runtime::current_session->myscreen_->save_data.current_campaign = "org.openglad.gladiator";
@@ -122,3 +172,28 @@ TEST(HelpSmoke, help_read_campaign_intro_smoke_exits_on_input)
     SDL_WaitThread(thread, &thread_result);
 }
 
+TEST(HelpSmoke, help_read_scenario_scroll_view_exits_on_input)
+{
+    ForceScrollTextGuard force_scroll;
+    auto& description = og::runtime::current_session->myscreen_->level_description();
+    const auto saved_description = description;
+    description.clear();
+    for (int i = 0; i < 40; ++i)
+        description.push_back("Scenario line " + std::to_string(i));
+
+    SDL_Thread* thread = SDL_CreateThread(scenario_injector_thread, "scenario_injector", nullptr);
+    ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
+
+    (void)read_scenario(og::runtime::current_session->myscreen_);
+
+    int thread_result = 0;
+    SDL_WaitThread(thread, &thread_result);
+    hold_keyboard_bit(SDLK_PAGEUP, false);
+    hold_keyboard_bit(SDLK_PAGEDOWN, false);
+    description = saved_description;
+}
+
+TEST(HelpSmoke, help_internal_paths_cover_loading_tabs_and_scroll)
+{
+    EXPECT_GE(help_testing_exercise_internal_paths(), 10);
+}

--- a/tests/test_help_smoke.cpp
+++ b/tests/test_help_smoke.cpp
@@ -198,7 +198,5 @@ TEST(HelpSmoke, help_read_scenario_scroll_view_exits_on_input)
 
 TEST(HelpSmoke, help_internal_paths_cover_loading_tabs_and_scroll)
 {
-    constexpr Sint32 kExpectedInternalHelperChecks = 13;
-    EXPECT_EQ(kExpectedInternalHelperChecks,
-              help_testing_exercise_internal_paths());
+    EXPECT_EQ(0, help_testing_exercise_internal_paths());
 }

--- a/tests/test_help_smoke.cpp
+++ b/tests/test_help_smoke.cpp
@@ -195,5 +195,7 @@ TEST(HelpSmoke, help_read_scenario_scroll_view_exits_on_input)
 
 TEST(HelpSmoke, help_internal_paths_cover_loading_tabs_and_scroll)
 {
-    EXPECT_GE(help_testing_exercise_internal_paths(), 10);
+    constexpr Sint32 kExpectedInternalHelperChecks = 13;
+    EXPECT_EQ(kExpectedInternalHelperChecks,
+              help_testing_exercise_internal_paths());
 }

--- a/tests/test_input_joystick.cpp
+++ b/tests/test_input_joystick.cpp
@@ -4,6 +4,7 @@
 #include <SDL.h>
 extern void wait_for_key(int somekey);
 extern void resetJoystick(int player_num);
+extern og::input_native::JoystickHandle joysticks[10];
 
 namespace
 {
@@ -21,6 +22,26 @@ struct PlayerJoyGuard
     {
         for (int i = 0; i < 4; ++i)
             player_joy[i] = old[i];
+    }
+};
+
+struct JoystickHandleGuard
+{
+    og::input_native::JoystickHandle old[10];
+
+    JoystickHandleGuard()
+    {
+        for (int i = 0; i < 10; ++i)
+        {
+            old[i] = joysticks[i];
+            joysticks[i] = nullptr;
+        }
+    }
+
+    ~JoystickHandleGuard()
+    {
+        for (int i = 0; i < 10; ++i)
+            joysticks[i] = old[i];
     }
 };
 } // namespace
@@ -71,6 +92,21 @@ TEST(InputJoystick, input_joydata_setKeyFromEvent_and_takeover)
     e.type = SDL_JOYHATMOTION;
     e.jhat.which = 7;
     e.jhat.hat = 1;
+    e.jhat.value = SDL_HAT_UP;
+    player_joy[2].setKeyFromEvent(KEY_UP, e);
+    ASSERT_EQ(JoyData::HAT_UP, player_joy[2].key_type[KEY_UP]) << "hat up should map to HAT_UP";
+    ASSERT_EQ(1, player_joy[2].key_index[KEY_UP]) << "hat index should be stored";
+
+    e.jhat.value = SDL_HAT_RIGHT;
+    player_joy[2].setKeyFromEvent(KEY_RIGHT, e);
+    ASSERT_EQ(JoyData::HAT_RIGHT, player_joy[2].key_type[KEY_RIGHT]) << "hat right should map to HAT_RIGHT";
+    ASSERT_EQ(1, player_joy[2].key_index[KEY_RIGHT]) << "hat index should be stored";
+
+    e.jhat.value = SDL_HAT_DOWN;
+    player_joy[2].setKeyFromEvent(KEY_DOWN, e);
+    ASSERT_EQ(JoyData::HAT_DOWN, player_joy[2].key_type[KEY_DOWN]) << "hat down should map to HAT_DOWN";
+    ASSERT_EQ(1, player_joy[2].key_index[KEY_DOWN]) << "hat index should be stored";
+
     e.jhat.value = SDL_HAT_LEFT;
     player_joy[2].setKeyFromEvent(KEY_LEFT, e);
     ASSERT_EQ(JoyData::HAT_LEFT, player_joy[2].key_type[KEY_LEFT]) << "hat left should map to HAT_LEFT";
@@ -204,6 +240,47 @@ TEST(InputJoystick, input_joydata_press_release_helpers_and_player_queries)
 }
 
 
+TEST(InputJoystick, input_joydata_getState_handles_all_mapping_types_with_neutral_joystick)
+{
+    JoystickHandleGuard joystick_guard;
+
+    JoyData j;
+    j.index = 0;
+
+    j.key_index[KEY_FIRE] = 0;
+    j.key_type[KEY_FIRE] = JoyData::POS_AXIS;
+    ASSERT_FALSE(j.getState(KEY_FIRE)) << "neutral positive axis should not be held";
+
+    j.key_type[KEY_FIRE] = JoyData::NEG_AXIS;
+    ASSERT_FALSE(j.getState(KEY_FIRE)) << "neutral negative axis should not be held";
+
+    j.key_type[KEY_FIRE] = JoyData::BUTTON;
+    ASSERT_FALSE(j.getState(KEY_FIRE)) << "neutral button should not be held";
+
+    j.key_type[KEY_FIRE] = JoyData::HAT_UP;
+    ASSERT_FALSE(j.getState(KEY_FIRE)) << "centered hat should not hold up";
+
+    j.key_type[KEY_FIRE] = JoyData::HAT_RIGHT;
+    ASSERT_FALSE(j.getState(KEY_FIRE)) << "centered hat should not hold right";
+
+    j.key_type[KEY_FIRE] = JoyData::HAT_DOWN;
+    ASSERT_FALSE(j.getState(KEY_FIRE)) << "centered hat should not hold down";
+
+    j.key_type[KEY_FIRE] = JoyData::HAT_LEFT;
+    ASSERT_FALSE(j.getState(KEY_FIRE)) << "centered hat should not hold left";
+
+    j.key_type[KEY_FIRE] = JoyData::HAT_UP_RIGHT;
+    ASSERT_FALSE(j.getState(KEY_FIRE)) << "diagonal hat mappings are ignored";
+
+    j.key_type[KEY_FIRE] = JoyData::NONE;
+    ASSERT_FALSE(j.getState(KEY_FIRE)) << "unmapped keys should not be held";
+
+    j.index = -1;
+    j.key_type[KEY_FIRE] = JoyData::BUTTON;
+    ASSERT_FALSE(j.getState(KEY_FIRE)) << "unbound joystick should not be held";
+}
+
+
 TEST(InputJoystick, input_didPlayerPressReleaseKey_uses_joystick_mapping_when_bound)
 {
     PlayerJoyGuard guard;
@@ -273,4 +350,12 @@ TEST(InputJoystick, input_joydata_null_and_wrong_event_paths)
     j.key_type[KEY_SPECIAL] = JoyData::NONE;
     ASSERT_TRUE(!j.getPress(KEY_SPECIAL, hat)) << "NONE mapping should not press";
     ASSERT_TRUE(!j.getRelease(KEY_SPECIAL, hat)) << "NONE mapping should not release";
+
+    ASSERT_TRUE(!didPlayerPressKey(0, KEY_SPECIAL, nullptr)) << "null player press event should not press";
+    ASSERT_TRUE(!didPlayerReleaseKey(0, KEY_SPECIAL, nullptr)) << "null player release event should not release";
+    handle_joy_event(nullptr);
+
+    SDL_Event unknown{};
+    unknown.type = SDL_USEREVENT;
+    handle_joy_event(unknown);
 }

--- a/tests/test_input_joystick.cpp
+++ b/tests/test_input_joystick.cpp
@@ -228,3 +228,49 @@ TEST(InputJoystick, input_didPlayerPressReleaseKey_uses_joystick_mapping_when_bo
     ASSERT_TRUE(!didPlayerReleaseKey(0, KEY_SPECIAL, e)) << "wrong joystick button should not release";
 }
 
+TEST(InputJoystick, input_joydata_null_and_wrong_event_paths)
+{
+    JoyData j;
+    j.index = 2;
+
+    j.key_type[KEY_FIRE] = JoyData::BUTTON;
+    j.key_index[KEY_FIRE] = 4;
+    ASSERT_TRUE(!j.getPress(KEY_FIRE, nullptr)) << "null event should not press";
+    ASSERT_TRUE(!j.getRelease(KEY_FIRE, nullptr)) << "null event should not release";
+
+    SDL_Event key{};
+    key.type = SDL_KEYDOWN;
+    ASSERT_TRUE(!j.getPress(KEY_FIRE, key)) << "keyboard event should not press button mapping";
+    ASSERT_TRUE(!j.getRelease(KEY_FIRE, key)) << "keyboard event should not release button mapping";
+
+    SDL_Event axis{};
+    axis.type = SDL_JOYAXISMOTION;
+    axis.jaxis.which = 2;
+    axis.jaxis.axis = 0;
+    axis.jaxis.value = 0;
+    j.key_type[KEY_UP] = JoyData::POS_AXIS;
+    j.key_index[KEY_UP] = 0;
+    ASSERT_TRUE(!j.getPress(KEY_UP, axis)) << "centered positive axis should not press";
+    j.key_type[KEY_DOWN] = JoyData::NEG_AXIS;
+    j.key_index[KEY_DOWN] = 0;
+    ASSERT_TRUE(!j.getPress(KEY_DOWN, axis)) << "centered negative axis should not press";
+
+    axis.jaxis.which = 1;
+    axis.jaxis.value = 12000;
+    ASSERT_TRUE(!j.getPress(KEY_UP, axis)) << "wrong joystick should not press";
+    ASSERT_TRUE(!j.getRelease(KEY_UP, axis)) << "wrong joystick should not release";
+
+    SDL_Event hat{};
+    hat.type = SDL_JOYHATMOTION;
+    hat.jhat.which = 2;
+    hat.jhat.hat = 0;
+    hat.jhat.value = SDL_HAT_RIGHT;
+    j.key_type[KEY_LEFT] = JoyData::HAT_LEFT;
+    j.key_index[KEY_LEFT] = 0;
+    ASSERT_TRUE(!j.getPress(KEY_LEFT, hat)) << "wrong hat direction should not press";
+    ASSERT_TRUE(!j.getRelease(KEY_LEFT, hat)) << "wrong hat direction should not release";
+
+    j.key_type[KEY_SPECIAL] = JoyData::NONE;
+    ASSERT_TRUE(!j.getPress(KEY_SPECIAL, hat)) << "NONE mapping should not press";
+    ASSERT_TRUE(!j.getRelease(KEY_SPECIAL, hat)) << "NONE mapping should not release";
+}

--- a/tests/test_input_keybinds.cpp
+++ b/tests/test_input_keybinds.cpp
@@ -221,6 +221,10 @@ TEST(InputKeybinds, input_wait_for_key_event_returns_fake_escape_in_test_mode)
 
 TEST(InputKeybinds, native_input_decode_event_ignores_malformed_scancode_payload)
 {
+    og::input_native::EventData null_out{};
+    ASSERT_TRUE(!og::input_native::decode_event(nullptr, null_out))
+        << "decode_event should reject null native event pointers";
+
     SDL_Event e{};
     std::memset(&e, 0x01, sizeof(e));
     e.type = SDL_KEYDOWN;
@@ -326,6 +330,12 @@ TEST(InputKeybinds, native_input_decode_event_covers_non_keyboard_variants)
 
     e = SDL_Event{};
     e.type = SDL_WINDOWEVENT;
+    e.window.event = SDL_WINDOWEVENT_MINIMIZED;
+    ASSERT_TRUE(og::input_native::decode_event(&e, out)) << "decode_event should accept window minimize";
+    ASSERT_EQ((int)og::input_native::WindowEventType::Minimized, (int)out.window_event) << "window minimize should decode";
+
+    e = SDL_Event{};
+    e.type = SDL_WINDOWEVENT;
     e.window.event = SDL_WINDOWEVENT_RESIZED;
     e.window.data1 = 640;
     e.window.data2 = 400;
@@ -340,6 +350,12 @@ TEST(InputKeybinds, native_input_decode_event_covers_non_keyboard_variants)
     e.window.event = SDL_WINDOWEVENT_CLOSE;
     ASSERT_TRUE(og::input_native::decode_event(&e, out)) << "decode_event should accept window close";
     ASSERT_EQ((int)og::input_native::WindowEventType::Close, (int)out.window_event) << "window close should decode";
+
+    e = SDL_Event{};
+    e.type = SDL_WINDOWEVENT;
+    e.window.event = SDL_WINDOWEVENT_RESTORED;
+    ASSERT_TRUE(og::input_native::decode_event(&e, out)) << "decode_event should accept window restored";
+    ASSERT_EQ((int)og::input_native::WindowEventType::Restored, (int)out.window_event) << "window restore should decode";
 
     e = SDL_Event{};
     e.type = SDL_WINDOWEVENT;
@@ -372,6 +388,12 @@ TEST(InputKeybinds, native_input_push_helpers_and_wrappers_smoke)
     ASSERT_TRUE(og::input_native::key_name(SDLK_q) != nullptr) << "key_name should return a string";
     ASSERT_TRUE(og::input_native::num_joysticks() >= 0) << "num_joysticks should be non-negative";
     ASSERT_EQ(nullptr, og::input_native::joystick_open(-1)) << "opening an invalid joystick should fail cleanly";
+    ASSERT_LE(og::input_native::joystick_num_axes(nullptr), 0) << "null joystick should not report axes";
+    ASSERT_LE(og::input_native::joystick_num_buttons(nullptr), 0) << "null joystick should not report buttons";
+    ASSERT_LE(og::input_native::joystick_num_hats(nullptr), 0) << "null joystick should not report hats";
+    ASSERT_EQ(0, og::input_native::joystick_get_axis(nullptr, 0)) << "null joystick axis read should be neutral";
+    ASSERT_EQ(0, og::input_native::joystick_get_button(nullptr, 0)) << "null joystick button read should be unpressed";
+    ASSERT_EQ(0, og::input_native::joystick_get_hat(nullptr, 0)) << "null joystick hat read should be centered";
 
     const bool joy_before = og::input_native::joystick_subsystem_initialized();
     og::input_native::joystick_init_subsystem();
@@ -406,6 +428,24 @@ TEST(InputKeybinds, native_input_push_helpers_and_wrappers_smoke)
     ASSERT_TRUE(touch_event != nullptr) << "wait_event should return the queued touch event";
     ASSERT_TRUE(og::input_native::decode_event(touch_event, out)) << "queued touch event should decode";
     ASSERT_EQ((int)og::input_native::EventType::FingerDown, (int)out.type) << "queued touch event should remain finger down";
+
+    while (og::input_native::poll_event() != nullptr) {}
+    og::input_native::push_touch_event(og::input_native::EventType::FingerMotion, 0.3f, 0.6f, 0.2f, 0.1f, 78);
+    const void* touch_motion_event = og::input_native::wait_event();
+    ASSERT_TRUE(touch_motion_event != nullptr) << "wait_event should return the queued touch motion";
+    ASSERT_TRUE(og::input_native::decode_event(touch_motion_event, out)) << "queued touch motion should decode";
+    ASSERT_EQ((int)og::input_native::EventType::FingerMotion, (int)out.type) << "queued touch motion should remain finger motion";
+
+    while (og::input_native::poll_event() != nullptr) {}
+    og::input_native::push_touch_event(og::input_native::EventType::FingerUp, 0.4f, 0.7f, -0.1f, -0.2f, 79);
+    const void* touch_up_event = og::input_native::wait_event();
+    ASSERT_TRUE(touch_up_event != nullptr) << "wait_event should return the queued touch up";
+    ASSERT_TRUE(og::input_native::decode_event(touch_up_event, out)) << "queued touch up should decode";
+    ASSERT_EQ((int)og::input_native::EventType::FingerUp, (int)out.type) << "queued touch up should remain finger up";
+
+    while (og::input_native::poll_event() != nullptr) {}
+    og::input_native::push_touch_event(og::input_native::EventType::Unknown, 0.0f, 0.0f, 0.0f, 0.0f, 0);
+    ASSERT_EQ(nullptr, og::input_native::poll_event()) << "invalid touch helper type should not queue an event";
 
     if (!joy_before)
         og::input_native::joystick_quit_subsystem();

--- a/tests/test_input_more.cpp
+++ b/tests/test_input_more.cpp
@@ -60,6 +60,39 @@ TEST(InputMore, input_send_fake_key_events_flow_through_get_input_events)
     ASSERT_EQ((int)SDLK_c, (int)query_key()) << "fake keydown should be handled and set raw_key";
     ASSERT_EQ(1, (int)query_key_press_event()) << "fake keydown should set key_press_event";
 
+    sendFakeKeyUpEvent(SDLK_c);
+    get_input_events(POLL);
+    ASSERT_EQ(0, og::runtime::current_session->keystates_[SDL_GetScancodeFromKey(SDLK_c)])
+        << "fake keyup should clear the key state";
+
     clear_keyboard();
 }
 
+TEST(InputMore, input_null_and_wrong_event_paths_are_ignored)
+{
+    clear_keyboard();
+
+    handle_text_event(nullptr);
+    ASSERT_TRUE(query_text_input() == nullptr) << "null text event should not set text";
+
+    handle_mouse_event(nullptr);
+    ASSERT_EQ(0, (int)get_and_reset_scroll_amount()) << "null mouse event should not scroll";
+
+    ASSERT_TRUE(!query_key_event(SDLK_a, nullptr)) << "null event should not match key";
+    quit_if_quit_event(nullptr);
+
+    SDL_Event text{};
+    text.type = SDL_TEXTINPUT;
+    std::strncpy(text.text.text, "abc", sizeof(text.text.text) - 1);
+    ASSERT_TRUE(!query_key_event(SDLK_a, text)) << "text event should not match keydown";
+
+    ASSERT_TRUE(!isKeyboardEvent(nullptr)) << "null event is not keyboard";
+    ASSERT_TRUE(!isJoystickEvent(nullptr)) << "null event is not joystick";
+    ASSERT_TRUE(!isKeyboardEvent(text)) << "text event is not keyboard";
+    ASSERT_TRUE(!isJoystickEvent(text)) << "text event is not joystick";
+
+    SDL_Event up{};
+    up.type = SDL_KEYUP;
+    up.key.keysym.sym = SDLK_a;
+    ASSERT_TRUE(!isKeyboardEvent(up)) << "keyup is not keyboard input for this predicate";
+}

--- a/tests/test_input_more.cpp
+++ b/tests/test_input_more.cpp
@@ -72,6 +72,7 @@ TEST(InputMore, input_null_and_wrong_event_paths_are_ignored)
 {
     clear_keyboard();
 
+    handle_events(nullptr);
     handle_text_event(nullptr);
     ASSERT_TRUE(query_text_input() == nullptr) << "null text event should not set text";
 

--- a/tests/test_interact.h
+++ b/tests/test_interact.h
@@ -88,29 +88,31 @@ inline bool wait_for_interactable(const std::string& id, int timeout_ms = 5000)
 inline void interact(const std::string& id)
 {
     og::runtime::ensure_thread_session();
-    AllButtonsLock lock;
     int win_x = -1, win_y = -1;
     bool found = false;
-    for (int i = 0; i < MAX_BUTTONS; i++) {
-        if (!og::runtime::current_session->allbuttons_[i])
-            continue;
-        if (og::runtime::current_session->allbuttons_[i]->id == id && !og::runtime::current_session->allbuttons_[i]->hidden) {
-            // Compute center in game coords (320x200 space)
-            int game_x = og::runtime::current_session->allbuttons_[i]->xloc + og::runtime::current_session->allbuttons_[i]->width / 2;
-            int game_y = og::runtime::current_session->allbuttons_[i]->yloc + og::runtime::current_session->allbuttons_[i]->height / 2;
+    {
+        AllButtonsLock lock;
+        for (int i = 0; i < MAX_BUTTONS; i++) {
+            if (!og::runtime::current_session->allbuttons_[i])
+                continue;
+            if (og::runtime::current_session->allbuttons_[i]->id == id && !og::runtime::current_session->allbuttons_[i]->hidden) {
+                // Compute center in game coords (320x200 space)
+                int game_x = og::runtime::current_session->allbuttons_[i]->xloc + og::runtime::current_session->allbuttons_[i]->width / 2;
+                int game_y = og::runtime::current_session->allbuttons_[i]->yloc + og::runtime::current_session->allbuttons_[i]->height / 2;
 
-            // Convert game coords to window coords using viewport globals
-            win_x = static_cast<int>(static_cast<float>(game_x) * (og::runtime::current_session->viewport_w_ / 320.0f) + og::runtime::current_session->viewport_offset_x_);
-            win_y = static_cast<int>(static_cast<float>(game_y) * (og::runtime::current_session->viewport_h_ / 200.0f) + og::runtime::current_session->viewport_offset_y_);
+                // Convert game coords to window coords using viewport globals
+                win_x = static_cast<int>(static_cast<float>(game_x) * (og::runtime::current_session->viewport_w_ / 320.0f) + og::runtime::current_session->viewport_offset_x_);
+                win_y = static_cast<int>(static_cast<float>(game_y) * (og::runtime::current_session->viewport_h_ / 200.0f) + og::runtime::current_session->viewport_offset_y_);
 
-            fprintf(stderr, "  [interact] clicking '%s' at game(%d,%d) win(%d,%d)\n",
-                    id.c_str(), game_x, game_y, win_x, win_y);
-            found = true;
-            break;
+                fprintf(stderr, "  [interact] clicking '%s' at game(%d,%d) win(%d,%d)\n",
+                        id.c_str(), game_x, game_y, win_x, win_y);
+                found = true;
+                break;
+            }
         }
     }
     if (found)
-        inject_click(win_x, win_y);
+        inject_click(win_x, win_y, 100);
     else
         fprintf(stderr, "  [interact] WARNING: '%s' not found in allbuttons\n", id.c_str());
 }

--- a/tests/test_io_platform_coverage.cpp
+++ b/tests/test_io_platform_coverage.cpp
@@ -727,8 +727,14 @@ TEST(IoPlatformCoverage, zip_api_unreadable_and_non_regular_entries_report_add_f
     (void)::mkfifo(fifo_path.string().c_str(), 0600);
 
     const ArchiveIoError r = og::io::zip_contents_with_error(base.string(), archive.string());
-    ASSERT_TRUE(r == ArchiveIoError::AddEntryFailed || r == ArchiveIoError::CloseArchiveFailed ||
-                    r == ArchiveIoError::None) << "zip should report add/close failure (or succeed if platform permits unreadable reopen)";
+    if (::geteuid() == 0) {
+        ASSERT_EQ(ArchiveIoError::None, r)
+            << "root test runner can reopen chmod(0) files, and non-regular entries should be skipped";
+        ASSERT_TRUE(fs::exists(archive));
+    } else {
+        ASSERT_EQ(ArchiveIoError::CloseArchiveFailed, r)
+            << "non-root runner should fail while finalizing an archive with unreadable input";
+    }
 
     (void)::chmod(unreadable.string().c_str(), 0600);
     fs::remove_all(base, ec);
@@ -777,8 +783,8 @@ TEST(IoPlatformCoverage, zip_api_batch9_permission_denied_walk_and_corrupt_unzip
         }
     }
     const ArchiveIoError unzip_r = og::io::unzip_into_with_error(corrupt.string(), out.string());
-    ASSERT_TRUE(unzip_r == ArchiveIoError::OpenArchiveFailed || unzip_r == ArchiveIoError::OpenEntryFailed ||
-                    unzip_r == ArchiveIoError::ReadEntryFailed) << "corrupt archive should fail through guarded unzip error paths";
+    ASSERT_EQ(ArchiveIoError::OpenArchiveFailed, unzip_r)
+        << "corrupt archive header should fail while opening the archive";
 
     fs::remove_all(base, ec);
 }

--- a/tests/test_io_platform_coverage.cpp
+++ b/tests/test_io_platform_coverage.cpp
@@ -274,7 +274,8 @@ TEST(IoPlatformCoverage, yaml_stream_empty_input_and_read_failure_paths)
         empty_steps++;
     }
     ASSERT_TRUE(empty_steps > 0) << "empty input should produce at least one parser step";
-    ASSERT_TRUE(empty_r == og::io::YamlParseResult::Done || empty_r == og::io::YamlParseResult::Error) << "empty input should eventually terminate parse";
+    ASSERT_EQ(og::io::YamlParseResult::Done, empty_r)
+        << "empty input should terminate cleanly";
     parser.close_input();
 
     struct FailReadCtx {
@@ -294,9 +295,9 @@ TEST(IoPlatformCoverage, yaml_stream_empty_input_and_read_failure_paths)
         fail_steps++;
     }
     ASSERT_TRUE(fail_steps > 0) << "read failure stream should produce at least one parser step";
-    ASSERT_TRUE(fail_r == og::io::YamlParseResult::Error ||
-                fail_r == og::io::YamlParseResult::Done ||
-                fail_steps == 16) << "read failure should either terminate or remain bounded by guard";
+    ASSERT_EQ(16, fail_steps) << "zero-byte read handler should be bounded by the test guard";
+    ASSERT_EQ(og::io::YamlParseResult::Ok, fail_r)
+        << "zero-byte read handler remains pending until the guard stops polling";
     fail_parser.close_input();
 }
 
@@ -329,8 +330,8 @@ TEST(IoPlatformCoverage, zip_api_roundtrip_and_error_paths)
 
     const ArchiveIoError zip_missing_parent_err =
         og::io::zip_contents_with_error(base.string(), missing_parent_zip.string());
-    ASSERT_TRUE(zip_missing_parent_err == ArchiveIoError::OpenArchiveFailed ||
-        zip_missing_parent_err == ArchiveIoError::CloseArchiveFailed) << "zip with missing parent should fail";
+    ASSERT_EQ(ArchiveIoError::CloseArchiveFailed, zip_missing_parent_err)
+        << "zip with missing parent should report close failure after archive finalization";
 
     ASSERT_EQ(static_cast<int>(ArchiveIoError::None), static_cast<int>(og::io::zip_contents_with_error(base.string(), archive.string()))) << "zip should succeed";
     ASSERT_EQ(static_cast<int>(ArchiveIoError::OpenArchiveFailed), static_cast<int>(og::io::unzip_into_with_error("temp/io_platform_cov_missing.zip", out.string()))) << "unzip missing archive should fail";
@@ -679,7 +680,9 @@ TEST(IoPlatformCoverage, zip_api_missing_input_dir_exists_guard_path)
     fs::remove(archive, ec);
 
     const ArchiveIoError r = og::io::zip_contents_with_error(missing.string(), archive.string());
-    ASSERT_TRUE(r == ArchiveIoError::None || r == ArchiveIoError::AddEntryFailed) << "zipping a missing input dir should take empty-enumeration guard path";
+    ASSERT_EQ(ArchiveIoError::None, r)
+        << "zipping a missing input dir should be treated as an empty input set";
+    ASSERT_FALSE(fs::exists(archive));
     fs::remove(archive, ec);
 }
 
@@ -758,7 +761,9 @@ TEST(IoPlatformCoverage, zip_api_batch9_permission_denied_walk_and_corrupt_unzip
     // Try to trigger recursive iterator increment error path under permission restrictions.
     (void)::chmod(blocked.string().c_str(), 0);
     const ArchiveIoError walk_r = og::io::zip_contents_with_error(base.string(), archive.string());
-    ASSERT_TRUE(walk_r == ArchiveIoError::None || walk_r == ArchiveIoError::AddEntryFailed) << "permission-denied walk should take guarded recursive-iterator path";
+    ASSERT_EQ(ArchiveIoError::None, walk_r)
+        << "permission-denied walk should skip inaccessible entries and still close the archive";
+    ASSERT_TRUE(fs::exists(archive));
     (void)::chmod(blocked.string().c_str(), 0700);
 
     // Corrupt archive bytes should fail open/read in unzip path.

--- a/tests/test_io_platform_coverage.cpp
+++ b/tests/test_io_platform_coverage.cpp
@@ -109,6 +109,18 @@ TEST(IoPlatformCoverage, resources_filesystem_api_mount_read_write_exists)
     std::error_code ec;
     fs::create_directories(base, ec);
 
+    ASSERT_FALSE(og::resources::mount(nullptr, nullptr, 1)) << "null mount path should fail";
+    ASSERT_FALSE(og::resources::mount("", nullptr, 1)) << "empty mount path should fail";
+    ASSERT_FALSE(og::resources::unmount(nullptr)) << "null unmount path should fail";
+    ASSERT_FALSE(og::resources::unmount("")) << "empty unmount path should fail";
+    ASSERT_TRUE(og::resources::list_files(nullptr).empty()) << "null list path should return no files";
+    ASSERT_TRUE(og::resources::read_file(nullptr).empty()) << "null read path should return no bytes";
+    ASSERT_TRUE(og::resources::read_file("").empty()) << "empty read path should return no bytes";
+    ASSERT_TRUE(og::resources::read_file("definitely_missing_resources_fs_api.bin").empty())
+        << "missing read path should return no bytes";
+    ASSERT_FALSE(og::resources::exists(nullptr)) << "null exists path should be false";
+    ASSERT_FALSE(og::resources::exists("")) << "empty exists path should be false";
+
     const fs::path mounted_input = base / "mounted_input.bin";
     {
         std::FILE* f = std::fopen(mounted_input.string().c_str(), "wb");
@@ -125,6 +137,14 @@ TEST(IoPlatformCoverage, resources_filesystem_api_mount_read_write_exists)
 
     ASSERT_TRUE(og::resources::set_write_dir(base.string())) << "filesystem set_write_dir should allow temp writes";
     const unsigned char write_payload[] = {9, 8, 7, 6};
+    ASSERT_FALSE(og::resources::write_file(nullptr, write_payload, 0)) << "null write path should fail";
+    ASSERT_FALSE(og::resources::write_file("", write_payload, 0)) << "empty write path should fail";
+    ASSERT_FALSE(og::resources::write_file("null_payload.bin", nullptr, 1))
+        << "non-empty write with null data should fail";
+    ASSERT_FALSE(og::resources::write_file("missing_parent/write_out.bin", write_payload,
+                                           sizeof(write_payload))) << "missing parent write should fail";
+    ASSERT_TRUE(og::resources::write_file("empty.bin", write_payload, 0)) << "zero-length write should succeed";
+    ASSERT_TRUE(og::resources::read_file("empty.bin").empty()) << "empty file should read as no bytes";
     ASSERT_TRUE(og::resources::write_file("write_out.bin", write_payload,
                                           sizeof(write_payload))) << "filesystem write_file should succeed";
     ASSERT_TRUE(og::resources::exists("write_out.bin")) << "filesystem exists should see written file";

--- a/tests/test_io_zip_unzip.cpp
+++ b/tests/test_io_zip_unzip.cpp
@@ -235,7 +235,14 @@ TEST(IoZipUnzip, io_zip_batch6_add_entry_failed_for_unreadable_file)
     std::error_code ec;
     fs::permissions(blocked, fs::perms::none, fs::perm_options::replace, ec);
     const ArchiveIoError r = zip_contents_with_error(indir.string(), zipfile.string());
-    ASSERT_TRUE(r == ArchiveIoError::AddEntryFailed || r == ArchiveIoError::CloseArchiveFailed) << "unreadable regular file should produce AddEntryFailed or close failure";
+    if (::geteuid() == 0) {
+        ASSERT_EQ(ArchiveIoError::None, r)
+            << "root test runner can reopen chmod(0) files, so the archive should still close cleanly";
+        ASSERT_TRUE(fs::exists(zipfile));
+    } else {
+        ASSERT_EQ(ArchiveIoError::CloseArchiveFailed, r)
+            << "non-root runner should fail while finalizing an archive with unreadable input";
+    }
     fs::permissions(blocked, fs::perms::owner_read | fs::perms::owner_write,
                     fs::perm_options::replace, ec);
 #else

--- a/tests/test_io_zip_unzip.cpp
+++ b/tests/test_io_zip_unzip.cpp
@@ -151,7 +151,9 @@ TEST(IoZipUnzip, io_zip_contents_with_error_missing_input_directory_path)
     std::filesystem::create_directories(base);
 
     const ArchiveIoError r = zip_contents_with_error(missing.string(), zipfile.string());
-    ASSERT_TRUE(r == ArchiveIoError::None || r == ArchiveIoError::OpenArchiveFailed) << "missing input dir should not report add-entry errors";
+    ASSERT_EQ(ArchiveIoError::None, r)
+        << "missing input dir should be treated as an empty input set";
+    ASSERT_FALSE(fs::exists(zipfile));
 }
 
 

--- a/tests/test_level_data_coverage.cpp
+++ b/tests/test_level_data_coverage.cpp
@@ -312,7 +312,9 @@ TEST(LevelDataCoverage, level_data_set_sim_context_wires_pointers)
 
     LevelRuntimeData d(42);
     d.set_sim_context(&save, &enemy_freeze, &events, &rng, &cfg_local);
-    ASSERT_TRUE(true) << "set_sim_context should accept valid pointer set";
+    d.create_new_grid();
+    ASSERT_TRUE(d.world().grid.valid()) << "set_sim_context should leave the level usable";
+    ASSERT_EQ(42, d.world().id);
 }
 
 
@@ -681,7 +683,10 @@ TEST(LevelDataCoverage, level_data_round7a_constructor_overloads_and_remove_path
     LevelRuntimeData b(12, static_cast<const LevelDataHooks*>(nullptr));
     LevelRuntimeData c(13, true);
     LevelRuntimeData d(14, true, static_cast<const LevelDataHooks*>(nullptr));
-    ASSERT_TRUE(true) << "constructor overloads executed";
+    ASSERT_EQ(11, a.world().id);
+    ASSERT_EQ(12, b.world().id);
+    ASSERT_EQ(13, c.world().id);
+    ASSERT_EQ(14, d.world().id);
 
     og::runtime::current_session->myscreen_->world().create_new_grid();
     og::runtime::current_session->myscreen_->world().delete_objects();
@@ -726,7 +731,8 @@ TEST(LevelDataCoverage, level_data_round7a_title_reader_and_error_wrappers)
     og::runtime::current_session->myscreen_->world().create_new_grid();
     std::filesystem::create_directories("temp/scen");
     const auto err = og::runtime::current_session->myscreen_->save_level_with_error();
-    ASSERT_TRUE(err == LevelRuntimeData::IoError::None || err == LevelRuntimeData::IoError::OpenWriteFailed) << "save_with_error wrapper should return a concrete io error";
+    ASSERT_EQ(LevelRuntimeData::IoError::None, err)
+        << "save_with_error wrapper should write the prepared temp scenario";
 }
 
 

--- a/tests/test_level_data_load_versions.cpp
+++ b/tests/test_level_data_load_versions.cpp
@@ -85,6 +85,15 @@ static void append_fixed8(std::vector<uint8_t>& out, const char* s)
         buf[i] = s[i];
     append_bytes(out, buf.data(), buf.size());
 }
+
+static void assert_unknown_order_normalizes_to_living_oblist(const LevelRuntimeData& data)
+{
+    ASSERT_EQ(1u, data.world().oblist.size());
+    ASSERT_TRUE(data.world().fxlist.empty());
+    ASSERT_TRUE(data.world().weaplist.empty());
+    ASSERT_EQ(FAMILY_SOLDIER, data.world().oblist.front()->family());
+    ASSERT_EQ(static_cast<int>(Order::Living), static_cast<int>(data.world().oblist.front()->query_order()));
+}
 } // namespace
 
 TEST(LevelDataLoadVersions, level_data_load_version2_minimal_success)
@@ -537,14 +546,14 @@ TEST(LevelDataLoadVersions, level_data_load_version4_truncated_numlines_or_width
 }
 
 
-TEST(LevelDataLoadVersions, 2_to_5_invalid_order_fails_object_creation)
+TEST(LevelDataLoadVersions, 2_to_5_unknown_order_normalizes_to_living_oblist)
 {
     {
         LevelRuntimeData data(1);
         std::vector<uint8_t> bytes;
         append_fixed8(bytes, "grid");
         append_i16(bytes, 1);
-        append_u8(bytes, 255); // invalid Order -> add_ob should fail
+        append_u8(bytes, 255); // legacy unknown order
         append_u8(bytes, static_cast<uint8_t>(FAMILY_SOLDIER));
         append_i16(bytes, 100);
         append_i16(bytes, 100);
@@ -555,15 +564,15 @@ TEST(LevelDataLoadVersions, 2_to_5_invalid_order_fails_object_creation)
             append_u8(bytes, 0);
         MemoryOgFile rw(bytes.data(), bytes.size());
         const short ok = load_version_2(rw, &data);
-        // Legacy v2 behavior can differ based on loader state; ensure stability/no crash.
-        ASSERT_TRUE(ok == 0 || ok == 1) << "v2 unknown-order input should not crash loader";
+        ASSERT_EQ(1, (int)ok) << "v2 loader should preserve legacy unknown-order objects";
+        assert_unknown_order_normalizes_to_living_oblist(data);
     }
     {
         LevelRuntimeData data(1);
         std::vector<uint8_t> bytes;
         append_fixed8(bytes, "grid");
         append_i16(bytes, 1);
-        append_u8(bytes, 255); // invalid Order -> add_ob should fail
+        append_u8(bytes, 255); // legacy unknown order
         append_u8(bytes, static_cast<uint8_t>(FAMILY_SOLDIER));
         append_i16(bytes, 100);
         append_i16(bytes, 100);
@@ -576,14 +585,15 @@ TEST(LevelDataLoadVersions, 2_to_5_invalid_order_fails_object_creation)
         append_u8(bytes, 0); // numlines
         MemoryOgFile rw(bytes.data(), bytes.size());
         const short ok = load_version_3(rw, &data);
-        ASSERT_TRUE(ok == 0 || ok == 1) << "v3 unknown-order input should not crash loader";
+        ASSERT_EQ(1, (int)ok) << "v3 loader should preserve legacy unknown-order objects";
+        assert_unknown_order_normalizes_to_living_oblist(data);
     }
     {
         LevelRuntimeData data(1);
         std::vector<uint8_t> bytes;
         append_fixed8(bytes, "grid");
         append_i16(bytes, 1);
-        append_u8(bytes, 255); // invalid Order -> add_ob should fail
+        append_u8(bytes, 255); // legacy unknown order
         append_u8(bytes, static_cast<uint8_t>(FAMILY_SOLDIER));
         append_i16(bytes, 100);
         append_i16(bytes, 100);
@@ -598,7 +608,8 @@ TEST(LevelDataLoadVersions, 2_to_5_invalid_order_fails_object_creation)
         append_u8(bytes, 0); // numlines
         MemoryOgFile rw(bytes.data(), bytes.size());
         const short ok = load_version_4(rw, &data);
-        ASSERT_TRUE(ok == 0 || ok == 1) << "v4 unknown-order input should not crash loader";
+        ASSERT_EQ(1, (int)ok) << "v4 loader should preserve legacy unknown-order objects";
+        assert_unknown_order_normalizes_to_living_oblist(data);
     }
     {
         LevelRuntimeData data(1);
@@ -606,7 +617,7 @@ TEST(LevelDataLoadVersions, 2_to_5_invalid_order_fails_object_creation)
         append_fixed8(bytes, "grid");
         append_u8(bytes, 1); // scenario type
         append_i16(bytes, 1);
-        append_u8(bytes, 255); // invalid Order -> add_ob should fail
+        append_u8(bytes, 255); // legacy unknown order
         append_u8(bytes, static_cast<uint8_t>(FAMILY_SOLDIER));
         append_i16(bytes, 100);
         append_i16(bytes, 100);
@@ -621,7 +632,8 @@ TEST(LevelDataLoadVersions, 2_to_5_invalid_order_fails_object_creation)
         append_u8(bytes, 0); // numlines
         MemoryOgFile rw(bytes.data(), bytes.size());
         const short ok = load_version_5(rw, &data);
-        ASSERT_TRUE(ok == 0 || ok == 1) << "v5 unknown-order input should not crash loader";
+        ASSERT_EQ(1, (int)ok) << "v5 loader should preserve legacy unknown-order objects";
+        assert_unknown_order_normalizes_to_living_oblist(data);
     }
 }
 
@@ -692,7 +704,8 @@ TEST(LevelDataLoadVersions, level_data_load_version6plus_invalid_counts_and_obje
         append_u8(bytes, 0); // num lines
         MemoryOgFile rw(bytes.data(), bytes.size());
         const short ok = load_version_6(rw, &data, 9);
-        ASSERT_TRUE(ok == 0 || ok == 1) << "v9 loader unknown order should not crash";
+        ASSERT_EQ(1, (int)ok) << "v9 loader should preserve legacy unknown-order objects";
+        assert_unknown_order_normalizes_to_living_oblist(data);
     }
 }
 
@@ -797,5 +810,8 @@ TEST(LevelDataLoadVersions, level_data_load_scenario_dispatch_case2_path)
     append_i16(bytes, 0); // listsize
     MemoryOgFile rw(bytes.data(), bytes.size());
     const short result = load_scenario_version(rw, &data, 2);
-    ASSERT_TRUE(result == 0 || result == 1) << "dispatch case 2 should execute without crashing";
+    ASSERT_EQ(1, (int)result) << "dispatch case 2 should accept a minimal empty v2 payload";
+    ASSERT_TRUE(data.world().oblist.empty());
+    ASSERT_TRUE(data.world().fxlist.empty());
+    ASSERT_TRUE(data.world().weaplist.empty());
 }

--- a/tests/test_level_data_unit.cpp
+++ b/tests/test_level_data_unit.cpp
@@ -309,7 +309,8 @@ TEST(LevelDataUnit, level_data_r11_query_grid_passable_terrain_branches)
     // arrow wall + weapon owner branch
     fx.level.world().grid.data[gx + gy * fx.level.world().grid.w] = PIX_WALL4;
     weap->set_owner(ob);
-    ASSERT_TRUE(!fx.level.query_grid_passable(weap->xpos(), weap->ypos(), weap) || fx.level.query_grid_passable(weap->xpos(), weap->ypos(), weap));
+    ASSERT_TRUE(fx.level.query_grid_passable(weap->xpos(), weap->ypos(), weap))
+        << "owner-adjacent weapons should be allowed through arrow wall tiles";
 }
 
 TEST(LevelDataUnit, level_data_r11_object_passability_and_search_sets)

--- a/tests/test_level_editor_helpers.cpp
+++ b/tests/test_level_editor_helpers.cpp
@@ -122,7 +122,10 @@ TEST(LevelEditorHelpers, level_editor_set_screen_pos_and_tile_matching)
     shareCampaign(og::runtime::current_session->myscreen_);
     std::string name = "Default";
     ASSERT_TRUE(prompt_for_string("Name", name)) << "prompt_for_string test-mode path should accept";
-    ASSERT_TRUE(level_editor_test_exercise_internal_helpers() > 0) << "internal helper exerciser should run";
+    constexpr int kExpectedInternalHelperChecks = 166;
+    ASSERT_EQ(kExpectedInternalHelperChecks,
+              level_editor_test_exercise_internal_helpers())
+        << "internal helper exerciser should run every check";
 
 }
 

--- a/tests/test_level_editor_helpers.cpp
+++ b/tests/test_level_editor_helpers.cpp
@@ -53,6 +53,33 @@ TEST(LevelEditorHelpers, level_editor_set_screen_pos_and_tile_matching)
     t = (unsigned char)get_random_matching_tile(PIX_PAVEMENT1);
     ASSERT_TRUE(t == PIX_PAVEMENT1 || t == PIX_PAVEMENT2 || t == PIX_PAVEMENT3) << "pavement variant should be one of pavement tiles";
 
+    t = (unsigned char)get_random_matching_tile(PIX_GRASS_DARK_B1);
+    ASSERT_TRUE(t == PIX_GRASS_DARK_B1 || t == PIX_GRASS_DARK_B2) << "dark grass bottom variant should be one of bottom tiles";
+
+    t = (unsigned char)get_random_matching_tile(PIX_GRASS_DARK_R1);
+    ASSERT_TRUE(t == PIX_GRASS_DARK_R1 || t == PIX_GRASS_DARK_R2) << "dark grass right variant should be one of right tiles";
+
+    t = (unsigned char)get_random_matching_tile(PIX_COBBLE_1);
+    ASSERT_TRUE(in_set(t, PIX_COBBLE_1, PIX_COBBLE_2, PIX_COBBLE_3, PIX_COBBLE_4)) << "cobble variant should be one of cobble tiles";
+
+    t = (unsigned char)get_random_matching_tile(PIX_BOULDER_1);
+    ASSERT_TRUE(in_set(t, PIX_BOULDER_1, PIX_BOULDER_2, PIX_BOULDER_3, PIX_BOULDER_4)) << "boulder variant should be one of boulder tiles";
+
+    t = (unsigned char)get_random_matching_tile(PIX_JAGGED_GROUND_1);
+    ASSERT_TRUE(in_set(t, PIX_JAGGED_GROUND_1, PIX_JAGGED_GROUND_2, PIX_JAGGED_GROUND_3, PIX_JAGGED_GROUND_4)) << "jagged variant should be one of jagged ground tiles";
+
+    for (int i = 0; i < 64; ++i) {
+        (void)get_random_matching_tile(PIX_GRASS1);
+        (void)get_random_matching_tile(PIX_GRASS_DARK_1);
+        (void)get_random_matching_tile(PIX_GRASS_DARK_B1);
+        (void)get_random_matching_tile(PIX_GRASS_DARK_R1);
+        (void)get_random_matching_tile(PIX_WATER1);
+        (void)get_random_matching_tile(PIX_PAVEMENT1);
+        (void)get_random_matching_tile(PIX_COBBLE_1);
+        (void)get_random_matching_tile(PIX_BOULDER_1);
+        (void)get_random_matching_tile(PIX_JAGGED_GROUND_1);
+    }
+
     // Default case should return original.
     t = (unsigned char)get_random_matching_tile(222);
     ASSERT_EQ(222, (int)t) << "unknown tiles should be returned unchanged";
@@ -71,6 +98,8 @@ TEST(LevelEditorHelpers, level_editor_set_screen_pos_and_tile_matching)
     ASSERT_TRUE(get_editor_family_label(Order::Generator, FAMILY_TOWER, test_livings, test_treasures, test_weapons) == "MAGE TOWER") << "generator tower label";
     ASSERT_TRUE(get_editor_family_label(Order::Generator, FAMILY_BONES, test_livings, test_treasures, test_weapons) == "BONEPILE") << "generator bones label";
     ASSERT_TRUE(get_editor_family_label(Order::Generator, FAMILY_TREEHOUSE, test_livings, test_treasures, test_weapons) == "TREEHOUSE") << "generator treehouse label";
+    ASSERT_TRUE(get_editor_family_label(Order::Generator, FAMILY_SKELETON, test_livings, test_treasures, test_weapons) == "GENERATOR") << "generic generator label";
+    ASSERT_TRUE(get_editor_family_label(Order::Living, -1, test_livings, test_treasures, test_weapons) == "UNKNOWN") << "invalid family label";
     ASSERT_TRUE(get_editor_family_label(Order::Special, 0, test_livings, test_treasures, test_weapons) == "START TILE") << "special start-tile label";
     ASSERT_TRUE(get_editor_family_label(Order::Living, FAMILY_SOLDIER, test_livings, test_treasures, test_weapons) == "SOLDIER") << "living label";
     ASSERT_TRUE(get_editor_family_label(Order::Treasure, FAMILY_KEY, test_livings, test_treasures, test_weapons) == "TREASURE") << "treasure family label";

--- a/tests/test_level_editor_helpers.cpp
+++ b/tests/test_level_editor_helpers.cpp
@@ -122,10 +122,8 @@ TEST(LevelEditorHelpers, level_editor_set_screen_pos_and_tile_matching)
     shareCampaign(og::runtime::current_session->myscreen_);
     std::string name = "Default";
     ASSERT_TRUE(prompt_for_string("Name", name)) << "prompt_for_string test-mode path should accept";
-    constexpr int kExpectedInternalHelperChecks = 166;
-    ASSERT_EQ(kExpectedInternalHelperChecks,
-              level_editor_test_exercise_internal_helpers())
-        << "internal helper exerciser should run every check";
+    ASSERT_EQ(0, level_editor_test_exercise_internal_helpers())
+        << "internal helper exerciser should report the first failed check as a negative index";
 
 }
 

--- a/tests/test_level_editor_prompt_block.cpp
+++ b/tests/test_level_editor_prompt_block.cpp
@@ -105,6 +105,37 @@ int prompt_block_editing_injector(void* data)
     st->finished = true;
     return 0;
 }
+
+int prompt_block_multiline_injector(void* data)
+{
+    og::runtime::ensure_thread_session();
+    PromptBlockInjectData* d = static_cast<PromptBlockInjectData*>(data);
+    PromptBlockInjectState* st = d->state;
+    st->started = true;
+
+    SDL_Delay(90);
+    inject_key_press(SDLK_RETURN, 20);    // split at the beginning
+    inject_key_press(SDLK_BACKSPACE, 20); // merge the split line back
+    inject_key_press(SDLK_RIGHT, 20);
+    inject_key_press(SDLK_BACKSPACE, 20); // delete within a line
+    for (int i = 0; i < 5; ++i)
+        inject_key_press(SDLK_RETURN, 15);
+    inject_key_press(SDLK_UP, 20);
+    inject_key_press(SDLK_DOWN, 20);
+    inject_key_press(SDLK_RIGHT, 20);
+    inject_key_press(SDLK_DELETE, 20);
+
+    SDL_Delay(40);
+    MouseState& m = query_mouse_no_poll();
+    m.x = 290.0f;
+    m.y = 6.0f;
+    m.left = true;
+    SDL_Delay(40);
+    m.left = false;
+
+    st->finished = true;
+    return 0;
+}
 } // namespace
 
 TEST(LevelEditorPromptBlock, level_editor_prompt_for_string_block_escape_cancel)
@@ -179,3 +210,23 @@ TEST(LevelEditorPromptBlock, level_editor_prompt_for_string_block_editing_keys_a
     ASSERT_TRUE(!edited.empty()) << "edited block should remain non-empty";
 }
 
+TEST(LevelEditorPromptBlock, level_editor_prompt_for_string_block_multiline_editing_paths)
+{
+    std::list<std::string> edited{"abc"};
+
+    PromptBlockInjectState st{};
+    KeyStateGuard keyguard;
+    PromptBlockInjectData inject_data{&st, &keyguard, false, false};
+    SDL_Thread* thread = SDL_CreateThread(prompt_block_multiline_injector, "prompt_block_multiline_injector", &inject_data);
+    ASSERT_TRUE(thread != nullptr) << "failed to create multiline injector thread";
+
+    bool accepted = prompt_for_string_block("Edit multiline text", edited);
+
+    int thread_result = 0;
+    SDL_WaitThread(thread, &thread_result);
+
+    ASSERT_TRUE(st.started) << "injector should have started";
+    ASSERT_TRUE(st.finished) << "injector should have finished";
+    ASSERT_TRUE(accepted) << "DONE button should accept multiline edits";
+    ASSERT_GE(edited.size(), 2u) << "return key should create multiple lines";
+}

--- a/tests/test_level_progress.cpp
+++ b/tests/test_level_progress.cpp
@@ -85,6 +85,11 @@ static int event_injector_thread(void* data)
     fprintf(stderr, "  [test] Step 4: clicking team back\n");
     interact("back");
 
+    // Back returns to the main menu. Trip the test-mode max-loop guard so
+    // picker_main() does not sit in a fresh mainmenu() waiting for input.
+    g_picker_mainmenu_calls = g_picker_max_mainmenu_calls;
+    SDL_Delay(500);
+
     seq->finished = true;
     return 0;
 }
@@ -141,4 +146,3 @@ TEST(LevelProgress, menu) {
     // Verify the progress menu was actually entered by checking traces
     ASSERT_TRUE(trace_contains("menu", "init_buttons")) << "menu buttons should have been initialized";
 }
-

--- a/tests/test_living_combat.cpp
+++ b/tests/test_living_combat.cpp
@@ -785,6 +785,7 @@ TEST(LivingCombat, living_round10_facing_and_action_follow_branch_matrix)
     {
         actor->set_team_num(2);
         leader->set_team_num(0);
+        leader->set_user(0);
         leader_foe->set_team_num(1);
         leader->set_foe(leader_foe);
         leader->setxy(actor->xpos() + 8, actor->ypos() + 8);
@@ -798,7 +799,9 @@ TEST(LivingCombat, living_round10_facing_and_action_follow_branch_matrix)
         actor->set_foe(nullptr);
         leader->set_foe(nullptr);
         const bool follow_res = lv->do_action();
-        ASSERT_TRUE(follow_res || !follow_res) << "ACTION_FOLLOW with leader and no foe should execute without crashing";
+        ASSERT_TRUE(follow_res) << "ACTION_FOLLOW with leader and no foe should enqueue follow command";
+        ASSERT_EQ(leader, actor->leader());
+        ASSERT_TRUE(actor->stats()->has_commands());
     }
 }
 

--- a/tests/test_living_unit.cpp
+++ b/tests/test_living_unit.cpp
@@ -85,7 +85,10 @@ TEST(LivingUnit, living_r11_act_owner_dead_and_action_follow)
     owner->set_dead(0);
     owner->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
     owner->set_team_num(0);
-    ASSERT_TRUE(self->do_action() == 1 || self->do_action() == 0);
+    owner->set_user(0);
+    ASSERT_TRUE(self->do_action());
+    ASSERT_EQ(owner, self->leader());
+    ASSERT_TRUE(self->stats()->has_commands());
 }
 
 TEST(LivingUnit, living_r11_facing_thresholds)
@@ -123,8 +126,13 @@ TEST(LivingUnit, living_r11_collide_and_act_type_switches)
     ASSERT_TRUE(self->act());
 
     self->set_act_type(ACT_DIE);
+    self->stats()->clear_command();
+    self->set_action(0);
+    self->set_user(-1);
+    self->set_curdir(FACE_UP);
+    self->set_enddir(FACE_UP);
     ASSERT_TRUE(self->act());
-    ASSERT_TRUE(self->dead() == 1 || self->dead() == 0);
+    ASSERT_TRUE(self->dead());
 }
 
 TEST(LivingUnit, living_r11_summon_difficulty_checkspecial_and_walk_paths)
@@ -266,7 +274,8 @@ TEST(LivingUnit, living_r14_lines_65_73_89_95_138_175_owner_lifetime_and_counter
     owner->set_dead(0);
     self->set_owner(owner);
     self->set_lifetime(1);
-    ASSERT_TRUE(!self->act() || self->dead() == 1);
+    (void)self->act();
+    ASSERT_TRUE(self->dead());
 }
 
 TEST(LivingUnit, living_r14_lines_155_190_196_212_219_226_235_245_259_266_270_303_308)
@@ -301,7 +310,11 @@ TEST(LivingUnit, living_r14_lines_155_190_196_212_219_226_235_245_259_266_270_30
     self->set_flight_left(0);
     self->set_ani_type(ANI_WALK);
     self->set_act_type(ACT_CONTROL);
-    ASSERT_TRUE(self->act() || self->dead() == 1);
+    ASSERT_TRUE(self->act());
+    ASSERT_FALSE(self->dead());
+    ASSERT_EQ(2, self->speed_bonus_left());
+    ASSERT_LT(self->attack_lunge(), 1.0f);
+    ASSERT_LT(self->hit_recoil(), 1.0f);
 
     self->set_dead(0);
     self->stats()->set_frozen_delay(1);
@@ -341,7 +354,8 @@ TEST(LivingUnit, living_r14_lines_371_375_380_419_433_440_shove_walk_and_animate
     assign_basic_ani(ally);
 
     ally->set_act_type(ACT_GUARD);
-    ASSERT_TRUE(self->shove(ally, 1, 0) == 0 || self->shove(ally, 1, 0) == 1);
+    ASSERT_EQ(1, self->shove(ally, 1, 0));
+    ASSERT_TRUE(ally->stats()->has_commands());
 
     self->set_curdir(FACE_LEFT);
     self->setxy(0, 0);

--- a/tests/test_mass_coverage.cpp
+++ b/tests/test_mass_coverage.cpp
@@ -6,6 +6,10 @@
 #include <openglad/interface/render/obmap_debug_draw.h>
 #include <openglad/gameplay/obmap.h>
 #include <openglad/gameplay/walker.h>
+#include <openglad/gameplay/effect.h>
+#include <openglad/gameplay/living.h>
+#include <openglad/gameplay/treasure.h>
+#include <openglad/gameplay/weap.h>
 #include <openglad/interface/button.h>
 #include <openglad/resources/pixie_data.h>
 #include <openglad/resources/yaml_stream.h>
@@ -391,6 +395,30 @@ TEST(MassCoverage, pixie_render_paths) {
     }
     p.set_accel(0);
     ASSERT_EQ(0, p.accel) << "set_accel(0) should disable acceleration";
+}
+
+TEST(MassCoverage, pixie_backed_entity_constructors_set_orders_and_sizes) {
+    PixieData data = make_test_pixie_data(2, 4, 5, 44);
+
+    effect fx(data);
+    EXPECT_EQ(Order::FX, fx.query_order());
+    EXPECT_EQ(4, fx.sizex());
+    EXPECT_EQ(5, fx.sizey());
+
+    living live(data);
+    EXPECT_EQ(Order::Living, live.query_order());
+    EXPECT_EQ(4, live.sizex());
+    EXPECT_EQ(5, live.sizey());
+
+    treasure loot(data);
+    EXPECT_EQ(Order::Treasure, loot.query_order());
+    EXPECT_EQ(4, loot.sizex());
+    EXPECT_EQ(5, loot.sizey());
+
+    weap weapon(data);
+    EXPECT_EQ(Order::Weapon, weapon.query_order());
+    EXPECT_EQ(4, weapon.sizex());
+    EXPECT_EQ(5, weapon.sizey());
 }
 
 TEST(MassCoverage, pixien_and_level_render_paths) {

--- a/tests/test_options_menu.cpp
+++ b/tests/test_options_menu.cpp
@@ -35,6 +35,22 @@ static void cleanup_picker_state()
     pks().main_title_logo_data.free();
 }
 
+static bool click_until_interactable(const std::string& click_id, const std::string& next_id, int timeout_ms)
+{
+    const Uint32 deadline = SDL_GetTicks() + static_cast<Uint32>(timeout_ms);
+    while (SDL_GetTicks() < deadline) {
+        if (has_interactable(next_id))
+            return true;
+        if (has_interactable(click_id)) {
+            interact(click_id);
+            SDL_Delay(250);
+            continue;
+        }
+        SDL_Delay(50);
+    }
+    return has_interactable(next_id);
+}
+
 // Test: Open options menu, toggle some settings, then exit.
 //
 // Flow: Main Menu -> Options -> toggle some settings -> Back -> (main menu exits)
@@ -64,27 +80,26 @@ static int options_injector(void* data)
         state->finished = true;
         return 0;
     }
-    SDL_Delay(300);
+    SDL_Delay(750);
 
     fprintf(stderr, "  [test] clicking options\n");
-    interact("options");
+    bool in_options = click_until_interactable("options", "toggle_hit_flash", 10000);
 
     // Options menu buttons
     SDL_Delay(150);
-    if (wait_for_interactable("toggle_hit_flash", 10000)) {
+    if (in_options || wait_for_interactable("toggle_hit_flash", 10000)) {
         state->saw_options = true;
         SDL_Delay(150);
 
         fprintf(stderr, "  [test] entering player controls\n");
-        interact("player_controls");
+        bool in_controls = click_until_interactable("player_controls", "player1_mode", 5000);
         SDL_Delay(150);
-        if (wait_for_interactable("player1_mode", 5000)) {
+        if (in_controls || wait_for_interactable("player1_mode", 5000)) {
             state->entered_controls = true;
             interact("player1_mode");
             if (wait_for_interactable("controls_back", 5000)) {
                 SDL_Delay(200);
-                interact("controls_back");
-                state->exited_controls = true;
+                state->exited_controls = click_until_interactable("controls_back", "toggle_hit_flash", 5000);
             }
             wait_for_interactable("toggle_hit_flash", 10000);
             SDL_Delay(150);
@@ -138,31 +153,24 @@ static int options_injector(void* data)
         if (wait_for_interactable("options_back", 5000)) {
             interact("options_back");
             state->used_options_back = true;
+            SDL_Delay(500);
         }
     }
 
     // Ensure mainmenu() returns so picker_main() can complete. Coverage builds
-    // can redraw the main menu slowly after leaving options, so keep nudging
-    // Escape / BACK until the quit button appears and can be clicked.
-    const Uint32 quit_deadline = SDL_GetTicks() + 10000;
+    // can redraw the main menu slowly after leaving options, so use Escape to
+    // unwind whichever menu is currently active.
+    const Uint32 quit_deadline = SDL_GetTicks() + 3000;
     while (SDL_GetTicks() < quit_deadline) {
-        if (wait_for_interactable("quit", 250)) {
+        if (has_interactable("quit")) {
             SDL_Delay(80);
             fprintf(stderr, "  [test] clicking quit\n");
             interact("quit");
             break;
         }
 
-        if (wait_for_interactable("options_back", 150)) {
-            fprintf(stderr, "  [test] retry clicking options_back\n");
-            interact("options_back");
-            state->used_options_back = true;
-            SDL_Delay(150);
-            continue;
-        }
-
-        inject_key_press(SDLK_ESCAPE, 10);
-        SDL_Delay(50);
+        inject_key_press(SDLK_ESCAPE, 20);
+        SDL_Delay(150);
     }
 
     state->finished = true;

--- a/tests/test_options_menu.cpp
+++ b/tests/test_options_menu.cpp
@@ -3,6 +3,7 @@
 #include <openglad/resources/pixie_data.h>
 #include <openglad/interface/button.h>
 #include <openglad/core/test_trace.h>
+#include <openglad/interface/input.h>
 #include <openglad/interface/render/pixien.h>
 #include <openglad/interface/screen.h>
 #include <gtest/gtest.h>
@@ -16,6 +17,8 @@
 void picker_main(Sint32 argc, char **argv);
 extern int g_picker_mainmenu_calls;
 extern int g_picker_max_mainmenu_calls;
+Sint32 edit_player_keymap(Sint32 arg);
+Sint32 toggle_player_control_mode(Sint32 arg);
 
 #include <openglad/interface/ui/picker_ui_state.h>
 static inline PickerState& pks() { return *og::runtime::current_session->picker_; }
@@ -207,4 +210,25 @@ TEST(OptionsMenu, options_menu) {
     ASSERT_TRUE(state.entered_controls) << "should have entered controls submenu";
     ASSERT_TRUE(state.exited_controls) << "should have exited via controls_back";
     ASSERT_TRUE(state.used_options_back) << "should have exited options via options_back";
+}
+
+TEST(OptionsMenu, edit_player_keymap_exercises_four_and_eight_direction_prompts)
+{
+    constexpr Sint32 kMenuRedraw = 2;
+    reset_default_player_controls();
+    const int original_fire = og::runtime::current_session->player_keys_[0][KEY_FIRE];
+
+    ASSERT_EQ(kMenuRedraw, edit_player_keymap(0))
+        << "four-direction remap should complete without changing ESC-kept keys";
+    ASSERT_EQ(original_fire, og::runtime::current_session->player_keys_[0][KEY_FIRE])
+        << "fake ESC key should preserve the existing binding";
+
+    ASSERT_EQ(kMenuRedraw, toggle_player_control_mode(0));
+    ASSERT_EQ(kMenuRedraw, edit_player_keymap(0))
+        << "eight-direction remap should also complete under TESTING";
+
+    ASSERT_EQ(kMenuRedraw, edit_player_keymap(-1))
+        << "invalid player index should be ignored safely";
+    ASSERT_EQ(kMenuRedraw, edit_player_keymap(4))
+        << "out-of-range player index should be ignored safely";
 }

--- a/tests/test_picker_detail_menu_driven.cpp
+++ b/tests/test_picker_detail_menu_driven.cpp
@@ -1,11 +1,15 @@
 #include <openglad/gameplay/guy.h>
 #include <openglad/interface/button.h>
+#include <openglad/interface/input.h>
+#include <openglad/interface/native_input.h>
 #include <openglad/legacy/base.h>
 #include <openglad/interface/screen.h>
 #include <gtest/gtest.h>
 #include <SDL.h>
 
 #include <array>
+#include <atomic>
+#include <cmath>
 #include <memory>
 
 // myscreen is now a macro defined in base.h (via game_session.h)
@@ -85,6 +89,7 @@ struct InjectorArgs
 {
     KeyStateGuard* ks = nullptr;
     bool go_to_promote = false;
+    std::atomic<bool>* done = nullptr;
 };
 
 static int injector_thread_exit_detail_menu(void* data)
@@ -101,22 +106,31 @@ static int injector_thread_exit_detail_menu(void* data)
         SDL_Delay(5);
     }
 
-    // Fastest deterministic exit path in picker menus is the ESC hotkey.
-    // leftmouse() treats held hotkeys as a click.
-    if (!a->go_to_promote)
+    const int logical_x = a->go_to_promote ? 200 : 20;
+    const int logical_y = a->go_to_promote ? 30 : 180;
+    const int click_x = static_cast<int>(std::lround(
+        static_cast<float>(logical_x) * og::runtime::current_session->viewport_w_ / 320.0f
+        + og::runtime::current_session->viewport_offset_x_));
+    const int click_y = static_cast<int>(std::lround(
+        static_cast<float>(logical_y) * og::runtime::current_session->viewport_h_ / 200.0f
+        + og::runtime::current_session->viewport_offset_y_));
+    do
     {
-        a->ks->pulse(SDL_SCANCODE_ESCAPE, 40, 10);
-        return 0;
-    }
-
-    // For promote we need menu_nav enabled and highlight moved to the promote button.
-    a->ks->pulse(SDL_SCANCODE_RIGHT, 30, 10);
-
-    // Activate: LCTRL is KEY_FIRE for player 0 by default. First pulse enables
-    // menu_nav, second pulse activates.
-    a->ks->pulse(SDL_SCANCODE_LCTRL, 30, 10);
-    a->ks->pulse(SDL_SCANCODE_LCTRL, 30, 10);
+        og::input_native::push_mouse_button_event(true, og::input_native::kMouseButtonLeft, click_x, click_y);
+        SDL_Delay(5);
+    } while (a->done && !a->done->load(std::memory_order_relaxed));
+    og::input_native::push_mouse_button_event(false, og::input_native::kMouseButtonLeft, click_x, click_y);
     return 0;
+}
+
+void prepare_detail_menu_mouse_click()
+{
+    clear_events();
+    auto& input_hw = input_hardware_state();
+    input_hw.mouse.left = 0;
+    input_hw.mouse.right = 0;
+    input_hw.picker_was_left_down = false;
+    input_hw.picker_was_right_down = false;
 }
 } // namespace
 
@@ -134,14 +148,18 @@ TEST(PickerDetailMenuDriven, picker_detail_menu_back_exercises_many_family_descr
     og::runtime::current_session->current_guy_ = std::make_unique<guy>(*og::runtime::current_session->myscreen_->save_data.team_list[0]);
 
     KeyStateGuard ks;
-    InjectorArgs args{&ks, false};
+    std::atomic<bool> done{false};
+    prepare_detail_menu_mouse_click();
+    InjectorArgs args{&ks, false, &done};
     SDL_Thread* th = SDL_CreateThread(injector_thread_exit_detail_menu, "picker_detail_exit", &args);
     ASSERT_TRUE(th != nullptr) << "injector thread started";
 
     Sint32 r = create_detail_menu(og::runtime::current_session->myscreen_->save_data.team_list[0].get());
+    done.store(true, std::memory_order_relaxed);
     int code = 0;
     if (th)
         SDL_WaitThread(th, &code);
+    clear_events();
 
     // create_detail_menu exits back to the edit menu and always returns REDRAW.
     ASSERT_EQ(2, (int)r) << "detail menu should return REDRAW on back";
@@ -162,16 +180,21 @@ TEST(PickerDetailMenuDriven, picker_detail_menu_promote_mage_to_archmage_branch)
     og::runtime::current_session->current_guy_ = std::make_unique<guy>(*og::runtime::current_session->myscreen_->save_data.team_list[0]);
 
     KeyStateGuard ks;
-    InjectorArgs args{&ks, true};
+    std::atomic<bool> done{false};
+    prepare_detail_menu_mouse_click();
+    InjectorArgs args{&ks, true, &done};
     SDL_Thread* th = SDL_CreateThread(injector_thread_exit_detail_menu, "picker_detail_promote_mage", &args);
     ASSERT_TRUE(th != nullptr) << "injector thread started";
 
     Sint32 r = create_detail_menu(og::runtime::current_session->myscreen_->save_data.team_list[0].get());
+    done.store(true, std::memory_order_relaxed);
     int code = 0;
     if (th)
         SDL_WaitThread(th, &code);
+    clear_events();
 
     ASSERT_EQ(2, (int)r) << "mage promote should request redraw";
+    ASSERT_EQ(FAMILY_ARCHMAGE, og::runtime::current_session->myscreen_->save_data.team_list[0]->family);
 }
 
 
@@ -189,16 +212,21 @@ TEST(PickerDetailMenuDriven, picker_detail_menu_promote_orc_to_captain_branch)
     og::runtime::current_session->current_guy_ = std::make_unique<guy>(*og::runtime::current_session->myscreen_->save_data.team_list[0]);
 
     KeyStateGuard ks;
-    InjectorArgs args{&ks, true};
+    std::atomic<bool> done{false};
+    prepare_detail_menu_mouse_click();
+    InjectorArgs args{&ks, true, &done};
     SDL_Thread* th = SDL_CreateThread(injector_thread_exit_detail_menu, "picker_detail_promote_orc", &args);
     ASSERT_TRUE(th != nullptr) << "injector thread started";
 
     Sint32 r = create_detail_menu(og::runtime::current_session->myscreen_->save_data.team_list[0].get());
+    done.store(true, std::memory_order_relaxed);
     int code = 0;
     if (th)
         SDL_WaitThread(th, &code);
+    clear_events();
 
     ASSERT_EQ(2, (int)r) << "orc promote should request redraw";
+    ASSERT_EQ(FAMILY_BIG_ORC, og::runtime::current_session->myscreen_->save_data.team_list[0]->family);
 }
 
 
@@ -207,4 +235,3 @@ TEST(PickerDetailMenuDriven, picker_family_name_copy_includes_archmage)
     const char* a = family_name_copy(FAMILY_ARCHMAGE);
     ASSERT_TRUE(a != nullptr) << "family_name_copy should return a string";
 }
-

--- a/tests/test_picker_dialogs_real.cpp
+++ b/tests/test_picker_dialogs_real.cpp
@@ -100,8 +100,10 @@ TEST(PickerDialogsReal, picker_dialogs_no_or_yes_default_paths)
 
 TEST(PickerDialogsReal, picker_dialogs_popup_dialog_testmode_noop)
 {
+    vbutton* buttons_before = og::runtime::current_session->localbuttons_;
     popup_dialog("Information", "This is a test popup\\nwith two lines.");
-    ASSERT_TRUE(true) << "popup_dialog should be non-blocking in test mode";
+    ASSERT_EQ(buttons_before, og::runtime::current_session->localbuttons_)
+        << "test-mode popup should return before installing dialog buttons";
 }
 
 

--- a/tests/test_picker_funcs.cpp
+++ b/tests/test_picker_funcs.cpp
@@ -7,12 +7,14 @@
 #include <openglad/interface/ui/picker_common.h>
 #include <openglad/interface/ui/picker_lobby_client.h>
 #include <openglad/interface/ui/picker_ui_state.h>
+#include <openglad/resources/io_common.h>
 #include <gtest/gtest.h>
 #include <array>
 #include <atomic>
 #include <cstdlib>
 #include <cstdint>
 #include <cstring>
+#include <fstream>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -35,6 +37,7 @@ bool yes_or_no_prompt(const char* title, const char* message, bool default_value
 Sint32 add_guy(guy* newguy);
 Sint32 do_save(Sint32 arg1);
 Sint32 do_load(Sint32 arg1);
+std::string get_saved_name(const char* filename);
 Sint32 delete_all();
 void quit(Sint32 arg1);
 Sint32 return_menu(Sint32 arg);
@@ -1933,4 +1936,47 @@ TEST(PickerFuncs, train_session_survives_team_slot_replacement_after_accept)
     save.numplayers = old_numplayers;
     for (int i = 0; i < 4; ++i)
         save.m_totalcash[i] = old_cash[i];
+}
+
+TEST(PickerFuncs, get_saved_name_handles_legacy_truncated_and_named_slots)
+{
+    create_dir(get_user_path() + "save");
+
+    auto write_slot = [](const std::string& slot, const std::string& bytes) {
+        const std::string path = get_user_path() + "save/" + slot + ".gtl";
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        ASSERT_TRUE(out.good()) << "failed to open " << path;
+        out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+        ASSERT_TRUE(out.good()) << "failed to write " << path;
+    };
+
+    EXPECT_EQ("EMPTY SLOT", get_saved_name("__picker_missing_slot__"));
+
+    write_slot("__picker_bad_header__", "BAD");
+    EXPECT_EQ("EMPTY SLOT", get_saved_name("__picker_bad_header__"));
+
+    write_slot("__picker_missing_version__", "GTL");
+    EXPECT_EQ("EMPTY SLOT", get_saved_name("__picker_missing_version__"));
+
+    write_slot("__picker_version_1__", std::string("GTL", 3) + std::string(1, '\x01'));
+    EXPECT_EQ("SAVED GAME", get_saved_name("__picker_version_1__"));
+
+    write_slot("__picker_version_0__", std::string("GTL", 3) + std::string(1, '\0'));
+    EXPECT_EQ("SAVED GAME", get_saved_name("__picker_version_0__"));
+
+    write_slot("__picker_version_2_truncated__", std::string("GTL", 3) + std::string(1, '\x02'));
+    EXPECT_EQ("SAVED GAME", get_saved_name("__picker_version_2_truncated__"));
+
+    write_slot("__picker_version_7_missing_registered__",
+               std::string("GTL", 3) + std::string(1, '\x07'));
+    EXPECT_EQ("SAVED GAME", get_saved_name("__picker_version_7_missing_registered__"));
+
+    std::string named = std::string("GTL", 3) + std::string(1, '\x07');
+    named.push_back('\x01');
+    named.push_back('\0');
+    std::array<char, 40> stored_name{};
+    std::memcpy(stored_name.data(), "Named Slot", 10);
+    named.append(stored_name.data(), stored_name.size());
+    write_slot("__picker_version_7_named__", named);
+    EXPECT_EQ("Named Slot", get_saved_name("__picker_version_7_named__"));
 }

--- a/tests/test_picker_network_client.cpp
+++ b/tests/test_picker_network_client.cpp
@@ -4094,8 +4094,7 @@ TEST(PickerNetworkClient, validation_helpers_reject_invalid_network_picker_input
 
 TEST(PickerNetworkClient, internal_helpers_cover_network_picker_paths)
 {
-    constexpr int kExpectedInternalHelperChecks = 59;
     EXPECT_EQ(
-        kExpectedInternalHelperChecks,
+        0,
         og::ui::detail::picker_lobby_network_testing_exercise_internal_helpers());
 }

--- a/tests/test_picker_network_client.cpp
+++ b/tests/test_picker_network_client.cpp
@@ -4094,7 +4094,7 @@ TEST(PickerNetworkClient, validation_helpers_reject_invalid_network_picker_input
 
 TEST(PickerNetworkClient, internal_helpers_cover_network_picker_paths)
 {
-    constexpr int kExpectedInternalHelperChecks = 58;
+    constexpr int kExpectedInternalHelperChecks = 59;
     EXPECT_EQ(
         kExpectedInternalHelperChecks,
         og::ui::detail::picker_lobby_network_testing_exercise_internal_helpers());

--- a/tests/test_picker_network_client.cpp
+++ b/tests/test_picker_network_client.cpp
@@ -88,6 +88,8 @@ og::sim::LobbyMessage make_join_message(
     short local_team,
     const std::array<bool, MAX_TEAM_SIZE>* excluded_slots);
 
+int picker_lobby_network_testing_exercise_internal_helpers();
+
 } // namespace og::ui::detail
 
 namespace {
@@ -4088,4 +4090,11 @@ TEST(PickerNetworkClient, validation_helpers_reject_invalid_network_picker_input
               og::ui::normalize_relay_base_url(" https://relay.invalid/// "));
     EXPECT_THROW(og::ui::normalize_relay_base_url("ftp://relay.invalid"),
                  std::invalid_argument);
+}
+
+TEST(PickerNetworkClient, internal_helpers_cover_network_picker_paths)
+{
+    EXPECT_GE(
+        og::ui::detail::picker_lobby_network_testing_exercise_internal_helpers(),
+        50);
 }

--- a/tests/test_picker_network_client.cpp
+++ b/tests/test_picker_network_client.cpp
@@ -4094,7 +4094,8 @@ TEST(PickerNetworkClient, validation_helpers_reject_invalid_network_picker_input
 
 TEST(PickerNetworkClient, internal_helpers_cover_network_picker_paths)
 {
-    EXPECT_GE(
-        og::ui::detail::picker_lobby_network_testing_exercise_internal_helpers(),
-        50);
+    constexpr int kExpectedInternalHelperChecks = 58;
+    EXPECT_EQ(
+        kExpectedInternalHelperChecks,
+        og::ui::detail::picker_lobby_network_testing_exercise_internal_helpers());
 }

--- a/tests/test_picker_uncovered.cpp
+++ b/tests/test_picker_uncovered.cpp
@@ -198,5 +198,7 @@ TEST(PickerUncovered, picker_team_wraps_on_negative_step)
 
 TEST(PickerUncovered, picker_team_build_internal_paths)
 {
-    ASSERT_GE(picker_team_build_testing_exercise_internal_paths(), 20);
+    constexpr int kExpectedInternalHelperChecks = 31;
+    ASSERT_EQ(kExpectedInternalHelperChecks,
+              picker_team_build_testing_exercise_internal_paths());
 }

--- a/tests/test_picker_uncovered.cpp
+++ b/tests/test_picker_uncovered.cpp
@@ -198,7 +198,5 @@ TEST(PickerUncovered, picker_team_wraps_on_negative_step)
 
 TEST(PickerUncovered, picker_team_build_internal_paths)
 {
-    constexpr int kExpectedInternalHelperChecks = 31;
-    ASSERT_EQ(kExpectedInternalHelperChecks,
-              picker_team_build_testing_exercise_internal_paths());
+    ASSERT_EQ(0, picker_team_build_testing_exercise_internal_paths());
 }

--- a/tests/test_picker_uncovered.cpp
+++ b/tests/test_picker_uncovered.cpp
@@ -20,6 +20,7 @@ Sint32 do_pick_campaign(Sint32 arg1);
 Sint32 do_set_scen_level(Sint32 arg1);
 Sint32 change_teamnum(Sint32 arg);
 Sint32 change_hire_teamnum(Sint32 arg);
+int picker_team_build_testing_exercise_internal_paths();
 
 namespace
 {
@@ -195,3 +196,7 @@ TEST(PickerUncovered, picker_team_wraps_on_negative_step)
     og::runtime::current_session->current_team_num_ = saved_team_num;
 }
 
+TEST(PickerUncovered, picker_team_build_internal_paths)
+{
+    ASSERT_GE(picker_team_build_testing_exercise_internal_paths(), 20);
+}

--- a/tests/test_results_screen_branches.cpp
+++ b/tests/test_results_screen_branches.cpp
@@ -56,27 +56,27 @@ void seed_save0_single_member(const char* name, short scen_num)
 TEST(ResultsScreenBranches, results_screen_ending_branches_smoke)
 {
     // Defeat generic.
-    (void)results_screen(1, -1);
+    ASSERT_FALSE(results_screen(1, -1));
     // Defeat retreat.
-    (void)results_screen(1, 2);
+    ASSERT_FALSE(results_screen(1, 2));
 
     // Victory, completed vs not completed.
     og::runtime::current_session->myscreen_->save_data.scen_num = 1;
     // Make sure completion state is deterministic: clear and set once.
     og::runtime::current_session->myscreen_->save_data.current_levels.clear();
     og::runtime::current_session->myscreen_->save_data.completed_levels.clear();
-    (void)results_screen(0, 2); // not completed -> "Victory!"
+    ASSERT_FALSE(results_screen(0, 2)); // not completed -> "Victory!"
 
     og::runtime::current_session->myscreen_->save_data.completed_levels[og::runtime::current_session->myscreen_->save_data.current_campaign].insert(
         og::runtime::current_session->myscreen_->save_data.scen_num);
-    (void)results_screen(0, 2); // completed -> "Traveling on..."
+    ASSERT_FALSE(results_screen(0, 2)); // completed -> "Traveling on..."
 
     results_screen_testing_set_force_full(true);
-    (void)results_screen(0, 2); // force the non-bypass TESTING overload path.
+    ASSERT_FALSE(results_screen(0, 2)); // force the non-bypass TESTING overload path.
     results_screen_testing_set_force_full(false);
 
     // Special defeat type.
-    (void)results_screen(SCEN_TYPE_SAVE_ALL, -1);
+    ASSERT_FALSE(results_screen(SCEN_TYPE_SAVE_ALL, -1));
 }
 
 
@@ -84,7 +84,7 @@ TEST(ResultsScreenBranches, results_screen_overload_calls_smoke)
 {
     std::map<int, guy*> before;
     std::map<int, walker*> after;
-    (void)results_screen(0, 2, before, after);
+    ASSERT_FALSE(results_screen(0, 2, before, after));
 }
 
 // Gap 4 ("hit play for next level") + Bug B regression: in a networked game the

--- a/tests/test_results_screen_branches.cpp
+++ b/tests/test_results_screen_branches.cpp
@@ -64,10 +64,16 @@ TEST(ResultsScreenBranches, results_screen_ending_branches_smoke)
     og::runtime::current_session->myscreen_->save_data.scen_num = 1;
     // Make sure completion state is deterministic: clear and set once.
     og::runtime::current_session->myscreen_->save_data.current_levels.clear();
+    og::runtime::current_session->myscreen_->save_data.completed_levels.clear();
     (void)results_screen(0, 2); // not completed -> "Victory!"
 
-    og::runtime::current_session->myscreen_->save_data.current_levels[og::runtime::current_session->myscreen_->save_data.current_campaign] = og::runtime::current_session->myscreen_->save_data.scen_num;
+    og::runtime::current_session->myscreen_->save_data.completed_levels[og::runtime::current_session->myscreen_->save_data.current_campaign].insert(
+        og::runtime::current_session->myscreen_->save_data.scen_num);
     (void)results_screen(0, 2); // completed -> "Traveling on..."
+
+    results_screen_testing_set_force_full(true);
+    (void)results_screen(0, 2); // force the non-bypass TESTING overload path.
+    results_screen_testing_set_force_full(false);
 
     // Special defeat type.
     (void)results_screen(SCEN_TYPE_SAVE_ALL, -1);
@@ -171,4 +177,3 @@ TEST(MpEndgameFlow, networked_terminal_defeat_ends_session_back_to_menu)
     og::runtime::current_session->networked_session_ = saved_net;
     og::runtime::current_session->myscreen_->world().end = saved_end;
 }
-

--- a/tests/test_results_screen_full_ui.cpp
+++ b/tests/test_results_screen_full_ui.cpp
@@ -2,6 +2,7 @@
 #include <openglad/gameplay/guy.h>
 #include <openglad/gameplay/walker.h>
 #include <openglad/interface/button.h>
+#include <openglad/interface/input.h>
 #include <openglad/interface/screen.h>
 #include <openglad/interface/ui/results_screen.h>
 
@@ -11,6 +12,8 @@
 
 #include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 // myscreen is now a macro defined in base.h (via game_session.h)
 
@@ -25,9 +28,20 @@ struct ResultsThreadState
     bool finished = false;
 };
 
+static void inject_results_click(int game_x, int game_y, int delay_ms = 10)
+{
+    MouseState& mouse = query_mouse_no_poll();
+    mouse.x = static_cast<float>(game_x);
+    mouse.y = static_cast<float>(game_y);
+    mouse.left = true;
+    SDL_Delay(delay_ms < 60 ? 60 : delay_ms);
+    mouse.left = false;
+    SDL_Delay(20);
+}
+
 static int results_ui_injector(void* data)
 {
-    og::runtime::ensure_thread_session();
+    og::runtime::current_session = og::runtime::primary_session.load();
     ResultsThreadState* st = static_cast<ResultsThreadState*>(data);
     st->started = true;
 
@@ -35,19 +49,25 @@ static int results_ui_injector(void* data)
 
     SDL_Event wheel{};
     wheel.type = SDL_MOUSEWHEEL;
+    wheel.wheel.y = 1;
+    SDL_PushEvent(&wheel);
+
     wheel.wheel.y = -1;
     SDL_PushEvent(&wheel);
 
     // Toggle tabs in the full results UI.
-    inject_click(220, 26, 10); // TROOPS
+    inject_results_click(220, 26, 10); // TROOPS
     SDL_Delay(40);
-    inject_click(70, 26, 10);  // OVERVIEW
-    SDL_Delay(40);
-    inject_click(220, 26, 10); // TROOPS again to execute both branches
+    for (int i = 0; i < 3; ++i)
+    {
+        inject_results_click(70, 26, 10);  // OVERVIEW
+        SDL_Delay(50);
+    }
+    inject_results_click(220, 26, 10); // TROOPS again to execute both branches
     SDL_Delay(40);
 
     // Exit via OK.
-    inject_click(130, 170, 10);
+    inject_results_click(130, 170, 10);
 
     // Failsafe in case click misses.
     SDL_Delay(500);
@@ -59,12 +79,12 @@ static int results_ui_injector(void* data)
 
 static int results_ui_scroll_injector(void* data)
 {
-    og::runtime::ensure_thread_session();
+    og::runtime::current_session = og::runtime::primary_session.load();
     ResultsThreadState* st = static_cast<ResultsThreadState*>(data);
     st->started = true;
 
     SDL_Delay(140);
-    inject_click(225, 26, 10); // TROOPS
+    inject_results_click(225, 26, 10); // TROOPS
     SDL_Delay(40);
 
     for (int i = 0; i < 12; ++i)
@@ -86,7 +106,7 @@ static int results_ui_scroll_injector(void* data)
     }
 
     SDL_Delay(80);
-    inject_click(132, 171, 10); // OK
+    inject_results_click(132, 171, 10); // OK
 
     SDL_Delay(400);
     og::runtime::current_session->myscreen_->world().end = 1;
@@ -94,6 +114,65 @@ static int results_ui_scroll_injector(void* data)
     st->finished = true;
     return 0;
 }
+
+static int results_ui_ok_injector(void* data)
+{
+    og::runtime::current_session = og::runtime::primary_session.load();
+    ResultsThreadState* st = static_cast<ResultsThreadState*>(data);
+    st->started = true;
+
+    SDL_Delay(140);
+    inject_results_click(130, 170, 10); // OK
+
+    SDL_Delay(300);
+    og::runtime::current_session->myscreen_->world().end = 1;
+
+    st->finished = true;
+    return 0;
+}
+
+static int results_ui_retry_injector(void* data)
+{
+    og::runtime::current_session = og::runtime::primary_session.load();
+    ResultsThreadState* st = static_cast<ResultsThreadState*>(data);
+    st->started = true;
+
+    SDL_Delay(140);
+    for (int i = 0; i < 6; ++i)
+    {
+        inject_results_click(187, 171, 10); // RETRY
+        SDL_Delay(60);
+    }
+
+    SDL_Delay(300);
+    og::runtime::current_session->myscreen_->world().end = 1;
+
+    st->finished = true;
+    return 0;
+}
+
+static int results_ui_troops_then_ok_injector(void* data)
+{
+    og::runtime::current_session = og::runtime::primary_session.load();
+    ResultsThreadState* st = static_cast<ResultsThreadState*>(data);
+    st->started = true;
+
+    SDL_Delay(140);
+    for (int i = 0; i < 4; ++i)
+    {
+        inject_results_click(220, 26, 10); // TROOPS
+        SDL_Delay(70);
+    }
+    SDL_Delay(500);
+    inject_results_click(130, 170, 10); // OK
+
+    SDL_Delay(300);
+    og::runtime::current_session->myscreen_->world().end = 1;
+
+    st->finished = true;
+    return 0;
+}
+
 } // namespace
 
 TEST(ResultsScreenFullUi, overview_and_troops_paths)
@@ -122,6 +201,7 @@ TEST(ResultsScreenFullUi, overview_and_troops_paths)
 
     static guy b1(FAMILY_SOLDIER);
     static guy b2(FAMILY_MAGE);
+    static guy b3(FAMILY_ARCHER);
     b1.name = "Alpha";
     b1.family = FAMILY_SOLDIER;
     b1.level = 2;
@@ -132,8 +212,14 @@ TEST(ResultsScreenFullUi, overview_and_troops_paths)
     b2.level = 3;
     b2.exp = calculate_exp(3) + 5;
 
+    b3.name = "Delta";
+    b3.family = FAMILY_ARCHER;
+    b3.level = 2;
+    b3.exp = calculate_exp(2) + 25;
+
     before[1] = &b1;
     before[2] = &b2;
+    before[4] = &b3;
 
     w1->myguy->name = "Alpha";
     w1->myguy->family = FAMILY_SOLDIER;
@@ -268,4 +354,191 @@ TEST(ResultsScreenFullUi, troop_scroll_paths_cover_bonus_losses_and_specials)
 
     ASSERT_TRUE(st.started && st.finished) << "scroll injector should run";
     ASSERT_TRUE(!retry) << "scrolling and OK should not request retry";
+}
+
+TEST(ResultsScreenFullUi, defeat_overview_path_reports_foe_totals)
+{
+    const char saved_end = og::runtime::current_session->myscreen_->world().end;
+    og::runtime::current_session->myscreen_->world().end = 0;
+
+    og::runtime::current_session->myscreen_->save_data.current_campaign = "org.openglad.gladiator";
+    og::runtime::current_session->myscreen_->save_data.scen_num = 1;
+    og::runtime::current_session->myscreen_->save_data.current_levels.clear();
+    og::runtime::current_session->myscreen_->save_data.m_score[0] = 75;
+
+    std::map<int, guy*> before;
+    std::map<int, walker*> after;
+
+    results_screen_testing_set_force_full(true);
+
+    ResultsThreadState st{};
+    SDL_Thread* thread = SDL_CreateThread(results_ui_ok_injector, "results_ui_ok_injector", &st);
+    ASSERT_TRUE(thread != nullptr) << "failed to create OK injector thread";
+
+    const bool retry = results_screen(1, -1, before, after);
+
+    int rc = 0;
+    SDL_WaitThread(thread, &rc);
+
+    results_screen_testing_set_force_full(false);
+    og::runtime::current_session->myscreen_->world().end = saved_end;
+
+    ASSERT_TRUE(st.started && st.finished) << "OK injector should run";
+    ASSERT_TRUE(!retry) << "defeat OK path should not request retry";
+}
+
+TEST(ResultsScreenFullUi, retry_button_accepts_prompt_and_returns_retry)
+{
+    const char saved_end = og::runtime::current_session->myscreen_->world().end;
+    og::runtime::current_session->myscreen_->world().end = 0;
+
+    og::runtime::current_session->myscreen_->save_data.current_campaign = "org.openglad.gladiator";
+    og::runtime::current_session->myscreen_->save_data.scen_num = 1;
+    og::runtime::current_session->myscreen_->save_data.current_levels.clear();
+
+    std::map<int, guy*> before;
+    std::map<int, walker*> after;
+
+    picker_testing_yes_or_no_queue_clear();
+    picker_testing_yes_or_no_queue_push(true);
+    results_screen_testing_set_force_full(true);
+
+    ResultsThreadState st{};
+    SDL_Thread* thread = SDL_CreateThread(results_ui_retry_injector, "results_ui_retry_injector", &st);
+    ASSERT_TRUE(thread != nullptr) << "failed to create retry injector thread";
+
+    const bool retry = results_screen(0, 2, before, after);
+
+    int rc = 0;
+    SDL_WaitThread(thread, &rc);
+
+    results_screen_testing_set_force_full(false);
+    picker_testing_yes_or_no_queue_clear();
+    og::runtime::current_session->myscreen_->world().end = saved_end;
+
+    ASSERT_TRUE(st.started && st.finished) << "retry injector should run";
+    ASSERT_TRUE(retry) << "accepted retry prompt should request retry";
+}
+
+TEST(ResultsScreenFullUi, completed_victory_zeroes_bonus_cash)
+{
+    const char saved_end = og::runtime::current_session->myscreen_->world().end;
+    og::runtime::current_session->myscreen_->world().end = 0;
+
+    auto& screen_ref = *og::runtime::current_session->myscreen_;
+    screen_ref.save_data.current_campaign = "org.openglad.gladiator";
+    screen_ref.save_data.scen_num = 1;
+    screen_ref.save_data.current_levels.clear();
+    screen_ref.save_data.completed_levels.clear();
+    screen_ref.save_data.completed_levels[screen_ref.save_data.current_campaign].insert(
+        screen_ref.save_data.scen_num);
+    screen_ref.save_data.m_score[0] = 250;
+    screen_ref.save_data.m_score[1] = 50;
+    screen_ref.world().time_bonus_limit = 500;
+    screen_ref.world().par_value = 4;
+    screen_ref.framecount = screen_ref.world().time_bonus_limit;
+
+    std::map<int, guy*> before;
+    std::map<int, walker*> after;
+
+    results_screen_testing_set_force_full(true);
+
+    ResultsThreadState st{};
+    SDL_Thread* thread = SDL_CreateThread(results_ui_ok_injector, "results_completed_ok_injector", &st);
+    ASSERT_TRUE(thread != nullptr) << "failed to create OK injector thread";
+
+    const bool retry = results_screen(0, 2, before, after);
+
+    int rc = 0;
+    SDL_WaitThread(thread, &rc);
+
+    results_screen_testing_set_force_full(false);
+    og::runtime::current_session->myscreen_->world().end = saved_end;
+
+    ASSERT_TRUE(st.started && st.finished) << "OK injector should run";
+    ASSERT_TRUE(!retry) << "completed victory OK path should not request retry";
+}
+
+TEST(ResultsScreenFullUi, troop_detail_paths_show_specials_and_negative_xp)
+{
+    const char saved_end = og::runtime::current_session->myscreen_->world().end;
+    og::runtime::current_session->myscreen_->world().end = 0;
+
+    auto& screen_ref = *og::runtime::current_session->myscreen_;
+    screen_ref.save_data.current_campaign = "org.openglad.gladiator";
+    screen_ref.save_data.scen_num = 1;
+    screen_ref.save_data.current_levels.clear();
+    screen_ref.save_data.m_score[0] = 150;
+    screen_ref.world().time_bonus_limit = 200;
+    screen_ref.world().par_value = 2;
+    screen_ref.framecount = 30;
+
+    const std::string saved_special = screen_ref.special_name[FAMILY_MAGE][2];
+    screen_ref.special_name[FAMILY_MAGE][2] = "Arcane Burst";
+
+    std::map<int, guy*> before;
+    std::map<int, walker*> after;
+    std::vector<std::unique_ptr<guy>> before_storage;
+
+    auto* gained = screen_ref.world().add_ob(Order::Living, FAMILY_MAGE);
+    auto* lost = screen_ref.world().add_ob(Order::Living, FAMILY_SOLDIER);
+    ASSERT_TRUE(gained != nullptr && lost != nullptr) << "expected walkers for troop detail test";
+    gained->set_owned_myguy(std::make_unique<guy>(FAMILY_MAGE));
+    lost->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+
+    auto gained_before = std::make_unique<guy>(FAMILY_MAGE);
+    gained_before->name = "Glyph";
+    gained_before->family = FAMILY_MAGE;
+    gained_before->level = 3;
+    gained_before->exp = calculate_exp(3) + 10;
+    before[1] = gained_before.get();
+    before_storage.push_back(std::move(gained_before));
+
+    gained->myguy->name = "Glyph";
+    gained->myguy->family = FAMILY_MAGE;
+    gained->myguy->exp = calculate_exp(4) + 40;
+    gained->myguy->scen_kills = 1;
+    gained->myguy->scen_damage = 12;
+    gained->myguy->scen_damage_taken = 1;
+    gained->myguy->scen_min_hp = 8;
+    gained->stats()->set_max_hitpoints(10);
+    gained->stats()->set_hitpoints(8);
+    after[1] = gained;
+
+    auto lost_before = std::make_unique<guy>(FAMILY_SOLDIER);
+    lost_before->name = "Bruise";
+    lost_before->family = FAMILY_SOLDIER;
+    lost_before->level = 5;
+    lost_before->exp = calculate_exp(5) + 120;
+    before[2] = lost_before.get();
+    before_storage.push_back(std::move(lost_before));
+
+    lost->myguy->name = "Bruise";
+    lost->myguy->family = FAMILY_SOLDIER;
+    lost->myguy->exp = calculate_exp(4) + 5;
+    lost->myguy->scen_kills = 2;
+    lost->myguy->scen_damage = 6;
+    lost->myguy->scen_damage_taken = 4;
+    lost->myguy->scen_min_hp = 5;
+    lost->stats()->set_max_hitpoints(10);
+    lost->stats()->set_hitpoints(5);
+    after[2] = lost;
+
+    results_screen_testing_set_force_full(true);
+
+    ResultsThreadState st{};
+    SDL_Thread* thread = SDL_CreateThread(results_ui_troops_then_ok_injector, "results_troops_ok_injector", &st);
+    ASSERT_TRUE(thread != nullptr) << "failed to create troop detail injector thread";
+
+    const bool retry = results_screen(0, 2, before, after);
+
+    int rc = 0;
+    SDL_WaitThread(thread, &rc);
+
+    results_screen_testing_set_force_full(false);
+    screen_ref.special_name[FAMILY_MAGE][2] = saved_special;
+    og::runtime::current_session->myscreen_->world().end = saved_end;
+
+    ASSERT_TRUE(st.started && st.finished) << "troop detail injector should run";
+    ASSERT_TRUE(!retry) << "troop detail OK path should not request retry";
 }

--- a/tests/test_results_screen_internal_helper.cpp
+++ b/tests/test_results_screen_internal_helper.cpp
@@ -3,8 +3,9 @@
 
 TEST(ResultsScreenInternalHelper, exercises_core_paths)
 {
-    int score = results_screen_test_exercise_internal();
-    ASSERT_TRUE(score > 0) << "internal helper should execute";
+    constexpr int kExpectedInternalHelperChecks = 8;
+    ASSERT_EQ(kExpectedInternalHelperChecks,
+              results_screen_test_exercise_internal())
+        << "internal helper should run every check";
 }
-
 

--- a/tests/test_results_screen_internal_helper.cpp
+++ b/tests/test_results_screen_internal_helper.cpp
@@ -3,9 +3,8 @@
 
 TEST(ResultsScreenInternalHelper, exercises_core_paths)
 {
-    constexpr int kExpectedInternalHelperChecks = 8;
+    constexpr int kExpectedInternalHelperChecks = 14;
     ASSERT_EQ(kExpectedInternalHelperChecks,
               results_screen_test_exercise_internal())
         << "internal helper should run every check";
 }
-

--- a/tests/test_results_screen_internal_helper.cpp
+++ b/tests/test_results_screen_internal_helper.cpp
@@ -3,8 +3,6 @@
 
 TEST(ResultsScreenInternalHelper, exercises_core_paths)
 {
-    constexpr int kExpectedInternalHelperChecks = 14;
-    ASSERT_EQ(kExpectedInternalHelperChecks,
-              results_screen_test_exercise_internal())
-        << "internal helper should run every check";
+    ASSERT_EQ(0, results_screen_test_exercise_internal())
+        << "internal helper should report the first failed check as a negative index";
 }

--- a/tests/test_screen_funcs.cpp
+++ b/tests/test_screen_funcs.cpp
@@ -40,14 +40,15 @@ TEST(ScreenFuncs, screen_first_of_found)
 
 TEST(ScreenFuncs, screen_first_of_not_found)
 {
+    og::runtime::current_session->myscreen_->world().delete_objects();
     walker* found = og::runtime::current_session->myscreen_->first_of(Order::Living, FAMILY_ARCHMAGE, 99);
-    // May or may not find one depending on test state, but should not crash
-    (void)found;
+    ASSERT_EQ(nullptr, found) << "first_of should return null when no matching object exists";
 }
 
 
 TEST(ScreenFuncs, screen_first_of_with_team)
 {
+    og::runtime::current_session->myscreen_->world().delete_objects();
     auto w = create_living(FAMILY_SOLDIER);
 	    ASSERT_TRUE(w != nullptr) << "create_walker should succeed";
 	    w->set_team_num(7);
@@ -58,7 +59,7 @@ TEST(ScreenFuncs, screen_first_of_with_team)
     ASSERT_TRUE(found != nullptr) << "first_of with matching team should find it";
 
     walker* not_found = og::runtime::current_session->myscreen_->first_of(Order::Living, FAMILY_SOLDIER, 99);
-    ASSERT_TRUE(not_found == nullptr || not_found->team_num() != 99) << "first_of with wrong team should not find team 99 unit";
+    ASSERT_EQ(nullptr, not_found) << "first_of with wrong team should not find a team-99 unit";
 
     og::runtime::current_session->myscreen_->world().oblist.pop_back();
 }

--- a/tests/test_sim_input_handler.cpp
+++ b/tests/test_sim_input_handler.cpp
@@ -818,21 +818,27 @@ TEST(SimInputHandler, sim_input_deep_branch_coverage_smoke)
     input.players[0].pressed[static_cast<int>(InputAction::Yell)] = true;
     result = sim_process_player_input(
         input.players[0], control, og::runtime::current_session->myscreen_->world(), 0, 0, debounce, special_names, &log);
-    ASSERT_TRUE(result.notify_source == control || result.notify_source == nullptr) << "yell path executes";
+    ASSERT_EQ(control, result.notify_source) << "plain yell should report the controlled walker as notification source";
 
     // Shift+yell summon, then release, then default.
     input.clear();
     input.players[0].held[static_cast<int>(InputAction::Shift)] = true;
     input.players[0].pressed[static_cast<int>(InputAction::Yell)] = true;
     control->set_action(0);
-    (void)sim_process_player_input(
+    result = sim_process_player_input(
         input.players[0], control, og::runtime::current_session->myscreen_->world(), 0, 0, debounce, special_names, &log);
+    ASSERT_EQ("SUMMONING DEFENSE!", result.notify_text) << "shift+yell should summon friendly units";
+    ASSERT_EQ(control, result.notify_source) << "summon notification should come from the controlled walker";
     control->set_action(ACTION_FOLLOW);
-    (void)sim_process_player_input(
+    result = sim_process_player_input(
         input.players[0], control, og::runtime::current_session->myscreen_->world(), 0, 0, debounce, special_names, &log);
+    ASSERT_EQ("RELEASING MEN!", result.notify_text) << "shift+yell while following should release units";
+    ASSERT_EQ(0, control->action()) << "release branch should clear follow action";
     control->set_action(99);
-    (void)sim_process_player_input(
+    result = sim_process_player_input(
         input.players[0], control, og::runtime::current_session->myscreen_->world(), 0, 0, debounce, special_names, &log);
+    ASSERT_TRUE(result.notify_text.empty()) << "default shift+yell branch should not claim a notification";
+    ASSERT_EQ(0, control->action()) << "default shift+yell branch should reset unknown actions";
 
     // Movement/action block with walk and fire/special branches.
     input.clear();

--- a/tests/test_sim_input_unit.cpp
+++ b/tests/test_sim_input_unit.cpp
@@ -347,7 +347,8 @@ TEST(SimInputUnit, sim_input_r11_animate_movement_and_bit_animate_paths)
     // held fire path
     input.clear();
     input.players[0].held[static_cast<int>(InputAction::Fire)] = true;
-    (void)sim_process_player_input(
+    result = sim_process_player_input(
         input.players[0], control, fx.level.world(), 0, 0, debounce, special_names, &fx.events);
+    ASSERT_EQ(control, result.new_control);
 }
 } // namespace detail_sim_input_r11

--- a/tests/test_smooth_coverage.cpp
+++ b/tests/test_smooth_coverage.cpp
@@ -556,7 +556,8 @@ TEST(SmoothCoverage, smooth_grass_dark_wall_water_tree_dirt_and_unknown_deep_bra
     ASSERT_EQ(0, (int)s.smooth()) << "smooth() without target should return 0";
     ExposedSmoother ex;
     ex.set_x_y(cx, cy, PIX_WATER1);
-    ASSERT_TRUE(true) << "deep smooth branch scenarios executed";
+    ASSERT_EQ(PIX_GRASS1, ex.query_x_y(cx, cy))
+        << "set_x_y without a target should keep the smoother in fallback mode";
 }
 
 
@@ -784,7 +785,8 @@ TEST(SmoothCoverage, smooth_round6_dark_grass_and_water_single_edge_switches)
     set_diagonals(grid, cx, cy, PIX_GRASS1, PIX_TREE_M1, PIX_GRASS1, PIX_TREE_M1);
     (void)s.smooth(cx, cy);
 
-    ASSERT_TRUE(true) << "dark-grass/water/tree switch branches executed";
+    ASSERT_EQ(PIX_TREE_ML, at(grid, cx, cy))
+        << "tree all-around split should select the left-edge middle tile";
 }
 
 
@@ -899,4 +901,3 @@ TEST(SmoothCoverage, smooth_round7a_query_guards_and_tree_branches)
     set_same_neighbors(grid, cx, cy, PIX_TREE_M1, PIX_GRASS1, TO_RIGHT | TO_UP);
     (void)s.smooth(cx, cy);
 }
-

--- a/tests/test_smooth_matrix.cpp
+++ b/tests/test_smooth_matrix.cpp
@@ -28,6 +28,29 @@ static unsigned char& at(PixieData& g, int x, int y)
     return g.data[x + y * g.w];
 }
 
+static bool is_dark_grass_branch_tile(int pix)
+{
+    switch (pix)
+    {
+        case PIX_GRASS1:
+        case PIX_GRASS_DARK_1:
+        case PIX_GRASS_DARK_2:
+        case PIX_GRASS_DARK_3:
+        case PIX_GRASS_DARK_4:
+        case PIX_GRASS_DARK_LL:
+        case PIX_GRASS_DARK_UR:
+        case PIX_GRASS_DARK_B1:
+        case PIX_GRASS_DARK_B2:
+        case PIX_GRASS_DARK_BR:
+        case PIX_GRASS_DARK_R1:
+        case PIX_GRASS_DARK_R2:
+        case PIX_GRASS_RUBBLE:
+            return true;
+        default:
+            return false;
+    }
+}
+
 static void set_neighbors_for_mask(PixieData& g, int cx, int cy, unsigned char same_type, unsigned char other_type, int mask)
 {
     at(g, cx, cy - 1) = (mask & 1) ? same_type : other_type;  // up
@@ -58,7 +81,7 @@ TEST(SmoothMatrix, covers_carpet_and_light_grass_masks)
         at(carpet, 2, 2) = PIX_CARPET_M;
         set_neighbors_for_mask(carpet, 2, 2, PIX_CARPET_M, PIX_GRASS1, mask);
         s.set_target(carpet);
-        (void)s.smooth(2, 2);
+        ASSERT_EQ(1, s.smooth(2, 2));
 
         const unsigned char cv = at(carpet, 2, 2);
         ASSERT_TRUE(cv >= PIX_CARPET_LL && cv <= PIX_CARPET_SMALL_TINY) << "carpet mask smoothing should emit a carpet tile variant";
@@ -67,7 +90,7 @@ TEST(SmoothMatrix, covers_carpet_and_light_grass_masks)
         at(light, 2, 2) = PIX_GRASS_LIGHT_1;
         set_neighbors_for_mask(light, 2, 2, PIX_GRASS_LIGHT_1, PIX_GRASS1, mask);
         s.set_target(light);
-        (void)s.smooth(2, 2);
+        ASSERT_EQ(1, s.smooth(2, 2));
 
         const unsigned char lv = at(light, 2, 2);
         ASSERT_TRUE(lv >= PIX_GRASS_LIGHT_1 && lv <= PIX_GRASS_LIGHT_LEFT_TOP) << "light-grass mask smoothing should emit a light-grass variant";
@@ -90,28 +113,30 @@ TEST(SmoothMatrix, covers_water_tree_dirt_and_dark_dirt_masks)
         at(water, 2, 2) = PIX_WATER1;
         set_neighbors_for_mask(water, 2, 2, PIX_WATER1, PIX_GRASS1, mask);
         s.set_target(water);
-        (void)s.smooth(2, 2);
+        ASSERT_EQ(1, s.smooth(2, 2));
+        ASSERT_EQ(TYPE_WATER, s.query_genre_x_y(2, 2));
 
         PixieData tree = make_grid(5, 5, PIX_GRASS1);
         at(tree, 2, 2) = PIX_TREE_M1;
         set_neighbors_for_mask(tree, 2, 2, PIX_TREE_M1, PIX_GRASS1, mask);
         s.set_target(tree);
-        (void)s.smooth(2, 2);
+        ASSERT_EQ(1, s.smooth(2, 2));
+        ASSERT_EQ(TYPE_TREES, s.query_genre_x_y(2, 2));
 
         PixieData dirt = make_grid(5, 5, PIX_GRASS1);
         at(dirt, 2, 2) = PIX_DIRT_1;
         set_neighbors_for_mask(dirt, 2, 2, PIX_DIRT_1, PIX_GRASS1, mask);
         s.set_target(dirt);
-        (void)s.smooth(2, 2);
+        ASSERT_EQ(1, s.smooth(2, 2));
+        ASSERT_EQ(TYPE_DIRT, s.query_genre_x_y(2, 2));
 
         PixieData dark_dirt = make_grid(5, 5, PIX_GRASS1);
         at(dark_dirt, 2, 2) = PIX_DIRT_DARK_1;
         set_neighbors_for_mask(dark_dirt, 2, 2, PIX_DIRT_DARK_1, PIX_GRASS1, mask);
         s.set_target(dark_dirt);
-        (void)s.smooth(2, 2);
+        ASSERT_EQ(1, s.smooth(2, 2));
+        ASSERT_EQ(TYPE_DIRT_DARK, s.query_genre_x_y(2, 2));
     }
-
-    ASSERT_TRUE(true) << "matrix smooth branch execution completed";
 }
 
 
@@ -130,28 +155,30 @@ TEST(SmoothMatrix, covers_grass_dark_grass_wall_and_cobble_paths)
         at(grass, 2, 2) = PIX_GRASS1;
         set_neighbors_for_mask(grass, 2, 2, PIX_GRASS1, PIX_DIRT_1, mask);
         s.set_target(grass);
-        (void)s.smooth(2, 2);
+        ASSERT_EQ(1, s.smooth(2, 2));
+        ASSERT_EQ(TYPE_GRASS, s.query_genre_x_y(2, 2));
 
         PixieData dark_grass = make_grid(5, 5, PIX_GRASS1);
         at(dark_grass, 2, 2) = PIX_GRASS_DARK_1;
         set_neighbors_for_mask(dark_grass, 2, 2, PIX_GRASS_DARK_1, PIX_GRASS1, mask);
         s.set_target(dark_grass);
-        (void)s.smooth(2, 2);
+        ASSERT_EQ(1, s.smooth(2, 2));
+        ASSERT_TRUE(is_dark_grass_branch_tile(at(dark_grass, 2, 2)));
 
         PixieData wall = make_grid(5, 6, PIX_GRASS1);
         at(wall, 2, 2) = PIX_H_WALL1;
         set_neighbors_for_mask(wall, 2, 2, PIX_H_WALL1, PIX_GRASS1, mask);
         at(wall, 2, 4) = PIX_H_WALL1;  // feed y+2 checks for wall cases
         s.set_target(wall);
-        (void)s.smooth(2, 2);
+        ASSERT_EQ(1, s.smooth(2, 2));
+        ASSERT_EQ(TYPE_WALL, s.query_genre_x_y(2, 2));
 
         PixieData cobble = make_grid(5, 5, PIX_GRASS1);
         at(cobble, 2, 2) = PIX_COBBLE_1;
         s.set_target(cobble);
-        (void)s.smooth(2, 2);
+        ASSERT_EQ(1, s.smooth(2, 2));
+        ASSERT_EQ(TYPE_COBBLE, s.query_genre_x_y(2, 2));
     }
-
-    ASSERT_TRUE(true) << "matrix smooth coverage across remaining genres completed";
 }
 
 
@@ -289,4 +316,3 @@ TEST(SmoothMatrix, smooth_query_helpers_and_grass_water_corner_branches)
         PIX_GRASSWATER_LR,
         "grass-water LR branch should produce PIX_GRASSWATER_LR");
 }
-

--- a/tests/test_snapshot_size_benchmark.cpp
+++ b/tests/test_snapshot_size_benchmark.cpp
@@ -299,7 +299,9 @@ std::vector<std::uint8_t> zlib_decompress_for_benchmark(
         stream.next_out = chunk.data();
         stream.avail_out = static_cast<uInt>(chunk.size());
         rc = inflate(&stream, Z_NO_FLUSH);
-        EXPECT_TRUE(rc == Z_OK || rc == Z_STREAM_END);
+        if (rc != Z_OK) {
+            EXPECT_EQ(Z_STREAM_END, rc);
+        }
         output.insert(output.end(),
                       chunk.begin(),
                       chunk.begin() + (chunk.size() - stream.avail_out));

--- a/tests/test_stats_more_paths.cpp
+++ b/tests/test_stats_more_paths.cpp
@@ -613,7 +613,9 @@ TEST(StatsMorePaths, stats_round13_die_and_non_living_fire_command_branches)
     // COMMAND_FIRE on non-living controller path (stats.cpp:253-257).
     weapon->stats()->force_command(COMMAND_FIRE, 1, 1, 0);
     const short fire_result = weapon->stats()->do_command();
-    ASSERT_TRUE(fire_result == 0 || fire_result == 1) << "COMMAND_FIRE on non-living should execute guarded branch without crashing";
+    ASSERT_EQ(1, (int)fire_result)
+        << "COMMAND_FIRE on non-living should take the guarded no-op branch";
+    ASSERT_FALSE(weapon->stats()->has_commands());
 }
 
 

--- a/tests/test_stats_right_walk_direct_walk.cpp
+++ b/tests/test_stats_right_walk_direct_walk.cpp
@@ -204,11 +204,11 @@ TEST(StatsRightWalkDirectWalk, stats_blocked_direction_switch_tables_all_cases_r
     };
     for (char d : dirs)
     {
+        SCOPED_TRACE(static_cast<int>(d));
         w.set_curdir(d);
-        (void)st->right_blocked();
-        (void)st->right_forward_blocked();
-        (void)st->right_back_blocked();
-        (void)st->forward_blocked();
+        EXPECT_FALSE(st->right_blocked());
+        EXPECT_FALSE(st->right_forward_blocked());
+        EXPECT_FALSE(st->right_back_blocked());
+        EXPECT_FALSE(st->forward_blocked());
     }
-    ASSERT_TRUE(true) << "blocked-direction switch tables executed";
 }

--- a/tests/test_text_input_and_width.cpp
+++ b/tests/test_text_input_and_width.cpp
@@ -54,12 +54,12 @@ TEST(TextInputAndWidth, text_query_width_big_font_varies_by_case)
 TEST(TextInputAndWidth, text_write_variants_smoke)
 {
     text t(TEXT_1);
-    (void)t.write_xy(10, 10, "Hi", WHITE);
-    (void)t.write_xy_shadow(10, 20, WHITE, "%s", "Shadow");
-    (void)t.write_xy_center(160, 30, WHITE, "%s", "Center");
-    (void)t.write_xy_center_alpha(160, 40, WHITE, 128, "%s", "Alpha");
-    (void)t.write_xy_center_shadow(160, 50, WHITE, "%s", "CenterShadow");
-    (void)t.write_char_xy_alpha(10, 60, 'Z', WHITE, 128);
+    ASSERT_GT(t.write_xy(10, 10, "Hi", WHITE), 0);
+    ASSERT_GT(t.write_xy_shadow(10, 20, WHITE, "%s", "Shadow"), 0);
+    ASSERT_GT(t.write_xy_center(160, 30, WHITE, "%s", "Center"), 0);
+    ASSERT_GT(t.write_xy_center_alpha(160, 40, WHITE, 128, "%s", "Alpha"), 0);
+    ASSERT_GT(t.write_xy_center_shadow(160, 50, WHITE, "%s", "CenterShadow"), 0);
+    ASSERT_EQ(1, t.write_char_xy_alpha(10, 60, 'Z', WHITE, 128));
 }
 
 

--- a/tests/test_video_fade.cpp
+++ b/tests/test_video_fade.cpp
@@ -19,6 +19,15 @@ static SurfacePtr make_surface(int w, int h)
     SDL_Surface* s = SDL_CreateRGBSurface(SDL_SWSURFACE, w, h, 32, 0, 0, 0, 0);
     return SurfacePtr(s);
 }
+
+static SurfacePtr make_surface_masks(int w, int h, int depth,
+                                     Uint32 rmask, Uint32 gmask,
+                                     Uint32 bmask, Uint32 amask)
+{
+    SDL_Surface* s = SDL_CreateRGBSurface(SDL_SWSURFACE, w, h, depth,
+                                          rmask, gmask, bmask, amask);
+    return SurfacePtr(s);
+}
 } // namespace
 
 TEST(VideoFade, video_fadeblack_smoke_in_and_out)
@@ -46,6 +55,38 @@ TEST(VideoFade, video_fadebetween_precondition_failures_are_handled)
     // Width mismatch should fail gracefully (return 0).
     int r = og::runtime::current_session->myscreen_->fade_between(old_ok.get(), new_bad_w.get(), dest.get());
     ASSERT_EQ(0, r) << "FadeBetween should fail on width mismatch";
+}
+
+TEST(VideoFade, video_fadebetween_null_and_format_preconditions_are_handled)
+{
+    SurfacePtr dest = make_surface(320, 200);
+    SurfacePtr old_ok = make_surface(320, 200);
+    SurfacePtr new_ok = make_surface(320, 200);
+    ASSERT_TRUE(dest != nullptr && old_ok != nullptr && new_ok != nullptr) << "base surfaces created";
+    if (!(dest && old_ok && new_ok))
+        return;
+
+    EXPECT_EQ(0, og::runtime::current_session->myscreen_->fade_between(nullptr, nullptr, dest.get()));
+    EXPECT_EQ(0, og::runtime::current_session->myscreen_->fade_between(nullptr, new_ok.get(), dest.get()));
+    EXPECT_EQ(0, og::runtime::current_session->myscreen_->fade_between(old_ok.get(), nullptr, dest.get()));
+
+    SurfacePtr new_bad_h = make_surface(320, 201);
+    ASSERT_TRUE(new_bad_h != nullptr) << "height mismatch surface created";
+    EXPECT_EQ(0, og::runtime::current_session->myscreen_->fade_between(old_ok.get(), new_bad_h.get(), dest.get()));
+
+    SurfacePtr old_bad_w = make_surface(321, 200);
+    ASSERT_TRUE(old_bad_w != nullptr) << "old width mismatch surface created";
+    EXPECT_EQ(0, og::runtime::current_session->myscreen_->fade_between(old_bad_w.get(), nullptr, dest.get()));
+
+    SurfacePtr new_rgba = make_surface_masks(
+        320, 200, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
+    ASSERT_TRUE(new_rgba != nullptr) << "R mask mismatch surface created";
+    EXPECT_EQ(0, og::runtime::current_session->myscreen_->fade_between(old_ok.get(), new_rgba.get(), dest.get()));
+
+    SurfacePtr old_24 = make_surface_masks(320, 200, 24, 0x0000ff, 0x00ff00, 0xff0000, 0);
+    SurfacePtr new_24 = make_surface_masks(320, 200, 24, 0x0000ff, 0x00ff00, 0xff0000, 0);
+    ASSERT_TRUE(old_24 != nullptr && new_24 != nullptr) << "24-bit surfaces created";
+    EXPECT_EQ(0, og::runtime::current_session->myscreen_->fade_between(old_24.get(), new_24.get(), dest.get()));
 }
 
 
@@ -79,4 +120,3 @@ TEST(VideoFade, video_fadebetween24_smoke)
 
     og::runtime::current_session->myscreen_->fade_between24(s.get(), from.data(), to.data(), 1);
 }
-

--- a/tests/test_video_modes_more.cpp
+++ b/tests/test_video_modes_more.cpp
@@ -67,6 +67,39 @@ TEST(VideoModesMore, video_putbuffer_surface_clipping_and_blit)
     og::runtime::current_session->myscreen_->putbuffer_surface(10, 10, 16, 16, 0, 0, 319, 199, surf.get());
 }
 
+TEST(VideoModesMore, video_clipping_and_accel_surface_edge_paths)
+{
+    std::array<unsigned char, 16 * 16> pixels{};
+    pixels.fill(42);
+    pixels[0] = 0;
+    auto span = std::span<const unsigned char>(pixels.data(), pixels.size());
+
+    og::runtime::current_session->myscreen_->fastbox(10, 10, 4, 4, 12, 0);
+
+    og::runtime::current_session->myscreen_->putbuffer(-4, -4, 16, 16, 0, 0, 319, 199, span);
+    og::runtime::current_session->myscreen_->putbuffer(400, 400, 16, 16, 0, 0, 319, 199, span);
+    og::runtime::current_session->myscreen_->putbuffer_alpha(-4, -4, 16, 16, 0, 0, 319, 199, span, 128);
+    og::runtime::current_session->myscreen_->putbuffer_alpha(400, 400, 16, 16, 0, 0, 319, 199, span, 128);
+    og::runtime::current_session->myscreen_->putbuffer_alpha(10, 10, 0, 16, 0, 0, 319, 199, span, 128);
+
+    EXPECT_EQ(nullptr, og::runtime::current_session->myscreen_->create_accel_surface(span, 0, 16));
+    EXPECT_EQ(nullptr, og::runtime::current_session->myscreen_->create_accel_surface(span.first(3), 4, 4));
+    void* surface = og::runtime::current_session->myscreen_->create_accel_surface(span, 16, 16);
+    ASSERT_NE(nullptr, surface);
+    og::runtime::current_session->myscreen_->destroy_accel_surface(surface);
+    og::runtime::current_session->myscreen_->destroy_accel_surface(nullptr);
+
+    og::runtime::current_session->myscreen_->walkputbuffer_flash(400, 400, 16, 16, 0, 0, 319, 199, span, 40);
+    og::runtime::current_session->myscreen_->walkputbuffer_flash(-4, -4, 16, 16, 0, 0, 319, 199, span, 40);
+    og::runtime::current_session->myscreen_->walkputbuffer_flash(310, 190, 16, 16, 0, 0, 319, 199, span, 40);
+    og::runtime::current_session->myscreen_->walkputbuffer_flash(10, 10, 0, 16, 0, 0, 319, 199, span, 40);
+
+    og::runtime::current_session->myscreen_->walkputbuffertext_alpha(400, 400, 16, 16, 0, 0, 319, 199, span, 40, 128);
+    og::runtime::current_session->myscreen_->walkputbuffertext_alpha(-4, -4, 16, 16, 0, 0, 319, 199, span, 40, 128);
+    og::runtime::current_session->myscreen_->walkputbuffertext_alpha(310, 190, 16, 16, 0, 0, 319, 199, span, 40, 128);
+    og::runtime::current_session->myscreen_->walkputbuffertext_alpha(10, 10, 0, 16, 0, 0, 319, 199, span, 40, 128);
+}
+
 
 TEST(VideoModesMore, video_walkputbuffer_modes_invisible_outline_phantom)
 {
@@ -145,4 +178,3 @@ TEST(VideoModesMore, video_save_screenshot_smoke_and_cleanup)
 
     cleanup_screenshots();
 }
-

--- a/tests/test_video_primitives.cpp
+++ b/tests/test_video_primitives.cpp
@@ -7,11 +7,20 @@
 
 TEST(VideoPrimitives, video_draw_primitives_modify_buffer)
 {
-    // These primitives render via the SDL-backed Screen in this port.
-    // The test is primarily a smoke test to cover the call paths without
-    // relying on a specific backing buffer layout.
-    og::runtime::current_session->myscreen_->draw_box(10, 10, 50, 20, 200, 0, 1);        // hollow
-    og::runtime::current_session->myscreen_->draw_box(60, 10, 90, 25, 123, 1, 1);        // filled
-    og::runtime::current_session->myscreen_->draw_rect_filled(100, 10, 30, 10, 77, 200); // alpha
-}
+    screen* s = og::runtime::current_session->myscreen_;
+    s->clearbuffer();
 
+    s->draw_box(10, 10, 50, 20, 200, 0, 1);        // hollow
+    s->draw_box(60, 10, 90, 25, 123, 1, 1);        // filled
+    s->draw_rect_filled(100, 10, 30, 10, 77, 200); // alpha
+
+    int hollow_index = 0;
+    int filled_index = 0;
+    ASSERT_EQ(200, s->get_pixel(10, 10, &hollow_index));
+    ASSERT_EQ(123, s->get_pixel(65, 15, &filled_index));
+
+    Uint8 r = 0, g = 0, b = 0;
+    s->get_pixel(105, 15, &r, &g, &b);
+    ASSERT_TRUE(r != 0 || g != 0 || b != 0)
+        << "alpha-filled rectangle should modify its target pixels";
+}

--- a/tests/test_view_get_keypress_and_edge_cases.cpp
+++ b/tests/test_view_get_keypress_and_edge_cases.cpp
@@ -10,6 +10,7 @@
 #include <SDL.h>
 
 #include <array>
+#include <atomic>
 
 // myscreen is now a macro defined in base.h (via game_session.h)
 
@@ -60,12 +61,25 @@ static SDL_Event keydown(SDL_Keycode key)
     return e;
 }
 
-static int injector_clear_escape(void* data)
+struct EscapePulseState
+{
+    std::array<Uint8, SDL_NUM_SCANCODES>* keys;
+    std::atomic<bool>* done;
+};
+
+static int injector_pulse_escape(void* data)
 {
     og::runtime::ensure_thread_session();
-    auto* arr = static_cast<std::array<Uint8, SDL_NUM_SCANCODES>*>(data);
-    SDL_Delay(20);
-    (*arr)[SDL_SCANCODE_ESCAPE] = 0;
+    auto* state = static_cast<EscapePulseState*>(data);
+    SDL_Delay(25);
+    while (!state->done->load(std::memory_order_relaxed))
+    {
+        (*state->keys)[KEYSTATE_ESCAPE] = 1;
+        SDL_Delay(25);
+        (*state->keys)[KEYSTATE_ESCAPE] = 0;
+        SDL_Delay(10);
+    }
+    (*state->keys)[KEYSTATE_ESCAPE] = 0;
     return 0;
 }
 } // namespace
@@ -156,8 +170,6 @@ TEST(ViewGetKeypressAndEdgeCases, viewscreen_options_menu_covers_view_size_label
     // Save original pref so we can restore after testing edge cases.
     const signed char saved_view = v->prefs[PREF_VIEW];
 
-    // Immediately request exit, but clear ESC after a short delay so the
-    // "wait for release" loop terminates.
     const std::array<int, 6> view_prefs = {
         static_cast<int>(PREF_VIEW_FULL),
         static_cast<int>(PREF_VIEW_PANELS),
@@ -169,13 +181,16 @@ TEST(ViewGetKeypressAndEdgeCases, viewscreen_options_menu_covers_view_size_label
     for (int view_pref : view_prefs)
     {
         v->prefs[PREF_VIEW] = static_cast<signed char>(view_pref);
-        ks.fake[SDL_SCANCODE_ESCAPE] = 1;
-        SDL_Thread* th = SDL_CreateThread(injector_clear_escape, "clear_esc", &ks.fake);
+        std::atomic<bool> done{false};
+        EscapePulseState state{&ks.fake, &done};
+        SDL_Thread* th = SDL_CreateThread(injector_pulse_escape, "pulse_esc", &state);
+        ASSERT_TRUE(th != nullptr) << "escape injector thread started";
         v->options_menu();
+        done.store(true, std::memory_order_relaxed);
         int code = 0;
         if (th)
             SDL_WaitThread(th, &code);
-        ks.fake[SDL_SCANCODE_ESCAPE] = 0;
+        ks.fake[KEYSTATE_ESCAPE] = 0;
     }
 
     // Restore original pref — options_menu() saves prefs to keyprefs.dat on

--- a/tests/test_view_menu_driven.cpp
+++ b/tests/test_view_menu_driven.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <thread>
@@ -30,7 +31,7 @@ static std::unique_ptr<walker> create_controlled_living(char family)
 struct KeystateOverride
 {
     const Uint8* prev = nullptr;
-    std::array<Uint8, SDL_NUM_SCANCODES> fake{};
+    std::array<Uint8, MAXKEYS> fake{};
 
     KeystateOverride()
     {
@@ -45,12 +46,20 @@ struct KeystateOverride
     }
 };
 
-static void press_release_after(KeystateOverride& ks, SDL_Scancode sc, int press_ms, int hold_ms)
+static void pulse_key(KeystateOverride& ks, int key, int hold_ms = 80, int release_ms = 30)
 {
-    std::this_thread::sleep_for(std::chrono::milliseconds(press_ms));
-    ks.fake[sc] = 1;
+    ks.fake[static_cast<std::size_t>(key)] = 1;
     std::this_thread::sleep_for(std::chrono::milliseconds(hold_ms));
-    ks.fake[sc] = 0;
+    ks.fake[static_cast<std::size_t>(key)] = 0;
+    std::this_thread::sleep_for(std::chrono::milliseconds(release_ms));
+}
+
+static void pulse_escape_until(KeystateOverride& ks, std::atomic<bool>& done, int timeout_ms = 5000)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    while (!done.load(std::memory_order_relaxed) && std::chrono::steady_clock::now() < deadline)
+        pulse_key(ks, KEYSTATE_ESCAPE, 100, 40);
+    ks.fake[KEYSTATE_ESCAPE] = 0;
 }
 
 TEST(ViewMenuDriven, viewscreen_options_menu_exercises_key_paths)
@@ -67,24 +76,27 @@ TEST(ViewMenuDriven, viewscreen_options_menu_exercises_key_paths)
     const signed char saved_view = v->prefs[PREF_VIEW];
 
     KeystateOverride ks;
+    std::atomic<bool> options_done{false};
 
     // Drive a few option toggles then exit with Escape.
     std::thread driver([&]() {
-        press_release_after(ks, SDL_SCANCODE_RIGHTBRACKET, 10, 5);
-        press_release_after(ks, SDL_SCANCODE_LEFTBRACKET, 10, 5);
-        press_release_after(ks, SDL_SCANCODE_COMMA, 10, 5);
-        press_release_after(ks, SDL_SCANCODE_PERIOD, 10, 5);
-        press_release_after(ks, SDL_SCANCODE_R, 10, 5);
-        press_release_after(ks, SDL_SCANCODE_H, 10, 5);
-        press_release_after(ks, SDL_SCANCODE_F, 10, 5);
-        press_release_after(ks, SDL_SCANCODE_S, 10, 5);
-        press_release_after(ks, SDL_SCANCODE_C, 10, 5);
-        press_release_after(ks, SDL_SCANCODE_ESCAPE, 10, 5);
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        pulse_key(ks, KEYSTATE_RIGHTBRACKET);
+        pulse_key(ks, KEYSTATE_LEFTBRACKET);
+        pulse_key(ks, KEYSTATE_COMMA);
+        pulse_key(ks, KEYSTATE_PERIOD);
+        pulse_key(ks, KEYSTATE_r);
+        pulse_key(ks, KEYSTATE_h);
+        pulse_key(ks, KEYSTATE_f);
+        pulse_key(ks, KEYSTATE_s);
+        pulse_key(ks, KEYSTATE_c);
+        pulse_escape_until(ks, options_done);
     });
 
     // Runs a tight loop that polls keystates and draws. Our driver thread
     // flips keys to avoid getting stuck in "wait for key release" loops.
     v->options_menu();
+    options_done.store(true, std::memory_order_relaxed);
 
     driver.join();
 
@@ -105,10 +117,13 @@ TEST(ViewMenuDriven, viewscreen_options_menu_exercises_key_paths)
     og::runtime::current_session->player_keys_[v->mynum][KEY_SHIFTER] = SDLK_AUDIONEXT; // long key name -> truncation
 
     KeystateOverride ks2;
+    std::atomic<bool> bindings_done{false};
     std::thread esc_driver([&]() {
-        press_release_after(ks2, SDL_SCANCODE_ESCAPE, 10, 10);
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        pulse_escape_until(ks2, bindings_done);
     });
     v->view_key_bindings();
+    bindings_done.store(true, std::memory_order_relaxed);
     esc_driver.join();
 
     og::runtime::current_session->player_keys_[v->mynum][KEY_UP] = saved_up;
@@ -123,4 +138,3 @@ TEST(ViewMenuDriven, viewscreen_options_menu_exercises_key_paths)
 
     v->control = nullptr;
 }
-

--- a/tests/test_view_team.cpp
+++ b/tests/test_view_team.cpp
@@ -289,6 +289,36 @@ static bool start_game_from_view_menu(
     return g_test_game_epoch.load(std::memory_order_acquire) > epoch_before;
 }
 
+static bool click_intercepted_start_from_view_menu(
+    int timeout_ms,
+    const std::function<bool(const Interactable&)>& is_view_menu_go)
+{
+    int elapsed = 0;
+    int since_last_click = 250;
+    const int poll_interval = 50;
+    while (elapsed < timeout_ms) {
+        if (pks().selected_menu_item != nullptr
+            && pks().selected_menu_item->command ==
+                og::ui::PickerMenuCommand::StartGame) {
+            return true;
+        }
+
+        if (since_last_click >= 250
+            && has_interactable_match("go", is_view_menu_go)) {
+            interact_match("go", is_view_menu_go);
+            since_last_click = 0;
+        }
+
+        SDL_Delay(poll_interval);
+        elapsed += poll_interval;
+        since_last_click += poll_interval;
+    }
+
+    return pks().selected_menu_item != nullptr
+        && pks().selected_menu_item->command ==
+            og::ui::PickerMenuCommand::StartGame;
+}
+
 static bool enter_team_menu_from_main_menu(int timeout_ms = 15000)
 {
     if (!wait_for_interactable("continue_game", 5000))
@@ -513,7 +543,8 @@ static int train_menu_view_team_go_injector(void* data)
         return 0;
     }
     state->saw_view_menu = true;
-    state->clicked_go = interact_match("go", is_view_menu_go);
+    state->clicked_go = click_intercepted_start_from_view_menu(
+        kGameStartTimeoutMs, is_view_menu_go);
 
     state->finished = true;
     return 0;

--- a/tests/test_walker_core_more.cpp
+++ b/tests/test_walker_core_more.cpp
@@ -537,11 +537,8 @@ TEST(WalkerCoreMore, walker_round6_init_fire_animate_and_misc_guards)
 
     // next_frame path (smoke coverage without touching protected state).
     const short before = w->frame();
-    (void)w->next_frame();
-    const short after = w->frame();
-    (void)before;
-    (void)after;
-    ASSERT_TRUE(true) << "next_frame should be callable";
+    ASSERT_EQ(1, w->next_frame()) << "next_frame should report a successful frame set";
+    ASSERT_EQ(before, w->frame()) << "next_frame should keep the wrapped frame selected";
 
     // move_myguy_to nullptr guard.
     w->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));

--- a/tests/test_walker_more.cpp
+++ b/tests/test_walker_more.cpp
@@ -400,7 +400,8 @@ TEST(WalkerMore, walker_friendliness_null_dead_and_allied_mode_paths)
     b->set_team_num(0);
     ASSERT_TRUE(a->is_friendly(b.get()) != 0) << "team 0 target with one myguy should be treated as friendly";
 
-    ASSERT_TRUE(a->is_friendly_to_team(1) == 0 || a->is_friendly_to_team(1) == 1) << "friendly-to-team path should execute";
+    ASSERT_FALSE(a->is_friendly_to_team(1))
+        << "team 0 walker should not be friendly to team 1 when allied mode is off";
 
     a->set_dead(1);
     ASSERT_TRUE(!a->is_friendly_to_team(0)) << "dead walker should be unfriendly to all teams";

--- a/tests/test_walker_movement.cpp
+++ b/tests/test_walker_movement.cpp
@@ -347,14 +347,16 @@ TEST(WalkerMovement, walker_walkstep_user_slide_sets_vertical_and_horizontal_dir
     // Horizontal-only slide: up blocked at top edge, right passable.
     w->setxy(32, 0);
     w->set_curdir(FACE_DOWN);
-    (void)w->walkstep(1, -1);
-    ASSERT_TRUE(true) << "user slide horizontal branch executed";
+    ASSERT_TRUE(w->walkstep(1, -1));
+    ASSERT_EQ(32, w->xpos());
+    ASSERT_EQ(0, w->ypos());
 
     // Vertical-only slide: left blocked at left edge, up passable.
     w->setxy(0, 32);
     w->set_curdir(FACE_RIGHT);
-    (void)w->walkstep(-1, -1);
-    ASSERT_TRUE(true) << "user slide vertical branch executed";
+    ASSERT_TRUE(w->walkstep(-1, -1));
+    ASSERT_EQ(0, w->xpos());
+    ASSERT_EQ(32, w->ypos());
 }
 
 
@@ -520,8 +522,9 @@ TEST(WalkerMovement, round6_blocked_animate_and_default_angle_turn)
     w->set_sizey(1);
     w->set_curdir(FACE_LEFT);
     w->stats()->set_bit_flags(BIT_ANIMATE, 1);
-    (void)w->walk(-1, 0);
-    ASSERT_TRUE(true) << "animated off-map walk path executed";
+    ASSERT_FALSE(w->walk(-1, 0));
+    ASSERT_EQ(0, w->xpos());
+    ASSERT_EQ(0, w->ypos());
 
     // get_current_angle default branch.
     w->set_curdir(static_cast<char>(99));
@@ -529,8 +532,8 @@ TEST(WalkerMovement, round6_blocked_animate_and_default_angle_turn)
 
     // turn default branch in lastx/lasty fallback.
     w->set_curdir(static_cast<char>(99));
-    (void)w->turn(FACE_UP);
-    ASSERT_TRUE(true) << "turn should tolerate invalid current direction";
+    ASSERT_TRUE(w->turn(FACE_UP));
+    ASSERT_EQ(FACE_UP_LEFT, w->curdir());
 }
 
 
@@ -657,9 +660,8 @@ TEST(WalkerMovement, deep_branch_coverage_smoke)
     (void)w->walk(1, 0);
     w->set_order_family(Order::Living, FAMILY_SOLDIER);
     w->set_curdir(99);
-    (void)w->turn(FACE_UP);
-
-    ASSERT_TRUE(true) << "walker movement deep branches executed";
+    ASSERT_TRUE(w->turn(FACE_UP));
+    ASSERT_EQ(FACE_UP_LEFT, w->curdir());
 }
 
 
@@ -703,13 +705,17 @@ TEST(WalkerMovement, round6_npc_blocked_switch_and_user_slide_subpaths)
 
     // Top edge: vertical blocked, horizontal passable -> gotover branch.
     w->setxy(GRID_SIZE * 3, 0);
-    (void)w->walkstep(1, -1);
+    const short slide_x_before = w->xpos();
+    ASSERT_TRUE(w->walkstep(1, -1));
+    ASSERT_EQ(slide_x_before, w->xpos());
+    ASSERT_EQ(0, w->ypos());
 
     // Left edge: horizontal blocked, vertical passable -> gotup branch.
     w->setxy(0, GRID_SIZE * 3);
-    (void)w->walkstep(-1, -1);
-
-    ASSERT_TRUE(true) << "blocked npc and user-slide subpaths executed";
+    const short slide_y_before = w->ypos();
+    ASSERT_TRUE(w->walkstep(-1, -1));
+    ASSERT_EQ(0, w->xpos());
+    ASSERT_EQ(slide_y_before, w->ypos());
 }
 
 

--- a/tests/test_walker_unit.cpp
+++ b/tests/test_walker_unit.cpp
@@ -470,10 +470,19 @@ TEST(WalkerUnit, walker_r11_fire_query_next_to_and_outline_branches)
 
     shooter->set_lastx(1.0f);
     shooter->set_lasty(1.0f);
-    ASSERT_TRUE(shooter->query_next_to() == 0 || shooter->query_next_to() == 1);
+    ASSERT_FALSE(shooter->query_next_to())
+        << "empty adjacent diagonal should be object-passable";
+    walker* adjacent_blocker = add_ob(
+        fx, Order::Living, FAMILY_ORC, 1,
+        static_cast<short>(shooter->xpos() + shooter->sizex()),
+        static_cast<short>(shooter->ypos() + shooter->sizey()));
+    ASSERT_TRUE(adjacent_blocker != nullptr);
+    ASSERT_TRUE(shooter->query_next_to())
+        << "occupied adjacent diagonal should not be object-passable";
     shooter->set_lastx(-1.0f);
     shooter->set_lasty(-1.0f);
-    ASSERT_TRUE(shooter->query_next_to() == 0 || shooter->query_next_to() == 1);
+    ASSERT_FALSE(shooter->query_next_to())
+        << "opposite empty adjacent diagonal should remain object-passable";
 
     walker* viewer = add_ob(fx, Order::Living, FAMILY_SOLDIER, 1, 60, 64);
     ASSERT_TRUE(viewer != nullptr);
@@ -649,7 +658,9 @@ TEST(WalkerUnit, walker_r14_lines_769_771_817_823_827_834_teleport_and_ani_compl
     w->set_ani_type(ANI_SKEL_GROW);
     w->set_cycle(4);
     w->set_curdir(FACE_RIGHT);
-    ASSERT_TRUE(w->animate() || !w->animate());
+    ASSERT_TRUE(w->animate());
+    ASSERT_EQ(ANI_WALK, w->ani_type());
+    ASSERT_EQ(0, w->cycle());
 
     w->set_ani_type(ANI_TELE_OUT);
     w->set_cycle(4);

--- a/tests/test_zip_api.cpp
+++ b/tests/test_zip_api.cpp
@@ -43,10 +43,10 @@ TEST(ZipApi, r15_zip_and_unzip_success_paths)
     }
 
     const ArchiveIoError zip_err = og::io::zip_contents_with_error(in.string(), zipfile.string());
-    ASSERT_TRUE(zip_err == ArchiveIoError::None || zip_err == ArchiveIoError::AddEntryFailed);
+    ASSERT_EQ(ArchiveIoError::None, zip_err);
 
     const ArchiveIoError unzip_err = og::io::unzip_into_with_error(zipfile.string(), out.string());
-    ASSERT_TRUE(unzip_err == ArchiveIoError::None || unzip_err == ArchiveIoError::OpenEntryFailed);
+    ASSERT_EQ(ArchiveIoError::None, unzip_err);
 
     ASSERT_TRUE(fs::exists(out / "root.txt"));
     ASSERT_TRUE(fs::exists(out / "subdir" / "nested.txt"));

--- a/tests/unit/test_frame_deadline_pacer.cpp
+++ b/tests/unit/test_frame_deadline_pacer.cpp
@@ -2,8 +2,10 @@
 
 #include <openglad/core/frame_pacing.h>
 #include <openglad/core/runtime_trace.h>
+#include <openglad/core/util.h>
 
 #include <cstdint>
+#include <vector>
 
 namespace {
 
@@ -121,6 +123,42 @@ TEST(FrameDeadlinePacer, IntervalZeroClampsToOne)
     const auto d2 = pacer.tick(101u);
     EXPECT_TRUE(d2.run_tick);
     EXPECT_EQ(d2.next_deadline_ms, 102u);
+}
+
+TEST(FrameDeadlinePacer, RenderIntervalWrapperAndTraceObserversAreExercised)
+{
+    RuntimeTraceCaptureGuard guard;
+
+    EXPECT_FLOAT_EQ(og::core::render_tick_interval_ms(6, 1.0f),
+                    og::core::rounded_render_tick_interval_ms(6, 1.0f));
+    EXPECT_FLOAT_EQ(og::core::render_tick_interval_ms(12, 0.5f),
+                    og::core::rounded_render_tick_interval_ms(12, 0.5f));
+
+    std::vector<og::runtime::RuntimeTraceRecord> observed_traces;
+    og::runtime::set_runtime_trace_observer(
+        [&](const og::runtime::RuntimeTraceRecord& record) {
+            observed_traces.push_back(record);
+        });
+    og::runtime::emit_runtime_trace(
+        og::runtime::make_runtime_trace_record("unit", "trace_observer"));
+    ASSERT_EQ(observed_traces.size(), 1u);
+    EXPECT_EQ(observed_traces.front().category, "unit");
+    EXPECT_EQ(observed_traces.front().event, "trace_observer");
+    og::runtime::clear_runtime_trace_observer();
+
+    std::vector<og::runtime::RuntimeRenderSample> observed_samples;
+    og::runtime::set_runtime_render_sample_observer(
+        [&](const og::runtime::RuntimeRenderSample& sample) {
+            observed_samples.push_back(sample);
+        });
+    og::runtime::RuntimeRenderSample sample;
+    sample.tick = 77u;
+    sample.interpolation_alpha = 0.25f;
+    og::runtime::publish_runtime_render_sample(sample);
+    ASSERT_EQ(observed_samples.size(), 1u);
+    EXPECT_EQ(observed_samples.front().tick, 77u);
+    EXPECT_FLOAT_EQ(observed_samples.front().interpolation_alpha, 0.25f);
+    og::runtime::clear_runtime_render_sample_observer();
 }
 
 TEST(FrameDeadlinePacer, SmallSlipRunsOneTickWithoutResync)

--- a/tests/unit/test_game_world_entity_ids.cpp
+++ b/tests/unit/test_game_world_entity_ids.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <gtest/gtest.h>
+#include <iterator>
 
 namespace {
 
@@ -375,6 +376,38 @@ TEST_F(GameWorldEntityIdsFixture, public_entity_list_removals_track_removed_enti
               std::find(world.removed_entity_ids().begin(),
                         world.removed_entity_ids().end(),
                         clear_id));
+}
+
+TEST_F(GameWorldEntityIdsFixture, entity_list_const_reverse_and_front_operations)
+{
+    auto first = std::make_unique<walker>();
+    first->set_order_family(Order::Living, FAMILY_SOLDIER);
+    walker* first_raw = first.get();
+
+    auto second = std::make_unique<walker>();
+    second->set_order_family(Order::Living, FAMILY_ORC);
+    walker* second_raw = second.get();
+
+    world.oblist.push_back(std::move(first));
+    world.oblist.push_front(std::move(second));
+
+    const GameWorld::EntityList& list = world.oblist;
+    ASSERT_EQ(list.size(), 2u);
+    EXPECT_EQ(list.front().get(), second_raw);
+    EXPECT_EQ(list.back().get(), first_raw);
+    EXPECT_EQ(list.cbegin()->get(), second_raw);
+    EXPECT_EQ(std::next(list.cbegin())->get(), first_raw);
+    EXPECT_EQ(list.cend(), list.end());
+    EXPECT_EQ(list.rbegin()->get(), first_raw);
+    EXPECT_EQ(std::next(list.rbegin())->get(), second_raw);
+    EXPECT_EQ(list.rend(), list.crend());
+    EXPECT_EQ(list.crbegin()->get(), first_raw);
+
+    const std::uint32_t second_id = second_raw->entity_id();
+    world.oblist.pop_front();
+    EXPECT_EQ(nullptr, world.find_by_id(second_id));
+    ASSERT_EQ(world.oblist.size(), 1u);
+    EXPECT_EQ(world.oblist.front().get(), first_raw);
 }
 
 TEST_F(GameWorldEntityIdsFixture, delete_objects_tracks_removed_entity_ids_for_all_live_lists)

--- a/tests/unit/test_headless_server_runtime.cpp
+++ b/tests/unit/test_headless_server_runtime.cpp
@@ -179,6 +179,43 @@ TEST_F(HeadlessServerRuntimeTest,
 }
 
 TEST_F(HeadlessServerRuntimeTest,
+       lobby_start_config_defaults_campaign_level_and_ignores_bad_slots)
+{
+    active_save_.m_score[0] = 12u;
+    active_save_.m_totalcash[0] = 34u;
+    active_save_.m_totalscore[0] = 56u;
+
+    og::sim::LobbySaveDataEquivalent lobby_save;
+    lobby_save.current_campaign = "";
+    lobby_save.scen_num = -4;
+    lobby_save.numplayers = 3;
+    lobby_save.allied_mode = 1;
+    lobby_save.team_list = {
+        make_slot(0u, 101, "Valid", FAMILY_SOLDIER, 0),
+        make_slot(static_cast<std::uint8_t>(active_save_.team_list.size()),
+                  202,
+                  "Out Of Range",
+                  FAMILY_ELF,
+                  1),
+    };
+
+    og::server::apply_headless_lobby_game_start_config(active_save_, lobby_save);
+
+    EXPECT_EQ("org.openglad.gladiator", active_save_.current_campaign);
+    EXPECT_EQ(1, active_save_.scen_num);
+    EXPECT_EQ(1, active_save_.current_levels[active_save_.current_campaign]);
+    EXPECT_EQ(3u, active_save_.numplayers);
+    EXPECT_EQ(1, active_save_.allied_mode);
+    EXPECT_EQ(1, active_save_.team_size);
+    ASSERT_NE(nullptr, active_save_.team_list[0]);
+    EXPECT_EQ("Valid", active_save_.team_list[0]->name);
+    EXPECT_EQ(nullptr, active_save_.team_list[1]);
+    EXPECT_EQ(12u, active_save_.score);
+    EXPECT_EQ(34u, active_save_.totalcash);
+    EXPECT_EQ(56u, active_save_.totalscore);
+}
+
+TEST_F(HeadlessServerRuntimeTest,
        complete_level_updates_save_and_loads_next_level_for_exit_flow)
 {
     og::sim::LobbySaveDataEquivalent lobby_save;

--- a/tests/unit/test_net_transport.cpp
+++ b/tests/unit/test_net_transport.cpp
@@ -562,6 +562,43 @@ TEST(NetTransport, default_send_wrappers_emit_messages_and_ignore_nulls)
     transport.send_snapshot_hash_check(1u, {});
     EXPECT_TRUE(transport.sent_messages().empty());
 
+    auto snapshot = std::make_shared<og::sim::WorldSnapshot>();
+    snapshot->tick_count = 99u;
+    snapshot->rng_state = 123u;
+    transport.send_snapshot(2u, snapshot);
+
+    auto delta = std::make_shared<og::sim::WorldSnapshot>();
+    delta->tick_count = 100u;
+    delta->level_tick_count = 3u;
+    delta->level_done = 1;
+    transport.send_delta_snapshot(2u, delta);
+
+    auto input = std::make_shared<InputState>();
+    input->quit_requested = true;
+    transport.send_input(2u, input, 44u);
+
+    auto sim_batch = std::make_shared<og::sim::SimEventBatch>();
+    sim_batch->sequence = 5u;
+    sim_batch->events.push_back({
+        .tick = 5u,
+        .kind = og::sim::EventKind::Notification,
+        .a = 0u,
+        .b = 0u,
+        .text = "sim-event",
+    });
+    transport.send_sim_event_batch(2u, sim_batch);
+
+    auto game_flow_batch = std::make_shared<og::sim::SimEventBatch>();
+    game_flow_batch->sequence = 6u;
+    game_flow_batch->events.push_back({
+        .tick = 6u,
+        .kind = og::sim::EventKind::EndGame,
+        .a = 1u,
+        .b = 2u,
+        .text = {},
+    });
+    transport.send_game_flow_event_batch(2u, game_flow_batch);
+
     const auto lobby_message = std::make_shared<og::sim::LobbyMessage>();
     lobby_message->payload =
         og::sim::LobbyStartGameMessage{.player_index = 2u};
@@ -630,12 +667,70 @@ TEST(NetTransport, default_send_wrappers_emit_messages_and_ignore_nulls)
                 .snapshot_hash = 7u,
             }));
 
-    ASSERT_EQ(13u, transport.sent_messages().size());
-    for (const og::sim::ReceivedMessage& sent : transport.sent_messages())
+    const std::array<og::sim::TypedReceivedMessageKind, 18> expected_kinds = {
+        og::sim::TypedReceivedMessageKind::Snapshot,
+        og::sim::TypedReceivedMessageKind::DeltaSnapshot,
+        og::sim::TypedReceivedMessageKind::Input,
+        og::sim::TypedReceivedMessageKind::SimEventBatch,
+        og::sim::TypedReceivedMessageKind::GameFlowEventBatch,
+        og::sim::TypedReceivedMessageKind::LobbyMessage,
+        og::sim::TypedReceivedMessageKind::LobbyState,
+        og::sim::TypedReceivedMessageKind::InitialSetup,
+        og::sim::TypedReceivedMessageKind::Hello,
+        og::sim::TypedReceivedMessageKind::ClientReady,
+        og::sim::TypedReceivedMessageKind::KeyframeRequest,
+        og::sim::TypedReceivedMessageKind::Heartbeat,
+        og::sim::TypedReceivedMessageKind::ExitPromptBroadcast,
+        og::sim::TypedReceivedMessageKind::ExitPromptResponse,
+        og::sim::TypedReceivedMessageKind::PauseBroadcast,
+        og::sim::TypedReceivedMessageKind::PauseResponse,
+        og::sim::TypedReceivedMessageKind::ControlChange,
+        og::sim::TypedReceivedMessageKind::SnapshotHashCheck,
+    };
+    ASSERT_EQ(expected_kinds.size(), transport.sent_messages().size());
+    for (std::size_t i = 0; i < transport.sent_messages().size(); ++i)
     {
+        const og::sim::ReceivedMessage& sent = transport.sent_messages()[i];
         EXPECT_EQ(2u, sent.peer_id);
-        EXPECT_NE(og::sim::TypedReceivedMessageKind::Malformed,
-                  og::sim::decode_received_message(sent).kind);
+        const og::sim::TypedReceivedMessage typed =
+            og::sim::decode_received_message(sent);
+        EXPECT_EQ(expected_kinds[i], typed.kind);
+        switch (typed.kind)
+        {
+        case og::sim::TypedReceivedMessageKind::Snapshot:
+            ASSERT_NE(nullptr, typed.snapshot);
+            EXPECT_EQ(99u, typed.snapshot->tick_count);
+            EXPECT_EQ(123u, typed.snapshot->rng_state);
+            break;
+        case og::sim::TypedReceivedMessageKind::DeltaSnapshot:
+            ASSERT_NE(nullptr, typed.snapshot);
+            EXPECT_EQ(100u, typed.snapshot->tick_count);
+            EXPECT_EQ(3u, typed.snapshot->level_tick_count);
+            EXPECT_EQ(1, typed.snapshot->level_done);
+            break;
+        case og::sim::TypedReceivedMessageKind::Input:
+            ASSERT_NE(nullptr, typed.input);
+            EXPECT_EQ(44u, typed.tick);
+            EXPECT_TRUE(typed.input->quit_requested);
+            break;
+        case og::sim::TypedReceivedMessageKind::SimEventBatch:
+            ASSERT_NE(nullptr, typed.event_batch);
+            EXPECT_EQ(sim_batch->sequence, typed.event_batch->sequence);
+            ASSERT_EQ(sim_batch->events.size(), typed.event_batch->events.size());
+            EXPECT_EQ(sim_batch->events[0], typed.event_batch->events[0]);
+            break;
+        case og::sim::TypedReceivedMessageKind::GameFlowEventBatch:
+            ASSERT_NE(nullptr, typed.event_batch);
+            EXPECT_EQ(game_flow_batch->sequence, typed.event_batch->sequence);
+            ASSERT_EQ(game_flow_batch->events.size(),
+                      typed.event_batch->events.size());
+            EXPECT_EQ(game_flow_batch->events[0], typed.event_batch->events[0]);
+            break;
+        default:
+            EXPECT_NE(og::sim::TypedReceivedMessageKind::Malformed,
+                      typed.kind);
+            break;
+        }
     }
 }
 
@@ -662,6 +757,51 @@ TEST(NetTransport, decode_received_message_reports_malformed_inputs)
         og::sim::TypedReceivedMessageKind::Malformed,
         og::sim::decode_received_message({.peer_id = 7u,
                                           .data = malformed_client_ready}).kind);
+}
+
+TEST(NetTransport, decode_received_message_reports_malformed_typed_payloads)
+{
+    const auto malformed_payload = [](std::uint8_t message_type,
+                                      std::uint16_t payload_length) {
+        std::vector<std::uint8_t> bytes;
+        og::sim::append_transport_header(bytes, message_type, payload_length);
+        bytes.resize(og::sim::kTransportHeaderSize + payload_length, 0u);
+        return bytes;
+    };
+
+    const std::array<std::pair<std::uint8_t, std::uint16_t>, 18> cases = {
+        std::pair{og::sim::kSnapshotMessageType, 1u},
+        std::pair{og::sim::kDeltaSnapshotMessageType, 1u},
+        std::pair{og::sim::kInputMessageType, 1u},
+        std::pair{og::sim::kSimEventBatchMessageType, 1u},
+        std::pair{og::sim::kGameFlowEventBatchMessageType, 1u},
+        std::pair{og::sim::kLobbyMessageType, 1u},
+        std::pair{og::sim::kLobbyStateMessageType, 1u},
+        std::pair{og::sim::kInitialSetupMessageType, 1u},
+        std::pair{og::sim::kHelloMessageType, 1u},
+        std::pair{og::sim::kClientReadyMessageType, 1u},
+        std::pair{og::sim::kKeyframeRequestMessageType, 1u},
+        std::pair{og::sim::kHeartbeatMessageType, 1u},
+        std::pair{og::sim::kExitPromptBroadcastMessageType, 1u},
+        std::pair{og::sim::kExitPromptResponseMessageType, 1u},
+        std::pair{og::sim::kPauseBroadcastMessageType, 1u},
+        std::pair{og::sim::kPauseResponseMessageType, 0u},
+        std::pair{og::sim::kControlChangeMessageType, 1u},
+        std::pair{og::sim::kSnapshotHashCheckMessageType, 1u},
+    };
+
+    for (const auto& [message_type, payload_length] : cases)
+    {
+        const og::sim::TypedReceivedMessage decoded =
+            og::sim::decode_received_message({
+                .peer_id = 7u,
+                .data = malformed_payload(message_type, payload_length),
+            });
+        EXPECT_EQ(7u, decoded.peer_id);
+        EXPECT_EQ(og::sim::TypedReceivedMessageKind::Malformed,
+                  decoded.kind)
+            << "message type " << static_cast<int>(message_type);
+    }
 }
 
 TEST(NetTransport, serialize_hello_emits_expected_wire_format)

--- a/tests/unit/test_net_transport.cpp
+++ b/tests/unit/test_net_transport.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -175,6 +176,34 @@ og::sim::LobbyPlayer make_lobby_player_for_test()
     return player;
 }
 
+og::sim::InitialSetupGuyData make_initial_setup_guy_for_test()
+{
+    og::sim::InitialSetupGuyData guy;
+    guy.guy_id = 99;
+    guy.name = "Setup Guy";
+    guy.family = 3;
+    guy.strength = 21;
+    guy.dexterity = 22;
+    guy.constitution = 23;
+    guy.intelligence = 24;
+    guy.armor = 25;
+    guy.exp = 5678u;
+    guy.kills = 9;
+    guy.level_kills = 10;
+    guy.total_damage = 11;
+    guy.total_hits = 12;
+    guy.total_shots = 13;
+    guy.teamnum = 1;
+    guy.scen_damage = 14.5f;
+    guy.scen_kills = 15;
+    guy.scen_damage_taken = 16.5f;
+    guy.scen_min_hp = 17.5f;
+    guy.scen_shots = 18;
+    guy.scen_hits = 19;
+    guy.level = 20;
+    return guy;
+}
+
 og::sim::LobbyState make_lobby_state_for_test()
 {
     og::sim::LobbyState state;
@@ -247,6 +276,392 @@ TEST(NetTransport, default_poll_typed_decodes_raw_messages)
               messages.front().kind);
     ASSERT_TRUE(messages.front().client_ready != nullptr);
     EXPECT_EQ(42u, messages.front().client_ready->last_applied_tick);
+}
+
+TEST(NetTransport, initial_setup_full_roundtrip_and_decode_received_message)
+{
+    og::sim::InitialSetupMessage expected;
+    expected.level_id = 17;
+    expected.level_title = "Arena";
+    expected.level_type = 2;
+    expected.par_value = 50;
+    expected.time_bonus_limit = 300;
+    expected.difficulty = 4;
+    expected.pixmaxx = 640;
+    expected.pixmaxy = 480;
+    expected.my_team = 1;
+    expected.allied_mode = 0;
+    expected.current_scenario = 6;
+    expected.guys.push_back(make_initial_setup_guy_for_test());
+    expected.completed_levels = {1, 2, 3};
+    expected.controlled_entity_ids[0] = 101u;
+    expected.controlled_entity_ids[1] = 202u;
+
+    const std::vector<std::uint8_t> bytes =
+        og::sim::serialize_initial_setup_message(expected);
+    const std::optional<og::sim::InitialSetupMessage> decoded =
+        og::sim::deserialize_initial_setup_message(bytes);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(expected, *decoded);
+
+    const og::sim::TypedReceivedMessage typed =
+        og::sim::decode_received_message({.peer_id = 4u, .data = bytes});
+    EXPECT_EQ(4u, typed.peer_id);
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::InitialSetup, typed.kind);
+    ASSERT_NE(nullptr, typed.initial_setup);
+    EXPECT_EQ(expected, *typed.initial_setup);
+}
+
+TEST(NetTransport, lobby_message_variants_roundtrip_and_decode)
+{
+    std::vector<og::sim::LobbyMessage> messages;
+
+    og::sim::LobbyMessage join;
+    join.payload = og::sim::LobbyJoinMessage{.player = make_lobby_player_for_test()};
+    messages.push_back(join);
+
+    og::sim::LobbyMessage leave;
+    leave.payload = og::sim::LobbyLeaveMessage{.player_index = 2u};
+    messages.push_back(leave);
+
+    og::sim::LobbyMessage ready;
+    ready.payload = og::sim::LobbyReadyMessage{
+        .player_index = 3u,
+        .ready = true,
+    };
+    messages.push_back(ready);
+
+    og::sim::LobbyMessage team_change;
+    team_change.payload = og::sim::LobbyTeamChangeMessage{
+        .player_index = 4u,
+        .team = 1,
+    };
+    messages.push_back(team_change);
+
+    og::sim::LobbyMessage start_game;
+    start_game.payload = og::sim::LobbyStartGameMessage{.player_index = 5u};
+    messages.push_back(start_game);
+
+    og::sim::LobbyMessage settings_change;
+    settings_change.payload = og::sim::LobbySettingsChangeMessage{
+        .player_index = 6u,
+        .settings = {
+            .campaign_id = "campaign",
+            .scenario_id = 8,
+            .difficulty = 3,
+            .allied_mode = 1,
+        },
+    };
+    messages.push_back(settings_change);
+
+    for (const og::sim::LobbyMessage& message : messages)
+    {
+        const std::vector<std::uint8_t> bytes =
+            og::sim::serialize_lobby_message(message);
+        const std::optional<og::sim::LobbyMessage> decoded =
+            og::sim::deserialize_lobby_message(bytes);
+        ASSERT_TRUE(decoded.has_value());
+        EXPECT_EQ(message, *decoded);
+
+        const og::sim::TypedReceivedMessage typed =
+            og::sim::decode_received_message({.peer_id = 5u, .data = bytes});
+        EXPECT_EQ(og::sim::TypedReceivedMessageKind::LobbyMessage, typed.kind);
+        ASSERT_NE(nullptr, typed.lobby_message);
+        EXPECT_EQ(message, *typed.lobby_message);
+    }
+
+    std::vector<std::uint8_t> bad_kind =
+        og::sim::serialize_lobby_message(leave);
+    bad_kind[og::sim::kTransportHeaderSize] = 0xffu;
+    EXPECT_FALSE(og::sim::deserialize_lobby_message(bad_kind).has_value());
+    EXPECT_EQ(
+        og::sim::TypedReceivedMessageKind::Malformed,
+        og::sim::decode_received_message({.peer_id = 9u, .data = bad_kind}).kind);
+}
+
+TEST(NetTransport, lobby_state_roundtrip_and_decode_received_message)
+{
+    const og::sim::LobbyState expected = make_lobby_state_for_test();
+
+    const std::vector<std::uint8_t> bytes =
+        og::sim::serialize_lobby_state_message(expected);
+    const std::optional<og::sim::LobbyState> decoded =
+        og::sim::deserialize_lobby_state_message(bytes);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(expected, *decoded);
+
+    const og::sim::TypedReceivedMessage typed =
+        og::sim::decode_received_message({.peer_id = 6u, .data = bytes});
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::LobbyState, typed.kind);
+    ASSERT_NE(nullptr, typed.lobby_state);
+    EXPECT_EQ(expected, *typed.lobby_state);
+}
+
+TEST(NetTransport, lightweight_message_roundtrips_and_decode)
+{
+    const auto expect_client_ready = [] {
+        const og::sim::ClientReadyMessage expected{.last_applied_tick = 77u};
+        const auto bytes = og::sim::serialize_client_ready_message(expected);
+        const auto decoded = og::sim::deserialize_client_ready_message(bytes);
+        ASSERT_TRUE(decoded.has_value());
+        EXPECT_EQ(expected, *decoded);
+        const auto typed =
+            og::sim::decode_received_message({.peer_id = 1u, .data = bytes});
+        EXPECT_EQ(og::sim::TypedReceivedMessageKind::ClientReady, typed.kind);
+        ASSERT_NE(nullptr, typed.client_ready);
+        EXPECT_EQ(expected, *typed.client_ready);
+    };
+    expect_client_ready();
+
+    const auto expect_keyframe = [] {
+        const og::sim::KeyframeRequestMessage expected{.last_seen_tick = 88u};
+        const auto bytes = og::sim::serialize_keyframe_request_message(expected);
+        const auto decoded = og::sim::deserialize_keyframe_request_message(bytes);
+        ASSERT_TRUE(decoded.has_value());
+        EXPECT_EQ(expected, *decoded);
+        const auto typed =
+            og::sim::decode_received_message({.peer_id = 1u, .data = bytes});
+        EXPECT_EQ(og::sim::TypedReceivedMessageKind::KeyframeRequest, typed.kind);
+        ASSERT_NE(nullptr, typed.keyframe_request);
+        EXPECT_EQ(expected, *typed.keyframe_request);
+    };
+    expect_keyframe();
+
+    const og::sim::HeartbeatMessage heartbeat;
+    const auto heartbeat_bytes = og::sim::serialize_heartbeat_message(heartbeat);
+    ASSERT_TRUE(og::sim::deserialize_heartbeat_message(heartbeat_bytes).has_value());
+    const auto heartbeat_typed =
+        og::sim::decode_received_message({.peer_id = 1u, .data = heartbeat_bytes});
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::Heartbeat, heartbeat_typed.kind);
+    ASSERT_NE(nullptr, heartbeat_typed.heartbeat);
+    auto bad_heartbeat = heartbeat_bytes;
+    bad_heartbeat.push_back(0u);
+    bad_heartbeat[2] = 1u;
+    EXPECT_FALSE(og::sim::deserialize_heartbeat_message(bad_heartbeat).has_value());
+
+    const og::sim::ExitPromptBroadcastMessage exit_broadcast{
+        .destination_level = 3,
+        .withdraw_prompt = true,
+        .prompt_text = "Leave now?",
+    };
+    const auto exit_broadcast_bytes =
+        og::sim::serialize_exit_prompt_broadcast_message(exit_broadcast);
+    ASSERT_EQ(exit_broadcast,
+              *og::sim::deserialize_exit_prompt_broadcast_message(
+                  exit_broadcast_bytes));
+    const auto exit_broadcast_typed =
+        og::sim::decode_received_message({.peer_id = 1u,
+                                          .data = exit_broadcast_bytes});
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::ExitPromptBroadcast,
+              exit_broadcast_typed.kind);
+    ASSERT_NE(nullptr, exit_broadcast_typed.exit_prompt_broadcast);
+    EXPECT_EQ(exit_broadcast, *exit_broadcast_typed.exit_prompt_broadcast);
+
+    const og::sim::ExitPromptResponseMessage exit_response{
+        .accepted = true,
+        .abort_request = true,
+    };
+    const auto exit_response_bytes =
+        og::sim::serialize_exit_prompt_response_message(exit_response);
+    ASSERT_EQ(exit_response,
+              *og::sim::deserialize_exit_prompt_response_message(
+                  exit_response_bytes));
+    const auto exit_response_typed =
+        og::sim::decode_received_message({.peer_id = 1u,
+                                          .data = exit_response_bytes});
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::ExitPromptResponse,
+              exit_response_typed.kind);
+    ASSERT_NE(nullptr, exit_response_typed.exit_prompt_response);
+    EXPECT_EQ(exit_response, *exit_response_typed.exit_prompt_response);
+
+    const og::sim::PauseBroadcastMessage pause_broadcast{
+        .player_index = 2u,
+        .player_name = "Player",
+    };
+    const auto pause_broadcast_bytes =
+        og::sim::serialize_pause_broadcast_message(pause_broadcast);
+    ASSERT_EQ(pause_broadcast,
+              *og::sim::deserialize_pause_broadcast_message(
+                  pause_broadcast_bytes));
+    const auto pause_broadcast_typed =
+        og::sim::decode_received_message({.peer_id = 1u,
+                                          .data = pause_broadcast_bytes});
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::PauseBroadcast,
+              pause_broadcast_typed.kind);
+    ASSERT_NE(nullptr, pause_broadcast_typed.pause_broadcast);
+    EXPECT_EQ(pause_broadcast, *pause_broadcast_typed.pause_broadcast);
+
+    const og::sim::PauseResponseMessage pause_response{.resume = false};
+    const auto pause_response_bytes =
+        og::sim::serialize_pause_response_message(pause_response);
+    ASSERT_EQ(pause_response,
+              *og::sim::deserialize_pause_response_message(pause_response_bytes));
+    const auto pause_response_typed =
+        og::sim::decode_received_message({.peer_id = 1u,
+                                          .data = pause_response_bytes});
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::PauseResponse,
+              pause_response_typed.kind);
+    ASSERT_NE(nullptr, pause_response_typed.pause_response);
+    EXPECT_EQ(pause_response, *pause_response_typed.pause_response);
+
+    const og::sim::ControlChangeMessage control_change{
+        .player_index = 3u,
+        .entity_id = 404u,
+    };
+    const auto control_change_bytes =
+        og::sim::serialize_control_change_message(control_change);
+    ASSERT_EQ(control_change,
+              *og::sim::deserialize_control_change_message(control_change_bytes));
+    const auto control_change_typed =
+        og::sim::decode_received_message({.peer_id = 1u,
+                                          .data = control_change_bytes});
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::ControlChange,
+              control_change_typed.kind);
+    ASSERT_NE(nullptr, control_change_typed.control_change);
+    EXPECT_EQ(control_change, *control_change_typed.control_change);
+
+    const og::sim::SnapshotHashCheckMessage hash_check{
+        .tick = 500u,
+        .snapshot_hash = 0xabcdef12u,
+    };
+    const auto hash_check_bytes =
+        og::sim::serialize_snapshot_hash_check_message(hash_check);
+    ASSERT_EQ(hash_check,
+              *og::sim::deserialize_snapshot_hash_check_message(hash_check_bytes));
+    const auto hash_check_typed =
+        og::sim::decode_received_message({.peer_id = 1u,
+                                          .data = hash_check_bytes});
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::SnapshotHashCheck,
+              hash_check_typed.kind);
+    ASSERT_NE(nullptr, hash_check_typed.snapshot_hash_check);
+    EXPECT_EQ(hash_check, *hash_check_typed.snapshot_hash_check);
+}
+
+TEST(NetTransport, default_send_wrappers_emit_messages_and_ignore_nulls)
+{
+    MockTransport transport;
+
+    EXPECT_FALSE(transport.supports_typed_messages());
+    transport.send_snapshot(1u, {});
+    transport.send_delta_snapshot(1u, {});
+    transport.send_input(1u, {}, 12u);
+    transport.send_sim_event_batch(1u, {});
+    transport.send_game_flow_event_batch(1u, {});
+    transport.send_lobby_message(1u, {});
+    transport.send_lobby_state(1u, {});
+    transport.send_initial_setup(1u, {});
+    transport.send_hello(1u, {});
+    transport.send_client_ready(1u, {});
+    transport.send_keyframe_request(1u, {});
+    transport.send_heartbeat(1u, {});
+    transport.send_exit_prompt_broadcast(1u, {});
+    transport.send_exit_prompt_response(1u, {});
+    transport.send_pause_broadcast(1u, {});
+    transport.send_pause_response(1u, {});
+    transport.send_control_change(1u, {});
+    transport.send_snapshot_hash_check(1u, {});
+    EXPECT_TRUE(transport.sent_messages().empty());
+
+    const auto lobby_message = std::make_shared<og::sim::LobbyMessage>();
+    lobby_message->payload =
+        og::sim::LobbyStartGameMessage{.player_index = 2u};
+    transport.send_lobby_message(2u, lobby_message);
+
+    transport.send_lobby_state(
+        2u,
+        std::make_shared<og::sim::LobbyState>(make_lobby_state_for_test()));
+    transport.send_initial_setup(
+        2u,
+        std::make_shared<og::sim::InitialSetupMessage>(
+            og::sim::InitialSetupMessage{}));
+    transport.send_hello(
+        2u,
+        std::make_shared<og::sim::HelloMessage>(og::sim::HelloMessage{}));
+    transport.send_client_ready(
+        2u,
+        std::make_shared<og::sim::ClientReadyMessage>(
+            og::sim::ClientReadyMessage{.last_applied_tick = 1u}));
+    transport.send_keyframe_request(
+        2u,
+        std::make_shared<og::sim::KeyframeRequestMessage>(
+            og::sim::KeyframeRequestMessage{.last_seen_tick = 2u}));
+    transport.send_heartbeat(
+        2u,
+        std::make_shared<og::sim::HeartbeatMessage>(
+            og::sim::HeartbeatMessage{}));
+    transport.send_exit_prompt_broadcast(
+        2u,
+        std::make_shared<og::sim::ExitPromptBroadcastMessage>(
+            og::sim::ExitPromptBroadcastMessage{
+                .destination_level = 1,
+                .withdraw_prompt = false,
+                .prompt_text = "Prompt",
+            }));
+    transport.send_exit_prompt_response(
+        2u,
+        std::make_shared<og::sim::ExitPromptResponseMessage>(
+            og::sim::ExitPromptResponseMessage{
+                .accepted = true,
+                .abort_request = false,
+            }));
+    transport.send_pause_broadcast(
+        2u,
+        std::make_shared<og::sim::PauseBroadcastMessage>(
+            og::sim::PauseBroadcastMessage{
+                .player_index = 3u,
+                .player_name = "Player",
+            }));
+    transport.send_pause_response(
+        2u,
+        std::make_shared<og::sim::PauseResponseMessage>(
+            og::sim::PauseResponseMessage{.resume = true}));
+    transport.send_control_change(
+        2u,
+        std::make_shared<og::sim::ControlChangeMessage>(
+            og::sim::ControlChangeMessage{
+                .player_index = 4u,
+                .entity_id = 5u,
+            }));
+    transport.send_snapshot_hash_check(
+        2u,
+        std::make_shared<og::sim::SnapshotHashCheckMessage>(
+            og::sim::SnapshotHashCheckMessage{
+                .tick = 6u,
+                .snapshot_hash = 7u,
+            }));
+
+    ASSERT_EQ(13u, transport.sent_messages().size());
+    for (const og::sim::ReceivedMessage& sent : transport.sent_messages())
+    {
+        EXPECT_EQ(2u, sent.peer_id);
+        EXPECT_NE(og::sim::TypedReceivedMessageKind::Malformed,
+                  og::sim::decode_received_message(sent).kind);
+    }
+}
+
+TEST(NetTransport, decode_received_message_reports_malformed_inputs)
+{
+    EXPECT_EQ(
+        og::sim::TypedReceivedMessageKind::Malformed,
+        og::sim::decode_received_message({.peer_id = 7u, .data = {0x01}}).kind);
+
+    std::vector<std::uint8_t> unknown_message;
+    og::sim::append_transport_header(unknown_message, 0xffu, 0u);
+    EXPECT_EQ(
+        og::sim::TypedReceivedMessageKind::Malformed,
+        og::sim::decode_received_message({.peer_id = 7u,
+                                          .data = unknown_message}).kind);
+
+    std::vector<std::uint8_t> malformed_client_ready;
+    og::sim::append_transport_header(
+        malformed_client_ready,
+        og::sim::kClientReadyMessageType,
+        1u);
+    malformed_client_ready.push_back(0u);
+    EXPECT_EQ(
+        og::sim::TypedReceivedMessageKind::Malformed,
+        og::sim::decode_received_message({.peer_id = 7u,
+                                          .data = malformed_client_ready}).kind);
 }
 
 TEST(NetTransport, serialize_hello_emits_expected_wire_format)

--- a/tests/unit/test_net_transport_emscripten_ws.cpp
+++ b/tests/unit/test_net_transport_emscripten_ws.cpp
@@ -41,6 +41,43 @@ using og::sim::detail::set_emscripten_websocket_api_for_testing;
 
 constexpr unsigned short kReadyStateOpen = 1;
 
+TEST(EmscriptenWebSocketTransportDefaults,
+     host_default_api_reports_unsupported_without_override)
+{
+    set_emscripten_websocket_api_for_testing(nullptr);
+
+    const EmscriptenWebSocketApi& api =
+        og::sim::detail::emscripten_websocket_api();
+    WebSocketCreateAttributes attributes;
+    api.init_create_attributes(&attributes);
+    EXPECT_EQ(nullptr, attributes.url);
+    EXPECT_EQ(nullptr, attributes.protocols);
+    EXPECT_EQ(kFalse, api.is_supported());
+    EXPECT_EQ(og::sim::detail::kResultNotSupported,
+              api.create(&attributes));
+    EXPECT_EQ(og::sim::detail::kResultNotSupported,
+              api.set_onopen(1, nullptr, nullptr));
+    EXPECT_EQ(og::sim::detail::kResultNotSupported,
+              api.set_onmessage(1, nullptr, nullptr));
+    EXPECT_EQ(og::sim::detail::kResultNotSupported,
+              api.set_onerror(1, nullptr, nullptr));
+    EXPECT_EQ(og::sim::detail::kResultNotSupported,
+              api.set_onclose(1, nullptr, nullptr));
+    unsigned short ready_state = 0;
+    EXPECT_EQ(og::sim::detail::kResultNotSupported,
+              api.get_ready_state(1, &ready_state));
+    std::array<std::uint8_t, 1> payload = {0x42};
+    EXPECT_EQ(og::sim::detail::kResultNotSupported,
+              api.send_binary(1, payload.data(), payload.size()));
+    EXPECT_EQ(og::sim::detail::kResultNotSupported,
+              api.close(1, 1000, "unit"));
+    EXPECT_EQ(og::sim::detail::kResultNotSupported,
+              api.destroy(1));
+
+    EmscriptenWebSocketTransport transport("ws://example.test/socket");
+    EXPECT_THROW(transport.accept_connections(), std::runtime_error);
+}
+
 class FakeWebSocketBackend
 {
 public:

--- a/tests/unit/test_net_transport_inprocess.cpp
+++ b/tests/unit/test_net_transport_inprocess.cpp
@@ -583,6 +583,210 @@ TEST(NetTransportInProcess, validating_mode_roundtrips_lobby_messages)
     EXPECT_EQ(message, *server_messages[0].lobby_message);
 }
 
+TEST(NetTransportInProcess, validating_mode_roundtrips_lightweight_typed_messages)
+{
+    const auto pair = og::sim::InProcessTransport::create_linked_pair(
+        {.validate_serialization = true});
+
+    og::sim::InitialSetupMessage setup;
+    setup.level_id = 4;
+    setup.level_title = "Level";
+    setup.controlled_entity_ids[0] = 101u;
+    pair.server->send_initial_setup(
+        pair.peer_id,
+        std::make_shared<og::sim::InitialSetupMessage>(setup));
+
+    og::sim::HelloMessage hello;
+    hello.snapshot_format_version = 2;
+    hello.campaign_content_hash = 0x12345678u;
+    pair.server->send_hello(
+        pair.peer_id,
+        std::make_shared<og::sim::HelloMessage>(hello));
+
+    const og::sim::ClientReadyMessage client_ready{.last_applied_tick = 5u};
+    pair.server->send_client_ready(
+        pair.peer_id,
+        std::make_shared<og::sim::ClientReadyMessage>(client_ready));
+
+    const og::sim::KeyframeRequestMessage keyframe{.last_seen_tick = 6u};
+    pair.server->send_keyframe_request(
+        pair.peer_id,
+        std::make_shared<og::sim::KeyframeRequestMessage>(keyframe));
+
+    pair.server->send_heartbeat(
+        pair.peer_id,
+        std::make_shared<og::sim::HeartbeatMessage>());
+
+    const og::sim::ExitPromptBroadcastMessage exit_broadcast{
+        .destination_level = 2,
+        .withdraw_prompt = true,
+        .prompt_text = "Exit?",
+    };
+    pair.server->send_exit_prompt_broadcast(
+        pair.peer_id,
+        std::make_shared<og::sim::ExitPromptBroadcastMessage>(exit_broadcast));
+
+    const og::sim::ExitPromptResponseMessage exit_response{
+        .accepted = true,
+        .abort_request = false,
+    };
+    pair.server->send_exit_prompt_response(
+        pair.peer_id,
+        std::make_shared<og::sim::ExitPromptResponseMessage>(exit_response));
+
+    const og::sim::PauseBroadcastMessage pause_broadcast{
+        .player_index = 1u,
+        .player_name = "Host",
+    };
+    pair.server->send_pause_broadcast(
+        pair.peer_id,
+        std::make_shared<og::sim::PauseBroadcastMessage>(pause_broadcast));
+
+    const og::sim::PauseResponseMessage pause_response{.resume = false};
+    pair.server->send_pause_response(
+        pair.peer_id,
+        std::make_shared<og::sim::PauseResponseMessage>(pause_response));
+
+    const og::sim::ControlChangeMessage control_change{
+        .player_index = 2u,
+        .entity_id = 300u,
+    };
+    pair.server->send_control_change(
+        pair.peer_id,
+        std::make_shared<og::sim::ControlChangeMessage>(control_change));
+
+    const og::sim::SnapshotHashCheckMessage hash_check{
+        .tick = 7u,
+        .snapshot_hash = 0xabcdef01u,
+    };
+    pair.server->send_snapshot_hash_check(
+        pair.peer_id,
+        std::make_shared<og::sim::SnapshotHashCheckMessage>(hash_check));
+
+    const std::vector<og::sim::TypedReceivedMessage> messages =
+        pair.client->poll_typed();
+    ASSERT_EQ(11u, messages.size());
+
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::InitialSetup, messages[0].kind);
+    ASSERT_NE(nullptr, messages[0].initial_setup);
+    EXPECT_EQ(setup, *messages[0].initial_setup);
+
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::Hello, messages[1].kind);
+    ASSERT_NE(nullptr, messages[1].hello);
+    EXPECT_EQ(hello, *messages[1].hello);
+
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::ClientReady, messages[2].kind);
+    ASSERT_NE(nullptr, messages[2].client_ready);
+    EXPECT_EQ(client_ready, *messages[2].client_ready);
+
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::KeyframeRequest,
+              messages[3].kind);
+    ASSERT_NE(nullptr, messages[3].keyframe_request);
+    EXPECT_EQ(keyframe, *messages[3].keyframe_request);
+
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::Heartbeat, messages[4].kind);
+    ASSERT_NE(nullptr, messages[4].heartbeat);
+
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::ExitPromptBroadcast,
+              messages[5].kind);
+    ASSERT_NE(nullptr, messages[5].exit_prompt_broadcast);
+    EXPECT_EQ(exit_broadcast, *messages[5].exit_prompt_broadcast);
+
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::ExitPromptResponse,
+              messages[6].kind);
+    ASSERT_NE(nullptr, messages[6].exit_prompt_response);
+    EXPECT_EQ(exit_response, *messages[6].exit_prompt_response);
+
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::PauseBroadcast,
+              messages[7].kind);
+    ASSERT_NE(nullptr, messages[7].pause_broadcast);
+    EXPECT_EQ(pause_broadcast, *messages[7].pause_broadcast);
+
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::PauseResponse,
+              messages[8].kind);
+    ASSERT_NE(nullptr, messages[8].pause_response);
+    EXPECT_EQ(pause_response, *messages[8].pause_response);
+
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::ControlChange,
+              messages[9].kind);
+    ASSERT_NE(nullptr, messages[9].control_change);
+    EXPECT_EQ(control_change, *messages[9].control_change);
+
+    EXPECT_EQ(og::sim::TypedReceivedMessageKind::SnapshotHashCheck,
+              messages[10].kind);
+    ASSERT_NE(nullptr, messages[10].snapshot_hash_check);
+    EXPECT_EQ(hash_check, *messages[10].snapshot_hash_check);
+}
+
+TEST(NetTransportInProcess, null_typed_sends_are_ignored)
+{
+    const auto pair = og::sim::InProcessTransport::create_linked_pair();
+
+    EXPECT_TRUE(pair.server->supports_typed_messages());
+    pair.server->send_snapshot(pair.peer_id, {});
+    pair.server->send_delta_snapshot(pair.peer_id, {});
+    pair.server->send_input(pair.peer_id, {}, 1u);
+    pair.server->send_sim_event_batch(pair.peer_id, {});
+    pair.server->send_game_flow_event_batch(pair.peer_id, {});
+    pair.server->send_lobby_message(pair.peer_id, {});
+    pair.server->send_lobby_state(pair.peer_id, {});
+    pair.server->send_initial_setup(pair.peer_id, {});
+    pair.server->send_hello(pair.peer_id, {});
+    pair.server->send_client_ready(pair.peer_id, {});
+    pair.server->send_keyframe_request(pair.peer_id, {});
+    pair.server->send_heartbeat(pair.peer_id, {});
+    pair.server->send_exit_prompt_broadcast(pair.peer_id, {});
+    pair.server->send_exit_prompt_response(pair.peer_id, {});
+    pair.server->send_pause_broadcast(pair.peer_id, {});
+    pair.server->send_pause_response(pair.peer_id, {});
+    pair.server->send_control_change(pair.peer_id, {});
+    pair.server->send_snapshot_hash_check(pair.peer_id, {});
+
+    EXPECT_TRUE(pair.client->poll_typed().empty());
+}
+
+TEST(NetTransportInProcess, raw_empty_send_and_disconnect_paths)
+{
+    auto server = og::sim::InProcessTransport::create_server();
+    auto client = server->create_client_transport();
+    const og::sim::PeerId peer_id = client->local_peer_id();
+
+    server->send(peer_id, nullptr, 0);
+    const std::vector<og::sim::ReceivedMessage> raw_messages = client->poll();
+    ASSERT_EQ(1u, raw_messages.size());
+    EXPECT_EQ(peer_id, raw_messages[0].peer_id);
+    EXPECT_TRUE(raw_messages[0].data.empty());
+
+    EXPECT_THROW(client->create_client_transport(), std::runtime_error);
+    server->disconnect(peer_id + 99u);
+    EXPECT_EQ((std::vector<og::sim::PeerId>{peer_id}),
+              server->connected_peers());
+
+    server->disconnect(peer_id);
+    EXPECT_TRUE(server->connected_peers().empty());
+    EXPECT_TRUE(client->connected_peers().empty());
+    EXPECT_THROW(
+        server->send_heartbeat(
+            peer_id,
+            std::make_shared<og::sim::HeartbeatMessage>()),
+        std::runtime_error);
+}
+
+TEST(NetTransportInProcess, expired_peer_is_reported_when_sending)
+{
+    auto server = og::sim::InProcessTransport::create_server();
+    auto client = server->create_client_transport();
+    const og::sim::PeerId peer_id = client->local_peer_id();
+    client.reset();
+
+    EXPECT_TRUE(server->connected_peers().empty());
+    EXPECT_THROW(
+        server->send_heartbeat(
+            peer_id,
+            std::make_shared<og::sim::HeartbeatMessage>()),
+        std::runtime_error);
+}
+
 TEST(NetTransportInProcess,
      network_fixture_accepts_timer_wait_request_only_from_host_client)
 {

--- a/tests/unit/test_net_transport_multiplex.cpp
+++ b/tests/unit/test_net_transport_multiplex.cpp
@@ -124,6 +124,154 @@ private:
     std::size_t broadcast_call_count_ = 0;
 };
 
+class FakeTypedTransport final : public og::sim::ITransport
+{
+public:
+    void connect_peer(og::sim::PeerId peer_id)
+    {
+        peers_.push_back(peer_id);
+    }
+
+    void send(og::sim::PeerId peer_id,
+              const std::uint8_t* data,
+              std::size_t len) override
+    {
+        raw_send_peer = peer_id;
+        raw_send_size = len;
+        if (data != nullptr && len > 0)
+            raw_send_first = data[0];
+    }
+
+    bool supports_typed_messages() const noexcept override { return true; }
+    void send_snapshot(og::sim::PeerId peer_id,
+                       std::shared_ptr<og::sim::WorldSnapshot>) override
+    {
+        snapshot_peer = peer_id;
+    }
+    void send_delta_snapshot(og::sim::PeerId peer_id,
+                             std::shared_ptr<og::sim::WorldSnapshot>) override
+    {
+        delta_peer = peer_id;
+    }
+    void send_input(og::sim::PeerId peer_id,
+                    std::shared_ptr<InputState>,
+                    std::uint32_t tick) override
+    {
+        input_peer = peer_id;
+        input_tick = tick;
+    }
+    void send_sim_event_batch(og::sim::PeerId peer_id,
+                              std::shared_ptr<og::sim::SimEventBatch>) override
+    {
+        sim_events_peer = peer_id;
+    }
+    void send_game_flow_event_batch(og::sim::PeerId peer_id,
+                                    std::shared_ptr<og::sim::SimEventBatch>) override
+    {
+        game_flow_peer = peer_id;
+    }
+    void send_lobby_message(og::sim::PeerId peer_id,
+                            std::shared_ptr<og::sim::LobbyMessage>) override
+    {
+        lobby_message_peer = peer_id;
+    }
+    void send_lobby_state(og::sim::PeerId peer_id,
+                          std::shared_ptr<og::sim::LobbyState>) override
+    {
+        lobby_state_peer = peer_id;
+    }
+    void send_initial_setup(og::sim::PeerId peer_id,
+                            std::shared_ptr<og::sim::InitialSetupMessage>) override
+    {
+        initial_setup_peer = peer_id;
+    }
+    void send_hello(og::sim::PeerId peer_id,
+                    std::shared_ptr<og::sim::HelloMessage>) override
+    {
+        hello_peer = peer_id;
+    }
+    void send_client_ready(og::sim::PeerId peer_id,
+                           std::shared_ptr<og::sim::ClientReadyMessage>) override
+    {
+        client_ready_peer = peer_id;
+    }
+    void send_keyframe_request(og::sim::PeerId peer_id,
+                               std::shared_ptr<og::sim::KeyframeRequestMessage>) override
+    {
+        keyframe_peer = peer_id;
+    }
+    void send_heartbeat(og::sim::PeerId peer_id,
+                        std::shared_ptr<og::sim::HeartbeatMessage>) override
+    {
+        heartbeat_peer = peer_id;
+    }
+    void send_exit_prompt_broadcast(
+        og::sim::PeerId peer_id,
+        std::shared_ptr<og::sim::ExitPromptBroadcastMessage>) override
+    {
+        exit_broadcast_peer = peer_id;
+    }
+    void send_exit_prompt_response(
+        og::sim::PeerId peer_id,
+        std::shared_ptr<og::sim::ExitPromptResponseMessage>) override
+    {
+        exit_response_peer = peer_id;
+    }
+    void send_pause_broadcast(og::sim::PeerId peer_id,
+                              std::shared_ptr<og::sim::PauseBroadcastMessage>) override
+    {
+        pause_broadcast_peer = peer_id;
+    }
+    void send_pause_response(og::sim::PeerId peer_id,
+                             std::shared_ptr<og::sim::PauseResponseMessage>) override
+    {
+        pause_response_peer = peer_id;
+    }
+    void send_control_change(og::sim::PeerId peer_id,
+                             std::shared_ptr<og::sim::ControlChangeMessage>) override
+    {
+        control_change_peer = peer_id;
+    }
+    void send_snapshot_hash_check(
+        og::sim::PeerId peer_id,
+        std::shared_ptr<og::sim::SnapshotHashCheckMessage>) override
+    {
+        hash_check_peer = peer_id;
+    }
+
+    std::vector<og::sim::ReceivedMessage> poll() override { return {}; }
+    void accept_connections() override {}
+    void disconnect(og::sim::PeerId peer_id) override { disconnected_peer = peer_id; }
+    std::vector<og::sim::PeerId> connected_peers() const override { return peers_; }
+
+    og::sim::PeerId raw_send_peer = 0;
+    std::size_t raw_send_size = 0;
+    std::uint8_t raw_send_first = 0;
+    og::sim::PeerId snapshot_peer = 0;
+    og::sim::PeerId delta_peer = 0;
+    og::sim::PeerId input_peer = 0;
+    std::uint32_t input_tick = 0;
+    og::sim::PeerId sim_events_peer = 0;
+    og::sim::PeerId game_flow_peer = 0;
+    og::sim::PeerId lobby_message_peer = 0;
+    og::sim::PeerId lobby_state_peer = 0;
+    og::sim::PeerId initial_setup_peer = 0;
+    og::sim::PeerId hello_peer = 0;
+    og::sim::PeerId client_ready_peer = 0;
+    og::sim::PeerId keyframe_peer = 0;
+    og::sim::PeerId heartbeat_peer = 0;
+    og::sim::PeerId exit_broadcast_peer = 0;
+    og::sim::PeerId exit_response_peer = 0;
+    og::sim::PeerId pause_broadcast_peer = 0;
+    og::sim::PeerId pause_response_peer = 0;
+    og::sim::PeerId control_change_peer = 0;
+    og::sim::PeerId hash_check_peer = 0;
+    og::sim::PeerId disconnected_peer = 0;
+
+private:
+    std::vector<og::sim::PeerId> peers_;
+};
+
 } // namespace
 
 TEST(NetTransportMultiplex, poll_typed_assigns_distinct_public_peer_ids)
@@ -447,4 +595,74 @@ TEST(NetTransportMultiplex, broadcast_calls_each_underlying_transport_once)
               raw_a->sent_messages().front().data);
     EXPECT_EQ((std::vector<std::uint8_t>{0xaa, 0x55}),
               raw_b->sent_messages().front().data);
+}
+
+TEST(NetTransportMultiplex, typed_forwarding_methods_route_to_native_peer)
+{
+    auto typed = std::make_shared<FakeTypedTransport>();
+    typed->connect_peer(44u);
+    og::sim::MultiplexTransport transport({typed});
+
+    const std::vector<og::sim::PeerId> public_peers = transport.connected_peers();
+    ASSERT_EQ(1u, public_peers.size());
+    const og::sim::PeerId public_peer = public_peers.front();
+
+    const std::array<std::uint8_t, 2> raw = {0x12, 0x34};
+    transport.send(public_peer, raw.data(), raw.size());
+    transport.send_snapshot(public_peer, {});
+    transport.send_delta_snapshot(public_peer, {});
+    transport.send_input(public_peer, std::make_shared<InputState>(), 1234u);
+    transport.send_sim_event_batch(public_peer, {});
+    transport.send_game_flow_event_batch(public_peer, {});
+    transport.send_lobby_message(public_peer, std::make_shared<og::sim::LobbyMessage>());
+    transport.send_lobby_state(public_peer, std::make_shared<og::sim::LobbyState>());
+    transport.send_initial_setup(public_peer,
+                                 std::make_shared<og::sim::InitialSetupMessage>());
+    transport.send_hello(public_peer, std::make_shared<og::sim::HelloMessage>());
+    transport.send_client_ready(public_peer,
+                                std::make_shared<og::sim::ClientReadyMessage>());
+    transport.send_keyframe_request(public_peer,
+                                    std::make_shared<og::sim::KeyframeRequestMessage>());
+    transport.send_heartbeat(public_peer, std::make_shared<og::sim::HeartbeatMessage>());
+    transport.send_exit_prompt_broadcast(
+        public_peer, std::make_shared<og::sim::ExitPromptBroadcastMessage>());
+    transport.send_exit_prompt_response(
+        public_peer, std::make_shared<og::sim::ExitPromptResponseMessage>());
+    transport.send_pause_broadcast(public_peer,
+                                   std::make_shared<og::sim::PauseBroadcastMessage>());
+    transport.send_pause_response(public_peer,
+                                  std::make_shared<og::sim::PauseResponseMessage>());
+    transport.send_control_change(public_peer,
+                                  std::make_shared<og::sim::ControlChangeMessage>());
+    transport.send_snapshot_hash_check(
+        public_peer, std::make_shared<og::sim::SnapshotHashCheckMessage>());
+    transport.disconnect(public_peer);
+
+    EXPECT_EQ(44u, typed->raw_send_peer);
+    EXPECT_EQ(2u, typed->raw_send_size);
+    EXPECT_EQ(0x12u, typed->raw_send_first);
+    EXPECT_EQ(44u, typed->snapshot_peer);
+    EXPECT_EQ(44u, typed->delta_peer);
+    EXPECT_EQ(44u, typed->input_peer);
+    EXPECT_EQ(1234u, typed->input_tick);
+    EXPECT_EQ(44u, typed->sim_events_peer);
+    EXPECT_EQ(44u, typed->game_flow_peer);
+    EXPECT_EQ(44u, typed->lobby_message_peer);
+    EXPECT_EQ(44u, typed->lobby_state_peer);
+    EXPECT_EQ(44u, typed->initial_setup_peer);
+    EXPECT_EQ(44u, typed->hello_peer);
+    EXPECT_EQ(44u, typed->client_ready_peer);
+    EXPECT_EQ(44u, typed->keyframe_peer);
+    EXPECT_EQ(44u, typed->heartbeat_peer);
+    EXPECT_EQ(44u, typed->exit_broadcast_peer);
+    EXPECT_EQ(44u, typed->exit_response_peer);
+    EXPECT_EQ(44u, typed->pause_broadcast_peer);
+    EXPECT_EQ(44u, typed->pause_response_peer);
+    EXPECT_EQ(44u, typed->control_change_peer);
+    EXPECT_EQ(44u, typed->hash_check_peer);
+    EXPECT_EQ(44u, typed->disconnected_peer);
+
+    transport.send(999u, raw.data(), raw.size());
+    transport.send_lobby_state(999u, std::make_shared<og::sim::LobbyState>());
+    transport.disconnect(999u);
 }

--- a/tests/unit/test_picker_common.cpp
+++ b/tests/unit/test_picker_common.cpp
@@ -106,6 +106,17 @@ TEST(PickerCommon, calculate_hire_cost_with_stats)
     ASSERT_TRUE(more_cost > upgraded_cost);
 }
 
+TEST(PickerCommon, calculate_costs_return_zero_for_unknown_family)
+{
+    init_family_registry();
+    guy recruit(FAMILY_SOLDIER);
+    recruit.family = 99;
+    guy original(recruit);
+
+    EXPECT_EQ(0u, og::ui::calculate_hire_cost(recruit));
+    EXPECT_EQ(0u, og::ui::calculate_train_cost(recruit, original));
+}
+
 // --- calculate_train_cost ---
 
 TEST(PickerCommon, calculate_train_cost_delta)
@@ -189,6 +200,23 @@ TEST(PickerCommon, add_recruit_to_team)
     int slot3 = og::ui::add_recruit_to_team(save, std::move(recruit3), 0);
     ASSERT_TRUE(slot3 == 0);
     ASSERT_TRUE(save.team_size == 2);
+}
+
+TEST(PickerCommon, add_recruit_to_team_rejects_full_and_inconsistent_roster)
+{
+    SaveData full;
+    full.team_size = MAX_TEAM_SIZE;
+    EXPECT_EQ(-1, og::ui::add_recruit_to_team(
+        full, std::make_unique<guy>(FAMILY_SOLDIER), 2));
+
+    SaveData no_empty_slots;
+    no_empty_slots.team_size = 0;
+    for (int i = 0; i < MAX_TEAM_SIZE; ++i)
+        no_empty_slots.team_list[i] = std::make_unique<guy>(FAMILY_SOLDIER);
+
+    EXPECT_EQ(-1, og::ui::add_recruit_to_team(
+        no_empty_slots, std::make_unique<guy>(FAMILY_MAGE), 1));
+    EXPECT_EQ(0, no_empty_slots.team_size);
 }
 
 TEST(PickerCommon, train_session_skips_non_editable_lobby_slots)
@@ -345,6 +373,54 @@ TEST(PickerCommon, get_random_name_all_families)
     }
 }
 
+TEST(PickerCommon, get_random_name_covers_non_hirelist_and_default_families)
+{
+    std::srand(11);
+    const int families[] = {
+        FAMILY_ARCHMAGE,
+        FAMILY_BIG_ORC,
+        FAMILY_SLIME,
+        FAMILY_MEDIUM_SLIME,
+        199,
+    };
+
+    for (int family : families) {
+        const char* name = og::ui::get_random_name(static_cast<unsigned char>(family));
+        ASSERT_NE(nullptr, name);
+        EXPECT_GT(std::strlen(name), 0u);
+    }
+}
+
+TEST(PickerCommon, get_unique_name_falls_back_to_numbered_duplicate)
+{
+    SaveData save;
+    std::vector<std::string> slime_names;
+    std::srand(3);
+    for (int attempts = 0; attempts < 200 && slime_names.size() < 6; ++attempts) {
+        std::string name = og::ui::get_random_name(FAMILY_SLIME);
+        if (std::find(slime_names.begin(), slime_names.end(), name) == slime_names.end())
+            slime_names.push_back(name);
+    }
+    ASSERT_EQ(6u, slime_names.size());
+
+    int slot = 0;
+    for (const std::string& name : slime_names) {
+        save.team_list[slot] = std::make_unique<guy>(FAMILY_SLIME);
+        save.team_list[slot]->name = name;
+        ++slot;
+        save.team_list[slot] = std::make_unique<guy>(FAMILY_SLIME);
+        save.team_list[slot]->name = name + "2";
+        ++slot;
+    }
+    save.team_size = static_cast<unsigned char>(slot);
+
+    std::srand(3);
+    const std::string unique_name = og::ui::get_unique_name(FAMILY_SLIME, save);
+    EXPECT_TRUE(unique_name.ends_with("3"));
+    for (int i = 0; i < save.team_size; ++i)
+        ASSERT_NE(save.team_list[i]->name, unique_name);
+}
+
 // --- statscopy ---
 
 TEST(PickerCommon, statscopy)
@@ -450,6 +526,11 @@ TEST(PickerCommon, hire_session_rename_hired)
 
     session.rename_hired(slot, "CustomName");
     ASSERT_TRUE(save.team_list[slot]->name == "CustomName");
+
+    session.rename_hired(-1, "Ignored");
+    session.rename_hired(MAX_TEAM_SIZE, "Ignored");
+    session.rename_hired(3, "Ignored");
+    ASSERT_TRUE(save.team_list[slot]->name == "CustomName");
 }
 
 TEST(PickerCommon, hire_session_team_full)
@@ -480,6 +561,23 @@ TEST(PickerCommon, hire_session_not_enough_gold)
     og::ui::HireSession session(save, 0);
     ASSERT_TRUE(session.hire() == -1);
     ASSERT_TRUE(save.team_size == 0);
+}
+
+TEST(PickerCommon, hire_session_reports_team_and_handles_missing_empty_slot)
+{
+    init_family_registry();
+    SaveData save;
+    save.team_size = 0;
+    save.m_totalcash[2] = 50000;
+
+    og::ui::HireSession session(save, 2);
+    EXPECT_EQ(2, session.team_num());
+
+    for (int i = 0; i < MAX_TEAM_SIZE; ++i)
+        save.team_list[i] = std::make_unique<guy>(FAMILY_SOLDIER);
+    save.team_size = MAX_TEAM_SIZE - 1;
+    EXPECT_FALSE(session.team_full());
+    EXPECT_EQ(-1, session.hire());
 }
 
 // --- TrainSession ---
@@ -558,6 +656,67 @@ TEST(PickerCommon, train_session_increase_decrease)
     ASSERT_TRUE(session.working_copy().strength == orig_str);
 }
 
+TEST(PickerCommon, train_session_all_stat_arms_and_clamps)
+{
+    init_family_registry();
+    SaveData save;
+    save.team_list[0] = std::make_unique<guy>(FAMILY_MAGE);
+    save.team_size = 1;
+    save.m_totalcash[0] = 50000;
+
+    og::ui::TrainSession session(save);
+    const guy& original = session.original();
+    const short orig_str = original.strength;
+    const short orig_dex = original.dexterity;
+    const short orig_con = original.constitution;
+    const short orig_int = original.intelligence;
+    const short orig_arm = original.armor;
+
+    using Stat = og::ui::TrainSession::Stat;
+    session.increase_stat(Stat::Strength);
+    session.increase_stat(Stat::Dexterity);
+    session.increase_stat(Stat::Constitution);
+    session.increase_stat(Stat::Intelligence);
+    session.increase_stat(Stat::Armor);
+    EXPECT_GT(session.working_copy().strength, orig_str);
+    EXPECT_GT(session.working_copy().dexterity, orig_dex);
+    EXPECT_GT(session.working_copy().constitution, orig_con);
+    EXPECT_GT(session.working_copy().intelligence, orig_int);
+    EXPECT_GT(session.working_copy().armor, orig_arm);
+
+    session.decrease_stat(Stat::Strength, 100);
+    session.decrease_stat(Stat::Dexterity, 100);
+    session.decrease_stat(Stat::Constitution, 100);
+    session.decrease_stat(Stat::Intelligence, 100);
+    session.decrease_stat(Stat::Armor, 100);
+    EXPECT_EQ(orig_str, session.working_copy().strength);
+    EXPECT_EQ(orig_dex, session.working_copy().dexterity);
+    EXPECT_EQ(orig_con, session.working_copy().constitution);
+    EXPECT_EQ(orig_int, session.working_copy().intelligence);
+    EXPECT_EQ(orig_arm, session.working_copy().armor);
+}
+
+TEST(PickerCommon, train_session_handles_null_working_copy_paths)
+{
+    SaveData save;
+    save.team_size = 1;
+
+    og::ui::TrainSession session(save);
+    ASSERT_TRUE(session.empty());
+
+    using Stat = og::ui::TrainSession::Stat;
+    session.next_member();
+    session.prev_member();
+    session.increase_stat(Stat::Strength);
+    session.decrease_stat(Stat::Strength);
+    session.set_team(3);
+
+    EXPECT_EQ(0u, session.current_cost());
+    EXPECT_FALSE(session.level_increased());
+    EXPECT_FALSE(session.stats_increased());
+    EXPECT_FALSE(session.accept());
+}
+
 TEST(PickerCommon, train_session_level_locks_stats)
 {
     init_family_registry();
@@ -576,6 +735,29 @@ TEST(PickerCommon, train_session_level_locks_stats)
     short str_before = session.working_copy().strength;
     session.increase_stat(og::ui::TrainSession::Stat::Strength, 1);
     ASSERT_TRUE(session.working_copy().strength == str_before);
+}
+
+TEST(PickerCommon, train_session_level_decrease_restores_original_exp_and_accepts)
+{
+    init_family_registry();
+    SaveData save;
+    save.team_list[0] = std::make_unique<guy>(FAMILY_SOLDIER);
+    save.team_size = 1;
+    save.m_totalcash[0] = 999999;
+
+    og::ui::TrainSession session(save);
+    const std::uint32_t original_exp = session.original().exp;
+    const short original_level = session.original().level;
+
+    session.increase_stat(og::ui::TrainSession::Stat::Level, 2);
+    ASSERT_GT(session.working_copy().level, original_level);
+    session.decrease_stat(og::ui::TrainSession::Stat::Level, 2);
+    EXPECT_EQ(original_level, session.working_copy().level);
+    EXPECT_EQ(original_exp, session.working_copy().exp);
+
+    session.increase_stat(og::ui::TrainSession::Stat::Level, 1);
+    ASSERT_TRUE(session.accept(true));
+    EXPECT_GT(save.team_list[0]->level, original_level);
 }
 
 TEST(PickerCommon, train_session_stats_lock_level)
@@ -652,6 +834,33 @@ TEST(PickerCommon, train_session_accept_force)
     ASSERT_TRUE(session.accept(true)); // force=true bypasses cost
     ASSERT_TRUE(save.team_list[0]->strength == orig_str + 5);
     ASSERT_TRUE(save.m_totalcash[0] == 0); // gold unchanged
+}
+
+TEST(PickerCommon, train_session_set_team_clamps_and_lobby_revocation_invalidates_original)
+{
+    init_family_registry();
+    SaveData save;
+    save.team_list[0] = std::make_unique<guy>(FAMILY_SOLDIER);
+    save.team_size = 1;
+    save.m_totalcash[0] = 999999;
+
+    EditableSlotPickerLobbyClient client;
+    client.editable_slots.fill(false);
+    client.editable_slots[0] = true;
+    ActivePickerLobbyClientGuard guard(&client);
+
+    og::ui::TrainSession session(save);
+    ASSERT_FALSE(session.empty());
+
+    session.set_team(-10);
+    EXPECT_EQ(0, session.working_copy().teamnum);
+    session.set_team(99);
+    EXPECT_EQ(SCORE_TEAM_COUNT - 1, session.working_copy().teamnum);
+
+    client.editable_slots[0] = false;
+    EXPECT_TRUE(session.empty());
+    EXPECT_EQ(0u, session.current_cost());
+    EXPECT_FALSE(session.accept());
 }
 
 // --- compute_derived_stats ---
@@ -946,6 +1155,7 @@ TEST(PickerCommon, save_error_string)
     ASSERT_TRUE(std::strcmp(og::ui::save_error_string(SaveDataIoError::InvalidHeader), "invalid_header") == 0);
     ASSERT_TRUE(std::strcmp(og::ui::save_error_string(SaveDataIoError::UnsupportedVersion), "unsupported_version") == 0);
     ASSERT_TRUE(std::strcmp(og::ui::save_error_string(SaveDataIoError::CampaignLoadFailed), "campaign_load_failed") == 0);
+    ASSERT_TRUE(std::strcmp(og::ui::save_error_string(static_cast<SaveDataIoError>(999)), "unknown") == 0);
 }
 
 // --- reset_for_new_game sets gold ---

--- a/tests/unit/test_platform_headless.cpp
+++ b/tests/unit/test_platform_headless.cpp
@@ -500,7 +500,6 @@ TEST(PlatformHeadless, text_picker_drives_menu_options_team_and_campaign_paths)
 TEST(PlatformHeadless, text_picker_internal_help_and_error_paths)
 {
     StdoutSilencer stdout_silencer;
-    constexpr int kExpectedInternalHelperChecks = 31;
-    EXPECT_EQ(kExpectedInternalHelperChecks,
+    EXPECT_EQ(0,
               og::ui::text_picker_testing_exercise_internal_paths());
 }

--- a/tests/unit/test_platform_headless.cpp
+++ b/tests/unit/test_platform_headless.cpp
@@ -391,7 +391,7 @@ TEST(PlatformHeadless, walker_render_stubs_keep_sim_state_without_render_compone
 TEST(PlatformHeadless, text_protocol_session_covers_commands_and_load_failure)
 {
     {
-        StdinRedirect input("tick 0\ntick -5\nevents\nstate\nunknown\nquit\n");
+        StdinRedirect input("tick 0\ntick -5\nevents\nstate\r\nunknown\nquit\n");
         CoutRedirect output;
 
         og::ui::TextProtocolArgs args;
@@ -422,12 +422,12 @@ TEST(PlatformHeadless, text_protocol_session_covers_commands_and_load_failure)
 TEST(PlatformHeadless, text_protocol_event_text_is_valid_json_escaped)
 {
     const std::string encoded = og::ui::text_protocol_testing_format_event_text(
-        "quote\" slash\\ newline\n tab\t carriage\r ctrl\x01");
+        "quote\" slash\\ backspace\b formfeed\f newline\n tab\t carriage\r ctrl\x01");
 
     EXPECT_NE(std::string::npos, encoded.find("\"tick\":7"));
     EXPECT_NE(std::string::npos, encoded.find("\"kind\":8"));
     EXPECT_NE(std::string::npos,
-              encoded.find("\"text\":\"quote\\\" slash\\\\ newline\\n tab\\t carriage\\r ctrl\\u0001\""));
+              encoded.find("\"text\":\"quote\\\" slash\\\\ backspace\\b formfeed\\f newline\\n tab\\t carriage\\r ctrl\\u0001\""));
     EXPECT_EQ(std::string::npos, encoded.find('\n'))
         << "event JSON must not contain raw newlines inside strings";
     EXPECT_EQ(std::string::npos, encoded.find('\r'))

--- a/tests/unit/test_platform_headless.cpp
+++ b/tests/unit/test_platform_headless.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <unistd.h>
 
@@ -190,6 +191,7 @@ PixieData make_pixie(unsigned char frames = 3, unsigned char w = 2, unsigned cha
 
 namespace og::ui {
 int text_picker_testing_exercise_internal_paths();
+std::string text_protocol_testing_format_event_text(std::string_view text);
 }
 
 TEST(PlatformHeadless, user_and_asset_paths_cover_normalization)
@@ -417,6 +419,21 @@ TEST(PlatformHeadless, text_protocol_session_covers_commands_and_load_failure)
     }
 }
 
+TEST(PlatformHeadless, text_protocol_event_text_is_valid_json_escaped)
+{
+    const std::string encoded = og::ui::text_protocol_testing_format_event_text(
+        "quote\" slash\\ newline\n tab\t carriage\r ctrl\x01");
+
+    EXPECT_NE(std::string::npos, encoded.find("\"tick\":7"));
+    EXPECT_NE(std::string::npos, encoded.find("\"kind\":8"));
+    EXPECT_NE(std::string::npos,
+              encoded.find("\"text\":\"quote\\\" slash\\\\ newline\\n tab\\t carriage\\r ctrl\\u0001\""));
+    EXPECT_EQ(std::string::npos, encoded.find('\n'))
+        << "event JSON must not contain raw newlines inside strings";
+    EXPECT_EQ(std::string::npos, encoded.find('\r'))
+        << "event JSON must not contain raw carriage returns inside strings";
+}
+
 TEST(PlatformHeadless, text_picker_drives_menu_options_team_and_campaign_paths)
 {
     const std::string input =
@@ -483,5 +500,7 @@ TEST(PlatformHeadless, text_picker_drives_menu_options_team_and_campaign_paths)
 TEST(PlatformHeadless, text_picker_internal_help_and_error_paths)
 {
     StdoutSilencer stdout_silencer;
-    EXPECT_GE(og::ui::text_picker_testing_exercise_internal_paths(), 3);
+    constexpr int kExpectedInternalHelperChecks = 23;
+    EXPECT_EQ(kExpectedInternalHelperChecks,
+              og::ui::text_picker_testing_exercise_internal_paths());
 }

--- a/tests/unit/test_platform_headless.cpp
+++ b/tests/unit/test_platform_headless.cpp
@@ -1,0 +1,487 @@
+#include <openglad/core/constants.h>
+#include <openglad/gameplay/game_world.h>
+#include <openglad/gameplay/guy.h>
+#include <openglad/gameplay/walker.h>
+#include <openglad/interface/input_state.h>
+#include <openglad/interface/level_render.h>
+#include <openglad/interface/level_runtime_data.h>
+#include <openglad/interface/platform_bridge.h>
+#include <openglad/interface/ui/picker.h>
+#include <openglad/interface/ui/text_protocol.h>
+#include <openglad/interface/walker_render.h>
+#include <openglad/legacy/base.h>
+#include <openglad/resources/gloader.h>
+#include <openglad/resources/io_common.h>
+#include <openglad/resources/level_data_hooks.h>
+#include <openglad/resources/og_file.h>
+#include <openglad/resources/pixie_data.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <filesystem>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <unistd.h>
+
+void headless_clear_stale_view_controls(LevelRuntimeData*);
+void clear_keyboard();
+void headless_level_data_draw(LevelRuntimeData*, screen*);
+std::unique_ptr<LevelRender> headless_create_level_render(PixieData[]);
+EntityFactory headless_create_entity_factory();
+loader* headless_entity_loader();
+void wire_world_with_loader(GameWorld* world, loader* game_loader);
+void headless_wire_world_entity_services(GameWorld* world, LevelRuntimeData* level);
+bool yes_or_no_prompt(const char* title, const char* message, bool default_value);
+int get_input_events();
+walker* find_follow_leader();
+extern short end_of_file;
+int toInt(const std::string& s);
+void input_state_from_sdl(InputState& out);
+void emit_headless_unsupported_warnings_probe();
+std::string get_asset_path();
+bool save_settings();
+bool load_settings();
+void io_init(int argc, char* argv[]);
+void io_exit();
+
+namespace {
+
+class EnvGuard {
+public:
+    explicit EnvGuard(const char* name)
+        : name_(name)
+    {
+        if (const char* value = std::getenv(name)) {
+            had_value_ = true;
+            old_value_ = value;
+        }
+    }
+
+    ~EnvGuard()
+    {
+        if (had_value_)
+            setenv(name_, old_value_.c_str(), 1);
+        else
+            unsetenv(name_);
+    }
+
+private:
+    const char* name_;
+    bool had_value_ = false;
+    std::string old_value_;
+};
+
+class MemoryOgFile final : public og::io::OgFile {
+public:
+    explicit MemoryOgFile(std::string data)
+        : data_(std::move(data))
+    {
+    }
+
+    std::size_t read(void* buf, std::size_t size, std::size_t count) override
+    {
+        const std::size_t requested = size * count;
+        const std::size_t available = pos_ < data_.size() ? data_.size() - pos_ : 0u;
+        const std::size_t bytes = requested < available ? requested : available;
+        if (bytes > 0)
+            std::memcpy(buf, data_.data() + pos_, bytes);
+        pos_ += bytes;
+        return size == 0 ? 0u : bytes / size;
+    }
+
+    std::size_t write(const void*, std::size_t, std::size_t) override { return 0; }
+
+    std::int64_t seek(std::int64_t offset, int whence) override
+    {
+        if (whence == 0)
+            pos_ = static_cast<std::size_t>(offset);
+        else if (whence == 1)
+            pos_ += static_cast<std::size_t>(offset);
+        else if (whence == 2)
+            pos_ = data_.size() + static_cast<std::size_t>(offset);
+        return static_cast<std::int64_t>(pos_);
+    }
+
+    std::int64_t tell() override { return static_cast<std::int64_t>(pos_); }
+
+private:
+    std::string data_;
+    std::size_t pos_ = 0;
+};
+
+class StdinRedirect {
+public:
+    explicit StdinRedirect(const std::string& input)
+        : input_(input)
+        , old_(std::cin.rdbuf(input_.rdbuf()))
+    {
+    }
+
+    ~StdinRedirect()
+    {
+        std::cin.rdbuf(old_);
+    }
+
+private:
+    std::istringstream input_;
+    std::streambuf* old_;
+};
+
+class CoutRedirect {
+public:
+    CoutRedirect()
+        : old_(std::cout.rdbuf(output_.rdbuf()))
+    {
+    }
+
+    ~CoutRedirect()
+    {
+        std::cout.rdbuf(old_);
+    }
+
+    std::string str() const { return output_.str(); }
+
+private:
+    std::ostringstream output_;
+    std::streambuf* old_;
+};
+
+class StdoutSilencer {
+public:
+    StdoutSilencer()
+        : saved_(dup(STDOUT_FILENO))
+        , null_(std::fopen("/dev/null", "w"))
+    {
+        if (saved_ >= 0 && null_ != nullptr)
+            dup2(fileno(null_), STDOUT_FILENO);
+    }
+
+    ~StdoutSilencer()
+    {
+        std::fflush(stdout);
+        if (saved_ >= 0) {
+            dup2(saved_, STDOUT_FILENO);
+            close(saved_);
+        }
+        if (null_ != nullptr)
+            std::fclose(null_);
+    }
+
+private:
+    int saved_;
+    FILE* null_;
+};
+
+PixieData make_pixie(unsigned char frames = 3, unsigned char w = 2, unsigned char h = 2)
+{
+    const std::size_t count = static_cast<std::size_t>(frames) * w * h;
+    auto* data = new unsigned char[count];
+    for (std::size_t i = 0; i < count; ++i)
+        data[i] = static_cast<unsigned char>(i + 1);
+    return PixieData(frames, w, h, data);
+}
+
+} // namespace
+
+namespace og::ui {
+int text_picker_testing_exercise_internal_paths();
+}
+
+TEST(PlatformHeadless, user_and_asset_paths_cover_normalization)
+{
+    EnvGuard config_guard("OPENGLAD_CONFIG_DIR");
+    EnvGuard home_guard("HOME");
+
+    setenv("OPENGLAD_CONFIG_DIR", "/tmp/openglad-headless///", 1);
+    EXPECT_EQ("/tmp/openglad-headless/", get_user_path());
+
+    setenv("OPENGLAD_CONFIG_DIR", "", 1);
+    setenv("HOME", "/tmp/openglad-home", 1);
+    EXPECT_EQ("/tmp/openglad-home/.openglad/", get_user_path());
+
+    unsetenv("OPENGLAD_CONFIG_DIR");
+    unsetenv("HOME");
+    EXPECT_EQ("./", get_user_path());
+
+    const std::string asset_path = get_asset_path();
+    ASSERT_FALSE(asset_path.empty());
+    EXPECT_EQ('/', asset_path.back());
+}
+
+TEST(PlatformHeadless, hooks_and_entity_services_are_wired)
+{
+    const LevelDataHooks& hooks = headless_level_data_hooks();
+    ASSERT_NE(nullptr, hooks.clear_stale_view_controls);
+    ASSERT_NE(nullptr, hooks.draw);
+    ASSERT_NE(nullptr, hooks.create_level_render);
+    ASSERT_NE(nullptr, hooks.create_entity_factory);
+    ASSERT_NE(nullptr, hooks.wire_world_entity_services);
+
+    hooks.clear_stale_view_controls(nullptr);
+    headless_clear_stale_view_controls(nullptr);
+    clear_keyboard();
+    hooks.draw(nullptr, nullptr);
+    headless_level_data_draw(nullptr, nullptr);
+    EXPECT_EQ(nullptr, hooks.create_level_render(nullptr));
+    EXPECT_EQ(nullptr, headless_create_level_render(nullptr));
+
+    EntityFactory factory = hooks.create_entity_factory();
+    EXPECT_FALSE(static_cast<bool>(factory.attach_render));
+    ASSERT_TRUE(static_cast<bool>(factory.report_error));
+    factory.report_error("headless factory test error");
+
+    restore_default_campaigns();
+    ASSERT_EQ(CampaignPackageIoError::None,
+              mount_campaign_package_with_error("org.openglad.gladiator"));
+
+    GameWorld world(0);
+    wire_world_with_loader(nullptr, headless_entity_loader());
+    wire_world_with_loader(&world, nullptr);
+    hooks.wire_world_entity_services(&world, nullptr);
+    ASSERT_TRUE(static_cast<bool>(world.entity_factory));
+    ASSERT_TRUE(static_cast<bool>(world.entity_configurator));
+    ASSERT_TRUE(static_cast<bool>(world.entity_derived_stats));
+
+    std::unique_ptr<walker> entity =
+        world.entity_factory(Order::Living, FAMILY_SOLDIER);
+    ASSERT_NE(nullptr, entity);
+    EXPECT_FALSE(entity->has_render());
+    EXPECT_NE(nullptr, world.entity_configurator(*entity, Order::Living, FAMILY_SOLDIER));
+    world.entity_derived_stats(entity.get(), Order::Living, FAMILY_SOLDIER);
+    world.entity_derived_stats(nullptr, Order::Living, FAMILY_SOLDIER);
+
+    GameWorld world_two(0);
+    headless_wire_world_entity_services(&world_two, nullptr);
+    EXPECT_TRUE(static_cast<bool>(world_two.entity_factory));
+
+    LevelRender render;
+    render.init_tiles(nullptr);
+    render.reset_tiles(nullptr);
+    render.draw_tile(0, 1, 2, nullptr);
+    og::runtime::VButtonDeleter{}(nullptr);
+}
+
+TEST(PlatformHeadless, io_init_installs_callable_headless_platform_bridge)
+{
+    EnvGuard config_guard("OPENGLAD_CONFIG_DIR");
+    const std::filesystem::path config_dir =
+        std::filesystem::temp_directory_path() / "openglad-headless-bridge";
+    std::error_code ec;
+    std::filesystem::remove_all(config_dir, ec);
+    std::filesystem::create_directories(config_dir, ec);
+    setenv("OPENGLAD_CONFIG_DIR", config_dir.string().c_str(), 1);
+
+    char arg0[] = "og_unit_headless_platform";
+    char* argv[] = {arg0, nullptr};
+    io_init(1, argv);
+
+    const PlatformBridge& bridge = platform_bridge();
+    ASSERT_TRUE(static_cast<bool>(bridge.present_frame));
+    ASSERT_TRUE(static_cast<bool>(bridge.play_sound));
+    ASSERT_TRUE(static_cast<bool>(bridge.play_music));
+    ASSERT_TRUE(static_cast<bool>(bridge.stop_music));
+    ASSERT_TRUE(static_cast<bool>(bridge.create_surface));
+    ASSERT_TRUE(static_cast<bool>(bridge.list_relay_rooms));
+
+    bridge.present_frame();
+    bridge.play_sound(7);
+    bridge.play_music("theme.ogg");
+    bridge.stop_music();
+    EXPECT_EQ(nullptr, bridge.create_surface(320, 200));
+    EXPECT_TRUE(bridge.list_relay_rooms("http://relay", "campaign").empty());
+
+    (void)load_settings();
+    (void)save_settings();
+
+    std::filesystem::remove_all(config_dir, ec);
+}
+
+TEST(PlatformHeadless, unsupported_platform_functions_return_documented_defaults)
+{
+    EXPECT_TRUE(yes_or_no_prompt("headless", "default true", true));
+    EXPECT_FALSE(yes_or_no_prompt("headless", "default false", false));
+    EXPECT_EQ(0, get_input_events());
+    EXPECT_EQ(nullptr, find_follow_leader());
+
+    EXPECT_EQ(NewFileIoError::OpenWriteFailed,
+              create_new_map_pix_with_error("headless-map.png", 3, 4));
+    EXPECT_EQ(NewFileIoError::OpenWriteFailed,
+              create_new_pix_with_error("headless-pix.png", 3, 4, 7));
+    EXPECT_EQ(NewFileIoError::OpenWriteFailed,
+              create_new_campaign_descriptor_with_error("headless-campaign.yaml"));
+    EXPECT_EQ(NewFileIoError::OpenWriteFailed,
+              create_new_scen_file_with_error("headless-scen", "scen0001"));
+
+    PixieData pixie = make_pixie(1, 1, 1);
+    load_map_data(&pixie);
+
+    EXPECT_EQ(42, toInt("42"));
+    EXPECT_EQ(-7, toInt("-7"));
+    EXPECT_EQ(0, toInt("not-a-number"));
+
+    InputState input;
+    input.timer_wait_request = 12;
+    input_state_from_sdl(input);
+    EXPECT_EQ(kNoTimerWaitRequest, input.timer_wait_request);
+
+    emit_headless_unsupported_warnings_probe();
+}
+
+TEST(PlatformHeadless, help_reader_stops_on_newline_carriage_return_limit_and_eof)
+{
+    MemoryOgFile file("alpha\rbravo\ncharlie");
+    end_of_file = 0;
+    EXPECT_EQ("alpha", read_one_line(file, HELP_WIDTH));
+    EXPECT_EQ("bravo", read_one_line(file, HELP_WIDTH));
+    EXPECT_EQ("charlie", read_one_line(file, HELP_WIDTH));
+    EXPECT_EQ("", read_one_line(file, HELP_WIDTH));
+    EXPECT_EQ(1, end_of_file);
+
+    MemoryOgFile limited("abcdef");
+    end_of_file = 0;
+    EXPECT_EQ("abc", read_one_line(limited, 3));
+    EXPECT_EQ(0, end_of_file);
+
+    MemoryOgFile many_lines("one\ntwo\nthree\n");
+    char help[HELP_WIDTH][MAX_LINES];
+    std::memset(help, 0, sizeof(help));
+    end_of_file = 0;
+    const short count = fill_help_array(help, many_lines);
+    EXPECT_GE(count, 3);
+    EXPECT_STREQ("one", help[0]);
+    EXPECT_STREQ("two", help[1]);
+    EXPECT_STREQ("three", help[2]);
+}
+
+TEST(PlatformHeadless, walker_render_stubs_keep_sim_state_without_render_component)
+{
+    PixieData pixie = make_pixie();
+    WalkerRender render(pixie);
+    EXPECT_EQ(nullptr, render.bmp_data());
+    render.set_frame(1);
+    render.set_data(pixie);
+
+    walker entity(pixie);
+    EXPECT_FALSE(entity.has_render());
+    EXPECT_EQ(2, entity.sizex());
+    EXPECT_EQ(2, entity.sizey());
+    EXPECT_EQ(nullptr, entity.bmp_data());
+    EXPECT_EQ(1, entity.set_frame(2));
+    EXPECT_EQ(2, entity.frame());
+    EXPECT_EQ(0, entity.set_frame(-1));
+    EXPECT_EQ(0, entity.set_frame(3));
+    entity.set_direct_frame(5);
+    EXPECT_EQ(5, entity.frame());
+
+    PixieData replacement = make_pixie(2, 4, 5);
+    entity.set_data(replacement);
+    EXPECT_EQ(4, entity.sizex());
+    EXPECT_EQ(5, entity.sizey());
+    EXPECT_EQ(1, entity.set_frame(1));
+    EXPECT_EQ(0, entity.set_frame(2));
+}
+
+TEST(PlatformHeadless, text_protocol_session_covers_commands_and_load_failure)
+{
+    {
+        StdinRedirect input("tick 0\ntick -5\nevents\nstate\nunknown\nquit\n");
+        CoutRedirect output;
+
+        og::ui::TextProtocolArgs args;
+        args.level = 1;
+        args.team_families = {FAMILY_SOLDIER, FAMILY_ELF};
+        args.seed = 99;
+        EXPECT_EQ(0, og::ui::run_text_protocol_session(args));
+
+        const std::string text = output.str();
+        EXPECT_NE(std::string::npos, text.find("\"status\":\"ready\""));
+        EXPECT_NE(std::string::npos, text.find("\"cmd\":\"tick\",\"count\":1"));
+        EXPECT_NE(std::string::npos, text.find("\"cmd\":\"events\""));
+        EXPECT_NE(std::string::npos, text.find("\"cmd\":\"state\""));
+        EXPECT_NE(std::string::npos, text.find("unknown command: unknown"));
+        EXPECT_NE(std::string::npos, text.find("\"cmd\":\"quit\",\"status\":\"ok\""));
+    }
+
+    {
+        StdinRedirect input("quit\n");
+        CoutRedirect output;
+
+        og::ui::TextProtocolArgs args;
+        args.level = 9999;
+        EXPECT_EQ(1, og::ui::run_text_protocol_session(args));
+    }
+}
+
+TEST(PlatformHeadless, text_picker_drives_menu_options_team_and_campaign_paths)
+{
+    const std::string input =
+        "bad\n"
+        "7\n"
+        "3\n"
+        "4\n"
+        "5\n"
+        "6\n"
+        "8\n"
+        "9\n"
+        "10\n"
+        "newslot\n"
+        "not-a-seed\n"
+        "10\n"
+        "textslot\n"
+        "123\n"
+        "2\n"
+        "1\n"
+        "\n"
+        "2\n"
+        "n\n"
+        "p\n"
+        "1\n"
+        "-1\n"
+        "6\n"
+        "a\n"
+        "b\n"
+        "3\n"
+        "p\n"
+        "n\n"
+        "h\n"
+        "b\n"
+        "5\n"
+        "4\n"
+        "8\n"
+        "9\n"
+        "0\n"
+        "9\n"
+        "2\n"
+        "10\n"
+        "11\n"
+        "999\n"
+        "11\n"
+        "\n"
+        "7\n"
+        "11\n";
+
+    StdinRedirect stdin_redirect(input);
+    CoutRedirect cout_redirect;
+    StdoutSilencer stdout_silencer;
+
+    og::ui::TextPickerConfig config;
+    config.team_families = {FAMILY_SOLDIER, FAMILY_MAGE};
+    og::ui::TextPickerError error;
+    og::ui::run_text_picker(config, &error);
+
+    EXPECT_EQ(og::ui::TextPickerErrorCode::None, error.code);
+    EXPECT_EQ("textslot", config.save_name);
+    EXPECT_EQ(2, config.level);
+    ASSERT_GE(config.team_families.size(), 2u);
+}
+
+TEST(PlatformHeadless, text_picker_internal_help_and_error_paths)
+{
+    StdoutSilencer stdout_silencer;
+    EXPECT_GE(og::ui::text_picker_testing_exercise_internal_paths(), 3);
+}

--- a/tests/unit/test_platform_headless.cpp
+++ b/tests/unit/test_platform_headless.cpp
@@ -500,7 +500,7 @@ TEST(PlatformHeadless, text_picker_drives_menu_options_team_and_campaign_paths)
 TEST(PlatformHeadless, text_picker_internal_help_and_error_paths)
 {
     StdoutSilencer stdout_silencer;
-    constexpr int kExpectedInternalHelperChecks = 23;
+    constexpr int kExpectedInternalHelperChecks = 31;
     EXPECT_EQ(kExpectedInternalHelperChecks,
               og::ui::text_picker_testing_exercise_internal_paths());
 }

--- a/tests/unit/test_replay.cpp
+++ b/tests/unit/test_replay.cpp
@@ -301,6 +301,170 @@ TEST(Replay, find_first_snapshot_difference_reports_nested_field)
     EXPECT_EQ("77", diff->actual_value);
 }
 
+TEST(Replay, snapshot_difference_formats_all_field_value_kinds)
+{
+    const auto expect_diff =
+        [](const og::sim::WorldSnapshot& expected,
+           const og::sim::WorldSnapshot& actual,
+           std::string_view field,
+           std::string_view expected_value,
+           std::string_view actual_value,
+           bool compare_dirty_masks = true) {
+            const std::optional<og::sim::ReplayVerificationFailure> diff =
+                og::sim::find_first_snapshot_difference(
+                    99u,
+                    expected,
+                    actual,
+                    compare_dirty_masks);
+            ASSERT_TRUE(diff.has_value()) << "expected difference for " << field;
+            EXPECT_EQ(99u, diff->tick);
+            EXPECT_EQ(field, diff->field);
+            EXPECT_EQ(expected_value, diff->expected_value);
+            EXPECT_EQ(actual_value, diff->actual_value);
+        };
+
+    {
+        og::sim::WorldSnapshot expected;
+        og::sim::WorldSnapshot actual = expected;
+        actual.game_ended = true;
+        expect_diff(expected, actual, "game_ended", "false", "true");
+    }
+
+    {
+        og::sim::WorldSnapshot expected;
+        og::sim::WorldSnapshot actual = expected;
+        expected.control_hp = 12.5f;
+        actual.control_hp = 3.25f;
+        expect_diff(expected, actual, "control_hp", "12.5", "3.25");
+    }
+
+    {
+        og::sim::WorldSnapshot expected;
+        og::sim::WorldSnapshot actual = expected;
+        expected.end = -2;
+        actual.end = 4;
+        expect_diff(expected, actual, "end", "-2", "4");
+    }
+
+    {
+        og::sim::WorldSnapshot expected;
+        og::sim::WorldSnapshot actual = expected;
+        expected.current_palette_id = 2u;
+        actual.current_palette_id = 9u;
+        expect_diff(expected, actual, "current_palette_id", "2", "9");
+    }
+
+    {
+        og::sim::WorldSnapshot expected;
+        og::sim::WorldSnapshot actual = expected;
+        expected.full_grid_data = {1u, 2u};
+        actual.full_grid_data = {1u, 2u, 3u};
+        expect_diff(expected,
+                    actual,
+                    "full_grid_data.size",
+                    "2",
+                    "3");
+    }
+
+    {
+        og::sim::WorldSnapshot expected;
+        og::sim::WorldSnapshot actual = expected;
+        expected.guy_snapshots.push_back({.name = "Expected"});
+        actual.guy_snapshots.push_back({.name = "Actual"});
+        expect_diff(expected,
+                    actual,
+                    "guy_snapshots[0].name",
+                    "Expected",
+                    "Actual");
+    }
+
+    {
+        og::sim::WorldSnapshot expected;
+        og::sim::WorldSnapshot actual = expected;
+        og::sim::EntitySnapshot expected_entity;
+        og::sim::EntitySnapshot actual_entity = expected_entity;
+        expected_entity.order = Order::Living;
+        actual_entity.order = Order::Weapon;
+        expected.oblist.push_back(expected_entity);
+        actual.oblist.push_back(actual_entity);
+        expect_diff(expected,
+                    actual,
+                    "oblist[0].order",
+                    "0",
+                    "1");
+    }
+
+    {
+        og::sim::WorldSnapshot expected;
+        og::sim::WorldSnapshot actual = expected;
+        og::sim::EntitySnapshot expected_entity;
+        og::sim::EntitySnapshot actual_entity = expected_entity;
+        expected_entity.special_cost[0] = 10u;
+        actual_entity.special_cost[0] = 20u;
+        expected.oblist.push_back(expected_entity);
+        actual.oblist.push_back(actual_entity);
+        expect_diff(expected,
+                    actual,
+                    "oblist[0].special_cost[0]",
+                    "10",
+                    "20");
+    }
+
+    {
+        og::sim::WorldSnapshot expected;
+        og::sim::WorldSnapshot actual = expected;
+        og::sim::EntitySnapshot expected_entity;
+        og::sim::EntitySnapshot actual_entity = expected_entity;
+        expected_entity.dirty_mask[0] = 1u;
+        actual_entity.dirty_mask[0] = 2u;
+        expected.oblist.push_back(expected_entity);
+        actual.oblist.push_back(actual_entity);
+        expect_diff(expected,
+                    actual,
+                    "oblist[0].dirty_mask[0]",
+                    "1",
+                    "2",
+                    true);
+    }
+}
+
+TEST(Replay, recorder_clear_and_world_snapshot_recorders_reset_state)
+{
+    TestGameWorld fx;
+    GameWorld& world = fx.world();
+    world.tick_count_ = 12u;
+
+    og::sim::ReplayRecorder recorder({
+        .version = og::sim::kReplayFormatVersion,
+        .initial_rng_state = 5u,
+        .level_id = 1,
+        .player_count = 1,
+        .timer_wait = 6,
+        .my_team = 0,
+        .allied_mode = 0,
+        .difficulty = 100,
+        .campaign_id = "org.openglad.gladiator",
+    });
+
+    recorder.record_initial_world(world);
+    EXPECT_TRUE(recorder.has_initial_snapshot());
+    recorder.record_world_snapshot(world.tick_count_, world);
+    recorder.record_world_keyframe(world.tick_count_ + 1u, world);
+    ASSERT_EQ(recorder.checkpoints().size(), 2u);
+    EXPECT_EQ(recorder.checkpoints()[0].kind,
+              og::sim::ReplayCheckpointKind::Snapshot);
+    EXPECT_EQ(recorder.checkpoints()[1].kind,
+              og::sim::ReplayCheckpointKind::Keyframe);
+
+    recorder.record_input(12u, make_sparse_input());
+    EXPECT_EQ(recorder.frame_count(), 1u);
+    recorder.clear();
+    EXPECT_FALSE(recorder.has_initial_snapshot());
+    EXPECT_TRUE(recorder.frames().empty());
+    EXPECT_TRUE(recorder.checkpoints().empty());
+    EXPECT_EQ(recorder.header().campaign_id, "");
+}
+
 TEST(Replay, replay_player_verify_world_tracks_first_divergence)
 {
     TestGameWorld fx;

--- a/tests/unit/test_world_snapshot.cpp
+++ b/tests/unit/test_world_snapshot.cpp
@@ -625,7 +625,9 @@ std::vector<std::uint8_t> zlib_decompress_for_test(
         stream.next_out = chunk.data();
         stream.avail_out = static_cast<uInt>(chunk.size());
         rc = inflate(&stream, Z_NO_FLUSH);
-        EXPECT_TRUE(rc == Z_OK || rc == Z_STREAM_END);
+        if (rc != Z_OK) {
+            EXPECT_EQ(Z_STREAM_END, rc);
+        }
         output.insert(output.end(),
                       chunk.begin(),
                       chunk.begin() + (chunk.size() - stream.avail_out));

--- a/tests/unit/test_world_snapshot.cpp
+++ b/tests/unit/test_world_snapshot.cpp
@@ -676,6 +676,29 @@ std::vector<std::uint8_t> decode_delta_payload_for_test(
     return zlib_decompress_for_test(wire_payload, wire_payload_length);
 }
 
+void append_u32_for_test(std::vector<std::uint8_t>& bytes,
+                         std::uint32_t value)
+{
+    bytes.push_back(static_cast<std::uint8_t>(value & 0xffu));
+    bytes.push_back(static_cast<std::uint8_t>((value >> 8) & 0xffu));
+    bytes.push_back(static_cast<std::uint8_t>((value >> 16) & 0xffu));
+    bytes.push_back(static_cast<std::uint8_t>((value >> 24) & 0xffu));
+}
+
+std::vector<std::uint8_t> frame_event_batch_payload_for_test(
+    std::uint8_t message_type,
+    const std::vector<std::uint8_t>& payload)
+{
+    std::vector<std::uint8_t> bytes;
+    bytes.reserve(og::sim::kTransportHeaderSize + payload.size());
+    bytes.push_back(og::sim::kSnapshotProtocolVersion);
+    bytes.push_back(message_type);
+    bytes.push_back(static_cast<std::uint8_t>(payload.size() & 0xffu));
+    bytes.push_back(static_cast<std::uint8_t>((payload.size() >> 8) & 0xffu));
+    bytes.insert(bytes.end(), payload.begin(), payload.end());
+    return bytes;
+}
+
 } // namespace
 
 TEST(WorldSnapshot, entity_snapshot_layout_matches_dirty_field_table)
@@ -2080,6 +2103,208 @@ TEST(WorldSnapshot, deserialize_snapshot_and_delta_reject_oversized_payloads_and
         (void)og::sim::deserialize_delta(bad_count_delta.data(),
                                          bad_count_delta.size()),
         std::runtime_error);
+}
+
+TEST(WorldSnapshot, serialize_rejects_invalid_grid_payloads)
+{
+    og::sim::WorldSnapshot snapshot;
+    snapshot.grid_dirty = true;
+    snapshot.grid_full_resend = true;
+    EXPECT_THROW((void)og::sim::serialize_snapshot(snapshot), std::runtime_error);
+
+    snapshot.grid_width = 2;
+    snapshot.grid_height = 2;
+    snapshot.full_grid_data = {1, 2, 3};
+    EXPECT_THROW((void)og::sim::serialize_snapshot(snapshot), std::runtime_error);
+
+    snapshot.grid_full_resend = false;
+    EXPECT_THROW((void)og::sim::serialize_snapshot(snapshot), std::runtime_error);
+
+    snapshot.grid_full_resend = true;
+    snapshot.grid_dirty = false;
+    snapshot.full_grid_data = {1, 2, 3, 4};
+    EXPECT_THROW((void)og::sim::serialize_snapshot(snapshot), std::runtime_error);
+
+    snapshot.grid_full_resend = false;
+    snapshot.full_grid_data.clear();
+    snapshot.grid_dirty_tiles.push_back({0, 0, 7});
+    EXPECT_THROW((void)og::sim::serialize_snapshot(snapshot), std::runtime_error);
+
+    snapshot.grid_dirty = true;
+    snapshot.grid_dirty_tiles = {{3, 0, 7}};
+    EXPECT_THROW((void)og::sim::serialize_snapshot(snapshot), std::runtime_error);
+}
+
+TEST(WorldSnapshot, event_batch_roundtrip_and_rejects_malformed_frames)
+{
+    og::sim::SimEventBatch batch;
+    batch.sequence = 7;
+    batch.events.push_back(og::sim::Event{
+        .tick = 8,
+        .kind = og::sim::EventKind::Notification,
+        .a = 1,
+        .b = 2,
+        .text = "event text",
+    });
+    batch.events.push_back(og::sim::Event{
+        .tick = 9,
+        .kind = og::sim::EventKind::EndGame,
+        .a = 0,
+        .b = 3,
+        .text = "",
+    });
+
+    const std::vector<std::uint8_t> bytes =
+        og::sim::serialize_sim_event_batch(batch);
+    const og::sim::SimEventBatch decoded =
+        og::sim::deserialize_sim_event_batch(bytes.data(), bytes.size());
+    EXPECT_EQ(batch.sequence, decoded.sequence);
+    EXPECT_EQ(batch.events, decoded.events);
+
+    const std::vector<std::uint8_t> flow_bytes =
+        og::sim::serialize_game_flow_event_batch(batch);
+    const og::sim::SimEventBatch decoded_flow =
+        og::sim::deserialize_game_flow_event_batch(flow_bytes.data(),
+                                                   flow_bytes.size());
+    EXPECT_EQ(batch.events, decoded_flow.events);
+
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(nullptr, 0),
+                 std::runtime_error);
+
+    std::vector<std::uint8_t> bad_protocol = bytes;
+    bad_protocol[0] =
+        static_cast<std::uint8_t>(og::sim::kSnapshotProtocolVersion + 1);
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
+                     bad_protocol.data(), bad_protocol.size()),
+                 std::runtime_error);
+
+    std::vector<std::uint8_t> bad_type = bytes;
+    bad_type[1] = og::sim::kGameFlowEventBatchMessageType;
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
+                     bad_type.data(), bad_type.size()),
+                 std::runtime_error);
+
+    std::vector<std::uint8_t> bad_length = bytes;
+    bad_length[2] = 0;
+    bad_length[3] = 0;
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
+                     bad_length.data(), bad_length.size()),
+                 std::runtime_error);
+
+    std::vector<std::uint8_t> too_many_events_payload;
+    append_u32_for_test(too_many_events_payload, 1);
+    append_u32_for_test(too_many_events_payload, 4097);
+    const std::vector<std::uint8_t> too_many_events =
+        frame_event_batch_payload_for_test(
+            og::sim::kSimEventBatchMessageType,
+            too_many_events_payload);
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
+                     too_many_events.data(), too_many_events.size()),
+                 std::runtime_error);
+
+    std::vector<std::uint8_t> oversized_string_payload;
+    append_u32_for_test(oversized_string_payload, 1);
+    append_u32_for_test(oversized_string_payload, 1);
+    append_u32_for_test(oversized_string_payload, 2);
+    append_u32_for_test(oversized_string_payload,
+                        static_cast<std::uint32_t>(og::sim::EventKind::Notification));
+    append_u32_for_test(oversized_string_payload, 0);
+    append_u32_for_test(oversized_string_payload, 0);
+    append_u32_for_test(oversized_string_payload, 1025);
+    const std::vector<std::uint8_t> oversized_string =
+        frame_event_batch_payload_for_test(
+            og::sim::kSimEventBatchMessageType,
+            oversized_string_payload);
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
+                     oversized_string.data(), oversized_string.size()),
+                 std::runtime_error);
+
+    std::vector<std::uint8_t> truncated_string_payload;
+    append_u32_for_test(truncated_string_payload, 1);
+    append_u32_for_test(truncated_string_payload, 1);
+    append_u32_for_test(truncated_string_payload, 3);
+    append_u32_for_test(truncated_string_payload,
+                        static_cast<std::uint32_t>(og::sim::EventKind::Notification));
+    append_u32_for_test(truncated_string_payload, 0);
+    append_u32_for_test(truncated_string_payload, 0);
+    append_u32_for_test(truncated_string_payload, 4);
+    truncated_string_payload.push_back('x');
+    const std::vector<std::uint8_t> truncated_string =
+        frame_event_batch_payload_for_test(
+            og::sim::kSimEventBatchMessageType,
+            truncated_string_payload);
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
+                     truncated_string.data(), truncated_string.size()),
+                 std::runtime_error);
+
+    std::vector<std::uint8_t> trailing_payload;
+    append_u32_for_test(trailing_payload, 1);
+    append_u32_for_test(trailing_payload, 0);
+    trailing_payload.push_back(0xee);
+    const std::vector<std::uint8_t> trailing =
+        frame_event_batch_payload_for_test(
+            og::sim::kSimEventBatchMessageType,
+            trailing_payload);
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
+                     trailing.data(), trailing.size()),
+                 std::runtime_error);
+
+    og::sim::SimEventBatch huge_text;
+    huge_text.events.push_back(og::sim::Event{
+        .tick = 1,
+        .kind = og::sim::EventKind::Notification,
+        .a = 0,
+        .b = 0,
+        .text = std::string(70000, 'x'),
+    });
+    EXPECT_THROW((void)og::sim::serialize_sim_event_batch(huge_text),
+                 std::runtime_error);
+}
+
+TEST(WorldSnapshot, apply_delta_covers_grid_materialization_edges)
+{
+    og::sim::WorldSnapshot baseline;
+    og::sim::WorldSnapshot zero_delta;
+    zero_delta.grid_width = 0;
+    zero_delta.grid_height = 0;
+    zero_delta.grid_dirty = true;
+    zero_delta.grid_full_resend = true;
+    zero_delta.full_grid_data = {1, 2, 3};
+    zero_delta.grid_dirty_tiles = {{0, 0, 9}};
+
+    og::sim::apply_delta(baseline, zero_delta);
+    EXPECT_FALSE(baseline.grid_dirty);
+    EXPECT_FALSE(baseline.grid_full_resend);
+    EXPECT_TRUE(baseline.full_grid_data.empty());
+    EXPECT_TRUE(baseline.grid_dirty_tiles.empty());
+
+    og::sim::WorldSnapshot sparse_delta;
+    sparse_delta.grid_width = 2;
+    sparse_delta.grid_height = 2;
+    sparse_delta.grid_dirty = true;
+    sparse_delta.grid_full_resend = false;
+    sparse_delta.grid_dirty_tiles = {{1, 1, 7}};
+
+    og::sim::apply_delta(baseline, sparse_delta);
+    EXPECT_TRUE(baseline.grid_dirty);
+    EXPECT_FALSE(baseline.grid_full_resend);
+    ASSERT_EQ(1u, baseline.grid_dirty_tiles.size());
+    EXPECT_EQ(7, baseline.grid_dirty_tiles.front().value);
+
+    baseline.grid_full_resend = true;
+    baseline.full_grid_data = {1, 2, 3, 4};
+    baseline.grid_dirty_tiles.clear();
+
+    og::sim::WorldSnapshot dirty_delta;
+    dirty_delta.grid_width = 2;
+    dirty_delta.grid_height = 2;
+    dirty_delta.grid_dirty = true;
+    dirty_delta.grid_dirty_tiles = {{0, 1, 8}, {5, 5, 9}};
+
+    og::sim::apply_delta(baseline, dirty_delta);
+    ASSERT_EQ(4u, baseline.full_grid_data.size());
+    EXPECT_EQ(8, baseline.full_grid_data[2]);
+    EXPECT_TRUE(baseline.grid_dirty_tiles.empty());
 }
 
 TEST(WorldSnapshot, apply_delta_with_all_fields_dirty_matches_current_world_state)


### PR DESCRIPTION
## Summary
- remove `ctest --repeat until-pass:3` from coverage, normal, and ASan CI so failures are not retried and coverage counters cannot accumulate from failed attempts
- exclude the large and residual `#ifdef TESTING` helper harnesses from gcovr using source markers, with consistent test-only `src/` harness comments
- tighten residual helper checks so the excluded harnesses assert behavior instead of just driving coverage: results-screen `TroopResult` branches now verify XP/HP/level/special/name state, and the level-editor synthetic menu clicks verify resulting editor/menu state
- keep the coverage workflow filters and thresholds intact; no threshold lowering and no broad production-code exclusions
- add production-path assertions to preserve the line gate after excluding harness code: net transport typed payloads, gparser config I/O, SDL native input and joystick state, filesystem wrappers, headless server lobby defaults, HUD bars, and text protocol escaping
- keep the text events protocol validated as JSON, including control-character escaping

## Verification
- `cmake --build --preset ci-coverage -j"$(nproc)"`
- `ctest --test-dir build/ci-coverage -R "^(og_test_menu_ui|og_test_level)$" --output-on-failure --timeout 420` — 2/2 passed
- `find build/ci-coverage -name '*.gcda' -delete && ctest --test-dir build/ci-coverage --output-on-failure --timeout 420` — rebuilt clean run 42/42 passed, 413.69s, no `--repeat`
- `build/gcovr-venv/bin/gcovr --root . --filter src/ --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --txt --output build/ci-coverage/coverage/coverage-summary.txt --json-summary build/ci-coverage/coverage/coverage-summary.json --fail-under-line 90 --fail-under-function 95 build/ci-coverage`
- `git diff --check`
- `rg "repeat until-pass|--repeat" -n .github/workflows || true` — no matches

Final coverage: line 35321 / 39233 (90.0%), function 3140 / 3256 (96.4%).