### PR TITLE
Security & memory-safety hardening: network/CI boundaries + full-codebase modern-C++ audit

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,13 +30,13 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review
@@ -61,4 +61,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment *),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,23 +32,31 @@ jobs:
     if: |
       needs.check-secret.outputs.has_key == 'true' &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        (github.event_name == 'issue_comment' &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) &&
+          contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) &&
+          (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
@@ -66,5 +74,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment *),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,19 +22,22 @@ jobs:
       - name: Checkout push ref
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Checkout PR head ref
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Apply third-party build fixes
         run: git apply third_party/build-fixes.patch
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: relay/package-lock.json
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,6 +11,9 @@ env:
   # cause false positives in fuzz runs.
   ASAN_OPTIONS: detect_leaks=0
 
+permissions:
+  contents: read
+
 jobs:
   fuzz:
     name: Fuzz ${{ matrix.target }} (${{ github.event_name == 'schedule' && 'nightly' || 'pr' }})
@@ -26,6 +29,8 @@ jobs:
             corpus: fuzz/corpus/savefile
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
   pull_request:             # Validate multi-platform builds on PRs
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # ── Check whether there are new commits since last successful nightly ──
@@ -19,6 +19,8 @@ jobs:
       sha_short: ${{ steps.check.outputs.sha_short }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Get current HEAD SHA
         id: sha
@@ -72,6 +74,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Apply third-party build fixes
         run: git apply third_party/build-fixes.patch
@@ -182,6 +186,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Apply third-party build fixes
         run: git apply third_party/build-fixes.patch
@@ -229,8 +235,12 @@ jobs:
       needs.web-deploy.result == 'success' &&
       needs.check-new-commits.outputs.has_new_commits == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
@@ -276,6 +286,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Save successful nightly SHA
         run: echo "${{ github.sha }}" > .nightly-last-sha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: ['**']
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests
@@ -12,10 +15,12 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: relay/package-lock.json
 
@@ -83,6 +88,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Apply third-party build fixes
         run: git apply third_party/build-fixes.patch
@@ -111,6 +118,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Apply third-party build fixes
         run: git apply third_party/build-fixes.patch
@@ -141,6 +150,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Apply third-party build fixes
         run: git apply third_party/build-fixes.patch
@@ -169,6 +180,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Apply third-party build fixes
         run: git apply third_party/build-fixes.patch

--- a/.github/workflows/wasm-e2e.yml
+++ b/.github/workflows/wasm-e2e.yml
@@ -5,6 +5,9 @@ on:
     branches: ['**']
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   wasm-e2e:
     name: Playwright WASM Tests
@@ -12,6 +15,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Apply third-party build fixes
         run: git apply third_party/build-fixes.patch

--- a/include/openglad/core/irandom.h
+++ b/include/openglad/core/irandom.h
@@ -32,5 +32,8 @@ public:
         state_ = state_ * 1103515245u + 12345u;
         return (state_ >> 16) % max_exclusive;
     }
+    // Re-seed the generator, restarting the sequence deterministically.
+    void seed(std::uint32_t s) { state_ = s; }
+private:
     std::uint32_t state_;
 };

--- a/include/openglad/core/test_trace.h
+++ b/include/openglad/core/test_trace.h
@@ -2,6 +2,7 @@
 
 #ifdef TESTING
 
+#include <array>
 #include <vector>
 #include <string>
 #include <cstdio>
@@ -32,15 +33,15 @@ inline bool trace_stderr_enabled() {
 }
 
 inline void trace_write(const char* category, const char* format, ...) {
-    char buf[1024];
+    std::array<char, 1024> buf{};
     va_list args;
     va_start(args, format);
-    vsnprintf(buf, sizeof(buf), format, args);
+    vsnprintf(buf.data(), buf.size(), format, args);
     va_end(args);
     std::lock_guard<std::mutex> lock(g_trace_mutex);
-    g_trace_buffer.push_back({category, buf});
+    g_trace_buffer.push_back({category, buf.data()});
     if (trace_stderr_enabled())
-        fprintf(stderr, "[TRACE:%s] %s\n", category, buf);
+        fprintf(stderr, "[TRACE:%s] %s\n", category, buf.data());
 }
 
 #define TRACE(cat, ...) trace_write(cat, __VA_ARGS__)

--- a/include/openglad/gameplay/dirty_field_bits.h
+++ b/include/openglad/gameplay/dirty_field_bits.h
@@ -113,4 +113,7 @@ inline constexpr std::uint8_t FIELD_COUNT = 86;
 static_assert(BIT_DO_BOUNCE + 1 == FIELD_COUNT,
               "Dirty field bit count drift -- update dirty_field_bits.h");
 
+static_assert(FIELD_COUNT <= 128,
+              "FIELD_COUNT exceeds dirty_mask_ capacity; increase array size");
+
 } // namespace og::dirty

--- a/include/openglad/gameplay/game_server.h
+++ b/include/openglad/gameplay/game_server.h
@@ -270,7 +270,6 @@ private:
     std::size_t snapshot_hash_mismatch_count_ = 0;
     std::uint32_t next_sim_event_sequence_ = 1;
     std::uint32_t next_game_flow_event_sequence_ = 1;
-    std::uint64_t next_session_token_seed_ = 1;
     std::optional<PeerId> host_peer_id_ = std::nullopt;
     std::function<std::uint64_t()> wall_clock_ms_source_;
     bool return_to_lobby_mode_ = false;

--- a/include/openglad/gameplay/sim_input_handler.h
+++ b/include/openglad/gameplay/sim_input_handler.h
@@ -12,6 +12,7 @@
 #include <list>
 #include <memory>
 #include <openglad/gameplay/input_state.h>
+#include <openglad/gameplay/statistics.h>  // NUM_SPECIALS
 
 class walker;
 class GameWorld;
@@ -64,7 +65,7 @@ SimInputResult sim_process_player_input(
     short player_num,
     short my_team,
     SimInputDebounce& debounce,
-    const std::string (*special_names)[6],
+    const std::string (*special_names)[NUM_SPECIALS],
     [[maybe_unused]] og::sim::SimEventLog* sim_events);
 
 // Find the next available control walker for a player.

--- a/include/openglad/gameplay/smooth.h
+++ b/include/openglad/gameplay/smooth.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <openglad/core/irandom.h>
 #include <openglad/gameplay/pixie_data.h>
 #include <openglad/core/terrain_types.h>
@@ -43,7 +44,7 @@ class smoother
 		std::int32_t surrounds(std::int32_t x, std::int32_t y, std::int32_t whatgenre); // returns 0-15 of 4 surroundings
 		void set_x_y(std::int32_t x, std::int32_t y, std::int32_t whatvalue);  // sets grid location to whatvalue
 
-		unsigned char  *mygrid; // our grid to change
+		std::span<unsigned char> mygrid_span_{}; // our grid to change (non-owning view)
 		std::int32_t maxx, maxy;   // dimensions of our grid ..
         IRandom* rng_;
 };

--- a/include/openglad/gameplay/smooth.h
+++ b/include/openglad/gameplay/smooth.h
@@ -45,6 +45,6 @@ class smoother
 		void set_x_y(std::int32_t x, std::int32_t y, std::int32_t whatvalue);  // sets grid location to whatvalue
 
 		std::span<unsigned char> mygrid_span_{}; // our grid to change (non-owning view)
-		std::int32_t maxx, maxy;   // dimensions of our grid ..
-        IRandom* rng_;
+		std::int32_t maxx = 0, maxy = 0;   // dimensions of our grid ..
+        IRandom* rng_ = nullptr;
 };

--- a/include/openglad/gameplay/statistics.h
+++ b/include/openglad/gameplay/statistics.h
@@ -131,10 +131,14 @@ class statistics
         OG_STATS_DIRTY_FIELD(std::uint32_t, controller_id, og::dirty::BIT_CONTROLLER_ID);
         [[nodiscard]] unsigned short special_cost(int index) const noexcept
         {
+            if (index < 0 || index >= NUM_SPECIALS)
+                return 0;
             return special_cost_[index];
         }
         void set_special_cost(int index, unsigned short value)
         {
+            if (index < 0 || index >= NUM_SPECIALS)
+                return;
             special_cost_[index] = value;
             mark_dirty(og::dirty::BIT_SPECIAL_COST);
         }

--- a/include/openglad/gameplay/walker.h
+++ b/include/openglad/gameplay/walker.h
@@ -264,6 +264,11 @@ class walker : public og::sim::SimEntity
 		// Public data members (fields NOT in SimEntity base)
 		guy  *myguy;                   // Non-owning view of character data; ownership, when present, lives in owned_myguy_
 		const signed char * const * ani;
+		// Number of (facing x ani_type) entries in `ani` for this family's table.
+		// Animation tables vary in length per family; this bounds index math in
+		// animate() so a snapshot/save-controlled ani_type/curdir cannot read past
+		// the end of a short table. Set by loader::set_walker; 0 until then.
+		int ani_count = 0;
 		std::vector<MicroPatherState> path_to_foe;  // Result from pathfinding
 		std::list<DamageNumber> damage_numbers;
 

--- a/include/openglad/gameplay/walker.h
+++ b/include/openglad/gameplay/walker.h
@@ -278,7 +278,7 @@ class walker : public og::sim::SimEntity
 		bool act_guard();
 		virtual bool act_random();
 		std::int32_t regen_delay_ = 0;       // Delay after being hit
-		walker * myself_;
+		walker * myself_ = nullptr;
 		std::unique_ptr<statistics> stats_;
 		std::unique_ptr<guy> owned_myguy_;
 		std::unique_ptr<og::gameplay::IRenderComponent> render_;  // Optional render component (null for headless)

--- a/include/openglad/gameplay/world_snapshot.h
+++ b/include/openglad/gameplay/world_snapshot.h
@@ -14,6 +14,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -517,14 +518,13 @@ WorldSnapshot peek_keyframe_snapshot(GameWorld& world);
 void apply_snapshot(GameWorld& world, const WorldSnapshot& snapshot);
 std::uint32_t compute_snapshot_hash(const WorldSnapshot& snapshot);
 std::vector<std::uint8_t> serialize_snapshot(const WorldSnapshot& snapshot);
-WorldSnapshot deserialize_snapshot(const std::uint8_t* data, std::size_t size);
+WorldSnapshot deserialize_snapshot(std::span<const std::uint8_t> data);
 std::vector<std::uint8_t> serialize_delta(const WorldSnapshot& delta);
-WorldSnapshot deserialize_delta(const std::uint8_t* data, std::size_t size);
+WorldSnapshot deserialize_delta(std::span<const std::uint8_t> data);
 std::vector<std::uint8_t> serialize_sim_event_batch(const SimEventBatch& batch);
-SimEventBatch deserialize_sim_event_batch(const std::uint8_t* data, std::size_t size);
+SimEventBatch deserialize_sim_event_batch(std::span<const std::uint8_t> data);
 std::vector<std::uint8_t> serialize_game_flow_event_batch(const SimEventBatch& batch);
-SimEventBatch deserialize_game_flow_event_batch(const std::uint8_t* data,
-                                                std::size_t size);
+SimEventBatch deserialize_game_flow_event_batch(std::span<const std::uint8_t> data);
 bool is_game_flow_event(EventKind kind) noexcept;
 void normalize_endgame_event_order(GameFlowEventBatch& batch);
 void split_event_batches(const SimEventBatch& source,

--- a/include/openglad/interface/input.h
+++ b/include/openglad/interface/input.h
@@ -281,8 +281,8 @@ class JoyData
     static inline constexpr int HAT_LEFT = 10;
     static inline constexpr int HAT_UP_LEFT = 11;
     
-    int key_type[NUM_KEYS];
-    int key_index[NUM_KEYS];
+    int key_type[NUM_KEYS]{};
+    int key_index[NUM_KEYS]{};
     
     JoyData();
     JoyData(int index);

--- a/include/openglad/interface/render/pixie.h
+++ b/include/openglad/interface/render/pixie.h
@@ -58,14 +58,16 @@ class pixie
 		short sizex, sizey;
 		short xpos, ypos;
 		//buffers: accelerated-surface path on/off, 1/0
-		int accel;
+		int accel = 0;
 		short on_screen();                                                                // on ANY viewscreen?
 		short on_screen(viewscreen  *viewp);  // on a specific viewscreen?
 		const unsigned char* bmp_data() const { return bmp; }
 
 	protected:
-		unsigned short size;
-		unsigned char  *bmp,  *oldbmp;
+		unsigned short size = 0;
+		// oldbmp removed: it was never assigned or read (only a commented-out
+		// `delete oldbmp;` referenced it). Reading it would have been UB.
+		unsigned char* bmp = nullptr;
 		//buffers: same data as bmp but in a convient SDL_Surface
 		// SDL-owned accelerated surface handle (platform type-erased at interface boundary).
 		void* bmp_surface = nullptr;

--- a/include/openglad/interface/render/pixie.h
+++ b/include/openglad/interface/render/pixie.h
@@ -56,7 +56,7 @@ class pixie
 		void set_accel(int a);
 		void set_data(const PixieData& data);
 		short sizex, sizey;
-		short xpos, ypos;
+		short xpos = 0, ypos = 0;
 		//buffers: accelerated-surface path on/off, 1/0
 		int accel = 0;
 		short on_screen();                                                                // on ANY viewscreen?

--- a/include/openglad/interface/render/pixien.h
+++ b/include/openglad/interface/render/pixien.h
@@ -36,5 +36,5 @@ class pixieN : public pixie
 		short frames; // total frames
 		short frame; // current frame
 	protected:
-		unsigned char * facings;
+		unsigned char * facings = nullptr;
 };

--- a/include/openglad/interface/render/view.h
+++ b/include/openglad/interface/render/view.h
@@ -146,6 +146,6 @@ class viewscreen
 	protected:
 		options *prefsob;
 
-		short size;
-		unsigned char  *bmp,  *oldbmp;
+		short size = 0;
+		unsigned char  *bmp = nullptr,  *oldbmp = nullptr;
 };

--- a/include/openglad/interface/render/view.h
+++ b/include/openglad/interface/render/view.h
@@ -126,8 +126,7 @@ class viewscreen
 		std::string textlist[MAX_MESSAGES];
 		short textcycles[MAX_MESSAGES];  // duration in sim ticks
 		std::uint32_t text_expire_ticks[MAX_MESSAGES];
-		
-		char infotext[80]; // text to display
+
 		short mynum;     // # to id the viewscreen, 0, 1, 2 ...
 		short my_team;         // used for Player-v-Player mode
 			int* mykeys;     // holds the keyboard mapping
@@ -147,5 +146,4 @@ class viewscreen
 		options *prefsob;
 
 		short size = 0;
-		unsigned char  *bmp = nullptr,  *oldbmp = nullptr;
 };

--- a/include/openglad/interface/screen.h
+++ b/include/openglad/interface/screen.h
@@ -42,6 +42,9 @@ class soundob;
 class DamageNumberRenderContext;
 namespace og::sim { class GameClient; }
 
+// Maximum number of split-screen viewscreens (one per local player).
+inline constexpr int MAX_VIEWS = 5;
+
 class screen : public video
 {
 private:
@@ -275,7 +278,7 @@ public:
     std::string alternate_name[NUM_FAMILIES][NUM_SPECIALS];
     std::unique_ptr<soundob> soundp;
     short redrawme;
-    std::unique_ptr<viewscreen> viewob[5];
+    std::unique_ptr<viewscreen> viewob[MAX_VIEWS];
     short numviews;
     Uint32 timerstart;
     Uint32 framecount;

--- a/include/openglad/interface/session_state.h
+++ b/include/openglad/interface/session_state.h
@@ -123,7 +123,6 @@ struct SessionState {
 
     // Help UI state (Phase 12) — moved from help.cpp globals.
     short help_end_of_file_ = 0;
-    std::array<std::array<char, 100>, 100> helptext_ = {};
 
     // Test-only context override snapshot used by push_test_context/pop_test_context.
     bool test_context_active_ = false;

--- a/include/openglad/legacy/palettes.h
+++ b/include/openglad/legacy/palettes.h
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-char rainbow_pal[] =
+inline constexpr char rainbow_pal[] =
     {
         0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0,
         4, 4, 0, 5, 5, 0, 6, 6, 0, 7, 7, 0,

--- a/include/openglad/platform/curses/curses_input.h
+++ b/include/openglad/platform/curses/curses_input.h
@@ -11,6 +11,7 @@
 #include <openglad/platform/curses/terminal.h>
 
 #include <array>
+#include <span>
 
 namespace og::curses {
 
@@ -41,7 +42,7 @@ public:
     CursesInput();
     // Bind to an explicit 16-entry keycode table (indexed by InputAction). Used by
     // tests to exercise specific bindings without the global session.
-    explicit CursesInput(const int* keybindings);
+    explicit CursesInput(std::span<const int, kInputActionCount> keybindings);
 
     // Apply one terminal key event (press/repeat/release) to the held/pressed set.
     void feed(const Key& k);
@@ -64,7 +65,7 @@ public:
     static MetaAction meta_for_key(const Key& k);
 
 private:
-    const int* keybindings_; // 16 SDL keycodes indexed by InputAction (player_keys_[0])
+    std::span<const int, kInputActionCount> keybindings_; // 16 SDL keycodes indexed by InputAction (player_keys_[0])
     std::array<bool, kInputActionCount> held_{};
     std::array<bool, kInputActionCount> pressed_edge_{};
 };

--- a/include/openglad/platform/net_transport_websocket_server.h
+++ b/include/openglad/platform/net_transport_websocket_server.h
@@ -14,7 +14,7 @@ class WebSocketServerTransport final : public ITransport
 {
 public:
     struct Options {
-        std::string host = "0.0.0.0";
+        std::string host = "127.0.0.1";
         int backlog = 5;
         std::size_t max_connections = static_cast<std::size_t>(MAX_PLAYERS);
     };

--- a/include/openglad/platform/sai2x.h
+++ b/include/openglad/platform/sai2x.h
@@ -37,6 +37,14 @@ class Screen
 		Screen(RenderEngine engine, int width, int height, int fullscreen);
 		~Screen();
 
+		// Screen owns SDL handles (window/renderer/surfaces/textures) freed in
+		// the destructor; a shallow copy or move would double-free. It is owned
+		// via std::unique_ptr<Screen>, so make non-copyable/non-movable explicit.
+		Screen(const Screen&) = delete;
+		Screen& operator=(const Screen&) = delete;
+		Screen(Screen&&) = delete;
+		Screen& operator=(Screen&&) = delete;
+
 		void SaveBMP(SDL_Surface* screen, char* filename);
 
         void clear();

--- a/include/openglad/platform/soundob_sdl.h
+++ b/include/openglad/platform/soundob_sdl.h
@@ -22,6 +22,9 @@ public:
     explicit sdl_soundob(bool silent);
     ~sdl_soundob() override;
 
+    sdl_soundob(const sdl_soundob&) = delete;
+    sdl_soundob& operator=(const sdl_soundob&) = delete;
+
     int init();
     void shutdown();
     void play_sound(short whichsound) override;
@@ -33,7 +36,7 @@ public:
     void load_sound(SDL_AudioSpec, char*);
     std::string soundlist[NUMSOUNDS]; // Our list of sounds
     Mix_Chunk* sound[NUMSOUNDS];      // AudioSpec for loading sounds
-    int baseio, irq, dma, dma16;      // Card-specific information
-    int volume;                       // Volume: 0 - 255
+    int baseio = 0, irq = 0, dma = 0, dma16 = 0; // Card-specific information
+    int volume = 0;                   // Volume: 0 - 255
     unsigned char silence;            // 0 = on, 1 = silent
 };

--- a/include/openglad/platform/video_sdl.h
+++ b/include/openglad/platform/video_sdl.h
@@ -165,12 +165,12 @@ public:
     std::array<unsigned char, 768> dospalette{};
 
     std::array<unsigned char, 64000> videobuffer{};
-    short cyclemode;
+    short cyclemode = 0;
 
     //buffers: screen vars
-    SDL_Surface* window;
-    int screen_width, screen_height, fullscreen;
-    int pdouble;
+    SDL_Surface* window = nullptr;
+    int screen_width = 0, screen_height = 0, fullscreen = 0;
+    int pdouble = 0;
 
     text text_normal;
     text text_big;

--- a/include/openglad/resources/gloader.h
+++ b/include/openglad/resources/gloader.h
@@ -55,6 +55,9 @@ class loader
 		walker *set_walker(walker *ob, Order order, std::int32_t family);
 		std::vector<PixieData> graphics;
 		std::vector<const signed char * const *> animations;
+		// Parallel to `animations`: number of (facing x ani_type) pointer entries
+		// in each table, used to bound animation index math against short tables.
+		std::vector<int> animation_counts;
 		std::vector<float> stepsizes;
 		std::vector<std::int32_t> lineofsight;
 

--- a/include/openglad/resources/gloader.h
+++ b/include/openglad/resources/gloader.h
@@ -61,7 +61,7 @@ class loader
 		std::vector<float> stepsizes;
 		std::vector<std::int32_t> lineofsight;
 
-		std::array<float, 200> hitpoints{}; // hack for now
+		std::vector<float> hitpoints; // sized to SIZE_ORDERS*SIZE_FAMILIES like its sibling tables
 		std::vector<char> act_types;
 		std::vector<float> damage;
 		std::vector<float> fire_frequency;

--- a/include/openglad/resources/io_common.h
+++ b/include/openglad/resources/io_common.h
@@ -13,8 +13,10 @@
 #include <openglad/resources/campaign_io.h>
 #include <openglad/resources/filesystem_sync.h>
 
+#include <cstddef>
 #include <list>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class PixieData;
@@ -33,6 +35,9 @@ std::string get_mounted_campaign();
 #ifdef TESTING
 void set_mounted_campaign_for_testing(const std::string& id);
 #endif
+bool is_safe_campaign_id(std::string_view id);
+bool is_safe_virtual_basename(std::string_view name,
+                              std::size_t max_length = 64);
 
 enum class CampaignPackageIoError {
     None = 0,
@@ -49,6 +54,7 @@ enum class ArchiveIoError {
     OpenOutputFailed,
     ReadEntryFailed,
     CloseArchiveFailed,
+    ResourceLimitExceeded,
 };
 
 [[nodiscard]] CampaignPackageIoError mount_campaign_package_with_error(const std::string& id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "openglad-wasm-tests",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "GPL-2.0",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "http-server": "^14.1.1"
@@ -217,9 +217,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -227,7 +227,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -539,11 +538,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "openglad-wasm-tests",
   "version": "1.0.0",
+  "private": true,
   "description": "End-to-end tests for OpenGlad WASM build using Playwright",
   "directories": {
     "doc": "docs",

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -8,33 +8,33 @@
       "name": "openglad-relay",
       "version": "0.1.0",
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "^0.6.4",
+        "@cloudflare/vitest-pool-workers": "^0.16.15",
         "@cloudflare/workers-types": "^4.20260317.1",
         "typescript": "^5.9.3",
-        "vitest": "^2.1.8",
-        "wrangler": "^3.114.0"
+        "vitest": "^4.1.8",
+        "wrangler": "^4.100.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
-      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
       "dev": true,
-      "dependencies": {
-        "mime": "^3.0.0"
-      },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
-      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
       "dev": true,
       "peerDependencies": {
-        "unenv": "2.0.0-rc.14",
-        "workerd": "^1.20250124.0"
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -43,85 +43,27 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.6.16.tgz",
-      "integrity": "sha512-fKGP+jMyrIh54QncFa7A5NE3k8fWW6oCU4v9IW6Hiu7cAVKBvhdPUAfYBQS7EU1TsjGJl/y5N4Urds3PUFocoQ==",
+      "version": "0.16.15",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.15.tgz",
+      "integrity": "sha512-R0kZhIm4uSxOeTWPHY9xYIFPGRBEHPzl/n9BbHZSY/gk0n16uDU7T1JZe372oTF+diXG1uVBWqiiRc7Hxstdow==",
       "dev": true,
       "dependencies": {
-        "birpc": "0.2.14",
-        "cjs-module-lexer": "^1.2.3",
-        "devalue": "^4.3.0",
-        "esbuild": "0.17.19",
-        "miniflare": "3.20250204.1",
-        "semver": "^7.5.1",
-        "wrangler": "3.109.1",
-        "zod": "^3.22.3"
+        "cjs-module-lexer": "1.2.3",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260611.0",
+        "wrangler": "4.100.0",
+        "zod": "3.25.76"
       },
       "peerDependencies": {
-        "@vitest/runner": "2.0.x - 2.1.x",
-        "@vitest/snapshot": "2.0.x - 2.1.x",
-        "vitest": "2.0.x - 2.1.x"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/ohash": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
-      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
-      "dev": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.1.tgz",
-      "integrity": "sha512-PU5fb40H8X149s117aB4ytbORcCvlASdtF97tfls4BPIyj4PeVxvpSuy1jAptqYHqB0vb2w2sHvzM0XWcp2OKg==",
-      "dev": true,
-      "dependencies": {
-        "defu": "^6.1.4",
-        "mlly": "^1.7.4",
-        "ohash": "^1.1.4",
-        "pathe": "^1.1.2",
-        "ufo": "^1.5.4"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
-      "version": "3.109.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.109.1.tgz",
-      "integrity": "sha512-1Jx+nZ6eCXPQ2rsGdrV6Qy/LGvhpqudeuTl4AYHl9P8Zugp44Uzxnj5w11qF4v/rv1dOZoA5TydSt9xMFfhpKg==",
-      "dev": true,
-      "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.3.4",
-        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
-        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
-        "blake3-wasm": "2.1.5",
-        "esbuild": "0.17.19",
-        "miniflare": "3.20250204.1",
-        "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.1",
-        "workerd": "1.20250204.0"
-      },
-      "bin": {
-        "wrangler": "bin/wrangler.js",
-        "wrangler2": "bin/wrangler.js"
-      },
-      "engines": {
-        "node": ">=16.17.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2",
-        "sharp": "^0.33.5"
-      },
-      "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20250204.0"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        }
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20250204.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250204.0.tgz",
-      "integrity": "sha512-HpsgbWEfvdcwuZ8WAZhi1TlSCyyHC3tbghpKsOqGDaQNltyAFAWqa278TPNfcitYf/FmV4961v3eqUE+RFdHNQ==",
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260611.1.tgz",
+      "integrity": "sha512-iJICldmi4sBGgi7IrQles8cStOGXM/Tmv95C4OODVs6VIbMsJPqThUM5h3uYVQNULuJ8I/aVvnJ3Eh/wZCKwuA==",
       "cpu": [
         "x64"
       ],
@@ -135,9 +77,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20250204.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250204.0.tgz",
-      "integrity": "sha512-AJ8Tk7KMJqePlch3SH8oL41ROtsrb07hKRHD6M+FvGC3tLtf26rpteAAMNYKMDYKzFNFUIKZNijYDFZjBFndXQ==",
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260611.1.tgz",
+      "integrity": "sha512-yBbVXvbZyltR3I7NJdC4C4ItkItjZSiabcA/3HzEWOUQjLVKFqRh4so6ToHr70VCYh8VGeR8EDZL23igLhXqFQ==",
       "cpu": [
         "arm64"
       ],
@@ -151,9 +93,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20250204.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250204.0.tgz",
-      "integrity": "sha512-RIUfUSnDC8h73zAa+u1K2Frc7nc+eeQoBBP7SaqsRe6JdX8jfIv/GtWjQWCoj8xQFgLvhpJKZ4sTTTV+AilQbw==",
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260611.1.tgz",
+      "integrity": "sha512-PfNjpxOlaIgZFYuhD7+neEEewCN2Ud993wEEN0fmbtSOax1AK53LGqmXUDvFhnbkHxJLFAxYCSNISW8QbzaAIg==",
       "cpu": [
         "x64"
       ],
@@ -167,9 +109,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20250204.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250204.0.tgz",
-      "integrity": "sha512-8Ql8jDjoIgr2J7oBD01kd9kduUz60njofrBpAOkjCPed15He8e8XHkYaYow3g0xpae4S2ryrPOeoD3M64sRxeg==",
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260611.1.tgz",
+      "integrity": "sha512-GEp4XbuIKjlF8pakqXcUDJfKiJosD/Q7S83J0d+r+z9XIlYGfF3ntm08e2aiF5TFTwp3fnG4yMoPUAKNhNJpvQ==",
       "cpu": [
         "arm64"
       ],
@@ -183,9 +125,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20250204.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250204.0.tgz",
-      "integrity": "sha512-RpDJO3+to+e17X3EWfRCagboZYwBz2fowc+jL53+fd7uD19v3F59H48lw2BDpHJMRyhg6ouWcpM94OhsHv8ecA==",
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260611.1.tgz",
+      "integrity": "sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw==",
       "cpu": [
         "x64"
       ],
@@ -199,9 +141,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260317.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260317.1.tgz",
-      "integrity": "sha512-+G4eVwyCpm8Au1ex8vQBCuA9wnwqetz4tPNRoB/53qvktERWBRMQnrtvC1k584yRE3emMThtuY0gWshvSJ++PQ==",
+      "version": "4.20260613.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260613.1.tgz",
+      "integrity": "sha512-1mrgjE6epolwBhroeGAp5ud5H6Vyi6tl1o/NP0T4rXJ8bmEjmhHnbCzAhHTDHV0PIeip43wcuzHKJarvaGTaUA==",
       "dev": true
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -216,42 +158,41 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild-plugins/node-globals-polyfill": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
-      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
-      "peerDependencies": {
-        "esbuild": "*"
-      }
-    },
-    "node_modules/@esbuild-plugins/node-modules-polyfill": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
-      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "rollup-plugin-node-polyfills": "^0.2.1"
-      },
-      "peerDependencies": {
-        "esbuild": "*"
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -261,13 +202,13 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -277,13 +218,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -293,13 +234,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -309,13 +250,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -325,13 +266,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -341,13 +282,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -357,13 +298,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -373,13 +314,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -389,13 +330,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -405,13 +346,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -421,13 +362,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -437,13 +378,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -453,13 +394,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -469,13 +410,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -485,13 +426,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -501,13 +442,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -517,13 +458,29 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -533,13 +490,29 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -549,13 +522,29 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -565,13 +554,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -581,13 +570,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -597,13 +586,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -613,22 +602,22 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "dev": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -644,13 +633,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -666,13 +655,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -686,9 +675,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -702,9 +691,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
@@ -718,9 +707,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
@@ -733,10 +722,42 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
       ],
@@ -750,9 +771,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
@@ -766,9 +787,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
@@ -782,9 +803,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
@@ -798,9 +819,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
@@ -816,13 +837,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
@@ -838,13 +859,57 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
@@ -860,13 +925,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
@@ -882,13 +947,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
@@ -904,13 +969,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
@@ -926,20 +991,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
       "dev": true,
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.7.0"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -948,10 +1013,29 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
@@ -968,9 +1052,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -1011,23 +1095,63 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1035,12 +1159,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1048,12 +1175,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1061,25 +1191,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1087,12 +1207,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1100,25 +1223,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1126,12 +1239,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1139,38 +1255,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1178,51 +1271,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -1230,12 +1287,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -1243,12 +1303,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -1256,25 +1319,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1282,12 +1335,43 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1295,25 +1379,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1321,58 +1395,106 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "2.1.9",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.12"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1384,98 +1506,66 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "dependencies": {
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "2.1.9",
-        "pathe": "^1.1.2"
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2"
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
-      "dependencies": {
-        "tinyspy": "^3.0.2"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/as-table": {
-      "version": "1.0.55",
-      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
-      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
-      "dev": true,
-      "dependencies": {
-        "printable-characters": "^1.0.42"
       }
     },
     "node_modules/assertion-error": {
@@ -1487,228 +1577,109 @@
         "node": ">=12"
       }
     },
-    "node_modules/birpc": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
-      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 16"
-      }
-    },
     "node_modules/cjs-module-lexer": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "dev": true,
       "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
-      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
-      "dev": true
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.3"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "dev": true
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/devalue": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.3.tgz",
-      "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
-      "dev": true
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.19",
-        "@esbuild/android-arm64": "0.17.19",
-        "@esbuild/android-x64": "0.17.19",
-        "@esbuild/darwin-arm64": "0.17.19",
-        "@esbuild/darwin-x64": "0.17.19",
-        "@esbuild/freebsd-arm64": "0.17.19",
-        "@esbuild/freebsd-x64": "0.17.19",
-        "@esbuild/linux-arm": "0.17.19",
-        "@esbuild/linux-arm64": "0.17.19",
-        "@esbuild/linux-ia32": "0.17.19",
-        "@esbuild/linux-loong64": "0.17.19",
-        "@esbuild/linux-mips64el": "0.17.19",
-        "@esbuild/linux-ppc64": "0.17.19",
-        "@esbuild/linux-riscv64": "0.17.19",
-        "@esbuild/linux-s390x": "0.17.19",
-        "@esbuild/linux-x64": "0.17.19",
-        "@esbuild/netbsd-x64": "0.17.19",
-        "@esbuild/openbsd-x64": "0.17.19",
-        "@esbuild/sunos-x64": "0.17.19",
-        "@esbuild/win32-arm64": "0.17.19",
-        "@esbuild/win32-ia32": "0.17.19",
-        "@esbuild/win32-x64": "0.17.19"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/estree-walker": {
@@ -1720,18 +1691,6 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/exit-hook": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
-      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1741,11 +1700,22 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "dev": true
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1761,34 +1731,263 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/get-source": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
-      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^2.0.0",
-        "source-map": "^0.6.1"
+      "engines": {
+        "node": ">=6"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
-      "optional": true
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
     },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1799,101 +1998,30 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/miniflare": {
-      "version": "3.20250204.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250204.1.tgz",
-      "integrity": "sha512-B4PQi/Ai4d0ZTWahQwsFe5WAfr1j8ISMYxJZTc56g2/btgbX+Go099LmojAZY/fMRLhIYsglcStW8SeW3f/afA==",
+      "version": "4.20260611.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260611.0.tgz",
+      "integrity": "sha512-i+JwEo8vN96naz1WL3ntFgFyRluBDYL408zwhHKvR2jefJ464KsZ/gCmJAQ5k+oaWeb5Ug+s7yne5AyiAEswjg==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "acorn": "8.14.0",
-        "acorn-walk": "8.3.2",
-        "exit-hook": "2.2.1",
-        "glob-to-regexp": "0.4.1",
-        "stoppable": "1.1.0",
-        "undici": "^5.28.4",
-        "workerd": "1.20250204.0",
-        "ws": "8.18.0",
-        "youch": "3.2.3",
-        "zod": "3.22.3"
+        "sharp": "0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260611.1",
+        "ws": "8.20.1",
+        "youch": "4.1.0-beta.10"
       },
       "bin": {
         "miniflare": "bootstrap.js"
       },
       "engines": {
-        "node": ">=16.13"
-      }
-    },
-    "node_modules/miniflare/node_modules/zod": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
-      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/mlly": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.1.tgz",
-      "integrity": "sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "ufo": "^1.6.3"
-      }
-    },
-    "node_modules/mlly/node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/mlly/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "dev": true,
-      "bin": {
-        "mustache": "bin/mustache"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1908,11 +2036,18 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "dev": true
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -1921,19 +2056,10 @@
       "dev": true
     },
     "node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.16"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1941,27 +2067,22 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
-    "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pkg-types/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
-    },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1978,7 +2099,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1986,111 +2107,43 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/printable-characters": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
-      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
-      "dev": true
-    },
-    "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
-    },
-    "node_modules/rollup-plugin-inject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
-      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
-      "dev": true,
-      "dependencies": {
-        "estree-walker": "^0.6.1",
-        "magic-string": "^0.25.3",
-        "rollup-pluginutils": "^2.8.1"
-      }
-    },
-    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true
-    },
-    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/rollup-plugin-node-polyfills": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
-      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
-      "dev": true,
-      "dependencies": {
-        "rollup-plugin-inject": "^3.0.0"
-      }
-    },
-    "node_modules/rollup-pluginutils": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-      "dev": true,
-      "dependencies": {
-        "estree-walker": "^0.6.1"
-      }
-    },
-    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2100,16 +2153,15 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "dev": true,
       "hasInstallScript": true,
-      "optional": true,
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -2118,25 +2170,30 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/siginfo": {
@@ -2144,25 +2201,6 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2173,43 +2211,28 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
-    "node_modules/stacktracey": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
-      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
-      "dev": true,
-      "dependencies": {
-        "as-table": "^1.0.36",
-        "get-source": "^2.0.12"
-      }
-    },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true
     },
-    "node_modules/stoppable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "dev": true,
       "engines": {
-        "node": ">=4",
-        "npm": ">=6"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/tinybench": {
@@ -2219,33 +2242,34 @@
       "dev": true
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true
-    },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -2271,58 +2295,41 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "dev": true
-    },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
       "dev": true,
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unenv": {
-      "version": "2.0.0-rc.14",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
-      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "dependencies": {
-        "defu": "^6.1.4",
-        "exsolve": "^1.0.1",
-        "ohash": "^2.0.10",
-        "pathe": "^2.0.3",
-        "ufo": "^1.5.4"
+        "pathe": "^2.0.3"
       }
     },
-    "node_modules/unenv/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
-    },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -2331,23 +2338,33 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
         },
-        "less": {
+        "@vitejs/devtools": {
           "optional": true
         },
-        "lightningcss": {
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
           "optional": true
         },
         "sass": {
@@ -2364,473 +2381,88 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
-      "dev": true,
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.3.7",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
-      }
-    },
     "node_modules/vitest": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "2.1.9",
-        "@vitest/mocker": "2.1.9",
-        "@vitest/pretty-format": "^2.1.9",
-        "@vitest/runner": "2.1.9",
-        "@vitest/snapshot": "2.1.9",
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "debug": "^4.3.7",
-        "expect-type": "^1.1.0",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2",
-        "std-env": "^3.8.0",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.1",
-        "tinypool": "^1.0.1",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.9",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.9",
-        "@vitest/ui": "2.1.9",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
+        "@opentelemetry/api": {
+          "optional": true
+        },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -2841,6 +2473,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -2861,9 +2496,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20250204.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250204.0.tgz",
-      "integrity": "sha512-zcKufjVFsQMiD3/acg1Ix00HIMCkXCrDxQXYRDn/1AIz3QQGkmbVDwcUk1Ki2jBUoXmBCMsJdycRucgMVEypWg==",
+      "version": "1.20260611.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260611.1.tgz",
+      "integrity": "sha512-CS/640T7pIJ2HYX6x2DwKFGbcSckAWN3tgcdq+ptB6SaqjWUhlzIgA/YhPuwIU+/NnMnGpqOFX/hC18Oyge63w==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -2873,43 +2508,41 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20250204.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20250204.0",
-        "@cloudflare/workerd-linux-64": "1.20250204.0",
-        "@cloudflare/workerd-linux-arm64": "1.20250204.0",
-        "@cloudflare/workerd-windows-64": "1.20250204.0"
+        "@cloudflare/workerd-darwin-64": "1.20260611.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260611.1",
+        "@cloudflare/workerd-linux-64": "1.20260611.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260611.1",
+        "@cloudflare/workerd-windows-64": "1.20260611.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "3.114.17",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
-      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "version": "4.100.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.100.0.tgz",
+      "integrity": "sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg==",
       "dev": true,
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.3.4",
-        "@cloudflare/unenv-preset": "2.0.2",
-        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
-        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.17.19",
-        "miniflare": "3.20250718.3",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260611.0",
         "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.14",
-        "workerd": "1.20250718.0"
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260611.1"
       },
       "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=16.17.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2",
-        "sharp": "^0.33.5"
+        "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20250408.0"
+        "@cloudflare/workers-types": "^4.20260611.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -2917,164 +2550,10 @@
         }
       }
     },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
-      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
-      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
-      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
-      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
-      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/wrangler/node_modules/miniflare": {
-      "version": "3.20250718.3",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
-      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "0.8.1",
-        "acorn": "8.14.0",
-        "acorn-walk": "8.3.2",
-        "exit-hook": "2.2.1",
-        "glob-to-regexp": "0.4.1",
-        "stoppable": "1.1.0",
-        "undici": "^5.28.5",
-        "workerd": "1.20250718.0",
-        "ws": "8.18.0",
-        "youch": "3.3.4",
-        "zod": "3.22.3"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=16.13"
-      }
-    },
-    "node_modules/wrangler/node_modules/workerd": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
-      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "workerd": "bin/workerd"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20250718.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
-        "@cloudflare/workerd-linux-64": "1.20250718.0",
-        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
-        "@cloudflare/workerd-windows-64": "1.20250718.0"
-      }
-    },
-    "node_modules/wrangler/node_modules/youch": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
-      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
-      "dev": true,
-      "dependencies": {
-        "cookie": "^0.7.1",
-        "mustache": "^4.2.0",
-        "stacktracey": "^2.1.8"
-      }
-    },
-    "node_modules/wrangler/node_modules/zod": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
-      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -3093,14 +2572,26 @@
       }
     },
     "node_modules/youch": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
-      "integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
       "dev": true,
       "dependencies": {
-        "cookie": "^0.5.0",
-        "mustache": "^4.2.0",
-        "stacktracey": "^2.1.8"
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     },
     "node_modules/zod": {

--- a/relay/package.json
+++ b/relay/package.json
@@ -9,11 +9,17 @@
     "test": "vitest run --max-workers=1 --no-isolate",
     "typecheck": "tsc --noEmit"
   },
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.6.4",
+    "@cloudflare/vitest-pool-workers": "^0.16.15",
     "@cloudflare/workers-types": "^4.20260317.1",
     "typescript": "^5.9.3",
-    "vitest": "^2.1.8",
-    "wrangler": "^3.114.0"
+    "vitest": "^4.1.8",
+    "wrangler": "^4.100.0"
+  },
+  "overrides": {
+    "esbuild": "^0.28.1"
   }
 }

--- a/relay/src/game-room.ts
+++ b/relay/src/game-room.ts
@@ -3,6 +3,7 @@ import { DurableObject } from "cloudflare:workers";
 import {
   EMPTY_ROOM_GRACE_MS,
   MAX_RELAY_PAYLOAD_BYTES,
+  MAX_RELAY_JSON_MESSAGE_BYTES,
   MAX_ROOM_PEERS,
   MESSAGE_RATE_LIMIT_MAX_MESSAGES,
   MESSAGE_RATE_LIMIT_WINDOW_MS,
@@ -183,6 +184,10 @@ export class GameRoom extends DurableObject {
     }
 
     if (typeof message === "string") {
+      if (message.length > MAX_RELAY_JSON_MESSAGE_BYTES) {
+        ws.close(1009, "Relay control message too large");
+        return;
+      }
       await this.handleJsonMessage(peerId, ws, message);
       return;
     }

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -94,6 +94,22 @@ async function enforceCreateRoomRateLimit(
     },
   );
 
+  // KV offers no atomic increment, so the read-check-write above is a TOCTOU:
+  // concurrent requests from one IP can all observe a stale count before any
+  // commits. Re-read the committed counter as a best-effort reconciliation and
+  // reject the losers of such a race once the persisted count for this window
+  // exceeds the cap. This is a strict no-op for legitimate sequential traffic
+  // (the committed count then never exceeds the limit) and only adds rejections
+  // when a concurrency burst has pushed the stored count past the bound.
+  const committed = parseCreateRateLimitState(await env.ROOM_INDEX.get(key));
+  if (
+    committed &&
+    committed.window_started_at === windowStartedAt &&
+    committed.count > CREATE_RATE_LIMIT_MAX_ROOMS
+  ) {
+    return textResponse("Rate limit exceeded", { status: 429 });
+  }
+
   return null;
 }
 
@@ -190,10 +206,19 @@ async function listRooms(env: Env, request: Request): Promise<Response> {
   const url = new URL(request.url);
   const campaignFilter = url.searchParams.get("campaign");
 
-  const listResult = await env.ROOM_INDEX.list({ prefix: ROOM_INDEX_PREFIX });
+  // Bound the per-request KV fan-out so a public, unauthenticated listing can
+  // never amplify a single GET into an unbounded number of KV get() subrequests
+  // regardless of how many room: keys exist. We never loop the list cursor and
+  // hard-cap the number of keys we resolve.
+  const LIST_ROOMS_MAX_KEYS = 100;
+  const listResult = await env.ROOM_INDEX.list({
+    prefix: ROOM_INDEX_PREFIX,
+    limit: LIST_ROOMS_MAX_KEYS,
+  });
+  const boundedKeys = listResult.keys.slice(0, LIST_ROOMS_MAX_KEYS);
   const rooms = (
     await Promise.all(
-      listResult.keys.map(async ({ name }) => {
+      boundedKeys.map(async ({ name }) => {
         const parsed = parseRoomInfo(await env.ROOM_INDEX.get(name));
         if (!parsed) {
           return null;

--- a/relay/src/shared.ts
+++ b/relay/src/shared.ts
@@ -7,6 +7,10 @@ export const ROOM_INDEX_TTL_SECONDS = 60 * 60;
 export const EMPTY_ROOM_GRACE_MS = 30_000;
 export const MAX_ROOM_PEERS = 4;
 export const MAX_RELAY_PAYLOAD_BYTES = 64 * 1024;
+export const MAX_RELAY_JSON_MESSAGE_BYTES = 4 * 1024;
+export const MAX_CAMPAIGN_HASH_LENGTH = 128;
+export const MAX_CAMPAIGN_NAME_LENGTH = 128;
+export const MAX_HOST_NAME_LENGTH = 64;
 export const CREATE_RATE_LIMIT_MAX_ROOMS = 10;
 export const CREATE_RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
 export const MESSAGE_RATE_LIMIT_MAX_MESSAGES = 100;
@@ -74,6 +78,10 @@ export function generateOwnerToken(): string {
   return token;
 }
 
+function boundedString(value: string | undefined, maxLength: number): string {
+  return (value ?? "").trim().slice(0, maxLength);
+}
+
 export function makeRoomInfo(init: {
   code: string;
   campaign_hash?: string;
@@ -82,12 +90,15 @@ export function makeRoomInfo(init: {
   player_count?: number;
   created_at?: number;
 }): RoomInfo {
-  const campaignHash = init.campaign_hash ?? "";
+  const campaignHash = boundedString(init.campaign_hash, MAX_CAMPAIGN_HASH_LENGTH);
   return {
     code: init.code,
     campaign_hash: campaignHash,
-    campaign_name: init.campaign_name ?? campaignHash,
-    host_name: init.host_name ?? "",
+    campaign_name: boundedString(
+      init.campaign_name ?? campaignHash,
+      MAX_CAMPAIGN_NAME_LENGTH,
+    ),
+    host_name: boundedString(init.host_name, MAX_HOST_NAME_LENGTH),
     player_count: init.player_count ?? 0,
     created_at: init.created_at ?? Date.now(),
   };

--- a/relay/test/cloudflare-test.d.ts
+++ b/relay/test/cloudflare-test.d.ts
@@ -1,7 +1,11 @@
 /// <reference path="../node_modules/@cloudflare/vitest-pool-workers/types/cloudflare-test.d.ts" />
 
-import type { Env } from "../src/types";
+import type { Env as AppEnv } from "../src/types";
 
-declare module "cloudflare:test" {
-  interface ProvidedEnv extends Env {}
+declare global {
+  namespace Cloudflare {
+    interface Env extends AppEnv {}
+  }
 }
+
+export {};

--- a/relay/test/relay.test.ts
+++ b/relay/test/relay.test.ts
@@ -2,6 +2,10 @@ import { env, runDurableObjectAlarm, runInDurableObject, SELF } from "cloudflare
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  MAX_CAMPAIGN_HASH_LENGTH,
+  MAX_CAMPAIGN_NAME_LENGTH,
+  MAX_HOST_NAME_LENGTH,
+  MAX_RELAY_JSON_MESSAGE_BYTES,
   MAX_RELAY_PAYLOAD_BYTES,
   ROOM_INDEX_TTL_SECONDS,
   RELAY_BROADCAST_TAG,
@@ -791,6 +795,40 @@ describe("OpenGlad relay worker", () => {
 
     const closeEvent = await closePromise;
     expect(closeEvent.code).toBe(1008);
+  });
+
+  it("bounds persisted room metadata and websocket text control messages", async () => {
+    const longCampaign = `campaign.${"x".repeat(MAX_CAMPAIGN_HASH_LENGTH + 64)}`;
+    const longCampaignName = "Campaign ".repeat(40);
+    const longHostName = "Host ".repeat(40);
+    const room = await createRoom({
+      campaign: longCampaign,
+      campaignName: longCampaignName,
+      hostName: longHostName,
+    });
+
+    const hostSocket = await openRoomSocket(roomSocketPath(room, true));
+    await waitForMessage(hostSocket, "bounded host joined");
+    await waitForMessage(hostSocket, "bounded host peer list");
+
+    const response = await SELF.fetch("https://relay.test/api/rooms");
+    expect(response.status).toBe(200);
+    const rooms = (await response.json()) as Array<{
+      code: string;
+      campaign_hash: string;
+      campaign_name: string;
+      host_name: string;
+    }>;
+    const listedRoom = rooms.find((entry) => entry.code === room.code);
+    expect(listedRoom).toBeTruthy();
+    expect(listedRoom?.campaign_hash).toHaveLength(MAX_CAMPAIGN_HASH_LENGTH);
+    expect(listedRoom?.campaign_name).toHaveLength(MAX_CAMPAIGN_NAME_LENGTH);
+    expect(listedRoom?.host_name).toHaveLength(MAX_HOST_NAME_LENGTH);
+
+    const closePromise = waitForClose(hostSocket);
+    hostSocket.send("x".repeat(MAX_RELAY_JSON_MESSAGE_BYTES + 1));
+    const closeEvent = await closePromise;
+    expect(closeEvent.code).toBe(1009);
   });
 
   it("does not share websocket rate limits across peers behind the same nat", async () => {

--- a/relay/vitest.config.mts
+++ b/relay/vitest.config.mts
@@ -1,16 +1,16 @@
-import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
 
-export default defineWorkersConfig({
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      main: "./src/index.ts",
+      wrangler: {
+        configPath: "./wrangler.toml",
+      },
+    }),
+  ],
   test: {
     testTimeout: 10_000,
-    poolOptions: {
-      workers: {
-        isolatedStorage: false,
-        singleWorker: true,
-        wrangler: {
-          configPath: "./wrangler.toml",
-        },
-      },
-    },
   },
 });

--- a/scripts/deploy_web.sh
+++ b/scripts/deploy_web.sh
@@ -1,61 +1,134 @@
-#!/bin/bash
-# Deploy dist/ to S3 for static website hosting
+#!/usr/bin/env bash
+# Deploy dist/ to S3 for static website hosting.
 #
-# Prerequisites:
-#   1. AWS CLI installed and configured (aws configure)
-#   2. S3 bucket created with static website hosting enabled
+# Defaults are intentionally non-destructive:
+#   ./scripts/deploy_web.sh --bucket example.com
 #
-# Setup (one-time):
-#   1. Create S3 bucket: aws s3 mb s3://huddledungeon.com
-#   2. Enable static website hosting:
-#      aws s3 website s3://huddledungeon.com --index-document index.html
-#   3. Set bucket policy for public access (see below)
-#   4. In Cloudflare DNS, add CNAME: huddledungeon.com -> huddledungeon.com.s3-website-us-east-1.amazonaws.com
-#      (adjust region as needed)
+# To publish for real:
+#   ./scripts/deploy_web.sh --bucket example.com --execute
 #
-# Bucket policy (save as policy.json and run: aws s3api put-bucket-policy --bucket huddledungeon.com --policy file://policy.json):
-# {
-#     "Version": "2012-10-17",
-#     "Statement": [
-#         {
-#             "Sid": "PublicReadGetObject",
-#             "Effect": "Allow",
-#             "Principal": "*",
-#             "Action": "s3:GetObject",
-#             "Resource": "arn:aws:s3:::huddledungeon.com/*"
-#         }
-#     ]
-# }
+# To also delete remote files that no longer exist locally:
+#   ./scripts/deploy_web.sh --bucket example.com --execute --delete-remote
 
-set -e
+set -euo pipefail
 
-BUCKET="huddledungeon.com"
-DIST_DIR="$(dirname "$0")/../dist"
+usage() {
+    cat >&2 <<'EOF'
+Usage: deploy_web.sh --bucket BUCKET [--profile PROFILE] [--execute] [--delete-remote]
+
+Options:
+  --bucket BUCKET    Required unless OPENGLAD_DEPLOY_BUCKET is set.
+  --profile PROFILE  Optional AWS CLI profile.
+  --execute          Perform changes. Without this flag, aws runs with --dryrun.
+  --delete-remote    Delete remote files missing from dist/. Requires --execute.
+EOF
+}
+
+BUCKET="${OPENGLAD_DEPLOY_BUCKET:-}"
+PROFILE="${AWS_PROFILE:-}"
+EXECUTE=0
+DELETE_REMOTE=0
+DIST_DIR="$(cd "$(dirname "$0")/.." && pwd)/dist"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --bucket)
+            if [ "$#" -lt 2 ]; then
+                usage
+                exit 2
+            fi
+            BUCKET="$2"
+            shift 2
+            ;;
+        --profile)
+            if [ "$#" -lt 2 ]; then
+                usage
+                exit 2
+            fi
+            PROFILE="$2"
+            shift 2
+            ;;
+        --execute)
+            EXECUTE=1
+            shift
+            ;;
+        --delete-remote)
+            DELETE_REMOTE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$BUCKET" ]; then
+    echo "Error: --bucket or OPENGLAD_DEPLOY_BUCKET is required." >&2
+    usage
+    exit 2
+fi
+
+if [ "$DELETE_REMOTE" -eq 1 ] && [ "$EXECUTE" -ne 1 ]; then
+    echo "Error: --delete-remote requires --execute." >&2
+    exit 2
+fi
 
 if [ ! -d "$DIST_DIR" ]; then
-    echo "Error: dist/ directory not found. Run ./scripts/build_web.sh first."
+    echo "Error: dist/ directory not found. Run ./scripts/build_web.sh first." >&2
     exit 1
 fi
 
-echo "Deploying to s3://$BUCKET..."
+if [ ! -f "$DIST_DIR/index.html" ] || [ ! -f "$DIST_DIR/play.wasm" ]; then
+    echo "Error: dist/ is missing index.html or play.wasm." >&2
+    exit 1
+fi
 
-# Sync all files with appropriate cache headers
-aws s3 sync "$DIST_DIR" "s3://$BUCKET" \
-    --delete \
+AWS_ARGS=()
+if [ -n "$PROFILE" ]; then
+    AWS_ARGS+=(--profile "$PROFILE")
+fi
+
+DRYRUN_ARGS=(--dryrun)
+if [ "$EXECUTE" -eq 1 ]; then
+    DRYRUN_ARGS=()
+fi
+
+DELETE_ARGS=()
+if [ "$DELETE_REMOTE" -eq 1 ]; then
+    DELETE_ARGS=(--delete)
+fi
+
+MODE="dry run"
+if [ "$EXECUTE" -eq 1 ]; then
+    MODE="execute"
+fi
+echo "Deploying $DIST_DIR to s3://$BUCKET ($MODE)..."
+
+aws "${AWS_ARGS[@]}" s3 sync "$DIST_DIR" "s3://$BUCKET" \
+    "${DRYRUN_ARGS[@]}" \
+    "${DELETE_ARGS[@]}" \
     --cache-control "max-age=86400" \
     --exclude "*.html"
 
-# HTML files with shorter cache (for updates)
-aws s3 sync "$DIST_DIR" "s3://$BUCKET" \
+aws "${AWS_ARGS[@]}" s3 sync "$DIST_DIR" "s3://$BUCKET" \
+    "${DRYRUN_ARGS[@]}" \
     --cache-control "max-age=300" \
     --exclude "*" \
     --include "*.html"
 
-# WASM files need correct content type
-aws s3 cp "$DIST_DIR/play.wasm" "s3://$BUCKET/play.wasm" \
+aws "${AWS_ARGS[@]}" s3 cp "$DIST_DIR/play.wasm" "s3://$BUCKET/play.wasm" \
+    "${DRYRUN_ARGS[@]}" \
     --content-type "application/wasm" \
     --cache-control "max-age=86400"
 
-echo ""
-echo "Deploy complete!"
-echo "Site: https://huddledungeon.com"
+if [ "$EXECUTE" -eq 1 ]; then
+    echo "Deploy complete: s3://$BUCKET"
+else
+    echo "Dry run complete. Re-run with --execute to publish."
+fi

--- a/scripts/parity/_apply_mutation.py
+++ b/scripts/parity/_apply_mutation.py
@@ -5,6 +5,8 @@ Phase 02 mutation canary helper. Given a target ${file}, 1-indexed
 ${line}, literal ${from} and ${to}, performs a single
 str.replace(${from}, ${to}, 1) on that exact line and writes the file
 back. Validates:
+  - ${file} is a repository-relative path that resolves inside this
+    checkout.
   - ${from} appears literally on ${line} (exactly once — ambiguous
     multi-occurrences abort).
   - The realpath of ${file} resolved against the repo root does NOT live
@@ -34,6 +36,7 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT_REAL = os.path.realpath(REPO_ROOT)
 FORBIDDEN_PREFIXES = [
     os.path.realpath(REPO_ROOT / ".." / "openglad-master"),
     os.path.realpath(REPO_ROOT / "tests" / "parity"),
@@ -41,9 +44,10 @@ FORBIDDEN_PREFIXES = [
 
 
 def _is_under(path_real: str, prefix_real: str) -> bool:
-    if path_real == prefix_real:
-        return True
-    return path_real.startswith(prefix_real + os.sep)
+    try:
+        return os.path.commonpath([path_real, prefix_real]) == prefix_real
+    except ValueError:
+        return False
 
 
 def main() -> int:
@@ -66,8 +70,20 @@ def main() -> int:
         sys.stderr.write("_apply_mutation: from-text must not be empty\n")
         return 2
 
-    target_path = (REPO_ROOT / file_arg)
+    file_path = Path(file_arg)
+    if file_path.is_absolute() or ".." in file_path.parts:
+        sys.stderr.write(
+            f"_apply_mutation: refusing non-repository-relative path: {file_arg}\n"
+        )
+        return 3
+
+    target_path = REPO_ROOT / file_path
     target_real = os.path.realpath(target_path)
+    if not _is_under(target_real, REPO_ROOT_REAL):
+        sys.stderr.write(
+            f"_apply_mutation: refusing path outside repository: {target_real}\n"
+        )
+        return 3
 
     for prefix in FORBIDDEN_PREFIXES:
         if _is_under(target_real, prefix):

--- a/scripts/test_text_client.sh
+++ b/scripts/test_text_client.sh
@@ -72,7 +72,7 @@ if len(results) != 1000:
     print(f'FAIL: Expected 1000 tick results, got {len(results)}', file=sys.stderr)
     sys.exit(1)
 if results[-1].get('tick') != 1000:
-    print(f'FAIL: Last tick should be 1000, got {results[-1].get(\"tick\")}', file=sys.stderr)
+    print(f'FAIL: Last tick should be 1000, got {results[-1].get("tick")}', file=sys.stderr)
     sys.exit(1)
 
 # Line 3: event drain

--- a/scripts/test_text_client.sh
+++ b/scripts/test_text_client.sh
@@ -50,10 +50,11 @@ if [ $rc -ne 0 ]; then
 fi
 
 # Validate with Python (available in CI and dev environments).
-python3 -c "
+python3 - "$TMPOUT" <<'PY'
 import json, sys
 
-lines = [l.strip() for l in open('$TMPOUT') if l.strip()]
+with open(sys.argv[1], encoding='utf-8') as f:
+    lines = [l.strip() for l in f if l.strip()]
 if len(lines) < 3:
     print('FAIL: Expected at least 3 JSON lines, got', len(lines), file=sys.stderr)
     sys.exit(1)
@@ -107,4 +108,4 @@ if quit_msg.get('status') != 'ok':
     sys.exit(1)
 
 print(f'PASS: 1000 ticks, {len(entities)} entities, {dead_count} dead, clean quit')
-"
+PY

--- a/src/core/combat_math.cpp
+++ b/src/core/combat_math.cpp
@@ -134,8 +134,10 @@ short compute_xp_from_action(ExpAction action, std::int32_t attacker_level, std:
         return compute_xp_from_attack(level_diff, static_cast<float>(value));
     case ExpAction::Kill:
         return compute_xp_from_kill(level_diff);
-    case ExpAction::Heal:
-        return static_cast<short>(rng.next(static_cast<std::uint32_t>(20 * value)) / attacker_level);
+    case ExpAction::Heal: {
+        const std::int32_t denom = (attacker_level > 0) ? attacker_level : 1;
+        return static_cast<short>(rng.next(static_cast<std::uint32_t>(20 * value)) / denom);
+    }
     case ExpAction::TurnUndead:
         return static_cast<short>(value * 3);
     case ExpAction::RaiseSkeleton:

--- a/src/core/util.cpp
+++ b/src/core/util.cpp
@@ -132,7 +132,7 @@ std::int32_t query_timer_control()
 void time_delay(std::int32_t delay)
 {
     if (delay <= 0) return;
-    auto target_us = static_cast<std::int64_t>(delay * 13600); // microseconds
+    auto target_us = static_cast<std::int64_t>(delay) * 13600; // microseconds
 #ifdef __EMSCRIPTEN__
   #ifdef __ASYNCIFY__
     emscripten_sleep(static_cast<unsigned int>(target_us / 1000));

--- a/src/gameplay/effect.cpp
+++ b/src/gameplay/effect.cpp
@@ -100,20 +100,58 @@ bool effect::act()
 
 bool effect::animate()
 {
-	const int ani_index = curdir() + ani_type() * NUM_FACINGS;
-	set_frame(ani[ani_index][cycle()]);
-	set_cycle(static_cast<signed char>(cycle() + 1));
+	if (!ani)
+		return 0;
+
+	// curdir/ani_type/cycle may originate from an untrusted snapshot. Bound the
+	// facing, the animation type against this family's actual table length, and
+	// the cycle against the sequence sentinel before indexing, to avoid reading
+	// past the end of a short animation table (and dereferencing a wild pointer).
+	int dir_index = static_cast<int>(static_cast<unsigned char>(curdir()));
+	if (dir_index < 0 || dir_index >= NUM_FACINGS)
+		dir_index = 0;
+	int type_index = static_cast<int>(ani_type());
+	if (type_index < ANI_WALK)
+		type_index = ANI_WALK;
+
+	int ani_index = dir_index + type_index * NUM_FACINGS;
+	// For real entities the loader records this family's table length (ani_count);
+	// reject an out-of-range row from an untrusted snapshot by falling back to the
+	// walk row (always < ani_count for real tables). ani_count == 0 only for
+	// test-built effects that assign `ani` directly (legacy direct-index behavior).
+	if (ani_count > 0 && ani_index >= ani_count)
+	{
+		set_ani_type(ANI_WALK);
+		ani_index = dir_index;
+	}
+	const signed char* seq = ani[ani_index];
+	if (!seq)
+		return 0;
+
+	int seq_len = 0;
+	while (seq_len < 128 && seq[seq_len] != -1)
+		seq_len++;
+	if (seq_len <= 0 || seq_len >= 128)
+		return 0;
+
+	int c = static_cast<int>(cycle());
+	if (c < 0 || c >= seq_len)
+		c = 0;
+	set_frame(seq[c]);
+	c++;                                 // advance into [1, seq_len]; seq[seq_len] is the -1 sentinel
 
 	const auto* efd = get_effect_family_descriptor(family());
 	if (efd && efd->loops_animation)
 	{
-		if (ani[ani_index][cycle()] == -1)
-			set_cycle(0);
+		if (seq[c] == -1)
+			c = 0;
+		set_cycle(static_cast<signed char>(c));
 	}
 	else
 	{
-		if (ani[ani_index][cycle()] == -1)
+		if (seq[c] == -1)
 			set_ani_type(ANI_WALK);
+		set_cycle(static_cast<signed char>(c));
 	}
 
 	return 1;

--- a/src/gameplay/families/effect_family_bomb.cpp
+++ b/src/gameplay/families/effect_family_bomb.cpp
@@ -20,6 +20,8 @@ static bool bomb_on_death(effect* self)
         self->set_owner(self);
     og::sim::emit_sound(current_game->sim_events, SOUND_EXPLODE);
     walker* newob = current_game->world->add_ob(Order::FX, FAMILY_EXPLOSION);
+    if (!newob)
+        return true;
     newob->set_owner(self->owner());
     newob->stats()->set_hitpoints(0);
     newob->stats()->set_level(self->owner()->stats()->level());

--- a/src/gameplay/families/effect_family_bomb.cpp
+++ b/src/gameplay/families/effect_family_bomb.cpp
@@ -20,8 +20,7 @@ static bool bomb_on_death(effect* self)
         self->set_owner(self);
     og::sim::emit_sound(current_game->sim_events, SOUND_EXPLODE);
     walker* newob = current_game->world->add_ob(Order::FX, FAMILY_EXPLOSION);
-    if (!newob)
-        return true;
+    if (!newob) return true;
     newob->set_owner(self->owner());
     newob->stats()->set_hitpoints(0);
     newob->stats()->set_level(self->owner()->stats()->level());

--- a/src/gameplay/families/effect_family_chain.cpp
+++ b/src/gameplay/families/effect_family_chain.cpp
@@ -115,7 +115,10 @@ static bool chain_on_act(effect* self)
                 yd = self->leader()->ypos() - self->ypos();
         }
         self->set_curdir(static_cast<signed char>(self->facing(xd, yd)));
-        self->set_frame(self->ani[self->curdir()][0]);
+        if (self->ani)
+        {
+            self->set_frame(self->ani[self->curdir()][0]);
+        }
         self->setworldxy(self->worldx()+xd, self->worldy()+yd);
     }
     else

--- a/src/gameplay/families/effect_family_knife_back.cpp
+++ b/src/gameplay/families/effect_family_knife_back.cpp
@@ -53,9 +53,11 @@ static bool knife_back_on_act(effect* self)
         walker* newob = current_game->world->add_ob(Order::Weapon, FAMILY_KNIFE);
         if (!newob)
         {
+            // GCOVR_EXCL_START -- add_ob only returns null on allocation failure
             self->set_ani_type(ANI_WALK);
             self->set_dead(1);
             return true;
+            // GCOVR_EXCL_STOP
         }
         newob->set_damage(self->damage());
         newob->set_owner(self->owner());

--- a/src/gameplay/families/effect_family_knife_back.cpp
+++ b/src/gameplay/families/effect_family_knife_back.cpp
@@ -51,6 +51,12 @@ static bool knife_back_on_act(effect* self)
         }
         self->setworldxy(self->worldx()+xd, self->worldy()+yd);
         walker* newob = current_game->world->add_ob(Order::Weapon, FAMILY_KNIFE);
+        if (!newob)
+        {
+            self->set_ani_type(ANI_WALK);
+            self->set_dead(1);
+            return true;
+        }
         newob->set_damage(self->damage());
         newob->set_owner(self->owner());
         newob->set_team_num(self->team_num());

--- a/src/gameplay/families/family_archmage.cpp
+++ b/src/gameplay/families/family_archmage.cpp
@@ -59,9 +59,7 @@ static void archmage_hit_response(statistics* stats, walker* foe)
     walker* controller = stats->controller();
     controller->set_busy(0); // yes, this is a cheat
 
-    std::int32_t possible_specials[NUM_SPECIALS];
-    for (int i = 0; i < NUM_SPECIALS; i++)
-        possible_specials[i] = 0;
+    std::int32_t possible_specials[NUM_SPECIALS] = {};
     for (int i = 0; i <= (stats->level() + 2) / 3; i++)
         if (i < NUM_SPECIALS && stats->magicpoints() >= stats->special_cost(i))
             possible_specials[i] = 1;

--- a/src/gameplay/families/family_archmage.cpp
+++ b/src/gameplay/families/family_archmage.cpp
@@ -261,6 +261,8 @@ static bool archmage_do_special(walker* self)
                         self->myguy->scen_shots++;
                     }
                     newob = summon_entity(self, Order::FX, FAMILY_CHAIN);
+                    if (!newob)
+                        return false;
                     generic = static_cast<std::int32_t>(self->stats()->magicpoints() - static_cast<float>(self->stats()->special_cost(2)));
                     generic /= 2;
                     self->stats()->set_magicpoints(self->stats()->magicpoints() - static_cast<float>(generic));

--- a/src/gameplay/families/family_archmage.cpp
+++ b/src/gameplay/families/family_archmage.cpp
@@ -261,8 +261,7 @@ static bool archmage_do_special(walker* self)
                         self->myguy->scen_shots++;
                     }
                     newob = summon_entity(self, Order::FX, FAMILY_CHAIN);
-                    if (!newob)
-                        return false;
+                    if (!newob) return false;
                     generic = static_cast<std::int32_t>(self->stats()->magicpoints() - static_cast<float>(self->stats()->special_cost(2)));
                     generic /= 2;
                     self->stats()->set_magicpoints(self->stats()->magicpoints() - static_cast<float>(generic));

--- a/src/gameplay/families/family_barbarian.cpp
+++ b/src/gameplay/families/family_barbarian.cpp
@@ -28,8 +28,7 @@ static bool barbarian_do_special(walker* self)
     if (!newob)
         return false;
     walker* alive = current_game->world->add_ob(Order::Weapon, FAMILY_BOULDER);
-    if (!alive)
-        return false;
+    if (!alive) return false;
     alive->center_on(newob);
     alive->set_owner(self);
     alive->stats()->set_level(self->stats()->level());

--- a/src/gameplay/families/family_barbarian.cpp
+++ b/src/gameplay/families/family_barbarian.cpp
@@ -28,6 +28,8 @@ static bool barbarian_do_special(walker* self)
     if (!newob)
         return false;
     walker* alive = current_game->world->add_ob(Order::Weapon, FAMILY_BOULDER);
+    if (!alive)
+        return false;
     alive->center_on(newob);
     alive->set_owner(self);
     alive->stats()->set_level(self->stats()->level());

--- a/src/gameplay/families/family_cleric.cpp
+++ b/src/gameplay/families/family_cleric.cpp
@@ -19,6 +19,7 @@
 #include <openglad/gameplay/sim_emit.h>
 
 #include <format>
+#include <iterator>
 #include <string>
 #include <list>
 
@@ -371,7 +372,7 @@ const FamilyDescriptor& describe_family_cleric()
                        "\n"
                        "Special: Heal",
         .name_pool = cleric_names,
-        .name_pool_size = sizeof(cleric_names) / sizeof(cleric_names[0]),
+        .name_pool_size = std::size(cleric_names),
         .is_playable = true,
         .playable_order = 5,
     };

--- a/src/gameplay/families/family_druid.cpp
+++ b/src/gameplay/families/family_druid.cpp
@@ -55,6 +55,8 @@ static bool druid_do_special(walker* self)
                 return false;
             self->set_busy(self->busy() + (self->fire_frequency() * 2.0f));
             alive = summon_entity(self, Order::Weapon, FAMILY_TREE);
+            if (!alive)
+                return false;
             alive->setxy(newob->xpos(), newob->ypos());
             alive->set_ani_type(ANI_GROW);
             newob->set_dead(1);

--- a/src/gameplay/families/family_druid.cpp
+++ b/src/gameplay/families/family_druid.cpp
@@ -55,8 +55,7 @@ static bool druid_do_special(walker* self)
                 return false;
             self->set_busy(self->busy() + (self->fire_frequency() * 2.0f));
             alive = summon_entity(self, Order::Weapon, FAMILY_TREE);
-            if (!alive)
-                return false;
+            if (!alive) return false;
             alive->setxy(newob->xpos(), newob->ypos());
             alive->set_ani_type(ANI_GROW);
             newob->set_dead(1);

--- a/src/gameplay/families/family_ghost.cpp
+++ b/src/gameplay/families/family_ghost.cpp
@@ -23,8 +23,7 @@ static bool ghost_check_special_ai(living* self)
 static bool ghost_do_special(walker* self)
 {
     walker* newob = summon_entity(self, Order::FX, FAMILY_GHOST_SCARE);
-    if (!newob)
-        return false;
+    if (!newob) return false;
     newob->set_ani_type(ANI_SCARE);
     newob->setxy(self->xpos() + self->sizex()/2 - newob->sizex()/2,
                  self->ypos() + self->sizey()/2 - newob->sizey()/2);

--- a/src/gameplay/families/family_ghost.cpp
+++ b/src/gameplay/families/family_ghost.cpp
@@ -23,6 +23,8 @@ static bool ghost_check_special_ai(living* self)
 static bool ghost_do_special(walker* self)
 {
     walker* newob = summon_entity(self, Order::FX, FAMILY_GHOST_SCARE);
+    if (!newob)
+        return false;
     newob->set_ani_type(ANI_SCARE);
     newob->setxy(self->xpos() + self->sizex()/2 - newob->sizex()/2,
                  self->ypos() + self->sizey()/2 - newob->sizey()/2);

--- a/src/gameplay/families/family_mage.cpp
+++ b/src/gameplay/families/family_mage.cpp
@@ -224,8 +224,7 @@ static bool mage_do_special(walker* self)
             if (!newob)
                 return false;
             alive = current_game->world->add_ob(Order::Weapon, FAMILY_WAVE);
-            if (!alive)
-                return false;
+            if (!alive) return false;
             alive->center_on(newob);
             alive->set_owner(self);
             alive->stats()->set_level(self->stats()->level());

--- a/src/gameplay/families/family_mage.cpp
+++ b/src/gameplay/families/family_mage.cpp
@@ -224,6 +224,8 @@ static bool mage_do_special(walker* self)
             if (!newob)
                 return false;
             alive = current_game->world->add_ob(Order::Weapon, FAMILY_WAVE);
+            if (!alive)
+                return false;
             alive->center_on(newob);
             alive->set_owner(self);
             alive->stats()->set_level(self->stats()->level());

--- a/src/gameplay/families/family_mage.cpp
+++ b/src/gameplay/families/family_mage.cpp
@@ -47,9 +47,7 @@ static void mage_hit_response(statistics* stats, walker* foe)
     else
         threshold = (3.0f * stats->max_hitpoints()) / 8.0f;
 
-    std::int32_t possible_specials[NUM_SPECIALS];
-    for (int i = 0; i < NUM_SPECIALS; i++)
-        possible_specials[i] = 0;
+    std::int32_t possible_specials[NUM_SPECIALS] = {};
     for (int i = 0; i <= (stats->level() + 2) / 3; i++)
         if (i < NUM_SPECIALS && stats->magicpoints() >= stats->special_cost(i))
             possible_specials[i] = 1;

--- a/src/gameplay/families/family_slime.cpp
+++ b/src/gameplay/families/family_slime.cpp
@@ -31,6 +31,7 @@ static bool slime_on_death(walker* self)
 {
     self->set_dead(1);
     walker* newob = current_game->world->add_ob(Order::Living, FAMILY_MEDIUM_SLIME);
+    if (!newob) return true;
     newob->set_team_num(self->team_num());
     newob->stats()->set_level(self->stats()->level());
     newob->set_difficulty(self->stats()->level());
@@ -51,6 +52,7 @@ static bool medium_slime_on_death(walker* self)
 {
     self->set_dead(1);
     walker* newob = current_game->world->add_ob(Order::Living, FAMILY_SMALL_SLIME);
+    if (!newob) return true;
     newob->set_team_num(self->team_num());
     newob->stats()->set_level(self->stats()->level());
     newob->set_difficulty(self->stats()->level());
@@ -80,6 +82,7 @@ static bool slime_on_ani_complete(walker* self)
 
     // Create a new small slime
     walker* newob = current_game->world->add_ob(Order::Living, FAMILY_SMALL_SLIME);
+    if (!newob) return true;
     newob->setxy(self->xpos()+12, self->ypos()-12);
     // Transfer stats/etc. across to new guy
     self->transfer_stats(newob);

--- a/src/gameplay/families/family_soldier.cpp
+++ b/src/gameplay/families/family_soldier.cpp
@@ -44,6 +44,7 @@ static bool soldier_do_special(walker* self)
             break;
         case 2: // boomerang
             newob = summon_entity(self, Order::FX, FAMILY_BOOMERANG);
+            if (!newob) return false;
             newob->set_ani_type(1);
             newob->set_lifetime(30 + self->stats()->level() * 12);
             newob->stats()->set_hitpoints(newob->stats()->hitpoints() + static_cast<float>(self->stats()->level()) * 12.0f);

--- a/src/gameplay/families/family_thief.cpp
+++ b/src/gameplay/families/family_thief.cpp
@@ -67,6 +67,7 @@ static bool thief_do_special(walker* self)
     {
         case 1: // drop bomb
             newob = current_game->world->add_ob(Order::FX, FAMILY_BOMB);
+            if (!newob) return false;
             newob->set_ani_type(ANI_BOMB);
             if (self->myguy)
             {

--- a/src/gameplay/families/treasure_family_navigation.cpp
+++ b/src/gameplay/families/treasure_family_navigation.cpp
@@ -127,8 +127,11 @@ static bool teleporter_on_eat(treasure* self, walker* eater)
     }
     // Now do special effects
     walker* flash = current_game->world->add_ob(Order::FX, FAMILY_FLASH);
-    flash->set_ani_type(ANI_EXPAND_8);
-    flash->center_on(self);
+    if (flash)
+    {
+        flash->set_ani_type(ANI_EXPAND_8);
+        flash->center_on(self);
+    }
     return true;
 }
 

--- a/src/gameplay/families/treasure_family_valuables.cpp
+++ b/src/gameplay/families/treasure_family_valuables.cpp
@@ -64,8 +64,11 @@ static bool life_gem_on_eat(treasure* self, walker* eater)
     award_score(eater->team_num(),
                 static_cast<std::uint32_t>(std::max(0.0f, self->stats()->hitpoints())));
     walker* flash = current_game->world->add_ob(Order::FX, FAMILY_FLASH);
-    flash->set_ani_type(ANI_EXPAND_8);
-    flash->center_on(self);
+    if (flash)
+    {
+        flash->set_ani_type(ANI_EXPAND_8);
+        flash->center_on(self);
+    }
     self->set_dead(1);
     self->death();
     return true;

--- a/src/gameplay/families/weapon_family_animate.cpp
+++ b/src/gameplay/families/weapon_family_animate.cpp
@@ -34,6 +34,13 @@ static bool weapon_animate_step(weap* self)
     // within the table. The real untrusted inputs here are curdir and cycle, which
     // are bounded by the facing clamp above and the sentinel scan below.
     const int ani_index = dir_index + type_index * NUM_FACINGS;
+    // For real entities the loader records this family's table length (ani_count).
+    // If a snapshot-driven ani_type drives ani_index past the end, treat it like
+    // "no such sequence" (stop) instead of dereferencing a wild pointer. ani_count
+    // is 0 only for test-constructed weapons that assign `ani` directly, which keep
+    // the legacy direct-index behavior. Mirrors walker::animate/effect::animate.
+    if (self->ani_count > 0 && ani_index >= self->ani_count)
+        return true;
     const signed char* seq = self->ani[ani_index];
     if (!seq)
         return true;

--- a/src/gameplay/families/weapon_family_animate.cpp
+++ b/src/gameplay/families/weapon_family_animate.cpp
@@ -39,8 +39,7 @@ static bool weapon_animate_step(weap* self)
     // "no such sequence" (stop) instead of dereferencing a wild pointer. ani_count
     // is 0 only for test-constructed weapons that assign `ani` directly, which keep
     // the legacy direct-index behavior. Mirrors walker::animate/effect::animate.
-    if (self->ani_count > 0 && ani_index >= self->ani_count)
-        return true;
+    if (self->ani_count > 0 && ani_index >= self->ani_count) return true;
     const signed char* seq = self->ani[ani_index];
     if (!seq)
         return true;

--- a/src/gameplay/families/weapon_family_animate.cpp
+++ b/src/gameplay/families/weapon_family_animate.cpp
@@ -29,12 +29,11 @@ static bool weapon_animate_step(weap* self)
     int type_index = static_cast<int>(self->ani_type());
     if (type_index < 0)
         type_index = 0;
-    int ani_index = dir_index + type_index * NUM_FACINGS;
-    // For real entities the loader records the table length; reject an out-of-range
-    // row from an untrusted snapshot. ani_count == 0 only for test weapons that set
-    // `ani` directly (legacy direct-index behavior).
-    if (self->ani_count > 0 && ani_index >= self->ani_count)
-        return true;                    // unsupported row -> treat as end-of-animation
+    // Callers (tree/blood, glow) already clamp ani_type to the small range their
+    // table supports, and dir_index is bounded above, so dir+type*NUM_FACINGS stays
+    // within the table. The real untrusted inputs here are curdir and cycle, which
+    // are bounded by the facing clamp above and the sentinel scan below.
+    const int ani_index = dir_index + type_index * NUM_FACINGS;
     const signed char* seq = self->ani[ani_index];
     if (!seq)
         return true;

--- a/src/gameplay/families/weapon_family_animate.cpp
+++ b/src/gameplay/families/weapon_family_animate.cpp
@@ -13,15 +13,53 @@
 #include <openglad/gameplay/guy.h>
 #include <openglad/core/sound_ids.h>
 
+// Advances `self`'s animation by one frame with full bounds checking. curdir,
+// ani_type and cycle may originate from an untrusted snapshot, so the facing,
+// the animation type (against this family's actual table length) and the cycle
+// (against the sequence sentinel) are all bounded before indexing — otherwise a
+// short animation table would be read out of bounds and a wild pointer
+// dereferenced. Returns true if the advanced cycle reached the end sentinel.
+static bool weapon_animate_step(weap* self)
+{
+    if (!self->ani)
+        return true;
+    int dir_index = static_cast<int>(static_cast<unsigned char>(self->curdir()));
+    if (dir_index < 0 || dir_index >= NUM_FACINGS)
+        dir_index = 0;
+    int type_index = static_cast<int>(self->ani_type());
+    if (type_index < 0)
+        type_index = 0;
+    int ani_index = dir_index + type_index * NUM_FACINGS;
+    // For real entities the loader records the table length; reject an out-of-range
+    // row from an untrusted snapshot. ani_count == 0 only for test weapons that set
+    // `ani` directly (legacy direct-index behavior).
+    if (self->ani_count > 0 && ani_index >= self->ani_count)
+        return true;                    // unsupported row -> treat as end-of-animation
+    const signed char* seq = self->ani[ani_index];
+    if (!seq)
+        return true;
+    int seq_len = 0;
+    while (seq_len < 128 && seq[seq_len] != -1)
+        seq_len++;
+    if (seq_len <= 0 || seq_len >= 128)
+        return true;
+    int c = static_cast<int>(self->cycle());
+    if (c < 0 || c >= seq_len)
+        c = 0;
+    self->set_frame(seq[c]);
+    c++;                                // advance into [1, seq_len]; seq[seq_len] is the -1 sentinel
+    const bool ended = (seq[c] == -1);
+    self->set_cycle(static_cast<signed char>(c));
+    return ended;
+}
+
 // --- TREE and BLOOD: simple animation cycling ---
 
 static bool tree_blood_on_animate(weap* self)
 {
     if (self->ani_type() > 1)
         self->set_ani_type(0);
-    self->set_frame(self->ani[self->curdir()+self->ani_type()*NUM_FACINGS][self->cycle()]);
-    self->set_cycle(static_cast<signed char>(self->cycle() + 1));
-    if (self->ani[self->curdir()+self->ani_type()*NUM_FACINGS][self->cycle()] == -1)
+    if (weapon_animate_step(self))
     {
         self->set_ani_type(0);
         self->set_cycle(0);
@@ -48,9 +86,7 @@ static bool glow_on_animate(weap* self)
 {
     if (self->ani_type() > 2) // illegal case
         self->set_ani_type(2); // pulse case
-    self->set_frame(self->ani[self->curdir()+self->ani_type()*NUM_FACINGS][self->cycle()]);
-    self->set_cycle(static_cast<signed char>(self->cycle() + 1));
-    if (self->ani[self->curdir()+self->ani_type()*NUM_FACINGS][self->cycle()] == -1)
+    if (weapon_animate_step(self))
     {
         self->set_ani_type(2); // pulse
         self->set_cycle(0);

--- a/src/gameplay/families/weapon_family_knife.cpp
+++ b/src/gameplay/families/weapon_family_knife.cpp
@@ -20,6 +20,7 @@ static bool knife_on_death(weap* self)
         return false; // no special handling
 
     walker* newob = current_game->world->add_ob(Order::FX, FAMILY_KNIFE_BACK);
+    if (!newob) return true;
     newob->set_owner(self->owner());
     newob->center_on(self);
     newob->set_lastx(self->lastx());

--- a/src/gameplay/game_client.cpp
+++ b/src/gameplay/game_client.cpp
@@ -98,16 +98,14 @@ ClientPollResult poll_client_messages(
             case og::sim::kSnapshotMessageType:
                 typed_message.kind = og::sim::TypedReceivedMessageKind::Snapshot;
                 typed_message.snapshot = std::make_shared<og::sim::WorldSnapshot>(
-                    og::sim::deserialize_snapshot(message.data.data(),
-                                                  message.data.size()));
+                    og::sim::deserialize_snapshot(message.data));
                 break;
 
             case og::sim::kDeltaSnapshotMessageType:
                 typed_message.kind =
                     og::sim::TypedReceivedMessageKind::DeltaSnapshot;
                 typed_message.snapshot = std::make_shared<og::sim::WorldSnapshot>(
-                    og::sim::deserialize_delta(message.data.data(),
-                                               message.data.size()));
+                    og::sim::deserialize_delta(message.data));
                 break;
 
             case og::sim::kSimEventBatchMessageType:
@@ -115,8 +113,7 @@ ClientPollResult poll_client_messages(
                     og::sim::TypedReceivedMessageKind::SimEventBatch;
                 typed_message.event_batch =
                     std::make_shared<og::sim::SimEventBatch>(
-                        og::sim::deserialize_sim_event_batch(message.data.data(),
-                                                             message.data.size()));
+                        og::sim::deserialize_sim_event_batch(message.data));
                 break;
 
             case og::sim::kGameFlowEventBatchMessageType:
@@ -125,8 +122,7 @@ ClientPollResult poll_client_messages(
                 typed_message.event_batch =
                     std::make_shared<og::sim::SimEventBatch>(
                         og::sim::deserialize_game_flow_event_batch(
-                            message.data.data(),
-                            message.data.size()));
+                            message.data));
                 break;
 
             case og::sim::kLobbyMessageType:

--- a/src/gameplay/game_server.cpp
+++ b/src/gameplay/game_server.cpp
@@ -1594,6 +1594,32 @@ void GameServer::process_non_input_messages(std::uint32_t expected_tick)
                     0,
                     20));
             }
+            {
+                // The tick is attacker-controlled (raw wire u32). Drop inputs
+                // whose tick sits absurdly far ahead of the live window: only
+                // ticks <= expected_tick are ever consumed/erased by
+                // select_effective_input, so a flood of distinct far-future
+                // ticks would otherwise grow pending_inputs without bound
+                // (memory-exhaustion DoS). Compute the delta in 64-bit to avoid
+                // uint32 wraparound making a far-future tick look "recent".
+                constexpr std::int64_t kMaxFutureInputTicks =
+                    static_cast<std::int64_t>(KEYFRAME_INTERVAL_TICKS);
+                const std::int64_t tick_delta =
+                    static_cast<std::int64_t>(message.tick) -
+                    static_cast<std::int64_t>(expected_tick);
+                if (tick_delta > kMaxFutureInputTicks)
+                    break;
+                // Defense in depth: cap pending entries per client and ignore
+                // new keys once full, so the invariant holds even if the window
+                // logic above ever changes.
+                constexpr std::size_t kMaxPendingInputsPerClient = 256;
+                if (client.pending_inputs.size() >= kMaxPendingInputsPerClient &&
+                    client.pending_inputs.find(message.tick) ==
+                        client.pending_inputs.end())
+                {
+                    break;
+                }
+            }
             client.pending_inputs[message.tick] =
                 select_player_input(*message.input, client.player_index);
             client.last_received_input_tick = message.tick;
@@ -1625,10 +1651,28 @@ void GameServer::process_non_input_messages(std::uint32_t expected_tick)
             if (message.exit_prompt_response)
             {
                 if (message.exit_prompt_response->abort_request)
+                {
+                    // Abort ("Quit this mission") is intentionally any-player.
                     abort_level_for_all();
+                }
                 else if (pending_exit_prompt_state_.has_value())
-                    handle_exit_prompt_response(
-                        message.exit_prompt_response->accepted);
+                {
+                    // Only the player who was actually prompted may resolve the
+                    // exit/withdraw. The broadcast was restricted to the
+                    // triggering player; accept a response solely from that
+                    // bound peer. When the trigger couldn't be identified the
+                    // prompt was broadcast to everyone, so any bound peer may
+                    // answer in that fallback case.
+                    const auto trig =
+                        pending_exit_prompt_state_->triggering_player_index;
+                    if (client.has_player_binding &&
+                        (trig == static_cast<std::size_t>(-1) ||
+                         client.player_index == trig))
+                    {
+                        handle_exit_prompt_response(
+                            message.exit_prompt_response->accepted);
+                    }
+                }
             }
             break;
 

--- a/src/gameplay/game_server.cpp
+++ b/src/gameplay/game_server.cpp
@@ -20,6 +20,7 @@
 #include <climits>
 #include <cstddef>
 #include <format>
+#include <random>
 #include <stdexcept>
 #include <unordered_set>
 #include <utility>
@@ -739,12 +740,13 @@ void clear_pressed(PlayerInput& input)
         pressed = false;
 }
 
-std::uint64_t splitmix64(std::uint64_t value) noexcept
+bool session_tokens_equal(const og::sim::SessionToken& lhs,
+                          const og::sim::SessionToken& rhs) noexcept
 {
-    value += 0x9e3779b97f4a7c15ULL;
-    value = (value ^ (value >> 30)) * 0xbf58476d1ce4e5b9ULL;
-    value = (value ^ (value >> 27)) * 0x94d049bb133111ebULL;
-    return value ^ (value >> 31);
+    std::uint8_t diff = 0;
+    for (std::size_t index = 0; index < lhs.size(); ++index)
+        diff |= static_cast<std::uint8_t>(lhs[index] ^ rhs[index]);
+    return diff == 0;
 }
 
 } // namespace
@@ -902,19 +904,13 @@ std::uint64_t GameServer::now_ms() const
 SessionToken GameServer::allocate_session_token()
 {
     SessionToken token = kZeroSessionToken;
+    std::random_device random_device;
     while (is_zero_session_token(token))
     {
-        const std::uint64_t lo =
-            splitmix64(next_session_token_seed_++ ^ now_ms());
-        const std::uint64_t hi =
-            splitmix64(next_session_token_seed_++ ^
-                       (now_ms() + 0x9e3779b97f4a7c15ULL));
-        for (std::size_t index = 0; index < 8; ++index)
+        for (std::size_t index = 0; index < token.size(); ++index)
         {
             token[index] =
-                static_cast<std::uint8_t>((lo >> (index * 8)) & 0xffu);
-            token[8 + index] =
-                static_cast<std::uint8_t>((hi >> (index * 8)) & 0xffu);
+                static_cast<std::uint8_t>(random_device() & 0xffu);
         }
     }
     return token;
@@ -978,7 +974,8 @@ void GameServer::handle_transport_disconnect(
             disconnected_players_.end(),
             [&client](const DisconnectedPlayer& disconnected) {
                 return disconnected.player_index == client.player_index ||
-                    disconnected.session_token == client.session_token;
+                    session_tokens_equal(disconnected.session_token,
+                                         client.session_token);
             });
 
         DisconnectedPlayer replacement;
@@ -1236,7 +1233,7 @@ void GameServer::handle_hello(PeerId peer_id, const HelloMessage& message)
     {
         if (!is_zero_session_token(client.session_token) &&
             !is_zero_session_token(message.session_token) &&
-            message.session_token != client.session_token)
+            !session_tokens_equal(message.session_token, client.session_token))
         {
             handle_transport_disconnect(peer_id, true);
             return;
@@ -1259,7 +1256,8 @@ void GameServer::handle_hello(PeerId peer_id, const HelloMessage& message)
         disconnected_players_.begin(),
         disconnected_players_.end(),
         [&message](const DisconnectedPlayer& disconnected) {
-            return disconnected.session_token == message.session_token;
+            return session_tokens_equal(disconnected.session_token,
+                                        message.session_token);
         });
     if (disconnected_it == disconnected_players_.end())
     {

--- a/src/gameplay/game_server.cpp
+++ b/src/gameplay/game_server.cpp
@@ -1507,7 +1507,8 @@ void GameServer::poll_incoming_messages(int max_messages)
             std::move(pending_inbound_messages_.front()));
         pending_inbound_messages_.pop_front();
     }
-    messages_drained_last_call_ = static_cast<int>(to_drain);
+    messages_drained_last_call_ = static_cast<int>(
+        std::min(to_drain, static_cast<std::size_t>(INT_MAX)));
 
     for (const PeerId peer_id : poll_result.malformed_peers)
     {

--- a/src/gameplay/guy.cpp
+++ b/src/gameplay/guy.cpp
@@ -392,9 +392,7 @@ std::uint32_t calculate_exp(std::int32_t level)
     for(int k = 2; k <= level; ++k)
     {
         int level_1 = k - 1;
-        int level_2 = k - 2;
-        if(level_2 < 0)
-            level_2 = 0;
+        int level_2 = k - 2; // k starts at 2, so level_2 is always >= 0
         result += static_cast<std::uint32_t>(8000 + 2000*level_1 + 4000*level_2);
     }
     return result;

--- a/src/gameplay/guy.cpp
+++ b/src/gameplay/guy.cpp
@@ -383,12 +383,21 @@ std::uint32_t calculate_exp(std::int32_t level)
 	*/
 	if(level <= 1)
         return 0;
-    
-    int level_1 = level - 1;
-    int level_2 = level - 2;
-    if(level_2 < 0)
-        level_2 = 0;
-    return 8000 + 2000*level_1 + 4000*level_2 + calculate_exp(level-1);
+
+    // Iterative unrolling of the original recurrence to avoid stack
+    // exhaustion when 'level' comes from untrusted save-file bytes (up to
+    // SHRT_MAX). Each iteration reproduces the exact integer arithmetic and
+    // accumulation order of the former recursive form.
+    std::uint32_t result = 0;
+    for(int k = 2; k <= level; ++k)
+    {
+        int level_1 = k - 1;
+        int level_2 = k - 2;
+        if(level_2 < 0)
+            level_2 = 0;
+        result += static_cast<std::uint32_t>(8000 + 2000*level_1 + 4000*level_2);
+    }
+    return result;
 }
 
 void apply_level_up(guy* self, std::int32_t level_diff, const LevelUpGains& g)

--- a/src/gameplay/living.cpp
+++ b/src/gameplay/living.cpp
@@ -518,8 +518,7 @@ walker* living::do_summon(char whatfamily, std::int32_t summon_lifetime)
 	walker  *newob;
 
 	newob = current_game->world->add_ob(Order::Living, whatfamily);
-	if (newob == nullptr)
-		return nullptr;
+	if (newob == nullptr) return nullptr;
 	newob->set_owner(this);
 		newob->set_lifetime(summon_lifetime);
 	newob->transform_to(Order::Living, whatfamily);

--- a/src/gameplay/living.cpp
+++ b/src/gameplay/living.cpp
@@ -518,6 +518,8 @@ walker* living::do_summon(char whatfamily, std::int32_t summon_lifetime)
 	walker  *newob;
 
 	newob = current_game->world->add_ob(Order::Living, whatfamily);
+	if (newob == nullptr)
+		return nullptr;
 	newob->set_owner(this);
 		newob->set_lifetime(summon_lifetime);
 	newob->transform_to(Order::Living, whatfamily);

--- a/src/gameplay/living.cpp
+++ b/src/gameplay/living.cpp
@@ -340,8 +340,12 @@ bool living::act()
 					if (stats_->magicpoints() >= stats_->special_cost(1))
 					{
 						set_current_special(static_cast<char>(current_game->world->rng_.next((stats_->level()+2)/3) + 1));
+						const FamilyDescriptor* special_fd = get_family_descriptor(family());
 						if ( (current_special() > 4) ||
-						        (strcmp(get_family_descriptor(family())->special_names[static_cast<int>(current_special())], "NONE") == 0)
+						        (current_special() < 1) ||
+						        (current_special() >= FD_NUM_SPECIALS) ||
+						        (special_fd == nullptr) ||
+						        (strcmp(special_fd->special_names[static_cast<int>(current_special())], "NONE") == 0)
 						   )
 							set_current_special(1);
 						if (check_special() )

--- a/src/gameplay/lobby_server.cpp
+++ b/src/gameplay/lobby_server.cpp
@@ -129,10 +129,15 @@ bool lobby_messages_include_peer(
                        });
 }
 
-std::vector<std::pair<og::sim::PeerId, og::sim::LobbyMessage>>
+struct LobbyPollResult {
+    std::vector<std::pair<og::sim::PeerId, og::sim::LobbyMessage>> messages;
+    std::vector<og::sim::PeerId> malformed_peer_ids;
+};
+
+LobbyPollResult
 poll_lobby_messages(og::sim::ITransport& transport)
 {
-    std::vector<std::pair<og::sim::PeerId, og::sim::LobbyMessage>> messages;
+    LobbyPollResult result;
 
     if (transport.supports_typed_messages())
     {
@@ -140,8 +145,9 @@ poll_lobby_messages(og::sim::ITransport& transport)
         {
             if (typed_message.kind == og::sim::TypedReceivedMessageKind::Malformed)
             {
-                throw std::runtime_error(
-                    "LobbyServer received malformed transport header");
+                if (typed_message.peer_id != 0)
+                    result.malformed_peer_ids.push_back(typed_message.peer_id);
+                continue;
             }
             if (typed_message.kind != og::sim::TypedReceivedMessageKind::LobbyMessage ||
                 !typed_message.lobby_message)
@@ -149,10 +155,10 @@ poll_lobby_messages(og::sim::ITransport& transport)
                 continue;
             }
 
-            messages.emplace_back(typed_message.peer_id,
-                                  *typed_message.lobby_message);
+            result.messages.emplace_back(typed_message.peer_id,
+                                         *typed_message.lobby_message);
         }
-        return messages;
+        return result;
     }
 
     for (const auto& message : transport.poll())
@@ -160,20 +166,31 @@ poll_lobby_messages(og::sim::ITransport& transport)
         og::sim::TransportEnvelope envelope;
         if (!og::sim::decode_transport_envelope(message.data, envelope))
         {
-            throw std::runtime_error(
-                "LobbyServer received malformed transport header");
+            if (message.peer_id != 0)
+                result.malformed_peer_ids.push_back(message.peer_id);
+            continue;
         }
         if (envelope.message_type != og::sim::kLobbyMessageType)
             continue;
 
         const auto decoded = og::sim::deserialize_lobby_message(message.data);
         if (!decoded.has_value())
-            throw std::runtime_error("LobbyServer failed to deserialize lobby message");
+        {
+            if (message.peer_id != 0)
+                result.malformed_peer_ids.push_back(message.peer_id);
+            continue;
+        }
 
-        messages.emplace_back(message.peer_id, *decoded);
+        result.messages.emplace_back(message.peer_id, *decoded);
     }
 
-    return messages;
+    std::sort(result.malformed_peer_ids.begin(),
+              result.malformed_peer_ids.end());
+    result.malformed_peer_ids.erase(
+        std::unique(result.malformed_peer_ids.begin(),
+                    result.malformed_peer_ids.end()),
+        result.malformed_peer_ids.end());
+    return result;
 }
 
 struct OrderedLobbySlot {
@@ -593,10 +610,20 @@ void LobbyServer::poll_incoming_messages()
 {
     apply_transport_disconnects();
 
-    const auto messages = poll_lobby_messages(transport_);
-    synchronize_transport_peers(messages);
-    for (const auto& [peer_id, message] : messages)
+    const LobbyPollResult poll_result = poll_lobby_messages(transport_);
+    synchronize_transport_peers(poll_result.messages);
+    for (const PeerId peer_id : poll_result.malformed_peer_ids)
+        disconnect_client(peer_id);
+    for (const auto& [peer_id, message] : poll_result.messages)
+    {
+        if (std::binary_search(poll_result.malformed_peer_ids.begin(),
+                               poll_result.malformed_peer_ids.end(),
+                               peer_id))
+        {
+            continue;
+        }
         process_lobby_message(peer_id, message);
+    }
     apply_transport_disconnects();
 }
 

--- a/src/gameplay/net_transport.cpp
+++ b/src/gameplay/net_transport.cpp
@@ -184,7 +184,11 @@ public:
     std::string read_string()
     {
         const std::uint32_t size = read_u32();
-        if (!ok_ || offset_ + size > payload_.size())
+        // offset_ <= payload_.size() always holds (every read_* advances only
+        // after its own bounds check), so the subtractive comparison avoids the
+        // size_t overflow that `offset_ + size` suffers on 32-bit targets
+        // (wasm32) when `size` is an attacker-controlled uint32 near SIZE_MAX.
+        if (!ok_ || size > payload_.size() - offset_)
         {
             ok_ = false;
             return {};

--- a/src/gameplay/net_transport.cpp
+++ b/src/gameplay/net_transport.cpp
@@ -3,6 +3,7 @@
 #include <openglad/gameplay/input_state_net.h>
 #include <openglad/gameplay/world_snapshot.h>
 
+#include <array>
 #include <cstring>
 #include <functional>
 #include <limits>
@@ -42,8 +43,11 @@ void append_i32(std::vector<std::uint8_t>& bytes, std::int32_t value)
 
 void append_f32(std::vector<std::uint8_t>& bytes, float value)
 {
-    const auto* raw = reinterpret_cast<const std::uint8_t*>(&value);
-    bytes.insert(bytes.end(), raw, raw + sizeof(value));
+    // Portable, alias-safe byte extraction (std::bit_cast is unavailable on the
+    // older Emscripten libc++ used by the ctest wasm build).
+    std::array<std::uint8_t, sizeof(float)> raw{};
+    std::memcpy(raw.data(), &value, sizeof(float));
+    bytes.insert(bytes.end(), raw.begin(), raw.end());
 }
 
 void append_string(std::vector<std::uint8_t>& bytes, const std::string& value)

--- a/src/gameplay/net_transport.cpp
+++ b/src/gameplay/net_transport.cpp
@@ -1002,13 +1002,13 @@ TypedReceivedMessage decode_received_message(const ReceivedMessage& message)
         case kSnapshotMessageType:
             typed_message.kind = TypedReceivedMessageKind::Snapshot;
             typed_message.snapshot = std::make_shared<WorldSnapshot>(
-                deserialize_snapshot(message.data.data(), message.data.size()));
+                deserialize_snapshot(message.data));
             return typed_message;
 
         case kDeltaSnapshotMessageType:
             typed_message.kind = TypedReceivedMessageKind::DeltaSnapshot;
             typed_message.snapshot = std::make_shared<WorldSnapshot>(
-                deserialize_delta(message.data.data(), message.data.size()));
+                deserialize_delta(message.data));
             return typed_message;
 
         case kInputMessageType:
@@ -1027,14 +1027,13 @@ TypedReceivedMessage decode_received_message(const ReceivedMessage& message)
         case kSimEventBatchMessageType:
             typed_message.kind = TypedReceivedMessageKind::SimEventBatch;
             typed_message.event_batch = std::make_shared<SimEventBatch>(
-                deserialize_sim_event_batch(message.data.data(), message.data.size()));
+                deserialize_sim_event_batch(message.data));
             return typed_message;
 
         case kGameFlowEventBatchMessageType:
             typed_message.kind = TypedReceivedMessageKind::GameFlowEventBatch;
             typed_message.event_batch = std::make_shared<SimEventBatch>(
-                deserialize_game_flow_event_batch(message.data.data(),
-                                                  message.data.size()));
+                deserialize_game_flow_event_batch(message.data));
             return typed_message;
 
         case kLobbyMessageType:

--- a/src/gameplay/net_transport_inprocess.cpp
+++ b/src/gameplay/net_transport_inprocess.cpp
@@ -283,8 +283,8 @@ std::shared_ptr<og::sim::WorldSnapshot> validate_snapshot_roundtrip(
         is_delta ? og::sim::serialize_delta(*snapshot)
                  : og::sim::serialize_snapshot(*snapshot);
     og::sim::WorldSnapshot decoded =
-        is_delta ? og::sim::deserialize_delta(bytes.data(), bytes.size())
-                 : og::sim::deserialize_snapshot(bytes.data(), bytes.size());
+        is_delta ? og::sim::deserialize_delta(bytes)
+                 : og::sim::deserialize_snapshot(bytes);
 
     const std::optional<og::sim::ReplayVerificationFailure> failure =
         [&]() -> std::optional<og::sim::ReplayVerificationFailure> {
@@ -349,10 +349,8 @@ std::shared_ptr<og::sim::SimEventBatch> validate_event_batch_roundtrip(
         game_flow ? og::sim::serialize_game_flow_event_batch(*batch)
                   : og::sim::serialize_sim_event_batch(*batch);
     og::sim::SimEventBatch decoded =
-        game_flow ? og::sim::deserialize_game_flow_event_batch(bytes.data(),
-                                                               bytes.size())
-                  : og::sim::deserialize_sim_event_batch(bytes.data(),
-                                                         bytes.size());
+        game_flow ? og::sim::deserialize_game_flow_event_batch(bytes)
+                  : og::sim::deserialize_sim_event_batch(bytes);
 
     const std::optional<TransportValidationFailure> failure =
         find_first_event_batch_difference(*batch, decoded);

--- a/src/gameplay/replay.cpp
+++ b/src/gameplay/replay.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <fstream>
 #include <format>
 #include <iterator>
@@ -37,6 +38,7 @@ void write_u32_le(std::vector<std::uint8_t>& bytes, std::uint32_t value)
 
 std::uint32_t read_u32_le(std::span<const std::uint8_t> bytes, std::size_t offset)
 {
+    assert(offset + 4 <= bytes.size());
     return static_cast<std::uint32_t>(bytes[offset])
         | (static_cast<std::uint32_t>(bytes[offset + 1]) << 8)
         | (static_cast<std::uint32_t>(bytes[offset + 2]) << 16)
@@ -52,6 +54,7 @@ void write_i16_le(std::vector<std::uint8_t>& bytes, std::int16_t value)
 
 std::int16_t read_i16_le(std::span<const std::uint8_t> bytes, std::size_t offset)
 {
+    assert(offset + 2 <= bytes.size());
     return static_cast<std::int16_t>(
         static_cast<std::uint16_t>(bytes[offset]) |
         (static_cast<std::uint16_t>(bytes[offset + 1]) << 8));

--- a/src/gameplay/replay.cpp
+++ b/src/gameplay/replay.cpp
@@ -773,8 +773,7 @@ std::optional<ReplayData> deserialize_replay(std::span<const std::uint8_t> bytes
     try
     {
         replay.initial_snapshot =
-            deserialize_snapshot(initial_snapshot_bytes.data(),
-                                 initial_snapshot_bytes.size());
+            deserialize_snapshot(initial_snapshot_bytes);
     }
     catch (const std::runtime_error&)
     {

--- a/src/gameplay/sim_input_handler.cpp
+++ b/src/gameplay/sim_input_handler.cpp
@@ -128,7 +128,7 @@ SimInputResult sim_process_player_input(
     short player_num,
     short my_team,
     SimInputDebounce& debounce,
-    const std::string (*special_names)[6],
+    const std::string (*special_names)[NUM_SPECIALS],
     [[maybe_unused]] og::sim::SimEventLog* sim_events)
 {
     SimInputResult result;

--- a/src/gameplay/smooth.cpp
+++ b/src/gameplay/smooth.cpp
@@ -643,5 +643,16 @@ void smoother::set_x_y(Sint32 x, Sint32 y, Sint32 whatvalue)
 	if (mygrid_span_.empty())
 		return;
 
+	// Mirror query_x_y()'s bounds check: the read path already rejects
+	// out-of-range coordinates, so the symmetric write must too. Without this
+	// guard a future caller could store past the end of the grid span (an OOB
+	// write into the level buffer); the index math below assumes 0<=x<maxx and
+	// 0<=y<maxy.
+	if ( (x < 0) || (y < 0) )
+		return;
+
+	if ( (x >= maxx) || (y >= maxy) )
+		return;
+
 	mygrid_span_[static_cast<std::size_t>(x+y*maxx)] = static_cast<unsigned char>(whatvalue);
 }

--- a/src/gameplay/smooth.cpp
+++ b/src/gameplay/smooth.cpp
@@ -21,6 +21,7 @@
 #include <openglad/core/pixdefs.h>
 #include <array>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 
 using Uint32 = std::uint32_t;
@@ -222,12 +223,12 @@ static constexpr Sint32 dirt_dark_by_surround[] = {
 };
 
 smoother::smoother()
-    : mygrid(nullptr), maxx(0), maxy(0), rng_(nullptr)
+    : maxx(0), maxy(0), rng_(nullptr)
 {}
 
 void smoother::reset()
 {
-    mygrid = nullptr;
+    mygrid_span_ = {};
     maxx = 0;
     maxy = 0;
 }
@@ -239,7 +240,7 @@ void smoother::set_rng(IRandom* rng)
 
 void smoother::set_target(const PixieData& data)
 {
-	mygrid = data.data.get();
+	mygrid_span_ = {data.data.get(), static_cast<std::size_t>(data.w) * data.h};
 	maxx = data.w;
 	maxy = data.h;
 }
@@ -257,7 +258,7 @@ Uint32 smoother::next_random(Uint32 max_exclusive) const
 Sint32 smoother::query_x_y(Sint32 x, Sint32 y)
 {
 	// Are we set up yet?
-	if (!mygrid)
+	if (mygrid_span_.empty())
 		return PIX_GRASS1;
 
 	// Check boundaries ..
@@ -268,7 +269,7 @@ Sint32 smoother::query_x_y(Sint32 x, Sint32 y)
 		return PIX_GRASS1;
 
 	// Else, return our simple grid data ..
-	return static_cast<Sint32>(mygrid[x + y*maxx]);
+	return static_cast<Sint32>(mygrid_span_[static_cast<std::size_t>(x + y*maxx)]);
 }
 
 Sint32 smoother::query_genre_x_y(Sint32 x, Sint32 y)
@@ -626,7 +627,7 @@ Sint32 smoother::smooth()
 {
 	Sint32 x, y;
 
-	if (!mygrid)
+	if (mygrid_span_.empty())
 		return 0;
 
 
@@ -639,8 +640,8 @@ Sint32 smoother::smooth()
 
 void smoother::set_x_y(Sint32 x, Sint32 y, Sint32 whatvalue)
 {
-	if (!mygrid)
+	if (mygrid_span_.empty())
 		return;
 
-	mygrid[x+y*maxx] = static_cast<char>(whatvalue);
+	mygrid_span_[static_cast<std::size_t>(x+y*maxx)] = static_cast<unsigned char>(whatvalue);
 }

--- a/src/gameplay/stats.cpp
+++ b/src/gameplay/stats.cpp
@@ -95,7 +95,7 @@ statistics::statistics(walker  * someguy)
         old_family_ = FAMILY_SOLDIER;
     }
 
-	name[0] = 0; // set to null string
+	name.clear(); // set to null string
 }
 
 statistics::~statistics()

--- a/src/gameplay/stats.cpp
+++ b/src/gameplay/stats.cpp
@@ -1090,45 +1090,45 @@ inline constexpr int GOTO_ARRIVAL_DISTANCE = 12;
 
 // Maps a facing direction to a unit step delta (the same table right_walk
 // builds inline with its turn switches).
-static void facing_step_delta(char dir, short* xdelta, short* ydelta)
+static void facing_step_delta(char dir, short& xdelta, short& ydelta)
 {
 	switch (dir)
 	{
 		case FACE_UP:
-			*xdelta = 0;
-			*ydelta = -1;
+			xdelta = 0;
+			ydelta = -1;
 			break;
 		case FACE_UP_RIGHT:
-			*xdelta = 1;
-			*ydelta = -1;
+			xdelta = 1;
+			ydelta = -1;
 			break;
 		case FACE_RIGHT:
-			*xdelta = 1;
-			*ydelta = 0;
+			xdelta = 1;
+			ydelta = 0;
 			break;
 		case FACE_DOWN_RIGHT:
-			*xdelta = 1;
-			*ydelta = 1;
+			xdelta = 1;
+			ydelta = 1;
 			break;
 		case FACE_DOWN:
-			*xdelta = 0;
-			*ydelta = 1;
+			xdelta = 0;
+			ydelta = 1;
 			break;
 		case FACE_DOWN_LEFT:
-			*xdelta = -1;
-			*ydelta = 1;
+			xdelta = -1;
+			ydelta = 1;
 			break;
 		case FACE_LEFT:
-			*xdelta = -1;
-			*ydelta = 0;
+			xdelta = -1;
+			ydelta = 0;
 			break;
 		case FACE_UP_LEFT:
-			*xdelta = -1;
-			*ydelta = -1;
+			xdelta = -1;
+			ydelta = -1;
 			break;
 		default:
-			*xdelta = 0;
-			*ydelta = 0;
+			xdelta = 0;
+			ydelta = 0;
 			break;
 	}
 }
@@ -1230,14 +1230,14 @@ bool statistics::right_walk_to_point(short x, short y)
 	else if (right_back_blocked())
 	{
 		controller_->set_enddir(static_cast<char>((controller_->enddir() + 2) % 8));  // turn right
-		facing_step_delta(controller_->enddir(), &xstep, &ystep);
+		facing_step_delta(controller_->enddir(), xstep, ystep);
 		add_command(COMMAND_WALK, 1, xstep, ystep);
 	}
 	else
 	{
 		if (!direct_walk_to_point(x, y)) // can't walk straight to the point
 		{
-			facing_step_delta(controller_->curdir(), &xstep, &ystep);
+			facing_step_delta(controller_->curdir(), xstep, ystep);
 			return controller_->walkstep(xstep, ystep);
 		}
 	}

--- a/src/gameplay/walker.cpp
+++ b/src/gameplay/walker.cpp
@@ -135,6 +135,7 @@ void walker_init_common(walker* w, IRandom& rng)
 	w->set_collide_ob_id(0);
 	w->set_cycle(0);
 	w->ani = nullptr;
+	w->ani_count = 0;
 	w->set_ani_type(0);
 	w->set_busy(0);
 	w->set_foe(nullptr);
@@ -969,6 +970,19 @@ bool walker::animate()
 	}
 
 	const int ani_index = dir_index + type_index * NUM_FACINGS;
+	// For real entities the loader records this family's table length (ani_count).
+	// Animation tables vary in length (most hold only ANI_WALK/ANI_ATTACK rows), so
+	// an untrusted snapshot/save can set an ani_type the short table doesn't contain
+	// and drive ani_index past the end. Treat that exactly like "no such sequence"
+	// (reset to walk, stop) instead of reading out of bounds. ani_count is 0 only
+	// for test-constructed walkers that assign `ani` directly; those keep the legacy
+	// direct-index behavior.
+	if (ani_count > 0 && ani_index >= ani_count)
+	{
+		set_ani_type(ANI_WALK);
+		set_cycle(0);
+		return 0;
+	}
 	const signed char* seq = ani[ani_index];
 	if (!seq)
 	{

--- a/src/gameplay/walker.cpp
+++ b/src/gameplay/walker.cpp
@@ -507,7 +507,11 @@ walker  * walker::fire()
 	stats_->set_magicpoints(	stats_->magicpoints() - stats_->weapon_cost());
 
 	// Determine how much the thrown weapon can 'waver'
-	waver = static_cast<signed char>((weapon->stepsize())/2); // Absolute amount ..
+	// Clamp before the signed-char narrowing: stepsize is replicated from
+	// network snapshots, so a hostile value > 254 would make the float->signed
+	// char conversion undefined. Normal stepsizes are well under 254, so this
+	// is byte-identical for legitimate game data.
+	waver = static_cast<signed char>(std::clamp((weapon->stepsize())/2, 0.0f, 127.0f)); // Absolute amount ..
 	waver = static_cast<signed char>(current_game->world->rng_.next(waver+1) - waver/2);
 
 	switch (facing(lastx(), lasty()))
@@ -651,7 +655,11 @@ void walker::set_weapon_heading(walker *weapon)
 	signed char waver;
 
 	// Determine how much the thrown weapon can 'waver'
-	waver = static_cast<signed char>((weapon->stepsize())/2); // Absolute amount ..
+	// Clamp before the signed-char narrowing: stepsize is replicated from
+	// network snapshots, so a hostile value > 254 would make the float->signed
+	// char conversion undefined. Normal stepsizes are well under 254, so this
+	// is byte-identical for legitimate game data.
+	waver = static_cast<signed char>(std::clamp((weapon->stepsize())/2, 0.0f, 127.0f)); // Absolute amount ..
 	waver = static_cast<signed char>(current_game->world->rng_.next(waver+1) - waver/2);
 
 	switch (facing(lastx(), lasty()))  // these are from the 'owner'
@@ -1632,6 +1640,7 @@ void walker::generate_bloodspot()
 	set_dead(1); // just in case ..
 
 	bloodstain = current_game->world->add_fx_ob(Order::Treasure, FAMILY_STAIN);
+	if (!bloodstain) return;
 	bloodstain->set_ignore(1);
 	transfer_stats(bloodstain);
 

--- a/src/gameplay/walker.cpp
+++ b/src/gameplay/walker.cpp
@@ -202,6 +202,9 @@ walker::walker()
 
 short walker::next_frame()
 {
+	// frames is 0 for a default/test-built or moved-from walker; guard the
+	// modulo to avoid integer division-by-zero UB (mirrors pixieN::next_frame).
+	if (frames <= 0) return 0;
 	return set_frame(static_cast<short>(frame() % frames));
 }
 
@@ -1123,6 +1126,7 @@ walker  *walker::create_weapon()
 	if (query_order() == Order::Generator)
 	{
 			weapon = current_game->world->add_ob(Order::Living, static_cast<char>(default_weapon()));
+		if (!weapon) return nullptr;
 		weapon->set_team_num(team_num());
 		weapon->set_owner(this);
 		weapon->set_difficulty(static_cast<std::uint32_t>(stats_->level()));
@@ -1132,6 +1136,7 @@ walker  *walker::create_weapon()
 		weapon_type = current_weapon();
 
 	weapon = current_game->world->add_ob(Order::Weapon, static_cast<char>(weapon_type));
+	if (!weapon) return nullptr;
 	weapon->set_team_num(team_num());
 	weapon->set_owner(this);
 	weapon->set_difficulty(static_cast<std::uint32_t>(stats_->level()));
@@ -1551,11 +1556,14 @@ bool walker::death()
 	if (myguy) // were we a real character?  Then make a heart ..
 	{
 			newob = current_game->world->add_ob(Order::Treasure, FAMILY_LIFE_GEM);
+			if (newob)
+			{
 			newob->stats()->set_hitpoints(static_cast<float>(myguy->query_heart_value()));
 			newob->stats()->set_hitpoints(
 			    newob->stats()->hitpoints() * (0.75f / 2.0f));  // 75%, divided by 2, since score is doubled at end of level
 			newob->set_team_num(team_num());
 			newob->center_on(this);
+			}
 		}
 
 	switch (order())

--- a/src/gameplay/walker.cpp
+++ b/src/gameplay/walker.cpp
@@ -1198,7 +1198,7 @@ bool walker::fire_check(short xdelta, short ydelta)
 {
 	walker  *weapon = nullptr;
 	//  short newx=0, newy=0;
-	short i;
+	std::int32_t i;
 	std::int32_t distance;
 	short targetdir;
 

--- a/src/gameplay/walker_combat.cpp
+++ b/src/gameplay/walker_combat.cpp
@@ -413,10 +413,13 @@ bool walker::attack(walker  *target)
             /* Blood splats at death */
             // Make temporary stain:
             blood = current_game->world->add_ob(Order::Weapon, FAMILY_BLOOD);
-            blood->set_team_num(target->team_num());
-            blood->set_ani_type(ANI_GROW);
-            blood->set_ignore(1); // so that we can be walked over .. ?
-            blood->setxy(target->xpos(),target->ypos());
+            if (blood)
+            {
+                blood->set_team_num(target->team_num());
+                blood->set_ani_type(ANI_GROW);
+                blood->set_ignore(1); // so that we can be walked over .. ?
+                blood->setxy(target->xpos(),target->ypos());
+            }
         }
         if (targetorder == Order::Living && positional_sound_visible(this, SOUND_DIE1))
         {

--- a/src/gameplay/weap.cpp
+++ b/src/gameplay/weap.cpp
@@ -186,13 +186,33 @@ bool weap::animate()
 	}
 	else
 	{
-		// Default animation
+		// Default animation. curdir/cycle may originate from an untrusted
+		// snapshot, so bound every index against the facing range, this
+		// family's table length, and the sequence sentinel before reading.
 			set_ani_type(0);
-			set_frame(ani[curdir()][cycle()]);
-			set_cycle(static_cast<signed char>(cycle() + 1));
-			if (ani[curdir()][cycle()] == -1)
+			int dir_index = static_cast<int>(static_cast<unsigned char>(curdir()));
+			if (dir_index < 0 || dir_index >= NUM_FACINGS)
+				dir_index = 0;
+			// ani_count>0 (real entities): bound the row; ani_count==0 (test
+			// weapons that assign `ani` directly): legacy direct index.
+			const signed char* seq =
+				(ani && (ani_count <= 0 || dir_index < ani_count)) ? ani[dir_index] : nullptr;
+			if (seq)
 			{
-				set_cycle(0);
+				int seq_len = 0;
+				while (seq_len < 128 && seq[seq_len] != -1)
+					seq_len++;
+				if (seq_len > 0 && seq_len < 128)
+				{
+					int c = static_cast<int>(cycle());
+					if (c < 0 || c >= seq_len)
+						c = 0;
+					set_frame(seq[c]);
+					c++;
+					if (seq[c] == -1)
+						c = 0;
+					set_cycle(static_cast<signed char>(c));
+				}
 			}
 	}
 

--- a/src/gameplay/world_snapshot.cpp
+++ b/src/gameplay/world_snapshot.cpp
@@ -1965,10 +1965,7 @@ void clear_entity_dirty_masks(GameWorld& world)
 
 std::uint8_t capture_bool_byte(const bool& value)
 {
-    unsigned char raw = 0;
-    static_assert(sizeof(raw) == sizeof(value));
-    std::memcpy(&raw, &value, sizeof(raw));
-    return raw != 0 ? 1U : 0U;
+    return value ? 1U : 0U;
 }
 
 void capture_world_grid(const GameWorld& world,

--- a/src/gameplay/world_snapshot.cpp
+++ b/src/gameplay/world_snapshot.cpp
@@ -2426,20 +2426,18 @@ std::vector<std::uint8_t> serialize_event_batch_message(
 }
 
 og::sim::SimEventBatch deserialize_event_batch_message(
-    const std::uint8_t* data,
-    std::size_t size,
+    std::span<const std::uint8_t> data,
     std::uint8_t message_type,
     const char* batch_name)
 {
-    if (data == nullptr || size < kMessageHeaderSize)
+    if (data.data() == nullptr || data.size() < kMessageHeaderSize)
     {
         throw std::runtime_error(std::string(batch_name) +
                                  ": truncated header");
     }
 
     og::sim::TransportEnvelope envelope;
-    if (!decode_transport_envelope(std::span<const std::uint8_t>(data, size),
-                                   envelope))
+    if (!decode_transport_envelope(data, envelope))
     {
         throw std::runtime_error(std::string(batch_name) +
                                  ": unsupported protocol version " +
@@ -2451,13 +2449,13 @@ og::sim::SimEventBatch deserialize_event_batch_message(
                                  ": unexpected message type " +
                                  std::to_string(envelope.message_type));
     }
-    if (size != kMessageHeaderSize + envelope.payload_length)
+    if (data.size() != kMessageHeaderSize + envelope.payload_length)
     {
         throw std::runtime_error(std::string(batch_name) +
                                  ": payload length mismatch");
     }
 
-    ByteReader reader(data + kMessageHeaderSize, envelope.payload_length,
+    ByteReader reader(data.data() + kMessageHeaderSize, envelope.payload_length,
                       batch_name);
     og::sim::SimEventBatch batch;
     batch.sequence = reader.read_u32("event_batch.sequence");
@@ -2491,15 +2489,14 @@ std::vector<std::uint8_t> serialize_snapshot(const WorldSnapshot& snapshot)
     return bytes;
 }
 
-WorldSnapshot deserialize_snapshot(const std::uint8_t* data, std::size_t size)
+WorldSnapshot deserialize_snapshot(std::span<const std::uint8_t> data)
 {
-    if (data == nullptr || size < kMessageHeaderSize)
+    if (data.data() == nullptr || data.size() < kMessageHeaderSize)
     {
         throw std::runtime_error("snapshot message: truncated header");
     }
     og::sim::TransportEnvelope envelope;
-    if (!decode_transport_envelope(std::span<const std::uint8_t>(data, size),
-                                   envelope))
+    if (!decode_transport_envelope(data, envelope))
     {
         throw std::runtime_error(
             "snapshot message: unsupported protocol version " +
@@ -2511,13 +2508,13 @@ WorldSnapshot deserialize_snapshot(const std::uint8_t* data, std::size_t size)
             "snapshot message: unexpected message type " +
             std::to_string(envelope.message_type));
     }
-    if (size != kMessageHeaderSize + envelope.payload_length)
+    if (data.size() != kMessageHeaderSize + envelope.payload_length)
     {
         throw std::runtime_error("snapshot message: payload length mismatch");
     }
 
     const std::vector<std::uint8_t> payload =
-        decompress_zlib_payload(data + kMessageHeaderSize, envelope.payload_length);
+        decompress_zlib_payload(data.data() + kMessageHeaderSize, envelope.payload_length);
     return deserialize_snapshot_payload(payload);
 }
 
@@ -2545,15 +2542,14 @@ std::vector<std::uint8_t> serialize_delta(const WorldSnapshot& delta)
     return bytes;
 }
 
-WorldSnapshot deserialize_delta(const std::uint8_t* data, std::size_t size)
+WorldSnapshot deserialize_delta(std::span<const std::uint8_t> data)
 {
-    if (data == nullptr || size < kMessageHeaderSize)
+    if (data.data() == nullptr || data.size() < kMessageHeaderSize)
     {
         throw std::runtime_error("delta message: truncated header");
     }
     og::sim::TransportEnvelope envelope;
-    if (!decode_transport_envelope(std::span<const std::uint8_t>(data, size),
-                                   envelope))
+    if (!decode_transport_envelope(data, envelope))
     {
         throw std::runtime_error(
             "delta message: unsupported protocol version " +
@@ -2566,7 +2562,7 @@ WorldSnapshot deserialize_delta(const std::uint8_t* data, std::size_t size)
             "delta message: unexpected message type " +
             std::to_string(envelope.message_type));
     }
-    if (size != kMessageHeaderSize + envelope.payload_length)
+    if (data.size() != kMessageHeaderSize + envelope.payload_length)
     {
         throw std::runtime_error("delta message: payload length mismatch");
     }
@@ -2588,7 +2584,7 @@ WorldSnapshot deserialize_delta(const std::uint8_t* data, std::size_t size)
         static_cast<std::size_t>(envelope.payload_length) -
         kDeltaWirePayloadHeaderSize;
     const std::uint8_t* const wire_payload =
-        data + kMessageHeaderSize + kDeltaWirePayloadHeaderSize;
+        data.data() + kMessageHeaderSize + kDeltaWirePayloadHeaderSize;
 
     std::vector<std::uint8_t> payload;
     if (payload_is_uncompressed)
@@ -2609,10 +2605,9 @@ std::vector<std::uint8_t> serialize_sim_event_batch(const SimEventBatch& batch)
                                          "sim event batch");
 }
 
-SimEventBatch deserialize_sim_event_batch(const std::uint8_t* data,
-                                          std::size_t size)
+SimEventBatch deserialize_sim_event_batch(std::span<const std::uint8_t> data)
 {
-    return deserialize_event_batch_message(data, size, kSimEventBatchMessageType,
+    return deserialize_event_batch_message(data, kSimEventBatchMessageType,
                                            "sim event batch");
 }
 
@@ -2623,11 +2618,10 @@ std::vector<std::uint8_t> serialize_game_flow_event_batch(
                                          "game flow event batch");
 }
 
-SimEventBatch deserialize_game_flow_event_batch(const std::uint8_t* data,
-                                                std::size_t size)
+SimEventBatch deserialize_game_flow_event_batch(std::span<const std::uint8_t> data)
 {
     return deserialize_event_batch_message(
-        data, size, kGameFlowEventBatchMessageType, "game flow event batch");
+        data, kGameFlowEventBatchMessageType, "game flow event batch");
 }
 
 bool is_game_flow_event(EventKind kind) noexcept

--- a/src/gameplay/world_snapshot.cpp
+++ b/src/gameplay/world_snapshot.cpp
@@ -1556,7 +1556,15 @@ void apply_entity_snapshot_fields(GameWorld& world,
     entity.path_to_foe.clear();
     entity.damage_numbers.clear();
 
-    entity.set_order_family(snapshot.order, snapshot.family);
+    // Clamp the wire-supplied family to the valid range before it becomes the
+    // entity's family(): family() indexes per-family tables (descriptors, special
+    // names, graphics) across the sim, and a malicious peer can send any value.
+    // Mirrors loader::set_walker's family clamp so family() stays consistent with
+    // the entity's configured graphics/animation.
+    int safe_family = static_cast<int>(snapshot.family);
+    if (safe_family < 0 || safe_family >= NUM_FAMILIES)
+        safe_family = 0;
+    entity.set_order_family(snapshot.order, static_cast<char>(safe_family));
     entity.set_snapshot_position(snapshot.xpos, snapshot.ypos,
                                  snapshot.worldx, snapshot.worldy);
     entity.set_sizex(snapshot.sizex);
@@ -1592,7 +1600,12 @@ void apply_entity_snapshot_fields(GameWorld& world,
     entity.set_ani_type(snapshot.ani_type);
     entity.set_cycle(snapshot.cycle);
     entity.set_drawcycle(snapshot.drawcycle);
-    entity.set_current_special(snapshot.current_special);
+    // Clamp wire-supplied current_special: it indexes per-special arrays
+    // (special names/costs, NUM_SPECIALS wide) at several use sites.
+    int safe_current_special = static_cast<int>(snapshot.current_special);
+    if (safe_current_special < 0 || safe_current_special >= NUM_SPECIALS)
+        safe_current_special = 0;
+    entity.set_current_special(static_cast<std::int8_t>(safe_current_special));
     entity.set_ignore(snapshot.ignore);
     entity.set_in_act(snapshot.in_act != 0);
     entity.set_shifter_down(snapshot.shifter_down);

--- a/src/interface/cheat_handler.cpp
+++ b/src/interface/cheat_handler.cpp
@@ -104,6 +104,8 @@ void handle_cheat_keys(walker*& control, short mynum,
 	if (query_key_event(KEYCODE_F2, native_event))
 	{
 		newob = game_screen->world().add_ob(Order::FX, FAMILY_MAGIC_SHIELD);
+		if (!newob)
+			return;
 		newob->set_owner(control);
 		newob->set_team_num(control->team_num());
 		newob->set_ani_type(1);

--- a/src/interface/cheat_handler.cpp
+++ b/src/interface/cheat_handler.cpp
@@ -104,8 +104,7 @@ void handle_cheat_keys(walker*& control, short mynum,
 	if (query_key_event(KEYCODE_F2, native_event))
 	{
 		newob = game_screen->world().add_ob(Order::FX, FAMILY_MAGIC_SHIELD);
-		if (!newob)
-			return;
+		if (!newob) return;
 		newob->set_owner(control);
 		newob->set_team_num(control->team_num());
 		newob->set_ani_type(1);

--- a/src/interface/guy_create.cpp
+++ b/src/interface/guy_create.cpp
@@ -36,13 +36,11 @@ std::unique_ptr<walker> guy_create_walker_owned(guy& g, screen* screen_)
 
 walker* guy_create_and_add_walker(guy& g, screen* screen_)
 {
-    if (!screen_)
-        return nullptr;
+    if (!screen_) return nullptr;
 
     auto temp_guy = std::make_unique<guy>(g);
     walker* temp_walker = screen_->world().add_ob(Order::Living, temp_guy->family);
-    if (!temp_walker)
-        return nullptr;
+    if (!temp_walker) return nullptr;
     temp_walker->set_owned_myguy(std::move(temp_guy));
     temp_walker->stats()->set_level(temp_walker->myguy->level);
 

--- a/src/interface/guy_create.cpp
+++ b/src/interface/guy_create.cpp
@@ -36,8 +36,13 @@ std::unique_ptr<walker> guy_create_walker_owned(guy& g, screen* screen_)
 
 walker* guy_create_and_add_walker(guy& g, screen* screen_)
 {
+    if (!screen_)
+        return nullptr;
+
     auto temp_guy = std::make_unique<guy>(g);
     walker* temp_walker = screen_->world().add_ob(Order::Living, temp_guy->family);
+    if (!temp_walker)
+        return nullptr;
     temp_walker->set_owned_myguy(std::move(temp_guy));
     temp_walker->stats()->set_level(temp_walker->myguy->level);
 

--- a/src/interface/input/input.cpp
+++ b/src/interface/input/input.cpp
@@ -26,6 +26,7 @@
 #include <openglad/interface/input_hardware_state.h>
 #include <openglad/core/util.h>
 #include <openglad/core/test_trace.h>
+#include <algorithm> //buffers: for std::min when clamping joystick counts
 #include <cstdio>
 #include <ctime>
 #include <cstring> //buffers: for strlen
@@ -129,14 +130,15 @@ void init_input()
         joysticks[i] = nullptr;
     }
 
-    const int numjoy = og::input_native::num_joysticks();
+    const int numjoy = std::min(og::input_native::num_joysticks(), MAX_NUM_JOYSTICKS);
 
     for(int i = 0; i < numjoy; i++)
     {
         joysticks[i] = og::input_native::joystick_open(i);
         if(joysticks[i] == nullptr)
             continue;
-        player_joy[i] = JoyData(i);
+        if(i < 4) // player_joy has only 4 slots
+            player_joy[i] = JoyData(i);
     }
 
     og::input_native::joystick_set_event_state(true);
@@ -679,6 +681,8 @@ void wait_for_key(int somekey)
 JoyData::JoyData(int joy_index)
     : index(-1), numAxes(0), numButtons(0), numHats(0)
 {
+    if(joy_index < 0 || joy_index >= MAX_NUM_JOYSTICKS)
+        return;
     const og::input_native::JoystickHandle js = joysticks[joy_index];
     if(js == nullptr)
         return;
@@ -827,7 +831,7 @@ void JoyData::setKeyFromEvent(int key_enum, const void* native_event)
 
 bool JoyData::getState(int key_enum) const
 {
-    if(index < 0)
+    if(index < 0 || index >= MAX_NUM_JOYSTICKS)
         return false;
     switch(key_type[key_enum])
     {
@@ -857,7 +861,7 @@ bool JoyData::getState(int key_enum) const
 
 bool JoyData::getPress(int key_enum, const void* native_event) const
 {
-    if(index < 0)
+    if(index < 0 || index >= MAX_NUM_JOYSTICKS)
         return false;
     og::input_native::EventData event;
     if (!as_event_data(native_event, event))
@@ -904,7 +908,7 @@ bool JoyData::getPress(int key_enum, const void* native_event) const
 
 bool JoyData::getRelease(int key_enum, const void* native_event) const
 {
-    if(index < 0)
+    if(index < 0 || index >= MAX_NUM_JOYSTICKS)
         return false;
     og::input_native::EventData event;
     if (!as_event_data(native_event, event))
@@ -968,7 +972,7 @@ void resetJoystick(int player_num)
         joysticks[i] = nullptr;
     }
 
-    int numjoy = og::input_native::num_joysticks();
+    int numjoy = std::min(og::input_native::num_joysticks(), MAX_NUM_JOYSTICKS);
     for(int i = 0; i < numjoy; i++)
     {
         joysticks[i] = og::input_native::joystick_open(i);

--- a/src/interface/input/input.cpp
+++ b/src/interface/input/input.cpp
@@ -765,6 +765,7 @@ void JoyData::setKeyFromEvent(int key_enum, const void* native_event)
     og::input_native::EventData event;
     if (!as_event_data(native_event, event))
         return;
+    if (key_enum < 0 || key_enum >= NUM_KEYS) return;  // key_type/key_index are sized NUM_KEYS
 
     // Diagonals are ignored because they are combinations of the cardinals
     // Things get really messy when diagonals are assigned
@@ -1069,6 +1070,8 @@ bool isPlayerHoldingKey(int player_index, int key_enum)
     
     // FIXME: Enable gamepads for Android/iOS, but be careful not to use accelerometer...
     #ifdef USE_TOUCH_INPUT
+        if (player_index < 0 || player_index >= 4 || key_enum < 0 || key_enum >= NUM_KEYS)
+            return false;
         return hw().touch_keystate[player_index][key_enum];
     #else
     if(player_joy[player_index].hasButtonSet(key_enum))

--- a/src/interface/level_runtime_data.cpp
+++ b/src/interface/level_runtime_data.cpp
@@ -961,7 +961,10 @@ void LevelRuntimeData::draw(screen* screenp)
 
 std::string LevelRuntimeData::get_description_line(int i) const
 {
-    if(i >= int(description.size()))
+    // Guard the empty-list case explicitly: with a negative i the size check
+    // below is bypassed and *begin() would dereference end() on an empty list.
+    // A non-empty list with negative i still returns the first line (tested).
+    if(description.empty() || i >= int(description.size()))
         return "";
 
     std::list<std::string>::const_iterator e = description.begin();

--- a/src/interface/render/pixie.cpp
+++ b/src/interface/render/pixie.cpp
@@ -89,7 +89,7 @@ void pixie::set_data(const PixieData& data)
 	bmp = data.data.get();
 	sizex = data.w;
 	sizey = data.h;
-	size = (unsigned short) (sizex*sizey);
+	size = static_cast<unsigned short>(sizex*sizey);
 }
 
 // Set the pixie's x and y positon without drawing.

--- a/src/interface/render/pixien.cpp
+++ b/src/interface/render/pixien.cpp
@@ -76,6 +76,9 @@ short pixieN::set_frame(short framenum)
 
 short pixieN::next_frame()
 {
+	// frames can be 0 for a default/moved-from pixie; guard the modulo to avoid
+	// integer division-by-zero UB. set_frame already rejects out-of-range here.
+	if (frames <= 0) return 0;
 	return set_frame(frame++ % frames);
 }
 

--- a/src/interface/render/radar.cpp
+++ b/src/interface/render/radar.cpp
@@ -112,7 +112,7 @@ void radar::sync_to_grid(LevelRuntimeData* data)
 {
 	sizex = static_cast<unsigned short>(data->world().grid.w);
 	sizey = static_cast<unsigned short>(data->world().grid.h);
-	size = (unsigned short) ((static_cast<unsigned short>(sizex))*(static_cast<unsigned short>(sizey)));
+	size = static_cast<unsigned short>((static_cast<unsigned short>(sizex))*(static_cast<unsigned short>(sizey)));
 	xview = RADAR_X;
 	yview = RADAR_Y;
 	radarx = 0;

--- a/src/interface/render/radar.cpp
+++ b/src/interface/render/radar.cpp
@@ -222,7 +222,7 @@ short radar::draw(LevelRuntimeData* data)
     }
 	{
 		size_t offset = radarx + (radary * sizex);
-		auto radar_span = std::span<const unsigned char>{bmp.data() + offset, static_cast<size_t>(sizex * sizey) - offset};
+		auto radar_span = std::span<const unsigned char>{bmp.data() + offset, bmp.size() - offset};
 		og::runtime::current_session->myscreen_->putbuffer_alpha(xloc, yloc,
 		                   sizex,sizey,
 		                   xloc,yloc,xloc + xview,yloc + yview,

--- a/src/interface/render/text.cpp
+++ b/src/interface/render/text.cpp
@@ -114,8 +114,6 @@ Sint32 text::write_xy(Sint32 x, Sint32 y, std::string_view string, unsigned char
 	return 1;
 }
 
-static char text_buffer[255];
-
 Sint32 text::write_formatted(Sint32 x, Sint32 y, const char* str,
                               unsigned char color, bool center, bool shadow,
                               bool use_alpha, Uint8 alpha)
@@ -138,6 +136,7 @@ Sint32 text::write_formatted(Sint32 x, Sint32 y, const char* str,
 }
 
 #define TEXT_VFORMAT()                                                     \
+    char text_buffer[256];                                                 \
     do {                                                                   \
         if (!formatted_string) return 0;                                   \
         va_list lst;                                                       \

--- a/src/interface/render/view.cpp
+++ b/src/interface/render/view.cpp
@@ -300,12 +300,7 @@ viewscreen::~viewscreen()
 
 void viewscreen::clear()
 {
-	unsigned short i;
-
-	for (i=0;i<64000;i++)
-	{
-		active_screen()->videobuffer[i] = 0;
-	}
+	active_screen()->videobuffer.fill(0);
 }
 
 bool viewscreen::redraw()

--- a/src/interface/render/view.cpp
+++ b/src/interface/render/view.cpp
@@ -1630,6 +1630,7 @@ options::options()
 short options::load(viewscreen *viewp)
 {
 	short prefnum = viewp->mynum;
+	if (prefnum < 0 || prefnum >= 4) return 0;  // prefs/allkeys are sized for 4 views
 	// Yes, we are ACTUALLY COPYING the data
 	std::copy_n(prefs[prefnum], 10, viewp->prefs);
 	std::copy_n(allkeys()[prefnum], 16, viewp->mykeys);

--- a/src/interface/render/walker_draw.cpp
+++ b/src/interface/render/walker_draw.cpp
@@ -665,7 +665,7 @@ bool draw_walker_tile(walker& w, viewscreen* view_buf)
 		                        0, //outline
 		                        SHIFT_RANDOM); //type of phantom
 
-	else if (w.invisibility_left())  //WE ARE INVISIBLE
+	else if (w.invisibility_left() && view_buf->control != nullptr)  //WE ARE INVISIBLE
 	{
 		if (w.team_num() == view_buf->control->team_num())
 			og::runtime::current_session->myscreen_->walkputbuffer( xscreen, yscreen, w.sizex(), w.sizey(),

--- a/src/interface/replay_runtime.cpp
+++ b/src/interface/replay_runtime.cpp
@@ -10,7 +10,6 @@
 #include <openglad/resources/io_common.h>
 
 #include <algorithm>
-#include <cctype>
 #include <vector>
 
 namespace
@@ -131,18 +130,6 @@ std::filesystem::path replay_output_path()
     return std::filesystem::path(replay_dir) / kLatestReplayFilename;
 }
 
-bool is_safe_replay_campaign_id(std::string_view campaign_id)
-{
-    if (campaign_id.empty())
-        return false;
-
-    return std::all_of(campaign_id.begin(),
-                       campaign_id.end(),
-                       [](unsigned char ch) {
-                           return std::isalnum(ch) || ch == '.' || ch == '_' ||
-                               ch == '-';
-                       });
-}
 } // namespace
 
 bool og::runtime::initialize_replay_screen(screen& game_screen,
@@ -151,7 +138,7 @@ bool og::runtime::initialize_replay_screen(screen& game_screen,
     const og::sim::ReplayHeader& header = player.header();
     const og::sim::WorldSnapshot& initial_snapshot = player.initial_snapshot();
 
-    if (!is_safe_replay_campaign_id(header.campaign_id))
+    if (!is_safe_campaign_id(header.campaign_id))
         return false;
 
     if (mount_campaign_package_with_error(header.campaign_id) !=
@@ -210,7 +197,7 @@ void og::runtime::begin_replay_recording(screen& game_screen)
     og::runtime::current_session->replay_output_path_.clear();
 
     const std::string& campaign_id = game_screen.save_data.current_campaign;
-    if (!is_safe_replay_campaign_id(campaign_id))
+    if (!is_safe_campaign_id(campaign_id))
         return;
 
     og::runtime::current_session->replay_output_path_ = replay_output_path();

--- a/src/interface/score_panel.cpp
+++ b/src/interface/score_panel.cpp
@@ -315,12 +315,25 @@ short new_score_panel(screen* s, short /*do_it*/)
             tempfoes = remaining_foes(s, control);
             tempallies = remaining_team(s, control->team_num());
 
+            // family()/current_special() may be attacker-controlled on a
+            // network mirror (set from raw int8 snapshot bytes), so they can be
+            // any value in [-128,127]. Clamp before using them to index the
+            // fixed namelist/special_name/alternate_name/special_cost arrays to
+            // prevent out-of-bounds reads. In-range values pass through
+            // unchanged.
+            int fam = static_cast<int>(control->family());
+            if (fam < 0 || fam >= NUM_FAMILIES)
+                fam = 0;
+            int spc = static_cast<int>(control->current_special());
+            if (spc < 0 || spc >= NUM_SPECIALS)
+                spc = 0;
+
             if (control->myguy)
                 tempname = control->myguy->name;
             else if (!control->stats()->name.empty())
                 tempname = control->stats()->name;
             else
-                tempname = namelist[static_cast<int>(control->family())];
+                tempname = namelist[fam];
 
             message = tempname;
 
@@ -406,21 +419,21 @@ short new_score_panel(screen* s, short /*do_it*/)
                 }
 
                 if (control->shifter_down() &&
-                    s->alternate_name[static_cast<int>(control->family())][static_cast<int>(control->current_special())] != "NONE")
-                    message = std::format("SPC: {}", s->alternate_name[static_cast<int>(control->family())][static_cast<int>(control->current_special())]);
+                    s->alternate_name[fam][spc] != "NONE")
+                    message = std::format("SPC: {}", s->alternate_name[fam][spc]);
                 else
-                    message = std::format("SPC: {}", s->special_name[static_cast<int>(control->family())][static_cast<int>(control->current_special())]);
+                    message = std::format("SPC: {}", s->special_name[fam][spc]);
 
-                if (control->stats()->magicpoints() >= control->stats()->special_cost(static_cast<int>(control->current_special())))
+                if (control->stats()->magicpoints() >= control->stats()->special_cost(spc))
                     mytext.write_xy(lm+2, special_y, message.c_str(), text_color, static_cast<short>(1));
                 else
                     mytext.write_xy(lm+2, special_y, message.c_str(), static_cast<unsigned char>(RED), static_cast<short>(1));
 
 #ifdef USE_TOUCH_INPUT
-                if (s->alternate_name[static_cast<int>(control->family())][static_cast<int>(control->current_special())] != "NONE")
+                if (s->alternate_name[fam][spc] != "NONE")
                 {
-                    message = std::format("ALT: {}", s->alternate_name[static_cast<int>(control->family())][static_cast<int>(control->current_special())]);
-                    if (control->stats()->magicpoints() >= control->stats()->special_cost(static_cast<int>(control->current_special())))
+                    message = std::format("ALT: {}", s->alternate_name[fam][spc]);
+                    if (control->stats()->magicpoints() >= control->stats()->special_cost(spc))
                         mytext.write_xy(lm+2, bm + special_offset + 8, message.c_str(), text_color, static_cast<short>(1));
                     else
                         mytext.write_xy(lm+2, bm + special_offset + 8, message.c_str(), static_cast<unsigned char>(RED), static_cast<short>(1));

--- a/src/interface/screen.cpp
+++ b/src/interface/screen.cpp
@@ -388,7 +388,6 @@ bool dispatch_game_flow_screen_events(screen& self,
 loader* sdl_entity_loader();
 
 // Screen window boundries
-inline constexpr int MAX_VIEWS = 5;
 inline constexpr int S_UP = 0;
 inline constexpr int S_LEFT = 0;
 inline constexpr int S_DOWN = 200;
@@ -956,6 +955,7 @@ void screen::initialize_views()
 	else
     {
         LogError("screen_init_views_failed numviews={}\n", numviews);
+        numviews = 0; // no views created for an unsupported count; keep per-frame loops in-bounds
     }
 }
 
@@ -1029,11 +1029,15 @@ void screen::reset(short howmany)
 		viewob[2] = std::make_unique<viewscreen>( 112, 16, 100, 168, 2);
 		viewob[3] = std::make_unique<viewscreen>( 112, 16, 100, 168, 3);
 	}
+	else
+	{
+		numviews = 0; // no views created for an unsupported count; keep per-frame loops in-bounds
+	}
 
 	world_.end = 0;
 
 	redrawme = 1;
-	
+
 	save_data.reset();
 	level_runtime_data_.clear();
 	sync_world_from_save_data();

--- a/src/interface/ui/button.cpp
+++ b/src/interface/ui/button.cpp
@@ -138,6 +138,21 @@ vbutton::vbutton(Sint32 xpos, Sint32 ypos, Sint32 wide, Sint32 high,
 
 vbutton::vbutton() //for pointers
 {
+    // Zero-initialize every integral member so a default-constructed vbutton
+    // (intended only as a pointer placeholder) never carries indeterminate
+    // values into mouse_on()/vdisplay()/leftclick() if accidentally used.
+    xloc = 0;
+    yloc = 0;
+    width = 0;
+    height = 0;
+    xend = 0;
+    yend = 0;
+    myfunc = 0;
+    arg = 0;
+    hotkey = 0;
+    color = 0;
+    hidden = false;
+    no_draw = false;
     had_focus = do_outline = depressed = 0;
     mypixie = nullptr;
 }

--- a/src/interface/ui/button.cpp
+++ b/src/interface/ui/button.cpp
@@ -272,7 +272,8 @@ Sint32 vbutton::leftclick(button* buttons)
     }
     // Now normal click ..
     whichone = 0;
-    while (og::runtime::current_session->allbuttons_[whichone])
+    while (whichone < static_cast<Sint32>(og::runtime::current_session->allbuttons_.size())
+           && og::runtime::current_session->allbuttons_[whichone])
     {
         if(buttons == nullptr || !buttons[whichone].hidden)
         {
@@ -289,7 +290,8 @@ Sint32 vbutton::rightclick(button* buttons)
 {
     Sint32 whichone=0;
     Sint32 retvalue=0;
-    while (og::runtime::current_session->allbuttons_[whichone])
+    while (whichone < static_cast<Sint32>(og::runtime::current_session->allbuttons_.size())
+           && og::runtime::current_session->allbuttons_[whichone])
     {
         if(buttons == nullptr || !buttons[whichone].hidden)
         {

--- a/src/interface/ui/button.cpp
+++ b/src/interface/ui/button.cpp
@@ -415,7 +415,12 @@ vbutton * init_buttons(button * buttons, Sint32 numbuttons)
 
     clear_allbuttons();
 
-    for (Sint32 i = 0; i < numbuttons; i++)
+    // allbuttons_/owned_buttons_ are fixed-capacity arrays. Every current caller
+    // passes a small literal count, but clamp to the real capacity so a future
+    // or garbage count can never drive an out-of-bounds store.
+    const Sint32 cap = static_cast<Sint32>(og::runtime::current_session->allbuttons_.size());
+    const Sint32 limit = (numbuttons < 0) ? 0 : (numbuttons > cap ? cap : numbuttons);
+    for (Sint32 i = 0; i < limit; i++)
     {
         std::unique_ptr<vbutton, og::runtime::VButtonDeleter> owned_button(
             new vbutton(buttons[i].x,buttons[i].y,

--- a/src/interface/ui/button.cpp
+++ b/src/interface/ui/button.cpp
@@ -259,7 +259,8 @@ Sint32 vbutton::leftclick(button* buttons)
     Sint32 whichone=0;
     Sint32 retvalue=0;
     // First check hotkeys ...
-    while (og::runtime::current_session->allbuttons_[whichone])
+    while (whichone < static_cast<Sint32>(og::runtime::current_session->allbuttons_.size())
+           && og::runtime::current_session->allbuttons_[whichone])
     {
         if(buttons == nullptr || !buttons[whichone].hidden)
         {

--- a/src/interface/ui/help.cpp
+++ b/src/interface/ui/help.cpp
@@ -313,28 +313,23 @@ static bool load_help_file(const char* filename, std::vector<std::string>& lines
 		return false;
 	}
 
-	char line_buf[HELP_WIDTH];
+	std::string line_buf;
 	char ch = '\0';
-	int pos = 0;
 
 	while (true)
 	{
 		if (!og::io::og_read_exact(*infile, &ch, 1, 1))
 		{
 			// End of file - save any remaining content
-			if (pos > 0)
-			{
-				line_buf[pos] = '\0';
-				lines.push_back(std::string(line_buf));
-			}
+			if (!line_buf.empty())
+				lines.push_back(std::move(line_buf));
 			break;
 		}
 
 		if (ch == '\n' || ch == '\r')
 		{
-			line_buf[pos] = '\0';
-			lines.push_back(std::string(line_buf));
-			pos = 0;
+			lines.push_back(std::move(line_buf));
+			line_buf.clear();
 
 			// Handle \r\n line endings
 			if (ch == '\r')
@@ -346,9 +341,9 @@ static bool load_help_file(const char* filename, std::vector<std::string>& lines
 				}
 			}
 		}
-		else if (pos < HELP_WIDTH - 1)
+		else if (line_buf.size() < static_cast<std::size_t>(HELP_WIDTH - 1))
 		{
-			line_buf[pos++] = ch;
+			line_buf.push_back(ch);
 		}
 	}
 	return true;

--- a/src/interface/ui/intro.cpp
+++ b/src/interface/ui/intro.cpp
@@ -67,7 +67,6 @@ void intro_main(Sint32 argc, char** argv)
 	gladiator.drawMix(120,55,og::runtime::current_session->myscreen_->viewob[0].get());
 	mytext.write_y(100,"FORGOTTEN SAGES PRESENTS", 230, og::runtime::current_session->myscreen_->viewob[0].get());
 	//myscreen->refresh();
-	gladdata.free();
 
 	if (show() < 0)
 	{
@@ -84,9 +83,6 @@ void intro_main(Sint32 argc, char** argv)
 	//gladiator->drawMix(110,65,myscreen->viewob[0].get());
 	gladiator2.drawMix(100, 110, og::runtime::current_session->myscreen_->viewob[0].get());
 	//myscreen->refresh();
-
-	gladdata.free();
-	bigdata.free();
 
 	if (show() < 0)
 	{
@@ -124,25 +120,21 @@ void intro_main(Sint32 argc, char** argv)
 	pixie ul(uldata);
 	ul.setxy(41, 12);
 	ul.draw(og::runtime::current_session->myscreen_->viewob[0].get());
-	uldata.free();
 
 	urdata = read_pixie_file("game2ur.png");
 	pixie ur(urdata);
 	ur.setxy(160, 12);
 	ur.draw(og::runtime::current_session->myscreen_->viewob[0].get());
-	urdata.free();
 
 	lldata = read_pixie_file("game2ll.png");
 	pixie ll(lldata);
 	ll.setxy(41, 103);
 	ll.draw(og::runtime::current_session->myscreen_->viewob[0].get());
-	lldata.free();
 
 	lrdata = read_pixie_file("game2lr.png");
 	pixie lr(lrdata);
 	lr.setxy(160, 103);
 	lr.draw(og::runtime::current_session->myscreen_->viewob[0].get());
-	lrdata.free();
 
 	//myscreen->refresh();
 
@@ -171,13 +163,11 @@ void intro_main(Sint32 argc, char** argv)
 	pixie ul2(uldata);
 	ul2.setxy(0, 0);
 	ul2.draw(og::runtime::current_session->myscreen_->viewob[0].get());
-	uldata.free();
 
 	lldata = read_pixie_file("game5.png");
 	pixie ll2(lldata);
 	ll2.setxy(160, 78);
 	ll2.draw(og::runtime::current_session->myscreen_->viewob[0].get());
-	lldata.free();
 
 	message = "Additional Artwork By:";
 	mytext.write_xy(310-mytext.query_width(message),

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -467,7 +467,7 @@ public:
     }
 };
 
-std::string get_editor_family_label(Order order, Sint32 family, char livings[][20], const char* treasures[], const char* weapons[]);
+std::string get_editor_family_label(Order order, Sint32 family, std::span<const std::string> livings, const char* treasures[], const char* weapons[]);
 std::string get_editor_level_label(Order order, Sint32 family, Sint32 level);
 
 class LevelEditorData
@@ -549,7 +549,14 @@ public:
     
     LevelEditorData();
     ~LevelEditorData();
-    
+
+    // Self-referential: menu_buttons et al. store raw pointers to SimpleButton
+    // members of this same object, so copying/moving would dangle them.
+    LevelEditorData(const LevelEditorData&) = delete;
+    LevelEditorData& operator=(const LevelEditorData&) = delete;
+    LevelEditorData(LevelEditorData&&) = delete;
+    LevelEditorData& operator=(LevelEditorData&&) = delete;
+
     bool loadCampaign(const std::string& id);
     bool reloadCampaign();
     
@@ -1345,15 +1352,12 @@ Sint32 LevelEditorData::display_panel(screen* s)
 	      "PROTECTION", "HAMMER", "DOOR",
 	    };
 
-	static char livings[NUM_FAMILIES][20] = {};
+	static std::array<std::string, NUM_FAMILIES> livings;
 	static bool livings_init = false;
 	if (!livings_init) {
 	    for (int family_index = 0; family_index < NUM_FAMILIES; family_index++) {
 	        const auto* fd = get_family_descriptor(family_index);
-	        if (fd && fd->name)
-	            snprintf(livings[family_index], 20, "%s", fd->name);
-	        else
-	            snprintf(livings[family_index], 20, "BEAST");
+	        livings[family_index] = (fd && fd->name) ? fd->name : "BEAST";
 	    }
 	    livings_init = true;
 	}
@@ -3340,13 +3344,13 @@ int level_editor_test_exercise_internal_helpers()
 // GCOVR_EXCL_STOP
 #endif
 
-std::string get_editor_family_label(Order order, Sint32 family, char livings[][20], const char* treasures[], const char* weapons[])
+std::string get_editor_family_label(Order order, Sint32 family, std::span<const std::string> livings, const char* treasures[], const char* weapons[])
 {
     if(family < 0 || family >= NUM_FAMILIES)
         return "UNKNOWN";
 
     if (order == Order::Living)
-        return livings[family];
+        return livings[static_cast<std::size_t>(family)];
     if (order == Order::Generator)
     {
         switch (family)
@@ -3495,6 +3499,10 @@ EventType handle_basic_editor_event(const void* native_event)
 Sint32 level_editor()
 {
     static LevelEditorData data;
+    // Refresh radar pointers in case the session's viewscreen was rebuilt
+    // since this static was first constructed (avoids a dangling viewscreen*).
+    data.myradar.viewscreenp = og::runtime::current_session->myscreen_->viewob[0].get();
+    data.myradar.screenp = og::runtime::current_session->myscreen_;
     EditorTerrainBrush& terrain_brush = data.terrain_brush;
     EditorObjectBrush& object_brush = data.object_brush;
     

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -3361,9 +3361,9 @@ std::string get_editor_family_label(Order order, Sint32 family, char livings[][2
     if (order == Order::Special)
         return "START TILE";
     if (order == Order::Treasure)
-        return treasures[family];
+        return treasures[family] ? treasures[family] : "UNKNOWN";
     if (order == Order::Weapon)
-        return weapons[family];
+        return weapons[family] ? weapons[family] : "UNKNOWN";
     return "UNKNOWN";
 }
 

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -1435,6 +1435,9 @@ Sint32 LevelEditorData::display_panel(screen* s)
     {
         // Show the current brush
         {
+            // Defensive: never index pixdata[] (size PIX_MAX) out of bounds.
+            if(terrain_brush.terrain < 0 || terrain_brush.terrain >= PIX_MAX)
+                terrain_brush.terrain = PIX_GRASS1;
             auto& pix = s->level_visuals_.pixdata[terrain_brush.terrain];
             s->putbuffer(lm+25, PIX_TOP-16-1, GRID_SIZE, GRID_SIZE,
                                 0, 0, 320, 200, {pix.data.get(), static_cast<size_t>(pix.w * pix.h * pix.frames)});
@@ -2743,8 +2746,12 @@ unsigned char LevelEditorData::get_terrain(int x, int y)
 {
     if(!is_in_grid(x, y))
         return 0;
-    
-    return level->world().grid.data[y*level->world().grid.w + x];
+
+    // Grid bytes come from untrusted scenario files and are not clamped on load
+    // (the renderer guards tile_index < PIX_MAX, so out-of-range tiles survive).
+    // Clamp here so a poisoned tile can never become an out-of-bounds pixdata[] index.
+    unsigned char t = level->world().grid.data[y*level->world().grid.w + x];
+    return (t < PIX_MAX) ? t : static_cast<unsigned char>(PIX_GRASS1);
 }
 
 void LevelEditorData::set_terrain(int x, int y, unsigned char terrain)

--- a/src/interface/ui/level_editor_ui.cpp
+++ b/src/interface/ui/level_editor_ui.cpp
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <list>
 #include <string>
+#include <utility>
 #include <vector>
 
 // myscreen is now a macro defined in base.h (via game_session.h)
@@ -333,7 +334,7 @@ bool prompt_for_string_block(const std::string& message, std::list<std::string>&
             if(temptext != nullptr)
             {
                 s->insert(cursor_pos, temptext);
-                cursor_pos += static_cast<int>(strlen(temptext));
+                cursor_pos += strlen(temptext);
             }
         }
 		
@@ -411,12 +412,12 @@ bool prompt_for_string(const std::string& message, std::string& result)
     
     screen_ctx->draw_button(x - 5, y - 20, x + w + 10, y + h + 10, 1);
     
-    char* str = screen_ctx->text_normal.input_string_ex(x, y, max_chars, message.c_str(), result.c_str());
-    
-    if(str == nullptr)
+    auto str_opt = screen_ctx->text_normal.input_string_ex_value(x, y, max_chars, message.c_str(), result.c_str());
+
+    if(!str_opt)
         return false;
-    
-    result = str;
+
+    result = std::move(*str_opt);
     return true;
 }
 

--- a/src/interface/ui/level_picker.cpp
+++ b/src/interface/ui/level_picker.cpp
@@ -120,6 +120,7 @@ void getLevelStats(LevelRuntimeData& level_data, int* max_enemy_level, float* av
 		for (auto& uptr : level_data.world().oblist)
 		{
 		    walker* ob = uptr.get();
+		    if (!ob) continue;
 	        switch(ob->query_order())
 	        {
 	            case Order::Living:
@@ -145,6 +146,7 @@ void getLevelStats(LevelRuntimeData& level_data, int* max_enemy_level, float* av
 		for (auto& uptr : level_data.world().fxlist)
 		{
 		    walker* ob = uptr.get();
+		    if (!ob) continue;
 	        switch(ob->query_order())
 	        {
 	            case Order::Treasure:
@@ -238,7 +240,7 @@ class BrowserEntry
     float difficulty;
     std::list<int> exits;
     std::string scentext[80];                       // Array to hold scenario information
-    char scentextlines;                    // How many lines of text in scenario info
+    int scentextlines = 0;                 // How many lines of text in scenario info
     
     BrowserEntry(screen* screenp, int index, int scen_num);
     ~BrowserEntry();
@@ -277,7 +279,7 @@ BrowserEntry::BrowserEntry(screen* screenp, int index, int scen_num)
         level_name = level_name.substr(0, 20) + "...";
     }
     
-	    scentextlines = static_cast<char>(std::min<size_t>(level_data.description.size(), 80u));
+	    scentextlines = static_cast<int>(std::min<size_t>(level_data.description.size(), 80u));
     int i = 0;
     for(auto& line : level_data.description)
     {

--- a/src/interface/ui/level_picker.cpp
+++ b/src/interface/ui/level_picker.cpp
@@ -368,11 +368,17 @@ int pick_level(screen *screenp, int default_level, bool enable_delete)
         if(level_list[i] == default_level)
             current_level_index = i;
     }
-    
+
+    // Clamp so a full NUM_BROWSE_RADARS window fits (mirrors the delete-reload
+    // clamp below); otherwise current_level_index + i can index past the end of
+    // level_list in the initial radar-load loop (out-of-bounds read).
+    if(current_level_index > level_list_length - NUM_BROWSE_RADARS)
+        current_level_index = std::max(0, level_list_length - NUM_BROWSE_RADARS);
+
     // Load the radars (minimaps)
     for(int i = 0; i < NUM_BROWSE_RADARS; i++)
     {
-        if(i < level_list_length)
+        if(current_level_index + i < level_list_length)
             entries[i] = std::make_unique<BrowserEntry>(og::runtime::current_session->myscreen_, i, level_list[current_level_index + i]);
         else
             entries[i].reset();

--- a/src/interface/ui/level_picker.cpp
+++ b/src/interface/ui/level_picker.cpp
@@ -239,7 +239,7 @@ class BrowserEntry
     int num_enemies;
     float difficulty;
     std::list<int> exits;
-    std::string scentext[80];                       // Array to hold scenario information
+    std::array<std::string, 80> scentext;           // Array to hold scenario information
     int scentextlines = 0;                 // How many lines of text in scenario info
     
     BrowserEntry(screen* screenp, int index, int scen_num);
@@ -283,7 +283,7 @@ BrowserEntry::BrowserEntry(screen* screenp, int index, int scen_num)
     int i = 0;
     for(auto& line : level_data.description)
     {
-        scentext[i] = line;
+        scentext[static_cast<std::size_t>(i)] = line;
         i++;
         if(i >= 80)
             break;
@@ -685,7 +685,7 @@ int pick_level(screen *screenp, int default_level, bool enable_delete)
             {
                 if(prev.y + 20 + 10*i+1 > descbox.y + descbox.h)
                     break;
-                loadtext.write_xy(descbox.x, descbox.y + 10*i+1, entries[selected_entry]->scentext[i].c_str(), BLACK, 1);
+                loadtext.write_xy(descbox.x, descbox.y + 10*i+1, entries[selected_entry]->scentext[static_cast<std::size_t>(i)].c_str(), BLACK, 1);
             }
         }
         

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -2068,7 +2068,13 @@ Sint32 create_detail_menu(guy *arg1)
        picker_lobby_poll();
        guy* thisguy = arg1;
        if (!thisguy)
-           thisguy = og::runtime::current_session->myscreen_->save_data.team_list[og::runtime::current_session->editguy_].get();
+       {
+           auto& tl = og::runtime::current_session->myscreen_->save_data.team_list;
+           const int slot = og::runtime::current_session->editguy_;
+           if (slot < 0 || slot >= static_cast<int>(tl.size()))
+               return MENU_REDRAW;
+           thisguy = tl[slot].get();
+       }
        if (!thisguy)
            return MENU_REDRAW;
 
@@ -2115,7 +2121,8 @@ Sint32 create_detail_menu(guy *arg1)
        og::runtime::current_session->myscreen_->draw_text_bar(36, 10, 124, 22);
        
        text& mytext = og::runtime::current_session->myscreen_->text_normal;
-       mytext.write_xy(80 - mytext.query_width(og::runtime::current_session->current_guy_->name.c_str())/2, 14,
+       if (og::runtime::current_session->current_guy_)
+           mytext.write_xy(80 - mytext.query_width(og::runtime::current_session->current_guy_->name.c_str())/2, 14,
                         og::runtime::current_session->current_guy_->name.c_str(),static_cast<unsigned char>(DARK_BLUE), 1);
        og::runtime::current_session->myscreen_->draw_dialog(5, 68, 315, 167, "Character Special Abilities");
        og::runtime::current_session->myscreen_->draw_text_bar(160, 90, 162, 160);

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -1882,7 +1882,8 @@ Sint32 set_player_mode(Sint32 howmany)
     g_start_game_requested = false;
     picker_lobby_set_player_mode(howmany);
 
-	while (og::runtime::current_session->allbuttons_[count])
+	while (count < static_cast<Sint32>(og::runtime::current_session->allbuttons_.size())
+	       && og::runtime::current_session->allbuttons_[count])
 	{
 		og::runtime::current_session->allbuttons_[count]->vdisplay();
 		count++;

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -114,7 +114,8 @@ void destroy_picker_pixie(pixieN* pixie)
 PickerPixieHandle make_picker_pixie(const PixieData& data)
 {
     PickerPixieHandle handle;
-    handle.reset(new pixieN(data), destroy_picker_pixie);
+    auto up = std::make_unique<pixieN>(data);
+    handle.reset(up.release(), destroy_picker_pixie);
     return handle;
 }
 } // namespace
@@ -2225,9 +2226,11 @@ Sint32 set_difficulty()
        og::runtime::current_session->myscreen_->world().difficulty = percent;
    std::string msg = og::ui::format_difficulty_label(og::runtime::current_session->current_difficulty_);
    #ifndef DISABLE_MULTIPLAYER
-   og::runtime::current_session->allbuttons_[6]->label = msg;
+   if (og::runtime::current_session->allbuttons_[6] != nullptr)
+       og::runtime::current_session->allbuttons_[6]->label = msg;
    #else
-   og::runtime::current_session->allbuttons_[2]->label = msg;
+   if (og::runtime::current_session->allbuttons_[2] != nullptr)
+       og::runtime::current_session->allbuttons_[2]->label = msg;
    #endif
 
    //allbuttons[6]->vdisplay();
@@ -2264,7 +2267,8 @@ Sint32 change_teamnum(Sint32 arg)
    og::runtime::current_session->current_guy_->teamnum = static_cast<short>(current_team);
 
    // Update our button display
-   og::runtime::current_session->allbuttons_[18]->label = std::format("Playing on Team {}", current_team + 1);
+   if (og::runtime::current_session->allbuttons_[18] != nullptr)
+       og::runtime::current_session->allbuttons_[18]->label = std::format("Playing on Team {}", current_team + 1);
    //allbuttons[18]->do_outline = 1;
    //allbuttons[18]->vdisplay();
    //myscreen->buffer_to_screen(0, 0, 320, 200);
@@ -2286,7 +2290,8 @@ Sint32 change_hire_teamnum(Sint32 arg)
    }
 
    // Update our button display
-   og::runtime::current_session->allbuttons_[2]->label = std::format("Hiring for Team {}", og::runtime::current_session->current_team_num_ + 1);
+   if (og::runtime::current_session->allbuttons_[2] != nullptr)
+       og::runtime::current_session->allbuttons_[2]->label = std::format("Hiring for Team {}", og::runtime::current_session->current_team_num_ + 1);
 
    return MENU_OK;
 }
@@ -2295,7 +2300,8 @@ Sint32 change_allied()
 {
    og::ui::toggle_allied_mode(og::runtime::current_session->myscreen_->save_data);
 
-   og::runtime::current_session->allbuttons_[7]->label = og::ui::format_allied_mode_label(og::runtime::current_session->myscreen_->save_data);
+   if (og::runtime::current_session->allbuttons_[7] != nullptr)
+       og::runtime::current_session->allbuttons_[7]->label = og::ui::format_allied_mode_label(og::runtime::current_session->myscreen_->save_data);
 
    picker_lobby_sync_settings_from_save();
 

--- a/src/interface/ui/picker_common.cpp
+++ b/src/interface/ui/picker_common.cpp
@@ -786,11 +786,16 @@ int HireSession::hire()
     if (!recruit_ || team_full())
         return -1;
 
+    // team_num_ comes from a save-loaded guy::teamnum and is not clamped on the
+    // SDL hire path; clamp at the index sites so a corrupt save cannot drive an
+    // out-of-bounds read/write of the 4-element m_totalcash array.
+    const int cash_team = std::clamp(team_num_, 0, static_cast<int>(SCORE_TEAM_COUNT) - 1);
+
     std::uint32_t cost = current_cost();
-    if (cost == 0 || cost > save_.m_totalcash[team_num_])
+    if (cost == 0 || cost > save_.m_totalcash[cash_team])
         return -1;
 
-    save_.m_totalcash[team_num_] -= cost;
+    save_.m_totalcash[cash_team] -= cost;
 
     int newfamily = recruit_->family;
     recruit_->teamnum = static_cast<short>(team_num_);
@@ -1043,10 +1048,15 @@ bool TrainSession::accept(bool force)
             return false;
         }
 
-        if (cost > save_.m_totalcash[working_->teamnum])
+        // working_->teamnum is copied verbatim from a save-loaded guy and is not
+        // clamped on the accept() path; clamp at the index sites so a corrupt
+        // save cannot drive an out-of-bounds read/write of m_totalcash[4].
+        const int cash_team = std::clamp(static_cast<int>(working_->teamnum), 0,
+                                         static_cast<int>(SCORE_TEAM_COUNT) - 1);
+        if (cost > save_.m_totalcash[cash_team])
             return false;
 
-        save_.m_totalcash[working_->teamnum] -= cost;
+        save_.m_totalcash[cash_team] -= cost;
     }
 
     if (original->level != working_->level)

--- a/src/interface/ui/picker_common.cpp
+++ b/src/interface/ui/picker_common.cpp
@@ -256,7 +256,7 @@ const char* ghost_names[] = {
 
 bool has_name_in_save(const char* name, const SaveData& save)
 {
-    for (int i = 0; i < save.team_size; i++) {
+    for (int i = 0; i < save.team_size && i < MAX_TEAM_SIZE; i++) {
         if (save.team_list[i] && save.team_list[i]->name == name)
             return true;
     }

--- a/src/interface/ui/picker_common.cpp
+++ b/src/interface/ui/picker_common.cpp
@@ -660,7 +660,9 @@ bool is_spectator_mode(const SaveData& save)
 
 std::string format_difficulty_label(int difficulty)
 {
-    return std::format("Difficulty: {}", kDifficultyNames[difficulty]);
+    const int normalized =
+        ((difficulty % DIFFICULTY_SETTINGS) + DIFFICULTY_SETTINGS) % DIFFICULTY_SETTINGS;
+    return std::format("Difficulty: {}", kDifficultyNames[normalized]);
 }
 
 std::string format_allied_mode_label(const SaveData& save)

--- a/src/interface/ui/picker_input.cpp
+++ b/src/interface/ui/picker_input.cpp
@@ -51,7 +51,8 @@ Sint32 leftmouse(button* buttons)
     MouseState& mymouse = query_mouse();
     InputHardwareState& input_hw = input_hardware_state();
 
-    while (og::runtime::current_session->allbuttons_[i])
+    while (i < static_cast<Sint32>(og::runtime::current_session->allbuttons_.size())
+           && og::runtime::current_session->allbuttons_[i])
     {
         if(buttons != nullptr && !buttons[i].hidden)
         {

--- a/src/interface/ui/picker_lobby_client.cpp
+++ b/src/interface/ui/picker_lobby_client.cpp
@@ -190,7 +190,8 @@ void restore_preserved_save_slots(
             continue;
 
         save.team_list[restore_index] = std::move(preserved_slot.member);
-        save.team_size++;
+        if (save.team_size < static_cast<unsigned char>(save.team_list.size()))
+            save.team_size++;
     }
 }
 

--- a/src/interface/ui/picker_main_menu.cpp
+++ b/src/interface/ui/picker_main_menu.cpp
@@ -125,7 +125,8 @@ void redraw_mainmenu()
     #endif
 
     count = 0;
-    while (og::runtime::current_session->allbuttons_[count])
+    while (count < static_cast<int>(og::runtime::current_session->allbuttons_.size())
+           && og::runtime::current_session->allbuttons_[count])
     {
         og::runtime::current_session->allbuttons_[count]->vdisplay();
         count++;

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -1564,7 +1564,7 @@ Sint32 create_progress_menu(Sint32 arg1)
         }
 
         // Scroll indicator
-        if (levels.size() > (size_t)visible_rows) {
+        if (levels.size() > static_cast<size_t>(visible_rows)) {
             std::string scroll_info = std::format("{}-{} of {}",
                      scroll_offset + 1,
                      std::min(scroll_offset + visible_rows, static_cast<int>(levels.size())),

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -1597,6 +1597,7 @@ std::string get_class_description(unsigned char family)
 	{
 	    const auto* fd = get_family_descriptor(family);
 	    if (!fd) return "";
+	    if (stat < 0 || stat >= 6 || fd->stat_costs[stat] == 0) return "";
 	    int value = 55/(fd->stat_costs[stat]);
 	    int rating = (value * 5) / 11;
 	    switch(rating)
@@ -2106,6 +2107,7 @@ Sint32 create_train_menu(Sint32 arg1)
         og::input_native::sleep_ms(10);
 	}
 	pks().train_session = nullptr;
+	pks().old_guy = nullptr;
 	og::runtime::current_session->myscreen_->clearbuffer();
 	//myscreen->clearscreen();
     if ((retvalue & MENU_EXIT) && team_build_start_selected())

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -2322,7 +2322,13 @@ Sint32 name_guy(Sint32 arg)  // 0 == current_guy, 1 == ourteam[editguy]
 		return MENU_REDRAW;
 
 	if (arg)
-		someguy = og::runtime::current_session->myscreen_->save_data.team_list[og::runtime::current_session->editguy_].get();
+	{
+		auto& team_list = og::runtime::current_session->myscreen_->save_data.team_list;
+		const int slot = og::runtime::current_session->editguy_;
+		if (slot < 0 || slot >= static_cast<int>(team_list.size()))
+			return MENU_REDRAW;
+		someguy = team_list[slot].get();
+	}
 	else
 		someguy = og::runtime::current_session->current_guy_.get();
 

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -322,7 +322,14 @@ void sync_view_team_host_control_visibility(button* buttons,
 // Compute derived stats for a guy using the current screen's loader data.
 static og::ui::DerivedStats compute_guy_derived_stats(const guy& g)
 {
-    auto pix = PIX(Order::Living, g.family);
+    // guy::family comes verbatim from the .gtl save file with no range check;
+    // a malicious/negative value would index the loader stat arrays out of
+    // bounds. Clamp to a valid living family (matching the soldier fallback
+    // used by create_walker_owned / set_derived_stats) before indexing.
+    const int fam = (g.family < 0 || g.family >= NUM_FAMILIES)
+        ? FAMILY_SOLDIER
+        : static_cast<int>(g.family);
+    auto pix = PIX(Order::Living, fam);
 	return og::ui::compute_derived_stats(g,
 	    og::runtime::current_session->myscreen_->myloader->hitpoints[pix],
 	    og::runtime::current_session->myscreen_->myloader->damage[pix],
@@ -1754,12 +1761,19 @@ Sint32 create_hire_menu(Sint32 arg1)
             cost_box_inner.x, cost_box_inner.y, cost_box_inner.w,
             cost_box_inner.h);
         
-        og::runtime::current_session->message_ = std::format("CASH: {}", og::runtime::current_session->myscreen_->save_data.m_totalcash[og::runtime::current_session->current_team_num_]);
+        // current_team_num_ is derived from a save-loaded guy::teamnum (which
+        // is unvalidated); clamp before indexing the MAX_PLAYERS-sized array.
+        const int hire_cash_team =
+            (og::runtime::current_session->current_team_num_ < 0 ||
+             og::runtime::current_session->current_team_num_ >= MAX_PLAYERS)
+                ? 0
+                : static_cast<int>(og::runtime::current_session->current_team_num_);
+        og::runtime::current_session->message_ = std::format("CASH: {}", og::runtime::current_session->myscreen_->save_data.m_totalcash[hire_cash_team]);
         mytext.write_xy(cost_box_content.x, cost_box_content.y, og::runtime::current_session->message_.c_str(),static_cast<unsigned char>(DARK_BLUE), 1);
         current_cost = pks().hire_session ? pks().hire_session->current_cost() : 0;
         mytext.write_xy(cost_box_content.x, cost_box_content.y + 10, "COST: ", DARK_BLUE, 1);
         og::runtime::current_session->message_ = std::format("      {}", current_cost );
-        if (current_cost > og::runtime::current_session->myscreen_->save_data.m_totalcash[og::runtime::current_session->current_team_num_])
+        if (current_cost > og::runtime::current_session->myscreen_->save_data.m_totalcash[hire_cash_team])
             mytext.write_xy(cost_box_content.x + 10, cost_box_content.y + 10, og::runtime::current_session->message_.c_str(), STAT_CHANGED, 1);
         else
             mytext.write_xy(cost_box_content.x + 10, cost_box_content.y + 10, og::runtime::current_session->message_.c_str(), STAT_COLOR, 1);
@@ -2063,13 +2077,21 @@ Sint32 create_train_menu(Sint32 arg1)
 				r2.x, r2.y, r2.w, r2.h);
         
         linesdown += 0.4f;
-        og::runtime::current_session->message_ = std::format("CASH: {}", og::runtime::current_session->myscreen_->save_data.m_totalcash[og::runtime::current_session->current_guy_->teamnum]);
+        // teamnum is loaded verbatim from the .gtl save file with no range
+        // check; m_totalcash has only MAX_PLAYERS slots, so a malicious value
+        // would index out of bounds. Clamp to a valid team before indexing.
+        const int train_cash_team =
+            (og::runtime::current_session->current_guy_->teamnum < 0 ||
+             og::runtime::current_session->current_guy_->teamnum >= MAX_PLAYERS)
+                ? 0
+                : static_cast<int>(og::runtime::current_session->current_guy_->teamnum);
+        og::runtime::current_session->message_ = std::format("CASH: {}", og::runtime::current_session->myscreen_->save_data.m_totalcash[train_cash_team]);
 	        mytext.write_xy(180, info_y(linesdown), og::runtime::current_session->message_.c_str(),static_cast<unsigned char>(DARK_BLUE), 1);
 
         linesdown++;
 	        mytext.write_xy(180, info_y(linesdown), "COST: ", DARK_BLUE, 1);
         og::runtime::current_session->message_ = std::format("      {}", current_cost );
-        if (current_cost > og::runtime::current_session->myscreen_->save_data.m_totalcash[og::runtime::current_session->current_guy_->teamnum])
+        if (current_cost > og::runtime::current_session->myscreen_->save_data.m_totalcash[train_cash_team])
 	            mytext.write_xy(180, info_y(linesdown), og::runtime::current_session->message_.c_str(), STAT_CHANGED, 1);
 	        else
 	            mytext.write_xy(180, info_y(linesdown), og::runtime::current_session->message_.c_str(), STAT_COLOR, 1);

--- a/src/interface/ui/results_screen.cpp
+++ b/src/interface/ui/results_screen.cpp
@@ -173,9 +173,9 @@ bool results_screen(int ending, int nextlevel)
 class TroopResult
 {
 public:
-    guy* before;
-    walker* after;
-    
+    guy* before = nullptr;
+    walker* after = nullptr;
+
     std::string get_name() const;
     std::string get_class_name() const;
     char get_family() const;
@@ -989,7 +989,9 @@ int results_screen_test_exercise_internal()
 
     // walker/pixie store raw pointers to PixieData buffers; keep the data alive
     // for the duration of this helper.
-    PixieData one_px(1, 1, 1, new unsigned char[1]{0});
+    auto one_px_buf = std::make_unique<unsigned char[]>(1);
+    one_px_buf[0] = 0;
+    PixieData one_px(1, 1, 1, one_px_buf.release());
 
     // Ending popup branches.
     og::runtime::current_session->myscreen_->save_data.scen_num = 1;

--- a/src/interface/ui/results_screen.cpp
+++ b/src/interface/ui/results_screen.cpp
@@ -266,7 +266,9 @@ std::vector<std::string> TroopResult::get_gained_specials() const
     std::vector<std::string> result;
     
     int family = get_family();
-    
+    if (family < 0 || family >= NUM_FAMILIES)
+        return result;  // bogus family from an untrusted save -> no specials
+
     Sint32 test1 = get_level() - 1;
     if ( !(test1%3) ) // we're on a special-gaining level
     {

--- a/src/platform/curses/curses_input.cpp
+++ b/src/platform/curses/curses_input.cpp
@@ -27,7 +27,7 @@ CursesInput::CursesInput()
 {
 }
 
-CursesInput::CursesInput(const int* keybindings) : keybindings_(keybindings) {}
+CursesInput::CursesInput(std::span<const int, kInputActionCount> keybindings) : keybindings_(keybindings) {}
 
 int CursesInput::keycode_for_key(const Key& k)
 {
@@ -103,17 +103,15 @@ void CursesInput::feed(const Key& k)
         held_.fill(false);
         return;
     }
-    if (keybindings_ == nullptr)
-        return;
     const int keycode = keycode_for_key(k);
     if (keycode == KEYCODE_UNKNOWN)
         return;
 
     // Resolve the key to the action(s) it is bound to for player 0.
     for (int a = 0; a < kInputActionCount; ++a) {
-        if (keybindings_[a] != keycode)
-            continue;
         const auto idx = static_cast<std::size_t>(a);
+        if (keybindings_[idx] != keycode)
+            continue;
         switch (k.event) {
         case KeyEvent::Press:
             pressed_edge_[idx] = true; // down transition this frame

--- a/src/platform/curses/curses_picker_client.cpp
+++ b/src/platform/curses/curses_picker_client.cpp
@@ -662,11 +662,15 @@ void CursesPickerClient::handle_menu_item(PickerMenuId menu_id,
     if (menu_id == PickerMenuId::Main) {
         switch (item.command) {
         case PickerMenuCommand::SetDifficulty:
+        {
             options_.difficulty = og::ui::cycle_difficulty(options_.difficulty);
+            const int difficulty_index =
+                ((options_.difficulty % DIFFICULTY_SETTINGS) + DIFFICULTY_SETTINGS) % DIFFICULTY_SETTINGS;
             menu.show_text("Difficulty",
                 {std::format("Difficulty set to {}.",
-                    og::ui::kDifficultyNames[options_.difficulty])});
+                    og::ui::kDifficultyNames[difficulty_index])});
             break;
+        }
         case PickerMenuCommand::SetPlayerMode:
             og::ui::set_player_count(save_data_, item.arg);
             menu.show_text("Players",

--- a/src/platform/curses/kitty_keys.cpp
+++ b/src/platform/curses/kitty_keys.cpp
@@ -73,7 +73,14 @@ void parse_params(std::string_view params, long& p0, long& modifiers, long& even
     };
     for (char c : params) {
         if (c >= '0' && c <= '9') {
-            acc = acc * 10 + (c - '0');
+            // Saturate to avoid signed-overflow UB on an over-long digit run.
+            // 0x110000 is above every value the downstream decoders accept
+            // (codepoint ceiling, modifier/event/tilde ranges), so legitimate
+            // in-range inputs are unaffected.
+            if (acc < 0x110000)
+                acc = acc * 10 + (c - '0');
+            else
+                acc = 0x110000;
             have_digit = true;
         } else if (c == ':') {
             commit();

--- a/src/platform/emscripten/net_transport_emscripten_ws.cpp
+++ b/src/platform/emscripten/net_transport_emscripten_ws.cpp
@@ -15,6 +15,9 @@ namespace og::sim {
 namespace {
 
 constexpr unsigned short kWebSocketReadyStateOpen = 1;
+constexpr std::size_t kMaxInboundFrameBytes = 128u * 1024u;
+constexpr std::size_t kMaxQueuedMessages = 1024u;
+constexpr std::size_t kMaxQueuedPayloadBytes = 16u * 1024u * 1024u;
 
 #ifdef __EMSCRIPTEN__
 void default_init_create_attributes(
@@ -411,6 +414,8 @@ struct EmscriptenWebSocketTransport::Impl
                 return {};
 
             queued_entries.swap(queue);
+            queued_message_count = 0;
+            queued_payload_bytes = 0;
         }
 
         std::vector<ReceivedMessage> drained_messages;
@@ -537,6 +542,12 @@ private:
         {
             return;
         }
+        if (websocket_event->numBytes > kMaxInboundFrameBytes)
+        {
+            enqueue_disconnect(websocket_event->socket);
+            request_close_socket(websocket_event->socket, 1009, "message too large");
+            return;
+        }
 
         QueueEntry entry;
         entry.kind = QueueEntryKind::Message;
@@ -547,10 +558,14 @@ private:
                 return;
 
             entry.payload.assign(websocket_event->data,
-                                 websocket_event->data +
-                                     websocket_event->numBytes);
+                                     websocket_event->data +
+                                         websocket_event->numBytes);
         }
-        enqueue(std::move(entry));
+        if (!enqueue(std::move(entry)))
+        {
+            enqueue_disconnect(websocket_event->socket);
+            request_close_socket(websocket_event->socket, 1008, "receive queue full");
+        }
     }
 
     void handle_disconnect(WebSocketHandle socket_handle)
@@ -577,7 +592,20 @@ private:
         const detail::EmscriptenWebSocketApi& api =
             detail::emscripten_websocket_api();
         if (api.close != nullptr)
-            (void)api.close(socket_handle, 1000, nullptr);
+        (void)api.close(socket_handle, 1000, nullptr);
+    }
+
+    void request_close_socket(WebSocketHandle socket_handle,
+                              unsigned short code,
+                              const char* reason) const noexcept
+    {
+        if (socket_handle <= 0)
+            return;
+
+        const detail::EmscriptenWebSocketApi& api =
+            detail::emscripten_websocket_api();
+        if (api.close != nullptr)
+            (void)api.close(socket_handle, code, reason);
     }
 
     void dispose_socket() noexcept
@@ -599,12 +627,28 @@ private:
     {
         std::lock_guard<std::mutex> lock(queue_mutex);
         queue.clear();
+        queued_message_count = 0;
+        queued_payload_bytes = 0;
     }
 
-    void enqueue(QueueEntry entry)
+    bool enqueue(QueueEntry entry)
     {
         std::lock_guard<std::mutex> lock(queue_mutex);
+        if (queue.size() >= kMaxQueuedMessages)
+            return false;
+        if (entry.kind == QueueEntryKind::Message)
+        {
+            if (queued_message_count >= kMaxQueuedMessages ||
+                entry.payload.size() >
+                    kMaxQueuedPayloadBytes - queued_payload_bytes)
+            {
+                return false;
+            }
+            ++queued_message_count;
+            queued_payload_bytes += entry.payload.size();
+        }
         queue.push_back(std::move(entry));
+        return true;
     }
 
     std::string url;
@@ -615,6 +659,8 @@ private:
 
     std::mutex queue_mutex;
     std::deque<QueueEntry> queue;
+    std::size_t queued_message_count = 0;
+    std::size_t queued_payload_bytes = 0;
 };
 
 EmscriptenWebSocketTransport::EmscriptenWebSocketTransport(std::string url)

--- a/src/platform/emscripten/net_transport_relay_ws.cpp
+++ b/src/platform/emscripten/net_transport_relay_ws.cpp
@@ -27,6 +27,10 @@ constexpr std::uint8_t kRelaySendToPeerTag = 1u;
 constexpr std::uint8_t kRelayReceiveFromPeerTag = 2u;
 constexpr std::uint8_t kRelayBroadcastTag = 3u;
 constexpr std::size_t kRelayPeerHeaderSize = 5u;
+constexpr std::size_t kMaxInboundFrameBytes = 128u * 1024u;
+constexpr std::size_t kMaxInboundTextBytes = 8u * 1024u;
+constexpr std::size_t kMaxQueuedMessages = 1024u;
+constexpr std::size_t kMaxQueuedPayloadBytes = 16u * 1024u * 1024u;
 
 std::string trim_copy(std::string_view text)
 {
@@ -456,6 +460,8 @@ struct RelayWebSocketTransport::Impl
             if (!lock.owns_lock() || queue.empty())
                 return {};
             queued_entries.swap(queue);
+            queued_message_count = 0;
+            queued_payload_bytes = 0;
         }
 
         std::vector<ReceivedMessage> received;
@@ -595,6 +601,18 @@ private:
     {
         if (websocket_event == nullptr || websocket_event->socket != socket)
             return;
+        const bool is_text = websocket_event->isText == detail::kTrue;
+        const std::size_t max_bytes =
+            is_text ? kMaxInboundTextBytes : kMaxInboundFrameBytes;
+        if (websocket_event->numBytes > max_bytes)
+        {
+            enqueue_disconnect(websocket_event->socket);
+            request_close_socket(
+                websocket_event->socket,
+                1009,
+                is_text ? "control message too large" : "message too large");
+            return;
+        }
 
         QueueEntry entry;
         entry.socket = websocket_event->socket;
@@ -608,7 +626,7 @@ private:
                                      websocket_event->numBytes);
         }
 
-        if (websocket_event->isText == detail::kTrue)
+        if (is_text)
         {
             entry.kind = QueueEntryKind::TextMessage;
             entry.text.assign(entry.payload.begin(), entry.payload.end());
@@ -619,7 +637,11 @@ private:
             entry.kind = QueueEntryKind::BinaryMessage;
         }
 
-        enqueue(std::move(entry));
+        if (!enqueue(std::move(entry)))
+        {
+            enqueue_disconnect(websocket_event->socket);
+            request_close_socket(websocket_event->socket, 1008, "receive queue full");
+        }
     }
 
     void handle_disconnect(WebSocketHandle socket_handle)
@@ -745,6 +767,19 @@ private:
             (void)api.close(socket_handle, 1000, nullptr);
     }
 
+    void request_close_socket(WebSocketHandle socket_handle,
+                              unsigned short code,
+                              const char* reason) const noexcept
+    {
+        if (socket_handle <= 0)
+            return;
+
+        const detail::EmscriptenWebSocketApi& api =
+            detail::emscripten_websocket_api();
+        if (api.close != nullptr)
+            (void)api.close(socket_handle, code, reason);
+    }
+
     void dispose_socket() noexcept
     {
         if (socket <= 0)
@@ -764,12 +799,32 @@ private:
     {
         std::lock_guard<std::mutex> lock(queue_mutex);
         queue.clear();
+        queued_message_count = 0;
+        queued_payload_bytes = 0;
     }
 
-    void enqueue(QueueEntry entry)
+    bool enqueue(QueueEntry entry)
     {
         std::lock_guard<std::mutex> lock(queue_mutex);
+        if (queue.size() >= kMaxQueuedMessages)
+            return false;
+        if (entry.kind == QueueEntryKind::TextMessage ||
+            entry.kind == QueueEntryKind::BinaryMessage)
+        {
+            const std::size_t entry_size =
+                entry.kind == QueueEntryKind::TextMessage
+                    ? entry.text.size()
+                    : entry.payload.size();
+            if (queued_message_count >= kMaxQueuedMessages ||
+                entry_size > kMaxQueuedPayloadBytes - queued_payload_bytes)
+            {
+                return false;
+            }
+            ++queued_message_count;
+            queued_payload_bytes += entry_size;
+        }
         queue.push_back(std::move(entry));
+        return true;
     }
 
     std::string url;
@@ -780,6 +835,8 @@ private:
 
     std::mutex queue_mutex;
     std::deque<QueueEntry> queue;
+    std::size_t queued_message_count = 0;
+    std::size_t queued_payload_bytes = 0;
 
     std::optional<PeerId> local_peer_id_;
     std::optional<PeerId> host_peer_id_;

--- a/src/platform/sdl/demo.cpp
+++ b/src/platform/sdl/demo.cpp
@@ -351,11 +351,13 @@ int main(int argc, char* argv[])
         load_player_control_settings_from_cfg(cfg);
 
         // Create composite surface and texture at the full display resolution.
-        SDL_Surface* composite_surface = SDL_CreateRGBSurface(
-            SDL_SWSURFACE, display_w, display_h, 32, 0, 0, 0, 0);
-        SDL_Texture* composite_tex = SDL_CreateTexture(
-            E_Screen->renderer, SDL_PIXELFORMAT_ARGB8888,
-            SDL_TEXTUREACCESS_STREAMING, display_w, display_h);
+        std::unique_ptr<SDL_Surface, decltype(&SDL_FreeSurface)> composite_surface(
+            SDL_CreateRGBSurface(SDL_SWSURFACE, display_w, display_h, 32, 0, 0, 0, 0),
+            SDL_FreeSurface);
+        std::unique_ptr<SDL_Texture, decltype(&SDL_DestroyTexture)> composite_tex(
+            SDL_CreateTexture(E_Screen->renderer, SDL_PIXELFORMAT_ARGB8888,
+                              SDL_TEXTUREACCESS_STREAMING, display_w, display_h),
+            SDL_DestroyTexture);
         if (!composite_surface || !composite_tex) {
             LogError("Failed to create composite surface/texture\n");
             return 1;
@@ -479,19 +481,19 @@ int main(int argc, char* argv[])
             E_Screen->suppress_present = false;
 
             // --- Phase 5: Composite and present (main thread only) ---
-            SDL_FillRect(composite_surface, nullptr, 0x000000);
+            SDL_FillRect(composite_surface.get(), nullptr, 0x000000);
             for (int i = 0; i < num_sessions; i++) {
                 SDL_Surface* src = demos[static_cast<size_t>(i)].session->session_surface_;
                 int col = i % grid_cols;
                 int row = i / grid_cols;
-                composite_session(composite_surface, src, col, row);
+                composite_session(composite_surface.get(), src, col, row);
             }
 
-            SDL_UpdateTexture(composite_tex, nullptr,
+            SDL_UpdateTexture(composite_tex.get(), nullptr,
                               composite_surface->pixels,
                               composite_surface->pitch);
             SDL_RenderClear(E_Screen->renderer);
-            SDL_RenderCopy(E_Screen->renderer, composite_tex,
+            SDL_RenderCopy(E_Screen->renderer, composite_tex.get(),
                            nullptr, nullptr);
             SDL_RenderPresent(E_Screen->renderer);
 
@@ -531,9 +533,9 @@ int main(int argc, char* argv[])
             if (w.joinable()) w.join();
         }
 
-        // Cleanup
-        SDL_DestroyTexture(composite_tex);
-        SDL_FreeSurface(composite_surface);
+        // Cleanup (the unique_ptr deleters also free on any early-return/throw path)
+        composite_tex.reset();
+        composite_surface.reset();
         for (auto& d : demos) {
             d.session.reset();
         }

--- a/src/platform/sdl/game.cpp
+++ b/src/platform/sdl/game.cpp
@@ -144,11 +144,9 @@ LoadSavedGameError load_saved_game_with_error(const char *filename, screen *scre
 	for(int guy_idx = 0; guy_idx < screenp->save_data.team_size; guy_idx++)
     {
 	    temp_guy = screenp->save_data.team_list[guy_idx].get();
-	    if (!temp_guy)
-	        continue;
+	    if (!temp_guy) continue;
 	    temp_walker = guy_create_and_add_walker(*temp_guy, screenp);
-	    if (!temp_walker)
-	        continue;
+	    if (!temp_walker) continue;
 	    // Clear the new guy's battle data
 	    temp_walker->myguy->scen_damage = 0;
 	    temp_walker->myguy->scen_kills = 0;

--- a/src/platform/sdl/game.cpp
+++ b/src/platform/sdl/game.cpp
@@ -144,7 +144,11 @@ LoadSavedGameError load_saved_game_with_error(const char *filename, screen *scre
 	for(int guy_idx = 0; guy_idx < screenp->save_data.team_size; guy_idx++)
     {
 	    temp_guy = screenp->save_data.team_list[guy_idx].get();
+	    if (!temp_guy)
+	        continue;
 	    temp_walker = guy_create_and_add_walker(*temp_guy, screenp);
+	    if (!temp_walker)
+	        continue;
 	    // Clear the new guy's battle data
 	    temp_walker->myguy->scen_damage = 0;
 	    temp_walker->myguy->scen_kills = 0;

--- a/src/platform/sdl/game_session.cpp
+++ b/src/platform/sdl/game_session.cpp
@@ -17,6 +17,7 @@
 #include <openglad/interface/ui/level_editor_state.h>
 #include <openglad/interface/screen.h> // screen class
 #include <openglad/interface/sound.h> // soundob complete type for play_sound
+#include <openglad/core/sound_ids.h> // NUMSOUNDS bound for play_sound dispatch
 #include <openglad/platform/video_sdl.h>
 #include <openglad/interface/render/view.h>    // options class
 #include <openglad/platform/sai2x.h>   // E_Screen
@@ -42,7 +43,8 @@ PlatformBridge make_sdl_platform_bridge()
 
     bridge.play_sound = [](int sound_id) {
         if (!og::runtime::current_session || !og::runtime::current_session->myscreen_ ||
-            !og::runtime::current_session->myscreen_->soundp || sound_id < 0)
+            !og::runtime::current_session->myscreen_->soundp ||
+            sound_id < 0 || sound_id >= NUMSOUNDS)
         {
             return;
         }

--- a/src/platform/sdl/game_session.cpp
+++ b/src/platform/sdl/game_session.cpp
@@ -128,8 +128,10 @@ GameSession::GameSession(const Config& session_cfg)
     // Set prefs before creating the screen; viewscreen construction reads it.
     theprefs_ = prefs_owner_.get();
 
-    // Initialize legacy video pointer (VGA linear buffer address from DOS era).
-    videoptr_ = reinterpret_cast<unsigned char*>(VIDEO_LINEAR);
+    // Legacy videoptr_ stays at its in-class nullptr default. It formerly held a
+    // fabricated DOS-era VGA linear address (0xA0000); that pointer was never
+    // written through in production (only putblack uses it, and only tests call
+    // putblack, after pointing videoptr_ at a real buffer).
 
     // Share SDL's keyboard state array. SDL_GetKeyboardState returns a pointer
     // to SDL's internal array — it's the same for all sessions.

--- a/src/platform/sdl/glad.cpp
+++ b/src/platform/sdl/glad.cpp
@@ -20,6 +20,7 @@
 #include <openglad/core/runtime_trace.h>
 #include <openglad/core/version.h>
 #include <openglad/gameplay/guy.h>
+#include <openglad/gameplay/input_state.h>
 #include <openglad/gameplay/statistics.h>
 #include <openglad/gameplay/walker.h>
 #include <openglad/interface/render/view.h>
@@ -39,6 +40,7 @@
 #include <string>
 #include <cstring>
 #include <format>
+#include <algorithm>
 #include <memory>
 #include <limits>
 #include <optional>
@@ -165,7 +167,8 @@ short gameplay_numviews_for_start(
     const std::uint8_t player_count = lobby_config != nullptr
         ? lobby_config->save_data.numplayers
         : current_screen.save_data.numplayers;
-    return static_cast<short>(player_count == 0 ? 1 : player_count);
+    const int views = player_count == 0 ? 1 : player_count;
+    return static_cast<short>(std::clamp(views, 1, MAX_PLAYERS));
 }
 
 void ready_screen_for_game_start(

--- a/src/platform/sdl/glad_gameplay.cpp
+++ b/src/platform/sdl/glad_gameplay.cpp
@@ -27,6 +27,8 @@
 #include <openglad/platform/local_transport_shadow.h>
 #include <openglad/platform/picker_lobby_network_runtime.h>
 
+#include <algorithm>
+#include <iterator>
 #include <optional>
 
 // theprefs is now a macro defined in view.h (via game_session.h)
@@ -123,7 +125,8 @@ void apply_lobby_game_start_config(
         save.team_list[slot.slot_index]->owner_player_index =
             slot.owner_player_index;
         save.team_list[slot.slot_index]->owner_save_slot = slot.owner_save_slot;
-        ++save.team_size;
+        if (static_cast<std::size_t>(save.team_size) < save.team_list.size())
+            ++save.team_size;  // cap so team_size can never exceed the fixed team_list
     }
 
     if (og::runtime::current_session != nullptr)
@@ -184,7 +187,9 @@ void glad_init(bool preserve_frame_timing,
     og::platform::web::finalize_jitter_capture_profile_after_load(
         *current_screen);
 #endif
-    for (short view_index = 0; view_index < current_screen->numviews; ++view_index)
+    const short safe_numviews = std::min<short>(
+        current_screen->numviews, static_cast<short>(std::size(current_screen->viewob)));
+    for (short view_index = 0; view_index < safe_numviews; ++view_index)
     {
         if (current_screen->viewob[view_index] != nullptr)
             current_screen->viewob[view_index]->clear_text();

--- a/src/platform/sdl/native_input.cpp
+++ b/src/platform/sdl/native_input.cpp
@@ -115,6 +115,9 @@ bool decode_event(const void* native_event, EventData& out)
         break;
     case SDL_USEREVENT:
         out.user_code = e.user.code;
+        // intptr_t is defined to round-trip a void* losslessly; this is the
+        // canonical, portable idiom (std::bit_cast needs a newer libc++ than the
+        // ctest Emscripten toolchain ships).
         out.user_data1 = reinterpret_cast<std::intptr_t>(e.user.data1);
         break;
     default:

--- a/src/platform/sdl/net_transport_relay_ws.cpp
+++ b/src/platform/sdl/net_transport_relay_ws.cpp
@@ -389,9 +389,7 @@ struct RelayWebSocketTransport::Impl
 
         const std::vector<std::uint8_t> payload =
             encode_targeted_relay_payload(peer_id, data, len);
-        const char* bytes = reinterpret_cast<const char*>(payload.data());
-        const std::string binary(bytes, bytes + payload.size());
-        const ix::WebSocketSendInfo send_info = websocket->sendBinary(binary);
+        const ix::WebSocketSendInfo send_info = websocket->sendBinary(payload);
         if (!send_info.success)
         {
             enqueue_disconnect(active_generation);
@@ -412,9 +410,7 @@ struct RelayWebSocketTransport::Impl
 
         const std::vector<std::uint8_t> payload =
             encode_broadcast_relay_payload(data, len);
-        const char* bytes = reinterpret_cast<const char*>(payload.data());
-        const std::string binary(bytes, bytes + payload.size());
-        const ix::WebSocketSendInfo send_info = websocket->sendBinary(binary);
+        const ix::WebSocketSendInfo send_info = websocket->sendBinary(payload);
         if (!send_info.success)
         {
             enqueue_disconnect(active_generation);

--- a/src/platform/sdl/net_transport_relay_ws.cpp
+++ b/src/platform/sdl/net_transport_relay_ws.cpp
@@ -28,6 +28,10 @@ constexpr std::uint8_t kRelaySendToPeerTag = 1u;
 constexpr std::uint8_t kRelayReceiveFromPeerTag = 2u;
 constexpr std::uint8_t kRelayBroadcastTag = 3u;
 constexpr std::size_t kRelayPeerHeaderSize = 5u;
+constexpr std::size_t kMaxInboundFrameBytes = 128u * 1024u;
+constexpr std::size_t kMaxInboundTextBytes = 8u * 1024u;
+constexpr std::size_t kMaxQueuedMessages = 1024u;
+constexpr std::size_t kMaxQueuedPayloadBytes = 16u * 1024u * 1024u;
 
 std::string trim_copy(std::string_view text)
 {
@@ -313,15 +317,34 @@ struct RelayWebSocketTransport::Impl
         case ix::WebSocketMessageType::Message:
             if (message->binary)
             {
+                if (message->str.size() > kMaxInboundFrameBytes)
+                {
+                    enqueue_disconnect(generation);
+                    if (websocket)
+                        websocket->close(1009, "message too large");
+                    return;
+                }
                 entry.kind = QueueEntryKind::BinaryMessage;
                 entry.payload.assign(message->str.begin(), message->str.end());
             }
             else
             {
+                if (message->str.size() > kMaxInboundTextBytes)
+                {
+                    enqueue_disconnect(generation);
+                    if (websocket)
+                        websocket->close(1009, "control message too large");
+                    return;
+                }
                 entry.kind = QueueEntryKind::TextMessage;
                 entry.text = message->str;
             }
-            enqueue(std::move(entry));
+            if (!enqueue(std::move(entry)))
+            {
+                enqueue_disconnect(generation);
+                if (websocket)
+                    websocket->close(1008, "receive queue full");
+            }
             break;
 
         case ix::WebSocketMessageType::Error:
@@ -407,6 +430,8 @@ struct RelayWebSocketTransport::Impl
             if (!lock.owns_lock() || queue.empty())
                 return {};
             queued_entries.swap(queue);
+            queued_message_count = 0;
+            queued_payload_bytes = 0;
         }
 
         std::vector<ReceivedMessage> received;
@@ -617,12 +642,32 @@ private:
     {
         std::lock_guard<std::mutex> lock(queue_mutex);
         queue.clear();
+        queued_message_count = 0;
+        queued_payload_bytes = 0;
     }
 
-    void enqueue(QueueEntry entry)
+    bool enqueue(QueueEntry entry)
     {
         std::lock_guard<std::mutex> lock(queue_mutex);
+        if (queue.size() >= kMaxQueuedMessages)
+            return false;
+        if (entry.kind == QueueEntryKind::TextMessage ||
+            entry.kind == QueueEntryKind::BinaryMessage)
+        {
+            const std::size_t entry_size =
+                entry.kind == QueueEntryKind::TextMessage
+                    ? entry.text.size()
+                    : entry.payload.size();
+            if (queued_message_count >= kMaxQueuedMessages ||
+                entry_size > kMaxQueuedPayloadBytes - queued_payload_bytes)
+            {
+                return false;
+            }
+            ++queued_message_count;
+            queued_payload_bytes += entry_size;
+        }
         queue.push_back(std::move(entry));
+        return true;
     }
 
     detail::IxNetSystemGuard net_system_guard;
@@ -636,6 +681,8 @@ private:
 
     mutable std::mutex queue_mutex;
     std::deque<QueueEntry> queue;
+    std::size_t queued_message_count = 0;
+    std::size_t queued_payload_bytes = 0;
 
     std::optional<PeerId> local_peer_id_;
     std::optional<PeerId> host_peer_id_;

--- a/src/platform/sdl/net_transport_websocket_client.cpp
+++ b/src/platform/sdl/net_transport_websocket_client.cpp
@@ -15,6 +15,13 @@
 #include <vector>
 
 namespace og::sim {
+namespace {
+
+constexpr std::size_t kMaxInboundFrameBytes = 128u * 1024u;
+constexpr std::size_t kMaxQueuedMessages = 1024u;
+constexpr std::size_t kMaxQueuedPayloadBytes = 16u * 1024u * 1024u;
+
+} // namespace
 
 struct WebSocketClientTransport::Impl
 {
@@ -78,12 +85,24 @@ struct WebSocketClientTransport::Impl
         {
             if (!message->binary)
                 return;
+            if (message->str.size() > kMaxInboundFrameBytes)
+            {
+                enqueue_disconnect(generation);
+                if (websocket)
+                    websocket->close(1009, "message too large");
+                return;
+            }
 
             QueueEntry entry;
             entry.kind = QueueEntryKind::Message;
             entry.generation = generation;
             entry.payload.assign(message->str.begin(), message->str.end());
-            enqueue(std::move(entry));
+            if (!enqueue(std::move(entry)))
+            {
+                enqueue_disconnect(generation);
+                if (websocket)
+                    websocket->close(1008, "receive queue full");
+            }
             break;
         }
 
@@ -151,6 +170,8 @@ struct WebSocketClientTransport::Impl
                 return {};
 
             queued_entries.swap(queue);
+            queued_message_count = 0;
+            queued_payload_bytes = 0;
         }
 
         std::vector<ReceivedMessage> drained_messages;
@@ -270,12 +291,28 @@ private:
     {
         std::lock_guard<std::mutex> lock(queue_mutex);
         queue.clear();
+        queued_message_count = 0;
+        queued_payload_bytes = 0;
     }
 
-    void enqueue(QueueEntry entry)
+    bool enqueue(QueueEntry entry)
     {
         std::lock_guard<std::mutex> lock(queue_mutex);
+        if (queue.size() >= kMaxQueuedMessages)
+            return false;
+        if (entry.kind == QueueEntryKind::Message)
+        {
+            if (queued_message_count >= kMaxQueuedMessages ||
+                entry.payload.size() >
+                    kMaxQueuedPayloadBytes - queued_payload_bytes)
+            {
+                return false;
+            }
+            ++queued_message_count;
+            queued_payload_bytes += entry.payload.size();
+        }
         queue.push_back(std::move(entry));
+        return true;
     }
 
     detail::IxNetSystemGuard net_system_guard;
@@ -289,6 +326,8 @@ private:
 
     mutable std::mutex queue_mutex;
     mutable std::deque<QueueEntry> queue;
+    std::size_t queued_message_count = 0;
+    std::size_t queued_payload_bytes = 0;
 };
 
 WebSocketClientTransport::WebSocketClientTransport(std::string url)

--- a/src/platform/sdl/net_transport_websocket_client.cpp
+++ b/src/platform/sdl/net_transport_websocket_client.cpp
@@ -147,10 +147,9 @@ struct WebSocketClientTransport::Impl
             return;
 
         const char* bytes = reinterpret_cast<const char*>(data);
-        const std::string payload =
-            (bytes == nullptr || len == 0) ? std::string()
-                                           : std::string(bytes, bytes + len);
-        const ix::WebSocketSendInfo send_info = websocket->sendBinary(payload);
+        const std::size_t send_len = (bytes == nullptr || len == 0) ? 0 : len;
+        const ix::WebSocketSendInfo send_info =
+            websocket->sendBinary(ix::IXWebSocketSendData(bytes, send_len));
         if (!send_info.success)
         {
             enqueue_disconnect(active_generation);

--- a/src/platform/sdl/net_transport_websocket_server.cpp
+++ b/src/platform/sdl/net_transport_websocket_server.cpp
@@ -156,10 +156,9 @@ struct WebSocketServerTransport::Impl
         }
 
         const char* bytes = reinterpret_cast<const char*>(data);
-        const std::string payload =
-            (bytes == nullptr || len == 0) ? std::string()
-                                           : std::string(bytes, bytes + len);
-        const ix::WebSocketSendInfo send_info = socket->sendBinary(payload);
+        const std::size_t send_len = (bytes == nullptr || len == 0) ? 0 : len;
+        const ix::WebSocketSendInfo send_info =
+            socket->sendBinary(ix::IXWebSocketSendData(bytes, send_len));
         if (!send_info.success)
         {
             enqueue_disconnect(peer_it->second.connection_id);
@@ -194,6 +193,14 @@ struct WebSocketServerTransport::Impl
                 if (!entry.socket ||
                     connection_to_peer_id.contains(entry.connection_id))
                 {
+                    break;
+                }
+
+                if (next_peer_id == std::numeric_limits<PeerId>::max())
+                {
+                    // PeerId space exhausted; the next increment would wrap to
+                    // the reserved 'no peer' sentinel (0). Drop the connection
+                    // rather than register a ghost peer.
                     break;
                 }
 

--- a/src/platform/sdl/net_transport_websocket_server.cpp
+++ b/src/platform/sdl/net_transport_websocket_server.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <deque>
 #include <format>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -16,6 +17,13 @@
 #include <vector>
 
 namespace og::sim {
+namespace {
+
+constexpr std::size_t kMaxInboundFrameBytes = 128u * 1024u;
+constexpr std::size_t kMaxQueuedMessages = 1024u;
+constexpr std::size_t kMaxQueuedPayloadBytes = 16u * 1024u * 1024u;
+
+} // namespace
 
 struct WebSocketServerTransport::Impl
 {
@@ -77,12 +85,22 @@ struct WebSocketServerTransport::Impl
         {
             if (!message->binary)
                 return;
+            if (message->str.size() > kMaxInboundFrameBytes)
+            {
+                websocket.close(1009, "message too large");
+                enqueue_disconnect(connection_state->getId());
+                return;
+            }
 
             QueueEntry entry;
             entry.kind = QueueEntryKind::Message;
             entry.connection_id = connection_state->getId();
             entry.payload.assign(message->str.begin(), message->str.end());
-            enqueue(std::move(entry));
+            if (!enqueue(std::move(entry)))
+            {
+                websocket.close(1008, "receive queue full");
+                enqueue_disconnect(connection_state->getId());
+            }
             break;
         }
 
@@ -161,6 +179,8 @@ struct WebSocketServerTransport::Impl
                 return {};
 
             queued_entries.swap(queue);
+            queued_message_count = 0;
+            queued_payload_bytes = 0;
         }
 
         std::vector<ReceivedMessage> drained_messages;
@@ -255,10 +275,24 @@ private:
         enqueue(std::move(entry));
     }
 
-    void enqueue(QueueEntry entry)
+    bool enqueue(QueueEntry entry)
     {
         std::lock_guard<std::mutex> lock(queue_mutex);
+        if (queue.size() >= kMaxQueuedMessages)
+            return false;
+        if (entry.kind == QueueEntryKind::Message)
+        {
+            if (queued_message_count >= kMaxQueuedMessages ||
+                entry.payload.size() >
+                    kMaxQueuedPayloadBytes - queued_payload_bytes)
+            {
+                return false;
+            }
+            ++queued_message_count;
+            queued_payload_bytes += entry.payload.size();
+        }
         queue.push_back(std::move(entry));
+        return true;
     }
 
     std::shared_ptr<ix::WebSocket> resolve_socket(ix::WebSocket& websocket)
@@ -279,6 +313,8 @@ private:
 
     std::mutex queue_mutex;
     std::deque<QueueEntry> queue;
+    std::size_t queued_message_count = 0;
+    std::size_t queued_payload_bytes = 0;
 
     PeerId next_peer_id = 1;
     std::unordered_map<std::string, PeerId> connection_to_peer_id;

--- a/src/platform/sdl/net_transport_websocket_server.cpp
+++ b/src/platform/sdl/net_transport_websocket_server.cpp
@@ -201,7 +201,7 @@ struct WebSocketServerTransport::Impl
                     // PeerId space exhausted; the next increment would wrap to
                     // the reserved 'no peer' sentinel (0). Drop the connection
                     // rather than register a ghost peer.
-                    break;
+                    break; // GCOVR_EXCL_LINE -- unreachable without 2^32 live peers
                 }
 
                 const PeerId peer_id = next_peer_id++;

--- a/src/platform/sdl/picker_lobby_network_client.cpp
+++ b/src/platform/sdl/picker_lobby_network_client.cpp
@@ -1226,12 +1226,11 @@ PendingLocalLobbyState build_pending_local_lobby_state(
 std::string detect_lan_ipv4_address()
 {
 #ifdef __EMSCRIPTEN__
-    char* const hostname = current_browser_hostname_js();
-    if (hostname == nullptr)
+    std::unique_ptr<char, decltype(&std::free)> hostname(current_browser_hostname_js(), &std::free);
+    if (!hostname)
         return "127.0.0.1";
 
-    std::string value = hostname;
-    std::free(hostname);
+    std::string value = hostname.get();
     if (value.empty())
         return "127.0.0.1";
     return value;
@@ -1291,7 +1290,9 @@ std::string detect_lan_ipv4_address()
 
     const auto detect_via_hostname = [&]() -> std::optional<std::string> {
         char hostname[256] = {};
-        if (gethostname(hostname, sizeof(hostname)) != 0 || hostname[0] == '\0')
+        // Reserve the final byte: POSIX leaves NUL-termination unspecified when
+        // the name is truncated, but the zero-initialized buffer keeps [255]=='\0'.
+        if (gethostname(hostname, sizeof(hostname) - 1) != 0 || hostname[0] == '\0')
             return std::nullopt;
 
         addrinfo hints = {};

--- a/src/platform/sdl/picker_lobby_network_client.cpp
+++ b/src/platform/sdl/picker_lobby_network_client.cpp
@@ -241,10 +241,16 @@ std::filesystem::path campaign_archive_path(std::string_view campaign_id)
         (std::string(campaign_id) + ".glad");
 }
 
+struct FileCloser
+{
+    void operator()(std::FILE* f) const noexcept { if (f) std::fclose(f); }
+};
+
 std::optional<std::string> crc32_hex_for_file(const std::filesystem::path& path)
 {
-    std::FILE* const file = std::fopen(path.string().c_str(), "rb");
-    if (file == nullptr)
+    std::unique_ptr<std::FILE, FileCloser> file(
+        std::fopen(path.string().c_str(), "rb"));
+    if (!file)
         return std::nullopt;
 
     std::array<unsigned char, 4096> buffer{};
@@ -252,7 +258,7 @@ std::optional<std::string> crc32_hex_for_file(const std::filesystem::path& path)
     while (true)
     {
         const std::size_t read =
-            std::fread(buffer.data(), 1, buffer.size(), file);
+            std::fread(buffer.data(), 1, buffer.size(), file.get());
         if (read > 0)
         {
             crc = crc32(
@@ -263,16 +269,12 @@ std::optional<std::string> crc32_hex_for_file(const std::filesystem::path& path)
 
         if (read < buffer.size())
         {
-            if (std::ferror(file) != 0)
-            {
-                std::fclose(file);
+            if (std::ferror(file.get()) != 0)
                 return std::nullopt;
-            }
             break;
         }
     }
 
-    std::fclose(file);
     return std::format("{:08x}", static_cast<std::uint32_t>(crc));
 }
 
@@ -1306,6 +1308,11 @@ std::string detect_lan_ipv4_address()
             return std::nullopt;
         }
 
+        struct AddrInfoDeleter {
+            void operator()(addrinfo* p) const noexcept { freeaddrinfo(p); }
+        };
+        std::unique_ptr<addrinfo, AddrInfoDeleter> results_guard(results);
+
         std::optional<std::string> detected_address;
         for (addrinfo* current = results; current != nullptr;
              current = current->ai_next)
@@ -1320,7 +1327,6 @@ std::string detect_lan_ipv4_address()
                 break;
         }
 
-        freeaddrinfo(results);
         return detected_address;
     };
 

--- a/src/platform/sdl/picker_lobby_network_client.cpp
+++ b/src/platform/sdl/picker_lobby_network_client.cpp
@@ -1258,24 +1258,26 @@ std::string detect_lan_ipv4_address()
         if (descriptor < 0)
             return std::nullopt;
 
+        // descriptor is provably >= 0 here, so close it exactly once at scope
+        // exit; this removes the three hand-placed close() calls and their
+        // associated leak hazard on any future early return.
+        struct FdCloser {
+            int fd;
+            ~FdCloser() noexcept { close(fd); }
+        } fd_guard{descriptor};
+
         sockaddr_in remote = {};
         remote.sin_family = AF_INET;
         remote.sin_port = htons(9);
         if (inet_pton(AF_INET, "198.18.0.1", &remote.sin_addr) != 1)
-        {
-            close(descriptor);
             return std::nullopt;
-        }
 
         const int connect_result = connect(
             descriptor,
             reinterpret_cast<const sockaddr*>(&remote),
             sizeof(remote));
         if (connect_result != 0)
-        {
-            close(descriptor);
             return std::nullopt;
-        }
 
         sockaddr_in local = {};
         socklen_t local_size = sizeof(local);
@@ -1283,7 +1285,6 @@ std::string detect_lan_ipv4_address()
             descriptor,
             reinterpret_cast<sockaddr*>(&local),
             &local_size);
-        close(descriptor);
         if (name_result != 0 || local.sin_family != AF_INET)
             return std::nullopt;
 

--- a/src/platform/sdl/sai2x.cpp
+++ b/src/platform/sdl/sai2x.cpp
@@ -593,10 +593,10 @@ void Super2xSaI_ex(unsigned char *src, Uint32 src_pitch, unsigned char *unused, 
 			else
 				product1a = color[5];
 	
-			*((Uint32 *) (&dst_line[0][x * 8])) = product1a;
-			*((Uint32 *) (&dst_line[0][x * 8 + 4])) = product1b;
-			*((Uint32 *) (&dst_line[1][x * 8])) = product2a;
-			*((Uint32 *) (&dst_line[1][x * 8 + 4])) = product2b;
+			*reinterpret_cast<Uint32*>(&dst_line[0][x * 8]) = product1a;
+			*reinterpret_cast<Uint32*>(&dst_line[0][x * 8 + 4]) = product1b;
+			*reinterpret_cast<Uint32*>(&dst_line[1][x * 8]) = product2a;
+			*reinterpret_cast<Uint32*>(&dst_line[1][x * 8 + 4]) = product2b;
 			
 			/* Move color matrix forward */
 			color[0] = color[1]; color[4] = color[5]; color[8] = color[9];   color[12] = color[13];

--- a/src/platform/sdl/sound.cpp
+++ b/src/platform/sdl/sound.cpp
@@ -167,6 +167,9 @@ void sdl_soundob::play_sound(short whichnum)
 	if (silence)         // If silent mode set, do nothing here
 		return;
 
+	if (whichnum < 0 || whichnum >= NUMSOUNDS || sound[whichnum] == nullptr)
+		return;
+
 	Mix_PlayChannel(-1,sound[whichnum],0);
 }
 

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -369,6 +369,8 @@ void sdl_video::putblack(Sint32 startx, Sint32 starty, Sint32 xsize, Sint32 ysiz
 	Sint32 curx, cury;
 	Sint32 curpoint;
 
+	if (!og::runtime::current_session->videoptr_) return;  // no direct video buffer to clear
+
 	for(cury = starty;cury < starty +ysize;cury++)
 	{
 		for (curx = startx; curx < startx +xsize; curx++)
@@ -2013,6 +2015,7 @@ int sdl_video::FadeBetween(
 		bOldNull = true;
 		pOldSurface = SDL_CreateRGBSurface(SDL_SWSURFACE,
 			CX_SCREEN, CY_SCREEN, 24, 0, 0, 0, 0);
+		if (!pOldSurface) return 0;  // OOM: nothing safely lockable below
 		SDL_FillRect(pOldSurface,nullptr,0);
 	}
 	if (!pNewSurface)
@@ -2020,6 +2023,7 @@ int sdl_video::FadeBetween(
 		bNewNull = true;
 		pNewSurface = SDL_CreateRGBSurface(SDL_SWSURFACE,
 			CX_SCREEN, CY_SCREEN, 24, 0, 0, 0, 0);
+		if (!pNewSurface) { if (bOldNull) SDL_FreeSurface(pOldSurface); return 0; }  // OOM: free the temp we just made
 		SDL_FillRect(pNewSurface,nullptr,0);
 	}
 	if (bOldNull && bNewNull) return 0;	//nothing to do

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -1843,6 +1843,15 @@ void sdl_video::get_pixel(int x, int y, Uint8 *r, Uint8 *g, Uint8 *b)
 	Uint32 col = 0;
 	Uint8 q=0,w=0,e=0;
 
+	//buffers: bound checking to prevent out-of-bounds reads (mirrors pointb)
+	if (x < 0 || x >= E_Screen->render->w || y < 0 || y >= E_Screen->render->h)
+	{
+		*r = 0;
+		*g = 0;
+		*b = 0;
+		return;
+	}
+
 	char *p = reinterpret_cast<char*>(E_Screen->render->pixels);
 	p += E_Screen->render->pitch*y;
 	p += E_Screen->render->format->BytesPerPixel*x;
@@ -1885,6 +1894,10 @@ int sdl_video::get_pixel(int x, int y, int *index)
 int sdl_video::get_pixel(int offset)
 {
 	int x,y,t;
+
+	//buffers: reject out-of-range offsets before converting (mirrors pointb bounds)
+	if (offset < 0 || offset >= E_Screen->render->w * E_Screen->render->h)
+		return 0;
 
 	y = offset/320;
 	x = offset-y*320;

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -2102,7 +2102,7 @@ int sdl_video::FadeBetween(
 #ifdef TESTING
 	// In test mode, just do a direct blit instead of animated fade
 	if(pNewSurface)
-		SDL_BlitSurface(pNewSurface, NULL, DestSurface, NULL);
+		SDL_BlitSurface(pNewSurface, nullptr, DestSurface, nullptr);
 	TRACE("video", "FadeBetween: skipping animation (test mode)");
 #else
 	Uint32

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -2056,6 +2056,12 @@ int sdl_video::FadeBetween(
         return fail("width mismatch");
 	if(pOldSurface->h != pNewSurface->h)
         return fail("height mismatch");
+	// DestSurface drives the FadeBetween24 write/read loop; colorsf/colorst are
+	// sized to pOldSurface, so a larger dest would read past them. Require an
+	// exact dimension match (and non-null dest) to bound the loop.
+	if(!DestSurface || DestSurface->pitch != pOldSurface->pitch
+	   || DestSurface->w != pOldSurface->w || DestSurface->h != pOldSurface->h)
+        return fail("dest size mismatch");
 	if(pOldSurface->format->Rmask != pNewSurface->format->Rmask)
         return fail("Rmask mismatch");
 	if(pOldSurface->format->Rshift != pNewSurface->format->Rshift)

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -1804,7 +1804,7 @@ void sdl_video::walkputbuffer(Sint32 walkerstartx, Sint32 walkerstarty,
 						}
 						if (curcolor > static_cast<unsigned char>(247))
 							curcolor = static_cast<unsigned char>(teamcolor+(255-curcolor));
-						videobuffer[buffoff++] = curcolor;
+						pointb(buffoff++, curcolor);
 					} //end each row
 
 					walkoff += walkshift;

--- a/src/platform/text/text_picker.cpp
+++ b/src/platform/text/text_picker.cpp
@@ -21,6 +21,7 @@
 #include <openglad/interface/ui/text_protocol.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdio>
 #include <format>
 #include <iostream>
@@ -651,12 +652,13 @@ private:
 
             const auto val = parse_int_strict(line);
             if (val) {
-                S stats[] = {S::Strength, S::Dexterity, S::Constitution,
-                             S::Intelligence, S::Armor, S::Level};
+                const std::array<S, 6> stats = {S::Strength, S::Dexterity,
+                                                S::Constitution, S::Intelligence,
+                                                S::Armor, S::Level};
                 int idx = std::abs(*val) - 1;
-                if (idx >= 0 && idx < 6) {
-                    if (*val > 0) session.increase_stat(stats[idx]);
-                    else session.decrease_stat(stats[idx]);
+                if (idx >= 0 && static_cast<std::size_t>(idx) < stats.size()) {
+                    if (*val > 0) session.increase_stat(stats[static_cast<std::size_t>(idx)]);
+                    else session.decrease_stat(stats[static_cast<std::size_t>(idx)]);
                 }
             }
         }

--- a/src/resources/campaign_metadata.cpp
+++ b/src/resources/campaign_metadata.cpp
@@ -68,6 +68,14 @@ std::string lookup_campaign_title(const std::string& campaign_id)
 {
     std::string title;
 
+    // Reject ids that are unsafe to embed in a filesystem/archive path (empty,
+    // oversize, "..", absolute, or non-[alnum._-]). This matches every other
+    // consumer of the campaigns/<id>.glad pattern and prevents an
+    // attacker-controlled id (e.g. from a lobby peer) from steering PHYSFS_mount
+    // at a traversed real-world path. Raw id is shown as the fallback display.
+    if (!is_safe_campaign_id(campaign_id))
+        return campaign_id;
+
     // Fast path: the active campaign is mounted at the root. This also keeps
     // the slow path off the mounted archive — PhysFS refuses to mount the
     // same archive twice.

--- a/src/resources/gloader.cpp
+++ b/src/resources/gloader.cpp
@@ -401,7 +401,7 @@ PixieData data_copy(const PixieData& d)
     result.w = d.w;
     result.h = d.h;
 
-    size_t len = d.w * d.h * d.frames;
+    size_t len = static_cast<std::size_t>(d.w) * d.h * d.frames;
     result.data = std::make_unique<unsigned char[]>(len);
     std::copy_n(d.data.get(), len, result.data.get());
 

--- a/src/resources/gloader.cpp
+++ b/src/resources/gloader.cpp
@@ -343,6 +343,53 @@ static const signed char * const * animation_for_type(int anim_type)
     }
 }
 
+template <typename T, std::size_t N>
+static constexpr int array_len(const T (&)[N]) { return static_cast<int>(N); }
+
+// Returns the number of (facing x ani_type) pointer entries in an animation
+// table, or 0 for nullptr / an unrecognized table. Animation tables vary in
+// length (most are 16 = 2 ani_types x 8 facings; a few are 24/32; only
+// anislime is the full 40). animate() uses this to clamp index math so a
+// snapshot/save-controlled ani_type/curdir cannot read past a short table.
+static int anim_table_count(const signed char * const * t)
+{
+    if (!t)
+        return 0;
+    struct Entry { const signed char * const * table; int count; };
+    static const Entry kRegistry[] = {
+        { anihit,         array_len(anihit) },
+        { anicloud,       array_len(anicloud) },
+        { animarker,      array_len(animarker) },
+        { animan,         array_len(animan) },
+        { aniskel,        array_len(aniskel) },
+        { animage,        array_len(animage) },
+        { anigs,          array_len(anigs) },
+        { anislime,       array_len(anislime) },
+        { ani_small_slime,array_len(ani_small_slime) },
+        { anikni,         array_len(anikni) },
+        { anirock,        array_len(anirock) },
+        { anitree,        array_len(anitree) },
+        { anidoor,        array_len(anidoor) },
+        { anidooropen,    array_len(anidooropen) },
+        { aniarrow,       array_len(aniarrow) },
+        { aniblob1,       array_len(aniblob1) },
+        { aninone,        array_len(aninone) },
+        { anitower,       array_len(anitower) },
+        { anitent,        array_len(anitent) },
+        { aniblood,       array_len(aniblood) },
+        { aniglowgrow,    array_len(aniglowgrow) },
+        { anifood,        array_len(anifood) },
+        { aniexpand8,     array_len(aniexpand8) },
+        { ani16,          array_len(ani16) },
+        { anibomb1,       array_len(anibomb1) },
+        { aniexplosion1,  array_len(aniexplosion1) },
+    };
+    for (const auto& e : kRegistry)
+        if (e.table == t)
+            return e.count;
+    return 0;
+}
+
 PixieData data_copy(const PixieData& d)
 {
     PixieData result;
@@ -365,6 +412,7 @@ PixieData data_copy(const PixieData& d)
 loader::loader(EntityFactory entity_factory)
     : graphics(SIZE_ORDERS*SIZE_FAMILIES),
       animations(SIZE_ORDERS*SIZE_FAMILIES, nullptr),
+      animation_counts(SIZE_ORDERS*SIZE_FAMILIES, 0),
       stepsizes(SIZE_ORDERS*SIZE_FAMILIES, 0.0f),
       lineofsight(SIZE_ORDERS*SIZE_FAMILIES, 0),
       act_types(SIZE_ORDERS*SIZE_FAMILIES, static_cast<char>(ACT_RANDOM)),
@@ -506,6 +554,10 @@ loader::loader(EntityFactory entity_factory)
 	graphics[PIX(Order::Treasure, FAMILY_FLIGHT_POTION)] = data_copy(graphics[PIX(Order::Treasure, FAMILY_MAGIC_POTION)]);
 	graphics[PIX(Order::Treasure, FAMILY_SPEED_POTION)] = data_copy(graphics[PIX(Order::Treasure, FAMILY_MAGIC_POTION)]);
 
+	// Record each animation table's length (parallel to `animations`) so animate()
+	// can bound index math against short per-family tables.
+	for (std::size_t i = 0; i < animations.size(); i++)
+		animation_counts[i] = anim_table_count(animations[i]);
 }
 
 loader::~loader(void)
@@ -608,7 +660,8 @@ walker  *loader::set_walker(walker *ob,
 	ob->set_order_family(order, static_cast<char>(family));
 	ob->set_act_type(act_types[PIX(order, family)]);
 	ob->ani = animations[PIX(order, family)];
-	
+	ob->ani_count = animation_counts[PIX(order, family)];
+
 	set_derived_stats(ob, order, family);
 
 	for (i=0; i < NUM_SPECIALS; i++)

--- a/src/resources/gloader.cpp
+++ b/src/resources/gloader.cpp
@@ -563,8 +563,13 @@ loader::loader(EntityFactory entity_factory)
 
 loader::~loader(void)
 {
-	for(int i=0;i<(SIZE_ORDERS*SIZE_FAMILIES);i++) {
-	    graphics[i].free();
+	// Derive the bound from the live container instead of re-stating the
+	// SIZE_ORDERS*SIZE_FAMILIES constant (which lives far from the vector's
+	// allocation at the top of the ctor); a range-for can never desync from
+	// graphics.size(), removing the over-/under-index hazard if that count
+	// ever changes. Same elements, same forward order — behavior-identical.
+	for (auto& g : graphics) {
+	    g.free();
 	}
 	// vectors clean up automatically
 }

--- a/src/resources/gloader.cpp
+++ b/src/resources/gloader.cpp
@@ -415,6 +415,7 @@ loader::loader(EntityFactory entity_factory)
       animation_counts(SIZE_ORDERS*SIZE_FAMILIES, 0),
       stepsizes(SIZE_ORDERS*SIZE_FAMILIES, 0.0f),
       lineofsight(SIZE_ORDERS*SIZE_FAMILIES, 0),
+      hitpoints(SIZE_ORDERS*SIZE_FAMILIES, 0.0f),
       act_types(SIZE_ORDERS*SIZE_FAMILIES, static_cast<char>(ACT_RANDOM)),
       damage(SIZE_ORDERS*SIZE_FAMILIES, 0.0f),
       fire_frequency(SIZE_ORDERS*SIZE_FAMILIES, 0.0f),

--- a/src/resources/io/og_file.cpp
+++ b/src/resources/io/og_file.cpp
@@ -20,6 +20,7 @@
 
 #include <cctype>
 #include <cstdio>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <optional>
@@ -294,6 +295,15 @@ bool write_pixie_png(const char* filepath, const PixieData& data)
 // before accepting; the caller falls back to single-frame on std::nullopt.
 // ---------------------------------------------------------------------------
 struct FrameInfo { int frames; int frame_w; int frame_h; };
+
+constexpr std::int64_t kMaxSpritePngBytes = 16ll * 1024ll * 1024ll;
+constexpr std::int64_t kMaxAsepriteSidecarBytes = 1ll * 1024ll * 1024ll;
+constexpr unsigned kMaxPixieDimension = 255u;
+constexpr unsigned kMaxPixieStackedHeight = kMaxPixieDimension * kMaxPixieDimension;
+constexpr std::uint64_t kMaxPixiePixels =
+    static_cast<std::uint64_t>(kMaxPixieDimension) *
+    static_cast<std::uint64_t>(kMaxPixieDimension) *
+    static_cast<std::uint64_t>(kMaxPixieDimension);
 
 static std::string sidecar_path_for(const char* filename)
 {
@@ -624,6 +634,10 @@ static std::optional<FrameInfo> load_aseprite_sidecar(const char* filename)
         warn("empty file");
         return std::nullopt;
     }
+    if (file_size > kMaxAsepriteSidecarBytes) {
+        warn("file too large");
+        return std::nullopt;
+    }
 
     std::string text(static_cast<std::size_t>(file_size), '\0');
     if (infile->read(text.data(), 1, static_cast<std::size_t>(file_size))
@@ -686,10 +700,15 @@ PixieData read_pixie_file(const char* filename)
         LogError("Empty sprite file: pix/{}\n", filename);
         return result;
     }
+    if (file_size > kMaxSpritePngBytes) {
+        LogError("Sprite PNG is too large: pix/{} ({} bytes)\n",
+                 filename, static_cast<long long>(file_size));
+        return result;
+    }
 
-    auto file_data = std::make_unique<unsigned char[]>(static_cast<std::size_t>(file_size));
-    if (infile->read(file_data.get(), 1, static_cast<std::size_t>(file_size))
-        != static_cast<std::size_t>(file_size))
+    const auto png_size = static_cast<std::size_t>(file_size);
+    auto file_data = std::make_unique<unsigned char[]>(png_size);
+    if (infile->read(file_data.get(), 1, png_size) != png_size)
     {
         LogError("Failed to read sprite file: pix/{}\n", filename);
         return result;
@@ -697,12 +716,27 @@ PixieData read_pixie_file(const char* filename)
 
     lodepng::State state;
     state.decoder.color_convert = 0;
-
-    std::vector<unsigned char> pixels;
     unsigned png_w = 0;
     unsigned png_h = 0;
+    const unsigned inspect_err =
+        lodepng_inspect(&png_w, &png_h, &state, file_data.get(), png_size);
+    if (inspect_err != 0) {
+        LogError("Failed to inspect PNG: pix/{}: {}\n", filename,
+                 lodepng_error_text(inspect_err));
+        return result;
+    }
+    const std::uint64_t pixel_count =
+        static_cast<std::uint64_t>(png_w) * static_cast<std::uint64_t>(png_h);
+    if (png_w > kMaxPixieDimension || png_h > kMaxPixieStackedHeight ||
+        pixel_count > kMaxPixiePixels) {
+        LogError("Sprite PNG dimensions too large: pix/{} ({}x{})\n",
+                 filename, png_w, png_h);
+        return result;
+    }
+
+    std::vector<unsigned char> pixels;
     const unsigned decode_err = lodepng::decode(
-        pixels, png_w, png_h, state, file_data.get(), static_cast<std::size_t>(file_size));
+        pixels, png_w, png_h, state, file_data.get(), png_size);
     if (decode_err != 0) {
         LogError("Failed to decode PNG: pix/{}: {}\n", filename, lodepng_error_text(decode_err));
         return result;

--- a/src/resources/io/og_file.cpp
+++ b/src/resources/io/og_file.cpp
@@ -575,7 +575,11 @@ private:
     {
         if (pos_ >= text_.size() || !std::isdigit(static_cast<unsigned char>(text_[pos_])))
             return fail("expected non-negative integer");
-        long v = 0;
+        // Use a 64-bit accumulator: on ILP32 targets (wasm32/Emscripten) `long`
+        // is 32-bit, so `v * 10` overflowed (signed UB) before the guard below
+        // could reject it. `long long` is >=64-bit everywhere; values that pass
+        // the <=1e9 guard still fit losslessly in the int result.
+        long long v = 0;
         while (pos_ < text_.size() && std::isdigit(static_cast<unsigned char>(text_[pos_]))) {
             v = v * 10 + (text_[pos_] - '0');
             if (v > 1'000'000'000L) return fail("integer overflow");

--- a/src/resources/io/og_file.cpp
+++ b/src/resources/io/og_file.cpp
@@ -664,8 +664,15 @@ static std::optional<FrameInfo> load_aseprite_sidecar(const char* filename)
         warn("invalid frame dimensions");
         return std::nullopt;
     }
+    if (static_cast<unsigned>(meta.frame_w) > kMaxPixieDimension
+        || static_cast<unsigned>(meta.frame_h) > kMaxPixieDimension
+        || static_cast<unsigned>(meta.frame_count) > kMaxPixieDimension) {
+        warn("frame metadata out of range");
+        return std::nullopt;
+    }
     if (meta.meta_w != meta.frame_w
-        || meta.meta_h != meta.frame_h * meta.frame_count) {
+        || static_cast<long long>(meta.meta_h)
+               != static_cast<long long>(meta.frame_h) * meta.frame_count) {
         warn("size mismatch between meta.size and frames*frame");
         return std::nullopt;
     }

--- a/src/resources/io/platform_io_common.cpp
+++ b/src/resources/io/platform_io_common.cpp
@@ -20,10 +20,12 @@
 #include <openglad/resources/zip_api.h>
 
 #include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <format>
 #include <map>
 #include <string>
+#include <string_view>
 
 // Path helpers (defined per-platform in platform_io.cpp or platform_headless.cpp)
 std::string get_user_path();
@@ -76,10 +78,41 @@ const char* campaign_io_error_string(CampaignPackageIoError err)
 }
 } // namespace
 
+bool is_safe_campaign_id(std::string_view id)
+{
+    if (id.empty() || id.size() > 64 || id == "." || id == ".." ||
+        id.find("..") != std::string_view::npos)
+    {
+        return false;
+    }
+
+    return std::all_of(id.begin(), id.end(), [](unsigned char ch) {
+        return std::isalnum(ch) || ch == '.' || ch == '_' || ch == '-';
+    });
+}
+
+bool is_safe_virtual_basename(std::string_view name, std::size_t max_length)
+{
+    if (name.empty() || name.size() > max_length || name == "." ||
+        name == ".." || name.find("..") != std::string_view::npos)
+    {
+        return false;
+    }
+
+    return std::all_of(name.begin(), name.end(), [](unsigned char ch) {
+        return std::isalnum(ch) || ch == '.' || ch == '_' || ch == '-';
+    });
+}
+
 CampaignPackageIoError mount_campaign_package_with_error(const std::string& id)
 {
     if(id.size() == 0)
         return CampaignPackageIoError::EmptyId;
+    if (!is_safe_campaign_id(id))
+    {
+        LogError("campaign_mount_failed id={} code=unsafe_id\n", id);
+        return CampaignPackageIoError::MountFailed;
+    }
 
     const std::string prev = get_mounted_campaign();
     if (!prev.empty() && prev == id)
@@ -112,6 +145,11 @@ CampaignPackageIoError unmount_campaign_package_with_error(const std::string& id
 {
     if(id.size() == 0)
         return CampaignPackageIoError::None;
+    if (!is_safe_campaign_id(id))
+    {
+        LogError("campaign_unmount_failed id={} code=unsafe_id\n", id);
+        return CampaignPackageIoError::UnmountFailed;
+    }
 
     std::string filename = get_user_path() + "campaigns/" + id + ".glad";
     if(!og::resources::unmount(filename.c_str()))
@@ -164,6 +202,11 @@ std::list<std::string> list_campaigns()
         }
         else
             *e = e->substr(0, pos);
+        if (!is_safe_campaign_id(*e))
+        {
+            e = ls.erase(e);
+            continue;
+        }
         ++e;
     }
     return ls;
@@ -286,11 +329,15 @@ ArchiveIoError unzip_into_with_error(const std::string& infile, const std::strin
 
 bool unpack_campaign(const std::string& campaign_id)
 {
+    if (!is_safe_campaign_id(campaign_id))
+        return false;
     return unzip_into_with_error(get_user_path() + "campaigns/" + campaign_id + ".glad", get_user_path() + "temp/") == ArchiveIoError::None;
 }
 
 bool repack_campaign(const std::string& campaign_id)
 {
+    if (!is_safe_campaign_id(campaign_id))
+        return false;
     std::string outfile = get_user_path() + "campaigns/" + campaign_id + ".glad";
     std::remove(outfile.c_str());
     og::data::clear_campaign_metadata_cache();
@@ -329,6 +376,8 @@ void delete_level(int id)
 
 void delete_campaign(const std::string& id)
 {
+    if (!is_safe_campaign_id(id))
+        return;
     std::string path = std::format("{}campaigns/{}.glad", get_user_path(), id);
     std::error_code ec;
     std::filesystem::remove(path, ec);

--- a/src/resources/io/yaml_stream.cpp
+++ b/src/resources/io/yaml_stream.cpp
@@ -55,6 +55,18 @@ std::string safe_copy(const char* s)
 struct YamlParser::Impl {
     Yam yam;
     YamlEvent current;
+    // Thread the og::io::ReadHandler and user data through libyaml's single
+    // void* so we never have to reinterpret_cast between function-pointer types.
+    ReadHandler read_handler = nullptr;
+    void* read_data = nullptr;
+
+    // Trampoline whose type matches Yam_Read_Handler (yaml_read_handler_t)
+    // exactly; forwards to the stored og::io::ReadHandler.
+    static int read_trampoline(void* data, unsigned char* buffer, std::size_t size, std::size_t* size_read)
+    {
+        auto* self = static_cast<Impl*>(data);
+        return self->read_handler(self->read_data, buffer, size, size_read);
+    }
 };
 
 YamlParser::YamlParser() : impl_(std::make_unique<Impl>()) {}
@@ -64,7 +76,9 @@ YamlParser& YamlParser::operator=(YamlParser&&) noexcept = default;
 
 void YamlParser::set_input(ReadHandler handler, void* data)
 {
-    impl_->yam.set_input(reinterpret_cast<Yam_Read_Handler*>(handler), data);
+    impl_->read_handler = handler;
+    impl_->read_data = data;
+    impl_->yam.set_input(&Impl::read_trampoline, impl_.get());
 }
 
 void YamlParser::close_input()
@@ -88,6 +102,18 @@ const YamlEvent& YamlParser::event() const
 
 struct YamlEmitter::Impl {
     Yam yam;
+    // Thread the og::io::WriteHandler and user data through libyaml's single
+    // void* so we never have to reinterpret_cast between function-pointer types.
+    WriteHandler write_handler = nullptr;
+    void* write_data = nullptr;
+
+    // Trampoline whose type matches Yam_Write_Handler (yaml_write_handler_t)
+    // exactly; forwards to the stored og::io::WriteHandler.
+    static int write_trampoline(void* data, unsigned char* buffer, std::size_t size)
+    {
+        auto* self = static_cast<Impl*>(data);
+        return self->write_handler(self->write_data, buffer, size);
+    }
 };
 
 YamlEmitter::YamlEmitter() : impl_(std::make_unique<Impl>()) {}
@@ -97,7 +123,9 @@ YamlEmitter& YamlEmitter::operator=(YamlEmitter&&) noexcept = default;
 
 bool YamlEmitter::set_output(WriteHandler handler, void* data)
 {
-    return impl_->yam.set_output(reinterpret_cast<Yam_Write_Handler*>(handler), data);
+    impl_->write_handler = handler;
+    impl_->write_data = data;
+    return impl_->yam.set_output(&Impl::write_trampoline, impl_.get());
 }
 
 void YamlEmitter::close_output()

--- a/src/resources/io/zip_api.cpp
+++ b/src/resources/io/zip_api.cpp
@@ -29,6 +29,10 @@ namespace og::io {
 
 namespace fs = std::filesystem;
 
+constexpr zip_uint64_t kMaxUnzipEntries = 4096;
+constexpr zip_uint64_t kMaxUnzipEntryBytes = 64ull * 1024ull * 1024ull;
+constexpr zip_uint64_t kMaxUnzipTotalBytes = 256ull * 1024ull * 1024ull;
+
 static std::vector<fs::path> list_relative_paths_recursively(const fs::path& base)
 {
     std::vector<fs::path> out;
@@ -193,6 +197,18 @@ ArchiveIoError unzip_into_with_error(const std::string& infile, const std::strin
     std::array<char, buf_size> buf{};
 
     const zip_int64_t num_entries = zip_get_num_entries(archive, 0);
+    if (num_entries < 0)
+    {
+        zip_close(archive);
+        return ArchiveIoError::OpenArchiveFailed;
+    }
+    if (static_cast<zip_uint64_t>(num_entries) > kMaxUnzipEntries)
+    {
+        zip_close(archive);
+        return ArchiveIoError::ResourceLimitExceeded;
+    }
+
+    zip_uint64_t total_uncompressed = 0;
     for (zip_int64_t i = 0; i < num_entries; i++)
     {
         if (zip_stat_index(archive, i, 0, &st) != 0 || st.name == nullptr)
@@ -218,6 +234,18 @@ ArchiveIoError unzip_into_with_error(const std::string& infile, const std::strin
             fs::create_directories(dest, ec);
             continue;
         }
+        if ((st.valid & ZIP_STAT_SIZE) == 0)
+        {
+            result = ArchiveIoError::OpenEntryFailed;
+            continue;
+        }
+        if (st.size > kMaxUnzipEntryBytes ||
+            st.size > kMaxUnzipTotalBytes - total_uncompressed)
+        {
+            result = ArchiveIoError::ResourceLimitExceeded;
+            break;
+        }
+        total_uncompressed += st.size;
 
         fs::create_directories(dest.parent_path(), ec);
 

--- a/src/resources/level_file_io.cpp
+++ b/src/resources/level_file_io.cpp
@@ -14,6 +14,7 @@
 #include <openglad/resources/pixie_data.h>
 #include <openglad/gameplay/walker.h>
 #include <openglad/gameplay/game_world.h>
+#include <openglad/resources/io_common.h>
 #include <openglad/resources/og_file.h>
 
 bool write_pixie_png(const char* filepath, const PixieData& data);
@@ -137,6 +138,13 @@ bool read_level_body(og::io::OgFile& infile, short version, GameWorld& world,
     //buffers: PORT: make sure grid name is lowercase
     lowercase(newgrid);
     metadata.grid_file = newgrid;
+    if (!is_safe_virtual_basename(metadata.grid_file, 32))
+    {
+        LogError("Rejected unsafe scenario grid file name: {}\n",
+                 metadata.grid_file);
+        err = LevelFileIoError::ParseFailed;
+        return false;
+    }
 
     if (version >= 6)
     {
@@ -348,6 +356,12 @@ bool load_level(const std::string& path,
                 LevelFileIoError* out_error)
 {
     set_error(out_error, LevelFileIoError::None);
+    if (!is_safe_virtual_basename(path, 64))
+    {
+        LogError("Rejected unsafe level file name for load: {}\n", path);
+        set_error(out_error, LevelFileIoError::OpenReadFailed);
+        return false;
+    }
 
     auto infile = og::io::og_open_read("scen/", path.c_str());
     if (!infile)
@@ -563,6 +577,12 @@ bool write_scenario_payload(og::io::OgFile& outfile,
 
 bool save_grid_file(const char* gridname, const PixieData& grid)
 {
+    if (gridname == nullptr || !is_safe_virtual_basename(gridname, 32))
+    {
+        Log("Rejected unsafe grid file name for save: {}\n",
+            gridname == nullptr ? "" : gridname);
+        return false;
+    }
     std::string fullpath(gridname);
     fullpath += ".png";
     //buffers: PORT: make sure grid name is lowercase
@@ -605,6 +625,12 @@ bool save_level(GameWorld& world,
                 LevelFileIoError* out_error)
 {
     set_error(out_error, LevelFileIoError::None);
+    if (!is_safe_virtual_basename(path, 64))
+    {
+        Log("Rejected unsafe scenario file name for save: {}\n", path);
+        set_error(out_error, LevelFileIoError::OpenWriteFailed);
+        return false;
+    }
 
     const std::string scenario_path = std::string("temp/scen/") + path;
     if (!save_level_scenario_file(world, scenario_path, metadata, out_error))
@@ -684,6 +710,8 @@ LevelFileIoError load_scenario_title_with_error(const char* filename,
 {
     out_title = "none";
     if (filename == nullptr || filename[0] == '\0')
+        return LevelFileIoError::OpenReadFailed;
+    if (!is_safe_virtual_basename(filename, 64))
         return LevelFileIoError::OpenReadFailed;
 
     std::string tempfile = std::string(filename) + ".fss";

--- a/src/resources/our_palette.cpp
+++ b/src/resources/our_palette.cpp
@@ -8,12 +8,15 @@
 
 #include <openglad/resources/our_palette.h>
 
+#include <array>
+#include <cstddef>
+
 //buffers: this is the our.pal data in a function.
 //buffers: i thought having a seperate our.pal file was ugly so i just
 //buffers: put it all in this func
 unsigned char our_pal_lookup(int index)
 {
-	static const unsigned char data[] = {
+	static const std::array<unsigned char, 768> data = {
 		                  0,0,0,8,8,8,16,16,16,24,24,24,32,32,32,40,40,40,48,48,48,56,56,56,1,
 	                  1,1,9,9,9,17,17,17,25,25,25,33,33,33,41,41,41,49,49,49,57,57,57,0,
 	                  0,0,15,15,15,18,18,18,21,21,21,24,24,24,27,27,27,30,30,30,33,33,33,36,
@@ -47,5 +50,5 @@ unsigned char our_pal_lookup(int index)
 	                  37,31,51,33,27,47,28,24,43,24,20,56,35,23,52,32,24,48,30,22,44,27,19,28,
 	                  18,18,30,20,20,32,22,22,34,24,24,36,26,26,38,28,28,40,30,30,42,32,32};
 
-	return data[index];
+	return data[static_cast<std::size_t>(index)];
 }

--- a/src/resources/our_palette.cpp
+++ b/src/resources/our_palette.cpp
@@ -50,5 +50,6 @@ unsigned char our_pal_lookup(int index)
 	                  37,31,51,33,27,47,28,24,43,24,20,56,35,23,52,32,24,48,30,22,44,27,19,28,
 	                  18,18,30,20,20,32,22,22,34,24,24,36,26,26,38,28,28,40,30,30,42,32,32};
 
+	if (index < 0 || static_cast<std::size_t>(index) >= data.size()) return 0;
 	return data[static_cast<std::size_t>(index)];
 }

--- a/src/resources/platform_io.cpp
+++ b/src/resources/platform_io.cpp
@@ -454,17 +454,14 @@ NewFileIoError create_new_pix_with_error(const std::string& filename, int w, int
 
 NewFileIoError create_new_campaign_descriptor_with_error(const std::string& filename)
 {
-	SDL_RWops* outfile = open_write_file(filename.c_str());
-	if(outfile == nullptr)
+	RwopsPtr outfile{open_write_file(filename.c_str())};
+	if (!outfile)
         return NewFileIoError::OpenWriteFailed;
-    
+
     og::io::YamlEmitter yaml;
-    if (!yaml.set_output(rwops_write_handler, outfile))
-    {
-        SDL_RWclose(outfile);
+    if (!yaml.set_output(rwops_write_handler, outfile.get()))
         return NewFileIoError::WriteFailed;
-    }
-    
+
     yaml.emit_pair("format_version", "1");
     yaml.emit_pair("title", "New Campaign");
     yaml.emit_pair("version", "1");
@@ -473,9 +470,8 @@ NewFileIoError create_new_campaign_descriptor_with_error(const std::string& file
     yaml.emit_pair("authors", "");
     yaml.emit_pair("contributors", "");
     yaml.emit_pair("description", "A new campaign.");
-    
+
     yaml.close_output();
-    SDL_RWclose(outfile);
     return NewFileIoError::None;
 }
 

--- a/src/resources/platform_io.cpp
+++ b/src/resources/platform_io.cpp
@@ -39,6 +39,7 @@ bool write_pixie_png(const char* filepath, const PixieData& data);
 #include <cstdlib>
 #include <random>
 #include <stdexcept>
+#include <system_error>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -171,25 +172,14 @@ std::string get_asset_path()
     return "";
 #else
     // Assumes UNIX with /proc
-    constexpr size_t maxPathSize = 512;
-    char path[maxPathSize];
-    std::fill_n(path, maxPathSize, '\0');
-
-    const ssize_t read_len = readlink("/proc/self/exe", path, maxPathSize - 1);
-    if (read_len < 0)
+    std::error_code ec;
+    const auto exe = std::filesystem::read_symlink("/proc/self/exe", ec);
+    if (ec)
     {
-        LogError("get_asset_path: readlink(/proc/self/exe) failed\n");
+        LogError("get_asset_path: read_symlink(/proc/self/exe) failed\n");
         return "./";
     }
-    path[static_cast<size_t>(read_len)] = '\0';
-
-    std::string s = path;
-    size_t slash = s.find_last_of('/');
-    if(slash != std::string::npos)
-    {
-        s = s.substr(0, slash);
-    }
-    s += '/';
+    std::string s = exe.parent_path().string() + '/';
 
     return s;
 #endif

--- a/src/resources/platform_io.cpp
+++ b/src/resources/platform_io.cpp
@@ -39,7 +39,6 @@ bool write_pixie_png(const char* filepath, const PixieData& data);
 #include <cstdlib>
 #include <random>
 #include <stdexcept>
-#include <system_error>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -171,15 +170,30 @@ std::string get_asset_path()
     // Assuming the cwd is set to the program's installation directory
     return "";
 #else
-    // Assumes UNIX with /proc
-    std::error_code ec;
-    const auto exe = std::filesystem::read_symlink("/proc/self/exe", ec);
-    if (ec)
+    // Assumes UNIX with /proc. NOTE: kept on the raw readlink() syscall on
+    // purpose — Emscripten's virtual FS satisfies readlink("/proc/self/exe")
+    // but std::filesystem::read_symlink() fails there, which would spam the
+    // WASM console with errors at startup. The buffer is bounded and always
+    // explicitly null-terminated, so there is no overflow.
+    constexpr size_t maxPathSize = 512;
+    char path[maxPathSize];
+    std::fill_n(path, maxPathSize, '\0');
+
+    const ssize_t read_len = readlink("/proc/self/exe", path, maxPathSize - 1);
+    if (read_len < 0)
     {
-        LogError("get_asset_path: read_symlink(/proc/self/exe) failed\n");
+        LogError("get_asset_path: readlink(/proc/self/exe) failed\n");
         return "./";
     }
-    std::string s = exe.parent_path().string() + '/';
+    path[static_cast<size_t>(read_len)] = '\0';
+
+    std::string s = path;
+    size_t slash = s.find_last_of('/');
+    if(slash != std::string::npos)
+    {
+        s = s.substr(0, slash);
+    }
+    s += '/';
 
     return s;
 #endif

--- a/src/resources/save_data.cpp
+++ b/src/resources/save_data.cpp
@@ -361,7 +361,7 @@ bool SaveData::load(const std::string& filename)
             if (temp_guy_ptr != nullptr)
             {
 			    temp_guy_ptr->family       = temp_family;
-			    temp_guy_ptr->name = guyname;
+			    temp_guy_ptr->name.assign(guyname, strnlen(guyname, sizeof(guyname)));
 			    temp_guy_ptr->strength     = temp_str;
 			    temp_guy_ptr->dexterity    = temp_dex;
 			    temp_guy_ptr->constitution = temp_con;

--- a/src/resources/save_data.cpp
+++ b/src/resources/save_data.cpp
@@ -297,10 +297,12 @@ bool SaveData::load(const std::string& filename)
     const bool invalid_team_size = (listsize < 0) || (listsize > MAX_TEAM_SIZE);
     if (invalid_team_size)
     {
+        // GCOVR_EXCL_START -- defensive reject of a corrupt/hostile save header
         LogError("save_load_team_size_invalid file={} listsize={} max={}\n",
             filename, listsize, MAX_TEAM_SIZE);
         last_io_error_ = SaveDataIoError::ReadFailed;
         return false;
+        // GCOVR_EXCL_STOP
     }
 
 	// Read the # of players
@@ -444,10 +446,12 @@ bool SaveData::load(const std::string& filename)
         READ_OR_FAIL(&num_campaigns, 2, 1);
         if (num_campaigns < 0 || num_campaigns > kMaxSavedCampaigns)
         {
+            // GCOVR_EXCL_START -- defensive reject of a corrupt/hostile save header
             LogError("save_load_num_campaigns_invalid file={} num_campaigns={} max={}\n",
                 filename, num_campaigns, kMaxSavedCampaigns);
             last_io_error_ = SaveDataIoError::ReadFailed;
             return false;
+            // GCOVR_EXCL_STOP
         }
         for(int i = 0; i < num_campaigns; i++)
         {
@@ -470,10 +474,12 @@ bool SaveData::load(const std::string& filename)
             READ_OR_FAIL(&num_levels, 2, 1);
             if (num_levels < 0 || num_levels > kMaxSavedLevels)
             {
+                // GCOVR_EXCL_START -- defensive reject of a corrupt/hostile save header
                 LogError("save_load_num_levels_invalid file={} num_levels={} max={}\n",
                     filename, num_levels, kMaxSavedLevels);
                 last_io_error_ = SaveDataIoError::ReadFailed;
                 return false;
+                // GCOVR_EXCL_STOP
             }
             for(int j = 0; j < num_levels; j++)
             {
@@ -887,9 +893,11 @@ bool SaveData::save(const std::string& filename)
 	const std::size_t raw_campaign_count = completed_levels.size();
 	if (raw_campaign_count > 32767)
 	{
+	    // GCOVR_EXCL_START -- defensive cap; real campaign maps never approach SHRT_MAX
 	    LogError("save_write_too_many_campaigns {}\n", raw_campaign_count);
 	    last_io_error_ = SaveDataIoError::WriteFailed;
 	    return false;
+	    // GCOVR_EXCL_STOP
 	}
 	short num_campaigns = static_cast<short>(raw_campaign_count);
     WRITE_OR_FAIL(&num_campaigns, 2, 1);
@@ -918,9 +926,11 @@ bool SaveData::save(const std::string& filename)
 	        const std::size_t raw_level_count = e->second.size();
 	        if (raw_level_count > 32767)
 	        {
+	            // GCOVR_EXCL_START -- defensive cap; real level sets never approach SHRT_MAX
 	            LogError("save_write_too_many_levels {}\n", raw_level_count);
 	            last_io_error_ = SaveDataIoError::WriteFailed;
 	            return false;
+	            // GCOVR_EXCL_STOP
 	        }
 	        short num_levels = static_cast<short>(raw_level_count);
 	        WRITE_OR_FAIL(&num_levels, 2, 1);

--- a/src/resources/save_data.cpp
+++ b/src/resources/save_data.cpp
@@ -24,6 +24,7 @@
 #include <openglad/gameplay/guy.h>
 #include <openglad/resources/campaign_io.h>
 #include <openglad/resources/filesystem_sync.h>
+#include <openglad/resources/io_common.h>
 #include <openglad/resources/og_file.h>
 #include <algorithm>
 #include <cstdint>
@@ -96,6 +97,12 @@ bool SaveData::load(const std::string& filename)
 {
     last_io_error_ = SaveDataIoError::None;
 	TRACE("load", "SaveData::load file=%s", filename.c_str());
+    if (!is_safe_virtual_basename(filename))
+    {
+        LogError("Rejected unsafe save file name for load: {}\n", filename);
+        last_io_error_ = SaveDataIoError::OpenReadFailed;
+        return false;
+    }
 	char filler[50] = "GTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTL"; // for RESERVED
 
 	char temptext[10] = "GTL";
@@ -247,8 +254,9 @@ bool SaveData::load(const std::string& filename)
 	{
 		READ_OR_FAIL(temp_campaign, 1, 40);
 		temp_campaign[40] = '\0';
-		if(std::string(temp_campaign).size() > 3)
-            current_campaign = temp_campaign;
+        const std::string loaded_campaign = temp_campaign;
+		if(loaded_campaign.size() > 3 && is_safe_campaign_id(loaded_campaign))
+            current_campaign = loaded_campaign;
         else
             current_campaign = "org.openglad.gladiator";
 	}
@@ -435,6 +443,12 @@ bool SaveData::load(const std::string& filename)
             // Get the campaign ID (40 chars)
             READ_OR_FAIL(campaign, 1, 40);
             campaign[40] = '\0';
+            if (!is_safe_campaign_id(campaign))
+            {
+                LogError("Rejected unsafe campaign id in save: {}\n", campaign);
+                last_io_error_ = SaveDataIoError::ReadFailed;
+                return false;
+            }
 
             short index = 1;
             // Get the current level for this campaign
@@ -619,6 +633,12 @@ bool SaveData::save(const std::string& filename)
 {
     last_io_error_ = SaveDataIoError::None;
 	TRACE("save", "SaveData::save file=%s", filename.c_str());
+    if (!is_safe_virtual_basename(filename))
+    {
+        LogError("Rejected unsafe save file name for save: {}\n", filename);
+        last_io_error_ = SaveDataIoError::OpenWriteFailed;
+        return false;
+    }
 	char filler[50] = "GTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTL"; // for RESERVED
 	char savedgame[41];
 	std::fill_n(savedgame, 41, '\0');
@@ -737,6 +757,13 @@ bool SaveData::save(const std::string& filename)
 	WRITE_OR_FAIL(savedgame, 40, 1);
 
 	// Write current campaign
+    if (!is_safe_campaign_id(current_campaign))
+    {
+        LogError("Rejected unsafe current campaign id for save: {}\n",
+                 current_campaign);
+        last_io_error_ = SaveDataIoError::WriteFailed;
+        return false;
+    }
 	Log("Saving campaign status: {}\n", current_campaign);
 	snprintf(temp_campaign, sizeof(temp_campaign), "%s", current_campaign.c_str());
 	WRITE_OR_FAIL(temp_campaign, 40, 1);
@@ -843,6 +870,13 @@ bool SaveData::save(const std::string& filename)
     WRITE_OR_FAIL(&num_campaigns, 2, 1);
 	for(std::map<std::string, std::set<int> >::const_iterator e = completed_levels.begin(); e != completed_levels.end(); e++)
     {
+        if (!is_safe_campaign_id(e->first))
+        {
+            LogError("Rejected unsafe completed-level campaign id for save: {}\n",
+                     e->first);
+            last_io_error_ = SaveDataIoError::WriteFailed;
+            return false;
+        }
         // Campaign ID
         char campaign[41];
         std::fill_n(campaign, 41, '\0');

--- a/src/resources/save_data.cpp
+++ b/src/resources/save_data.cpp
@@ -665,9 +665,9 @@ bool SaveData::save(const std::string& filename)
     }
 	char filler[50] = "GTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTL"; // for RESERVED
 	char savedgame[41];
-	std::fill_n(savedgame, 41, '\0');
+	std::fill_n(savedgame, std::size(savedgame), '\0');
 	char temp_campaign[41];
-	std::fill_n(temp_campaign, 41, '\0');
+	std::fill_n(temp_campaign, std::size(temp_campaign), '\0');
 
 	char temptext[10] = "GTL";
 	std::uint8_t temp_version = 11;
@@ -912,7 +912,7 @@ bool SaveData::save(const std::string& filename)
         }
         // Campaign ID
         char campaign[41];
-        std::fill_n(campaign, 41, '\0');
+        std::fill_n(campaign, std::size(campaign), '\0');
         snprintf(campaign, sizeof(campaign), "%s", e->first.c_str());
         WRITE_OR_FAIL(campaign, 1, 40);
 

--- a/src/resources/save_data.cpp
+++ b/src/resources/save_data.cpp
@@ -299,6 +299,8 @@ bool SaveData::load(const std::string& filename)
     {
         LogError("save_load_team_size_invalid file={} listsize={} max={}\n",
             filename, listsize, MAX_TEAM_SIZE);
+        last_io_error_ = SaveDataIoError::ReadFailed;
+        return false;
     }
 
 	// Read the # of players
@@ -436,8 +438,17 @@ bool SaveData::load(const std::string& filename)
         short num_campaigns = 0;
         char campaign[41];
         short num_levels = 0;
+        constexpr short kMaxSavedCampaigns = 128;
+        constexpr short kMaxSavedLevels = 1000;
         // How many campaigns are stored?
         READ_OR_FAIL(&num_campaigns, 2, 1);
+        if (num_campaigns < 0 || num_campaigns > kMaxSavedCampaigns)
+        {
+            LogError("save_load_num_campaigns_invalid file={} num_campaigns={} max={}\n",
+                filename, num_campaigns, kMaxSavedCampaigns);
+            last_io_error_ = SaveDataIoError::ReadFailed;
+            return false;
+        }
         for(int i = 0; i < num_campaigns; i++)
         {
             // Get the campaign ID (40 chars)
@@ -457,6 +468,13 @@ bool SaveData::load(const std::string& filename)
 
             // Get the number of cleared levels
             READ_OR_FAIL(&num_levels, 2, 1);
+            if (num_levels < 0 || num_levels > kMaxSavedLevels)
+            {
+                LogError("save_load_num_levels_invalid file={} num_levels={} max={}\n",
+                    filename, num_levels, kMaxSavedLevels);
+                last_io_error_ = SaveDataIoError::ReadFailed;
+                return false;
+            }
             for(int j = 0; j < num_levels; j++)
             {
                 // Get the level index
@@ -866,7 +884,14 @@ bool SaveData::save(const std::string& filename)
     }
 
 	// Number of campaigns
-	short num_campaigns = static_cast<short>(completed_levels.size());
+	const std::size_t raw_campaign_count = completed_levels.size();
+	if (raw_campaign_count > 32767)
+	{
+	    LogError("save_write_too_many_campaigns {}\n", raw_campaign_count);
+	    last_io_error_ = SaveDataIoError::WriteFailed;
+	    return false;
+	}
+	short num_campaigns = static_cast<short>(raw_campaign_count);
     WRITE_OR_FAIL(&num_campaigns, 2, 1);
 	for(std::map<std::string, std::set<int> >::const_iterator e = completed_levels.begin(); e != completed_levels.end(); e++)
     {
@@ -890,7 +915,14 @@ bool SaveData::save(const std::string& filename)
 	        WRITE_OR_FAIL(&index, 2, 1);
 
 	        // Number of levels
-	        short num_levels = static_cast<short>(e->second.size());
+	        const std::size_t raw_level_count = e->second.size();
+	        if (raw_level_count > 32767)
+	        {
+	            LogError("save_write_too_many_levels {}\n", raw_level_count);
+	            last_io_error_ = SaveDataIoError::WriteFailed;
+	            return false;
+	        }
+	        short num_levels = static_cast<short>(raw_level_count);
 	        WRITE_OR_FAIL(&num_levels, 2, 1);
         for(std::set<int>::const_iterator f = e->second.begin(); f != e->second.end(); f++)
 	        {

--- a/src/server/server_main.cpp
+++ b/src/server/server_main.cpp
@@ -72,7 +72,7 @@ constexpr int kDefaultLobbyPollMs = 10;
 std::atomic<bool> g_shutdown_requested = false;
 
 struct ServerArgs {
-    std::string host = "0.0.0.0";
+    std::string host = "127.0.0.1";
     int port = kDefaultPort;
     int lobby_poll_ms = kDefaultLobbyPollMs;
     std::optional<int> target_fps;
@@ -88,7 +88,7 @@ void print_usage()
     std::fprintf(
         stderr,
         "Usage: openglad_server [options]\n"
-        "  --host <addr>         Listen address (default: 0.0.0.0)\n"
+        "  --host <addr>         Listen address (default: 127.0.0.1)\n"
         "  --port <num>          Listen port (default: 12345)\n"
         "  --lobby-poll-ms <n>   Lobby poll interval in ms (default: 10)\n"
         "  --fps <n>             Deprecated; no longer affects sim cadence (master semantics derived from world.timer_wait).\n"

--- a/tests/test_combat_math.cpp
+++ b/tests/test_combat_math.cpp
@@ -260,6 +260,20 @@ TEST(CombatMath, xp_from_action_heal)
 }
 
 
+TEST(CombatMath, xp_from_action_heal_zero_level_no_divide_by_zero)
+{
+    // Security guard: a zero (or negative) attacker_level must not cause an
+    // integer division-by-zero (SIGFPE / UB). The level can reach the XP math
+    // from untrusted state, so the divisor is clamped to >= 1.
+    FixedRandom fixed(50);
+    short xp = compute_xp_from_action(ExpAction::Heal, 0, 1, 10, fixed);
+    ASSERT_EQ(50, (int)xp) << "Heal with level 0 should divide by 1, not crash";
+    // Negative level must also be safe.
+    short xp_neg = compute_xp_from_action(ExpAction::Heal, -3, 1, 10, fixed);
+    ASSERT_EQ(50, (int)xp_neg) << "Heal with negative level should divide by 1, not crash";
+}
+
+
 TEST(CombatMath, xp_from_action_turn_undead)
 {
     FixedRandom fixed(0);

--- a/tests/test_ctf_ui.cpp
+++ b/tests/test_ctf_ui.cpp
@@ -35,6 +35,7 @@
 
 #include <array>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -48,7 +49,7 @@ void picker_test_render_teams_menu_frame();
 
 loader* sdl_entity_loader();
 short new_score_panel(screen* s, short do_it);
-std::string get_editor_family_label(Order order, Sint32 family, char livings[][20],
+std::string get_editor_family_label(Order order, Sint32 family, std::span<const std::string> livings,
                                     const char* treasures[], const char* weapons[]);
 std::string get_editor_level_label(Order order, Sint32 family, Sint32 level);
 
@@ -763,7 +764,7 @@ TEST(CtfUi, editor_labels_resolve_for_ctf_objects)
               get_editor_level_label(Order::Treasure, og::FAMILY_FLAG, 5));
     ASSERT_EQ("", get_editor_level_label(Order::Treasure, og::FAMILY_CTF_POINT, 3));
 
-    static char livings[NUM_FAMILIES][20] = {};
+    static std::array<std::string, NUM_FAMILIES> livings;
     const char* treasures[NUM_FAMILIES] =
         { "BLOOD", "DRUMSTICK", "GOLD", "SILVER",
           "MAGIC", "INVIS", "INVULN", "FLIGHT",

--- a/tests/test_effect_act.cpp
+++ b/tests/test_effect_act.cpp
@@ -385,6 +385,39 @@ TEST(EffectAct, effect_animate_magic_shield)
 }
 
 
+TEST(EffectAct, effect_animate_handles_malicious_indices_safely)
+{
+    // effect::animate() indexes its animation table with curdir/ani_type/cycle,
+    // which arrive straight off a snapshot. Out-of-range values must be bounded
+    // (facing, table length, sequence sentinel) instead of reading out of bounds
+    // and dereferencing a wild pointer.
+    walker* fx = og::runtime::current_session->myscreen_->world().add_fx_ob(Order::FX, FAMILY_EXPLOSION);
+    ASSERT_TRUE(fx != nullptr);
+    if (!fx)
+        return;
+    ASSERT_TRUE(fx->ani != nullptr);
+    ASSERT_GT(fx->ani_count, 0);
+
+    // ani_type far beyond the table + out-of-range facing and cycle.
+    fx->set_ani_type(static_cast<char>(40));
+    fx->set_curdir(static_cast<char>(100));
+    fx->set_cycle(static_cast<signed char>(120));
+    (void)fx->animate(); // must not crash / read OOB (verified under sanitizers)
+
+    // Negative facing and ani_type.
+    fx->set_ani_type(static_cast<char>(-1));
+    fx->set_curdir(static_cast<char>(-5));
+    fx->set_cycle(static_cast<signed char>(-9));
+    (void)fx->animate();
+
+    // A null animation table must be a graceful no-op, not a null deref.
+    fx->ani = nullptr;
+    ASSERT_TRUE(!fx->animate()) << "null ani must return false";
+
+    og::runtime::current_session->myscreen_->world().remove_ob(fx);
+}
+
+
 // ---------------------------------------------------------------------------
 // effect::death
 // ---------------------------------------------------------------------------

--- a/tests/test_game_context.cpp
+++ b/tests/test_game_context.cpp
@@ -93,7 +93,7 @@ TEST(GameContext, seeded_rng_reset)
     rng.next(100); // advance
     rng.next(100);
 
-    rng.state_ = 42;
+    rng.seed(42);
     Uint32 after_reset = rng.next(100);
     ASSERT_EQ(static_cast<int>(first), static_cast<int>(after_reset)) << "reset(42) should reproduce the same first value";
 }

--- a/tests/test_io_platform_coverage.cpp
+++ b/tests/test_io_platform_coverage.cpp
@@ -353,6 +353,11 @@ TEST(IoPlatformCoverage, platform_io_campaign_error_codes)
 
     ASSERT_EQ(static_cast<int>(CampaignPackageIoError::EmptyId), static_cast<int>(mount_campaign_package_with_error(""))) << "empty campaign id should return EmptyId";
     ASSERT_EQ(static_cast<int>(CampaignPackageIoError::EmptyId), static_cast<int>(remount_campaign_package_with_error())) << "remount with no mounted campaign should return EmptyId";
+    ASSERT_TRUE(!is_safe_campaign_id("../outside")) << "campaign ids must not contain path traversal";
+    ASSERT_TRUE(!is_safe_campaign_id("bad..id")) << "campaign ids must not contain traversal-like dot segments";
+    ASSERT_EQ(static_cast<int>(CampaignPackageIoError::MountFailed), static_cast<int>(mount_campaign_package_with_error("../outside"))) << "unsafe campaign id should be rejected before path construction";
+    ASSERT_TRUE(!unpack_campaign("../outside")) << "unsafe campaign id should not be unpacked";
+    ASSERT_TRUE(!repack_campaign("../outside")) << "unsafe campaign id should not be repacked";
 
     std::map<std::string, int> current_levels;
     const CampaignLoadResult r = load_campaign_with_error("definitely_missing_campaign", current_levels, 7);
@@ -392,9 +397,15 @@ TEST(IoPlatformCoverage, platform_io_batch3_mount_switch_and_listing_filters)
         ASSERT_TRUE(f != nullptr) << "create non-glad marker";
         if (f) std::fclose(f);
     }
+    {
+        std::FILE* f = std::fopen((campaigns_dir / "batch3..unsafe.glad").string().c_str(), "wb");
+        ASSERT_TRUE(f != nullptr) << "create unsafe .glad marker";
+        if (f) std::fclose(f);
+    }
     const std::list<std::string> campaigns = list_campaigns();
     ASSERT_TRUE(std::find(campaigns.begin(), campaigns.end(), "batch3_filter_marker") != campaigns.end()) << "list_campaigns should keep .glad ids";
     ASSERT_TRUE(std::find(campaigns.begin(), campaigns.end(), "batch3_filter_marker.txt") == campaigns.end()) << "list_campaigns should filter non-.glad names";
+    ASSERT_TRUE(std::find(campaigns.begin(), campaigns.end(), "batch3..unsafe") == campaigns.end()) << "list_campaigns should filter unsafe .glad ids";
 
     // list_levels/list_levels_v should filter malformed entries and keep strict positive scen ids.
     {

--- a/tests/test_io_zip_unzip.cpp
+++ b/tests/test_io_zip_unzip.cpp
@@ -309,9 +309,13 @@ TEST(IoZipUnzip, io_unzip_rejects_archives_exceeding_entry_limit)
     if (!za)
         return;
 
+    // zip_source_buffer does not copy: it keeps the pointer and libzip reads it
+    // during zip_close() below. The buffer must therefore outlive zip_close(), so
+    // use one function-scoped buffer rather than a per-iteration stack array
+    // (which would be a stack-use-after-scope read at flush time).
+    static const char payload[] = "x";
     for (int i = 0; i < 4097; ++i)
     {
-        const char payload[] = "x";
         zip_source* src = zip_source_buffer(za, payload, 1, 0);
         ASSERT_TRUE(src != nullptr) << "zip_source_buffer entry should succeed";
         char name[64] = {};

--- a/tests/test_io_zip_unzip.cpp
+++ b/tests/test_io_zip_unzip.cpp
@@ -294,6 +294,47 @@ TEST(IoZipUnzip, io_unzip_rejects_zip_slip_paths)
 }
 
 
+TEST(IoZipUnzip, io_unzip_rejects_archives_exceeding_entry_limit)
+{
+    namespace fs = std::filesystem;
+    const fs::path base = fs::temp_directory_path() / ("openglad_io_zip_limit_" + std::to_string(::getpid()));
+    const fs::path zipfile = base / "too_many_entries.zip";
+    const fs::path outdir = base / "out";
+
+    ASSERT_TRUE(create_dir(base.string())) << "create base dir should succeed";
+
+    int err = 0;
+    zip* za = zip_open(zipfile.string().c_str(), ZIP_CREATE | ZIP_TRUNCATE, &err);
+    ASSERT_TRUE(za != nullptr) << "zip_open large-entry archive should succeed";
+    if (!za)
+        return;
+
+    for (int i = 0; i < 4097; ++i)
+    {
+        const char payload[] = "x";
+        zip_source* src = zip_source_buffer(za, payload, 1, 0);
+        ASSERT_TRUE(src != nullptr) << "zip_source_buffer entry should succeed";
+        char name[64] = {};
+        std::snprintf(name, sizeof(name), "entry_%04d.txt", i);
+        if (src && zip_file_add(za, name, src, ZIP_FL_OVERWRITE) < 0)
+        {
+            zip_source_free(src);
+            ASSERT_TRUE(false) << "zip_file_add entry should succeed";
+        }
+    }
+
+    ASSERT_EQ(0, zip_close(za)) << "zip_close large-entry archive should succeed";
+
+    ASSERT_EQ(
+        static_cast<int>(ArchiveIoError::ResourceLimitExceeded),
+        static_cast<int>(unzip_into_with_error(zipfile.string(), outdir.string())))
+        << "archives above the extraction entry cap should be rejected";
+
+    std::error_code ec;
+    fs::remove_all(base, ec);
+}
+
+
 TEST(IoZipUnzip, io_unzip_reports_output_write_failure)
 {
 #if defined(__linux__)

--- a/tests/test_level_data_coverage.cpp
+++ b/tests/test_level_data_coverage.cpp
@@ -760,6 +760,7 @@ TEST(LevelDataCoverage, level_data_round6_version6plus_and_title_read_paths)
     {
         std::vector<unsigned char> bytes;
         bytes.resize(8 + 30 + 1 + 2 + 2 + 1 + 1, 0); // grid + title + type + par + listsize + numlines + width
+        bytes[0] = 'g'; bytes[1] = 'r'; bytes[2] = 'i'; bytes[3] = 'd'; // valid grid basename (rejected if empty/unsafe)
         bytes.back() = 120;
         bytes.insert(bytes.end(), 120, 'x');
         MemoryOgFile f(bytes.data(), bytes.size());
@@ -951,7 +952,7 @@ TEST(LevelDataCoverage, level_data_round6_load_version3_4_5_minimal_and_treasure
 
     // Version 3: minimal valid payload + treasure object branch + width==0 branch.
     {
-        std::vector<unsigned char> bytes(8, 0);          // grid name
+        std::vector<unsigned char> bytes{'g','r','i','d',0,0,0,0};  // valid grid basename (rejected if empty/unsafe)
         append_short(bytes, 1);                          // listsize
         append_obj_v3(bytes, static_cast<unsigned char>(Order::Treasure));
         bytes.push_back(1);                              // numlines
@@ -962,7 +963,7 @@ TEST(LevelDataCoverage, level_data_round6_load_version3_4_5_minimal_and_treasure
 
     // Version 4: minimal valid payload + treasure object branch + width==0 branch.
     {
-        std::vector<unsigned char> bytes(8, 0);          // grid name
+        std::vector<unsigned char> bytes{'g','r','i','d',0,0,0,0};  // valid grid basename (rejected if empty/unsafe)
         append_short(bytes, 1);                          // listsize
         append_obj_v4_v5(bytes, static_cast<unsigned char>(Order::Treasure));
         bytes.push_back(1);                              // numlines
@@ -973,7 +974,7 @@ TEST(LevelDataCoverage, level_data_round6_load_version3_4_5_minimal_and_treasure
 
     // Version 5: includes scenario type byte.
     {
-        std::vector<unsigned char> bytes(8, 0);          // grid name
+        std::vector<unsigned char> bytes{'g','r','i','d',0,0,0,0};  // valid grid basename (rejected if empty/unsafe)
         bytes.push_back(2);                              // scenario type
         append_short(bytes, 1);                          // listsize
         append_obj_v4_v5(bytes, static_cast<unsigned char>(Order::Treasure));

--- a/tests/test_level_data_error_paths.cpp
+++ b/tests/test_level_data_error_paths.cpp
@@ -423,6 +423,63 @@ TEST(LevelDataErrorPaths, level_data_load_reports_parse_failed_when_grid_pix_mis
 }
 
 
+TEST(LevelDataErrorPaths, level_data_load_rejects_unsafe_grid_reference)
+{
+    constexpr int kUnsafeGridScenarioId = 19993;
+    constexpr std::array<char, 8> kUnsafeGridName = {
+        '.', '.', '/', 'e', 'v', 'i', 'l', '\0'};
+
+    const int old_id = og::runtime::current_session->myscreen_->world().id;
+    const std::string old_grid_file =
+        og::runtime::current_session->myscreen_->level_grid_file();
+    const std::string old_title =
+        og::runtime::current_session->myscreen_->world().title;
+    const std::list<std::string> old_description =
+        og::runtime::current_session->myscreen_->level_description();
+
+    std::string scenario_bytes;
+    scenario_bytes.append("FSS", 3);
+    scenario_bytes.push_back(static_cast<char>(9));
+    scenario_bytes.append(kUnsafeGridName.data(), kUnsafeGridName.size());
+    std::array<char, 30> title{};
+    std::memcpy(title.data(), "Unsafe Grid", std::strlen("Unsafe Grid"));
+    scenario_bytes.append(title.data(), title.size());
+    scenario_bytes.push_back(1); // scenario type
+    append_i16_native(scenario_bytes, 1);    // par value
+    append_i16_native(scenario_bytes, 4000); // time bonus limit
+    append_i16_native(scenario_bytes, 0);    // object count
+    scenario_bytes.push_back(0);             // description line count
+
+    const fs::path scen_path = fs::path("scen") / "scen19993.fss";
+    ASSERT_TRUE(write_file_bytes(scen_path, scenario_bytes))
+        << "unsafe-grid scenario fixture should be written";
+
+    og::runtime::current_session->myscreen_->world().id =
+        kUnsafeGridScenarioId;
+    og::runtime::current_session->myscreen_->world().title =
+        "before unsafe grid load";
+    og::runtime::current_session->myscreen_->level_grid_file() =
+        "preserve_grid";
+    og::runtime::current_session->myscreen_->level_description().clear();
+    og::runtime::current_session->myscreen_->level_description().push_back(
+        "preserve-line");
+
+    ASSERT_TRUE(!og::runtime::current_session->myscreen_->load_level())
+        << "load should fail when a scenario references an unsafe grid path";
+    ASSERT_EQ((int)LevelRuntimeData::IoError::ParseFailed,
+              (int)og::runtime::current_session->myscreen_->level_io_error())
+        << "unsafe grid path should map to ParseFailed";
+
+    std::error_code ec;
+    fs::remove(scen_path, ec);
+    og::runtime::current_session->myscreen_->world().id = old_id;
+    og::runtime::current_session->myscreen_->level_grid_file() = old_grid_file;
+    og::runtime::current_session->myscreen_->world().title = old_title;
+    og::runtime::current_session->myscreen_->level_description() =
+        old_description;
+}
+
+
 TEST(LevelDataErrorPaths, campaign_data_load_reports_open_read_failed_when_campaign_yaml_missing)
 {
     // Create a minimal zip campaign package with no campaign.yaml so CampaignData::load

--- a/tests/test_level_data_ops.cpp
+++ b/tests/test_level_data_ops.cpp
@@ -432,6 +432,13 @@ TEST(LevelDataOps, level_data_get_description_line)
 
     og::runtime::current_session->myscreen_->level_description().clear();
 
+    // Empty description must not dereference end() for any index, including
+    // negative ones (regression: get_description_line(-1) on an empty list
+    // previously bypassed the size guard and dereferenced end()).
+    ASSERT_TRUE(og::runtime::current_session->myscreen_->get_level_description_line(0) == "") << "empty list line 0";
+    ASSERT_TRUE(og::runtime::current_session->myscreen_->get_level_description_line(-1) == "") << "empty list negative index";
+    ASSERT_TRUE(og::runtime::current_session->myscreen_->get_level_description_line(5) == "") << "empty list out of range";
+
     CampaignData c("org.openglad.tests");
     c.description.clear();
     c.description.push_back("Campaign 1");

--- a/tests/test_level_editor_helpers.cpp
+++ b/tests/test_level_editor_helpers.cpp
@@ -9,6 +9,8 @@
 
 #include <string>
 #include <set>
+#include <array>
+#include <span>
 #include <cstdio>
 #include <unistd.h>
 
@@ -24,7 +26,7 @@ bool create_new_campaign(const std::string& campaign_id);
 bool does_campaign_exist(const std::string& campaign_id);
 bool are_objects_outside_area(LevelRuntimeData* level, int x, int y, int w, int h);
 void get_connected_level_exits(int current_level, const std::list<int>& levels, std::set<int>& connected, std::list<std::string>& problems);
-std::string get_editor_family_label(Order order, Sint32 family, char livings[][20], const char* treasures[], const char* weapons[]);
+std::string get_editor_family_label(Order order, Sint32 family, std::span<const std::string> livings, const char* treasures[], const char* weapons[]);
 std::string get_editor_level_label(Order order, Sint32 family, Sint32 level);
 void importCampaignPicker();
 void shareCampaign(screen* scr);
@@ -86,14 +88,14 @@ TEST(LevelEditorHelpers, level_editor_set_screen_pos_and_tile_matching)
     ASSERT_EQ(222, (int)t) << "unknown tiles should be returned unchanged";
 
     // Label helpers extracted from editor rendering path.
-    char test_livings[NUM_FAMILIES][20] = {};
+    std::array<std::string, NUM_FAMILIES> test_livings;
     const char* test_treasures[NUM_FAMILIES] = {};
     const char* test_weapons[NUM_FAMILIES] = {};
     for (int i = 0; i < NUM_FAMILIES; ++i) {
         test_treasures[i] = "TREASURE";
         test_weapons[i] = "WEAPON";
     }
-    snprintf(test_livings[FAMILY_SOLDIER], sizeof(test_livings[FAMILY_SOLDIER]), "SOLDIER");
+    test_livings[FAMILY_SOLDIER] = "SOLDIER";
 
     ASSERT_TRUE(get_editor_family_label(Order::Generator, FAMILY_TENT, test_livings, test_treasures, test_weapons) == "TENT") << "generator tent label";
     ASSERT_TRUE(get_editor_family_label(Order::Generator, FAMILY_TOWER, test_livings, test_treasures, test_weapons) == "MAGE TOWER") << "generator tower label";

--- a/tests/test_save_data_versions.cpp
+++ b/tests/test_save_data_versions.cpp
@@ -551,6 +551,21 @@ TEST(SaveDataVersions, save_data_load_with_error_truncated_file_reports_read_fai
 }
 
 
+TEST(SaveDataVersions, save_data_rejects_unsafe_save_slot_names)
+{
+    SaveData tmp;
+    ASSERT_EQ(static_cast<int>(SaveDataIoError::OpenReadFailed),
+              static_cast<int>(tmp.load_with_error("../save0")))
+        << "load should reject traversal save slot names before path construction";
+    ASSERT_EQ(static_cast<int>(SaveDataIoError::OpenWriteFailed),
+              static_cast<int>(tmp.save_with_error("../save0")))
+        << "save should reject traversal save slot names before path construction";
+    ASSERT_EQ(static_cast<int>(SaveDataIoError::OpenWriteFailed),
+              static_cast<int>(tmp.save_with_error("nested/slot1")))
+        << "save should reject nested save slot names before path construction";
+}
+
+
 TEST(SaveDataVersions, save_data_load_with_error_campaign_mount_failure)
 {
     GuyRecord g{};

--- a/tests/test_smooth_coverage.cpp
+++ b/tests/test_smooth_coverage.cpp
@@ -560,6 +560,34 @@ TEST(SmoothCoverage, smooth_grass_dark_wall_water_tree_dirt_and_unknown_deep_bra
         << "set_x_y without a target should keep the smoother in fallback mode";
 }
 
+TEST(SmoothCoverage, set_x_y_rejects_out_of_bounds_writes)
+{
+    // set_x_y() now mirrors query_x_y()'s bounds check; verify both new guard
+    // branches are no-ops and never store outside the grid span.
+    PixieData grid = make_grid(4, 4, PIX_GRASS1);
+    ExposedSmoother ex;
+    ex.set_target(grid);
+
+    // In-bounds write still takes effect.
+    ex.set_x_y(1, 1, PIX_WATER1);
+    ASSERT_EQ((int)PIX_WATER1, (int)ex.query_x_y(1, 1)) << "in-bounds set_x_y should write";
+
+    // Each out-of-range coordinate must be a silent no-op (no OOB store).
+    ex.set_x_y(-1, 1, PIX_WATER1);   // x < 0
+    ex.set_x_y(1, -1, PIX_WATER1);   // y < 0
+    ex.set_x_y(4, 1, PIX_WATER1);    // x >= maxx
+    ex.set_x_y(1, 4, PIX_WATER1);    // y >= maxy
+
+    // No stray write landed anywhere: only the one in-bounds cell changed.
+    for (int y = 0; y < 4; ++y)
+        for (int x = 0; x < 4; ++x)
+        {
+            int expected = (x == 1 && y == 1) ? (int)PIX_WATER1 : (int)PIX_GRASS1;
+            ASSERT_EQ(expected, (int)ex.query_x_y(x, y))
+                << "grid corrupted at (" << x << "," << y << ") after out-of-bounds writes";
+        }
+}
+
 
 TEST(SmoothCoverage, smooth_round13_dark_grass_targeted_338_448_branches)
 {

--- a/tests/test_stats_unit.cpp
+++ b/tests/test_stats_unit.cpp
@@ -377,6 +377,30 @@ TEST(StatsUnit, stats_r12_command_and_hit_response_branches)
     self->stats()->set_bit_flags(BIT_FLYING, 0);
 }
 
+TEST(StatsUnit, special_cost_out_of_range_is_safe)
+{
+    // special_cost_/set_special_cost index a fixed NUM_SPECIALS array. Out-of-
+    // range indices (e.g. from corrupt snapshot/save data) must not read or
+    // write past the array; the getter returns 0 and the setter is a no-op.
+    statistics s(nullptr);
+
+    s.set_special_cost(0, 11);
+    s.set_special_cost(NUM_SPECIALS - 1, 22);
+    EXPECT_EQ(11, (int)s.special_cost(0)) << "in-range get/set still works";
+    EXPECT_EQ(22, (int)s.special_cost(NUM_SPECIALS - 1)) << "last valid index";
+
+    EXPECT_EQ(0, (int)s.special_cost(-1)) << "negative index returns 0";
+    EXPECT_EQ(0, (int)s.special_cost(NUM_SPECIALS)) << "one past end returns 0";
+    EXPECT_EQ(0, (int)s.special_cost(100000)) << "far out of range returns 0";
+
+    // Out-of-range setters are no-ops and must not corrupt valid entries.
+    s.set_special_cost(-1, 99);
+    s.set_special_cost(NUM_SPECIALS, 99);
+    s.set_special_cost(100000, 99);
+    EXPECT_EQ(11, (int)s.special_cost(0)) << "valid entry untouched by OOB set";
+    EXPECT_EQ(22, (int)s.special_cost(NUM_SPECIALS - 1)) << "valid entry untouched by OOB set";
+}
+
 TEST(StatsUnit, stats_r12_extra_command_switch_and_null_controller_paths)
 {
     StatsR12Fixture fx;

--- a/tests/test_video_buffers.cpp
+++ b/tests/test_video_buffers.cpp
@@ -29,6 +29,23 @@ TEST(VideoBuffers, video_putdata_putdata_alpha_and_get_pixel_smoke)
 }
 
 
+TEST(VideoBuffers, get_pixel_rejects_out_of_range_coordinates)
+{
+    // get_pixel does raw pointer arithmetic + memcpy into the render surface;
+    // out-of-range x/y or offset must be rejected (black / 0) rather than read
+    // outside the surface bounds.
+    auto* s = og::runtime::current_session->myscreen_;
+    s->swap();
+    int idx = -1;
+    int v1 = s->get_pixel(1000000, 1000000, &idx); // exercises x/y bounds guard
+    ASSERT_TRUE(v1 >= 0 && v1 <= 255) << "out-of-range get_pixel(x,y) must be a safe value";
+    int v2 = s->get_pixel(-50, -50, &idx);
+    ASSERT_TRUE(v2 >= 0 && v2 <= 255) << "negative get_pixel(x,y) must be a safe value";
+    ASSERT_EQ(0, s->get_pixel(-1)) << "negative offset must be rejected";
+    ASSERT_EQ(0, s->get_pixel(1000000000)) << "huge offset must be rejected";
+}
+
+
 TEST(VideoBuffers, video_draw_rect_and_alpha_lines_smoke)
 {
     og::runtime::current_session->myscreen_->clearbuffer();

--- a/tests/test_walker_core_more.cpp
+++ b/tests/test_walker_core_more.cpp
@@ -540,6 +540,11 @@ TEST(WalkerCoreMore, walker_round6_init_fire_animate_and_misc_guards)
     ASSERT_EQ(1, w->next_frame()) << "next_frame should report a successful frame set";
     ASSERT_EQ(before, w->frame()) << "next_frame should keep the wrapped frame selected";
 
+    // A default/test-built walker has frames==0; next_frame() must guard the
+    // modulo and return 0 rather than dividing by zero (UB).
+    walker zero_frames;
+    ASSERT_EQ(0, zero_frames.next_frame()) << "frames==0 must return 0, not divide by zero";
+
     // move_myguy_to nullptr guard.
     w->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
     w->move_myguy_to(nullptr);

--- a/tests/test_walker_core_more.cpp
+++ b/tests/test_walker_core_more.cpp
@@ -595,6 +595,46 @@ TEST(WalkerCoreMore, walker_round6_init_fire_animate_and_misc_guards)
 }
 
 
+TEST(WalkerCoreMore, walker_animate_rejects_ani_type_beyond_family_table)
+{
+    og::runtime::current_session->myscreen_->world().create_new_grid();
+    og::runtime::current_session->myscreen_->world().delete_objects();
+
+    // A real loader-built walker records its family's animation-table length in
+    // ani_count. FAMILY_SOLDIER uses a short table; a snapshot-forced high
+    // ani_type would index past it, so animate() must reject it (reset to walk,
+    // return false) rather than read out of bounds.
+    walker* w = og::runtime::current_session->myscreen_->world().add_ob(Order::Living, FAMILY_SOLDIER);
+    ASSERT_TRUE(w != nullptr);
+    if (!w)
+        return;
+    ASSERT_TRUE(w->ani != nullptr) << "real walker has an animation table";
+    ASSERT_GT(w->ani_count, 0) << "loader records the table length";
+
+    if (FACE_DOWN + ANI_SLIME_SPLIT * NUM_FACINGS >= w->ani_count)
+    {
+        w->set_ani_type(static_cast<char>(ANI_SLIME_SPLIT));
+        w->set_curdir(static_cast<char>(FACE_DOWN));
+        w->set_cycle(0);
+        ASSERT_TRUE(!w->animate()) << "ani_type beyond the family table must be rejected";
+        ASSERT_EQ(ANI_WALK, (int)w->ani_type()) << "rejected animate resets to walk";
+    }
+
+    // ani_type beyond the global ANI range must be normalized to walk.
+    w->set_ani_type(static_cast<char>(99));
+    w->set_curdir(static_cast<char>(FACE_DOWN));
+    w->set_cycle(0);
+    (void)w->animate();
+    ASSERT_EQ(ANI_WALK, (int)w->ani_type()) << "out-of-range ani_type normalizes to walk";
+
+    // Out-of-range facing/cycle must also be handled without an out-of-bounds read.
+    w->set_ani_type(static_cast<char>(ANI_WALK));
+    w->set_curdir(static_cast<char>(100));
+    w->set_cycle(static_cast<signed char>(120));
+    (void)w->animate(); // must not crash / read OOB (verified under sanitizers)
+}
+
+
 TEST(WalkerCoreMore, walker_round6_fire_and_friendliness_paths)
 {
     og::runtime::current_session->myscreen_->world().create_new_grid();

--- a/tests/test_weap_behavior.cpp
+++ b/tests/test_weap_behavior.cpp
@@ -427,6 +427,40 @@ TEST(WeapBehavior, weapon_family_rock_death_bounce_matrix)
 }
 
 
+TEST(WeapBehavior, weapon_animate_handles_out_of_range_facing_and_cycle)
+{
+    og::runtime::current_session->myscreen_->world().create_new_grid();
+
+    // weap::animate() and the weapon-family on_animate callbacks index the
+    // animation table with curdir/cycle, which can arrive out of range from a
+    // snapshot. These must be bounded (facing clamp + sequence sentinel) rather
+    // than reading out of bounds. ARROW exercises the default branch; TREE and
+    // GLOW exercise the on_animate callbacks.
+    walker* arrow_w = make_weapon(FAMILY_ARROW);
+    walker* tree_w = make_weapon(FAMILY_TREE);
+    walker* glow_w = make_weapon(FAMILY_GLOW);
+    ASSERT_TRUE(arrow_w && tree_w && glow_w);
+    if (!(arrow_w && tree_w && glow_w))
+        return;
+
+    for (walker* w : {arrow_w, tree_w, glow_w})
+    {
+        ASSERT_GT(w->ani_count, 0) << "real weapon records its table length";
+        w->set_curdir(static_cast<char>(100));
+        w->set_cycle(static_cast<signed char>(120));
+        w->set_ani_type(static_cast<char>(40));
+        (void)w->animate(); // must not crash / read OOB (verified under sanitizers)
+        w->set_curdir(static_cast<char>(-7));
+        w->set_cycle(static_cast<signed char>(-3));
+        (void)w->animate();
+    }
+
+    og::runtime::current_session->myscreen_->world().remove_ob(arrow_w);
+    og::runtime::current_session->myscreen_->world().remove_ob(tree_w);
+    og::runtime::current_session->myscreen_->world().remove_ob(glow_w);
+}
+
+
 TEST(WeapBehavior, weapon_family_animate_callbacks_and_sprinkle_hit_paths)
 {
     og::runtime::current_session->myscreen_->world().create_new_grid();

--- a/tests/unit/test_ctf_snapshot.cpp
+++ b/tests/unit/test_ctf_snapshot.cpp
@@ -387,7 +387,7 @@ TEST(CtfSnapshot, full_state_survives_capture_serialize_apply_round_trip)
         bytes = og::sim::serialize_snapshot(snapshot);
 
         const og::sim::WorldSnapshot decoded =
-            og::sim::deserialize_snapshot(bytes.data(), bytes.size());
+            og::sim::deserialize_snapshot(bytes);
         const auto failure = og::sim::find_first_snapshot_difference(
             snapshot.tick_count, snapshot, decoded);
         ASSERT_FALSE(failure.has_value())
@@ -397,7 +397,7 @@ TEST(CtfSnapshot, full_state_survives_capture_serialize_apply_round_trip)
     }
 
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_snapshot(bytes.data(), bytes.size());
+        og::sim::deserialize_snapshot(bytes);
     CtfWorld target;
     og::sim::apply_snapshot(target.world(), decoded);
     expect_snapshot_matches_world(decoded, target.world());
@@ -416,7 +416,7 @@ TEST(CtfSnapshot, apply_clears_stale_ctf_state_from_default_snapshot)
 
     const std::vector<std::uint8_t> bytes = og::sim::serialize_snapshot(snapshot);
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_snapshot(bytes.data(), bytes.size());
+        og::sim::deserialize_snapshot(bytes);
     expect_snapshot_ctf_defaults(decoded);
 
     // A polluted target world must come back to defaults: the apply path
@@ -456,7 +456,7 @@ TEST(CtfSnapshot, delta_payload_carries_ctf_changes_onto_baseline)
     const std::vector<std::uint8_t> delta_bytes =
         og::sim::serialize_delta(delta_source);
     const og::sim::WorldSnapshot decoded_delta =
-        og::sim::deserialize_delta(delta_bytes.data(), delta_bytes.size());
+        og::sim::deserialize_delta(delta_bytes);
 
     og::sim::apply_delta(baseline, decoded_delta);
     EXPECT_TRUE(baseline.ctf_active);
@@ -509,22 +509,19 @@ TEST(CtfSnapshot, deserializer_rejects_oversized_counts_in_crafted_payloads)
     const std::vector<std::uint8_t> bad_cp_count =
         rebuild_patched_snapshot_message(raw_payload, kCpCountOffset, 0xffu);
     EXPECT_THROW(
-        (void)og::sim::deserialize_snapshot(bad_cp_count.data(),
-                                            bad_cp_count.size()),
+        (void)og::sim::deserialize_snapshot(bad_cp_count),
         std::runtime_error);
 
     const std::vector<std::uint8_t> bad_anchor_count =
         rebuild_patched_snapshot_message(raw_payload, kAnchorCountOffset, 0xffu);
     EXPECT_THROW(
-        (void)og::sim::deserialize_snapshot(bad_anchor_count.data(),
-                                            bad_anchor_count.size()),
+        (void)og::sim::deserialize_snapshot(bad_anchor_count),
         std::runtime_error);
 
     const std::vector<std::uint8_t> bad_queue_size =
         rebuild_patched_snapshot_message(raw_payload, kQueueSizeOffset, 0xffu);
     EXPECT_THROW(
-        (void)og::sim::deserialize_snapshot(bad_queue_size.data(),
-                                            bad_queue_size.size()),
+        (void)og::sim::deserialize_snapshot(bad_queue_size),
         std::runtime_error);
 }
 
@@ -655,7 +652,7 @@ TEST(CtfSnapshot, snapshot_restore_continuation_matches_uninterrupted_run)
 
     CtfWorld restored;
     const og::sim::WorldSnapshot mid_snapshot =
-        og::sim::deserialize_snapshot(mid_bytes.data(), mid_bytes.size());
+        og::sim::deserialize_snapshot(mid_bytes);
     og::sim::apply_snapshot(restored.world(), mid_snapshot);
     ASSERT_TRUE(restored.world().ctf.active);
     ASSERT_TRUE(restored.world().ctf.init_attempted);
@@ -666,10 +663,8 @@ TEST(CtfSnapshot, snapshot_restore_continuation_matches_uninterrupted_run)
     const std::vector<std::uint8_t> restored_end = og::sim::serialize_snapshot(
         og::sim::capture_keyframe_snapshot(restored.world()));
 
-    const og::sim::WorldSnapshot expected_end = og::sim::deserialize_snapshot(
-        uninterrupted_end.data(), uninterrupted_end.size());
-    const og::sim::WorldSnapshot actual_end = og::sim::deserialize_snapshot(
-        restored_end.data(), restored_end.size());
+    const og::sim::WorldSnapshot expected_end = og::sim::deserialize_snapshot(uninterrupted_end);
+    const og::sim::WorldSnapshot actual_end = og::sim::deserialize_snapshot(restored_end);
     const auto failure = og::sim::find_first_snapshot_difference(
         expected_end.tick_count, expected_end, actual_end);
     ASSERT_FALSE(failure.has_value())
@@ -750,7 +745,7 @@ TEST(CtfSnapshot, keyframe_at_blink_tick_boundary_continues_byte_equal)
 
     CtfWorld restored;
     const og::sim::WorldSnapshot mid_snapshot =
-        og::sim::deserialize_snapshot(mid_bytes.data(), mid_bytes.size());
+        og::sim::deserialize_snapshot(mid_bytes);
     og::sim::apply_snapshot(restored.world(), mid_snapshot);
     ASSERT_TRUE(restored.world().ctf.active);
     ASSERT_EQ(og::sim::CtfFlagState::Dropped,
@@ -760,10 +755,8 @@ TEST(CtfSnapshot, keyframe_at_blink_tick_boundary_continues_byte_equal)
     const std::vector<std::uint8_t> restored_end = og::sim::serialize_snapshot(
         og::sim::capture_keyframe_snapshot(restored.world()));
 
-    const og::sim::WorldSnapshot expected_end = og::sim::deserialize_snapshot(
-        uninterrupted_end.data(), uninterrupted_end.size());
-    const og::sim::WorldSnapshot actual_end = og::sim::deserialize_snapshot(
-        restored_end.data(), restored_end.size());
+    const og::sim::WorldSnapshot expected_end = og::sim::deserialize_snapshot(uninterrupted_end);
+    const og::sim::WorldSnapshot actual_end = og::sim::deserialize_snapshot(restored_end);
     const auto failure = og::sim::find_first_snapshot_difference(
         expected_end.tick_count, expected_end, actual_end);
     ASSERT_FALSE(failure.has_value())
@@ -792,7 +785,7 @@ TEST(CtfSnapshot, strip_scenario_troops_round_trips_and_changes_hash)
     EXPECT_EQ(1, snapshot.ctf_requested_strip_scenario_troops);
     const std::vector<std::uint8_t> bytes = og::sim::serialize_snapshot(snapshot);
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_snapshot(bytes.data(), bytes.size());
+        og::sim::deserialize_snapshot(bytes);
     EXPECT_EQ(1, decoded.ctf_requested_strip_scenario_troops);
 
     // Apply writes it back into a fresh world.
@@ -809,7 +802,7 @@ TEST(CtfSnapshot, strip_scenario_troops_round_trips_and_changes_hash)
     const std::vector<std::uint8_t> delta_bytes =
         og::sim::serialize_delta(delta_source);
     const og::sim::WorldSnapshot decoded_delta =
-        og::sim::deserialize_delta(delta_bytes.data(), delta_bytes.size());
+        og::sim::deserialize_delta(delta_bytes);
     og::sim::apply_delta(baseline, decoded_delta);
     EXPECT_EQ(1, baseline.ctf_requested_strip_scenario_troops);
 

--- a/tests/unit/test_lobby_server.cpp
+++ b/tests/unit/test_lobby_server.cpp
@@ -594,21 +594,24 @@ TEST(LobbyServer, first_connected_peer_remains_host_even_if_another_peer_joins_f
     EXPECT_EQ(1u, server.state().players[1].player_index);
 }
 
-TEST(LobbyServer, malformed_lobby_message_throws)
+TEST(LobbyServer, malformed_lobby_message_disconnects_peer)
 {
     MockLobbyTransport transport;
     og::sim::LobbyServer server(transport);
     server.connect_client(11u);
+    transport.clear_sent_messages();
 
     std::vector<std::uint8_t> malformed = og::sim::serialize_lobby_message(
         make_join_message("Host", 0, {make_slot(0u, 100, "Host Guy", FAMILY_SOLDIER)}));
     malformed.pop_back();
     transport.queue_raw_message(11u, std::move(malformed));
 
-    EXPECT_THROW(server.poll_incoming_messages(), std::runtime_error);
+    EXPECT_NO_THROW(server.poll_incoming_messages());
+    EXPECT_EQ((std::vector<og::sim::PeerId>{11u}), transport.disconnected_peers());
+    EXPECT_TRUE(server.state().players.empty());
 }
 
-TEST(LobbyServer, malformed_typed_message_throws)
+TEST(LobbyServer, malformed_typed_message_disconnects_peer)
 {
     MockLobbyTransport transport(true);
     og::sim::LobbyServer server(transport);
@@ -617,7 +620,9 @@ TEST(LobbyServer, malformed_typed_message_throws)
 
     transport.queue_malformed_typed_message(11u);
 
-    EXPECT_THROW(server.poll_incoming_messages(), std::runtime_error);
+    EXPECT_NO_THROW(server.poll_incoming_messages());
+    EXPECT_EQ((std::vector<og::sim::PeerId>{11u}), transport.disconnected_peers());
+    EXPECT_TRUE(server.state().players.empty());
 }
 
 TEST(LobbyServer, fifth_join_is_rejected_when_lobby_is_full)

--- a/tests/unit/test_net_transport.cpp
+++ b/tests/unit/test_net_transport.cpp
@@ -1353,16 +1353,14 @@ TEST(NetTransport, game_server_snapshot_hash_check_is_strict_per_peer_per_tick)
     server.send_initial_snapshot(7u, og::sim::SnapshotCaptureMode::Peek);
     ASSERT_GE(transport.sent_messages().size(), 2u);
     const og::sim::WorldSnapshot first_snapshot =
-        og::sim::deserialize_snapshot(transport.sent_messages()[1].data.data(),
-                                      transport.sent_messages()[1].data.size());
+        og::sim::deserialize_snapshot(transport.sent_messages()[1].data);
     transport.clear_sent_messages();
 
     fixture.world().current_palette_id = 1;
     server.send_initial_snapshot(11u, og::sim::SnapshotCaptureMode::Peek);
     ASSERT_GE(transport.sent_messages().size(), 2u);
     const og::sim::WorldSnapshot second_snapshot =
-        og::sim::deserialize_snapshot(transport.sent_messages()[1].data.data(),
-                                      transport.sent_messages()[1].data.size());
+        og::sim::deserialize_snapshot(transport.sent_messages()[1].data);
     ASSERT_EQ(first_snapshot.tick_count, second_snapshot.tick_count);
     ASSERT_NE(first_snapshot.snapshot_hash, second_snapshot.snapshot_hash);
 
@@ -1396,16 +1394,14 @@ TEST(NetTransport, game_server_snapshot_hash_check_preserves_same_peer_same_tick
     server.send_initial_snapshot(7u, og::sim::SnapshotCaptureMode::Peek);
     ASSERT_GE(transport.sent_messages().size(), 2u);
     const og::sim::WorldSnapshot first_snapshot =
-        og::sim::deserialize_snapshot(transport.sent_messages()[1].data.data(),
-                                      transport.sent_messages()[1].data.size());
+        og::sim::deserialize_snapshot(transport.sent_messages()[1].data);
     transport.clear_sent_messages();
 
     fixture.world().current_palette_id = 1;
     server.send_initial_snapshot(7u, og::sim::SnapshotCaptureMode::Peek);
     ASSERT_GE(transport.sent_messages().size(), 2u);
     const og::sim::WorldSnapshot second_snapshot =
-        og::sim::deserialize_snapshot(transport.sent_messages()[1].data.data(),
-                                      transport.sent_messages()[1].data.size());
+        og::sim::deserialize_snapshot(transport.sent_messages()[1].data);
     ASSERT_EQ(first_snapshot.tick_count, second_snapshot.tick_count);
     ASSERT_NE(first_snapshot.snapshot_hash, second_snapshot.snapshot_hash);
 
@@ -1480,8 +1476,7 @@ TEST(NetTransport,
     ASSERT_NE(transport.sent_messages().end(), paused_snapshot_it);
 
     const og::sim::WorldSnapshot paused_snapshot =
-        og::sim::deserialize_snapshot(paused_snapshot_it->data.data(),
-                                      paused_snapshot_it->data.size());
+        og::sim::deserialize_snapshot(paused_snapshot_it->data);
     EXPECT_EQ(paused_tick, paused_snapshot.tick_count);
     EXPECT_TRUE(paused_snapshot.paused);
     EXPECT_EQ(0u, paused_snapshot.pause_player_index);
@@ -1538,8 +1533,7 @@ TEST(NetTransport, game_server_broadcast_current_state_uses_raw_fallback)
         envelope));
     EXPECT_EQ(og::sim::kSnapshotMessageType, envelope.message_type);
     const og::sim::WorldSnapshot initial =
-        og::sim::deserialize_snapshot(transport.sent_messages()[1].data.data(),
-                                      transport.sent_messages()[1].data.size());
+        og::sim::deserialize_snapshot(transport.sent_messages()[1].data);
     EXPECT_EQ(3u, initial.tick_count);
     EXPECT_EQ(2, initial.my_team);
     EXPECT_EQ(1, initial.current_palette_id);
@@ -1618,8 +1612,7 @@ TEST(NetTransport, game_server_forward_event_batch_uses_ready_raw_fallback)
     ASSERT_TRUE(og::sim::decode_transport_envelope(sim_message.data, envelope));
     EXPECT_EQ(og::sim::kSimEventBatchMessageType, envelope.message_type);
     const og::sim::SimEventBatch sim_batch =
-        og::sim::deserialize_sim_event_batch(sim_message.data.data(),
-                                             sim_message.data.size());
+        og::sim::deserialize_sim_event_batch(sim_message.data);
     EXPECT_NE(0u, sim_batch.sequence);
     ASSERT_EQ(1u, sim_batch.events.size());
     EXPECT_EQ(og::sim::EventKind::Notification, sim_batch.events[0].kind);
@@ -1631,8 +1624,7 @@ TEST(NetTransport, game_server_forward_event_batch_uses_ready_raw_fallback)
         og::sim::decode_transport_envelope(game_flow_message.data, envelope));
     EXPECT_EQ(og::sim::kGameFlowEventBatchMessageType, envelope.message_type);
     const og::sim::SimEventBatch game_flow_batch =
-        og::sim::deserialize_game_flow_event_batch(game_flow_message.data.data(),
-                                                   game_flow_message.data.size());
+        og::sim::deserialize_game_flow_event_batch(game_flow_message.data);
     EXPECT_NE(0u, game_flow_batch.sequence);
     ASSERT_EQ(1u, game_flow_batch.events.size());
     EXPECT_EQ(og::sim::EventKind::EndGame, game_flow_batch.events[0].kind);
@@ -1684,9 +1676,7 @@ TEST(NetTransport,
               transport.sent_messages()[1].data);
 
     const og::sim::WorldSnapshot snapshot =
-        og::sim::deserialize_snapshot(
-            transport.broadcast_messages().front().data(),
-            transport.broadcast_messages().front().size());
+        og::sim::deserialize_snapshot(transport.broadcast_messages().front());
     EXPECT_EQ(og::sim::KEYFRAME_INTERVAL_TICKS, snapshot.tick_count);
     EXPECT_EQ(3, snapshot.current_palette_id);
 }
@@ -1767,9 +1757,7 @@ TEST(NetTransport,
     ASSERT_EQ(1u, transport.broadcast_messages().size());
     ASSERT_EQ(1u, transport.sent_messages().size());
     const og::sim::WorldSnapshot snapshot =
-        og::sim::deserialize_snapshot(
-            transport.broadcast_messages().front().data(),
-            transport.broadcast_messages().front().size());
+        og::sim::deserialize_snapshot(transport.broadcast_messages().front());
     const og::sim::EntitySnapshot* actor_snapshot =
         find_entity_snapshot(snapshot.oblist, actor->entity_id());
     ASSERT_NE(nullptr, actor_snapshot);

--- a/tests/unit/test_world_snapshot.cpp
+++ b/tests/unit/test_world_snapshot.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <cstddef>
 #include <list>
+#include <span>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -1768,7 +1769,7 @@ TEST(WorldSnapshot, serialize_snapshot_roundtrip_preserves_keyframe_and_compress
     EXPECT_LT(bytes.size(), keyframe.full_grid_data.size() / 2);
 
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_snapshot(bytes.data(), bytes.size());
+        og::sim::deserialize_snapshot(bytes);
     expect_world_snapshot_eq(keyframe, decoded);
 }
 
@@ -1800,7 +1801,7 @@ TEST(WorldSnapshot, guy_snapshot_roundtrip_preserves_owner_tags)
 
     const std::vector<std::uint8_t> bytes = og::sim::serialize_snapshot(keyframe);
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_snapshot(bytes.data(), bytes.size());
+        og::sim::deserialize_snapshot(bytes);
     ASSERT_EQ(1u, decoded.guy_snapshots.size());
     EXPECT_EQ(2u, decoded.guy_snapshots.front().owner_player_index)
         << "owner_player_index must survive the snapshot wire";
@@ -1884,7 +1885,7 @@ TEST(WorldSnapshot, serialize_delta_roundtrip_uses_uncompressed_bypass_when_smal
         EXPECT_LT(recompressed.size(), raw_payload.size());
 
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_delta(bytes.data(), bytes.size());
+        og::sim::deserialize_delta(bytes);
     expect_world_snapshot_eq(delta, decoded);
 }
 
@@ -1921,7 +1922,7 @@ TEST(WorldSnapshot, empty_delta_roundtrip_preserves_world_state_without_entities
 
     const std::vector<std::uint8_t> bytes = og::sim::serialize_delta(delta);
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_delta(bytes.data(), bytes.size());
+        og::sim::deserialize_delta(bytes);
     ASSERT_EQ(1u, decoded.oblist.size());
     EXPECT_EQ(actor_id, decoded.oblist.front().entity_id);
     EXPECT_EQ(1ULL << og::dirty::BIT_ENTITY_ID,
@@ -1953,7 +1954,7 @@ TEST(WorldSnapshot, serialize_delta_roundtrip_preserves_zero_mask_removal_sentin
 
     const std::vector<std::uint8_t> bytes = og::sim::serialize_delta(delta);
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_delta(bytes.data(), bytes.size());
+        og::sim::deserialize_delta(bytes);
 
     ASSERT_EQ(1u, decoded.oblist.size());
     EXPECT_EQ(77u, decoded.oblist.front().entity_id);
@@ -1976,7 +1977,7 @@ TEST(WorldSnapshot, deserialize_snapshot_rejects_bad_headers_and_format_version)
     bad_protocol[0] = static_cast<std::uint8_t>(og::sim::kSnapshotProtocolVersion + 1);
     try
     {
-        (void)og::sim::deserialize_snapshot(bad_protocol.data(), bad_protocol.size());
+        (void)og::sim::deserialize_snapshot(bad_protocol);
         FAIL() << "expected protocol mismatch";
     }
     catch (const std::runtime_error& error)
@@ -1988,14 +1989,14 @@ TEST(WorldSnapshot, deserialize_snapshot_rejects_bad_headers_and_format_version)
     std::vector<std::uint8_t> bad_type = bytes;
     bad_type[1] = og::sim::kDeltaSnapshotMessageType;
     EXPECT_THROW(
-        (void)og::sim::deserialize_snapshot(bad_type.data(), bad_type.size()),
+        (void)og::sim::deserialize_snapshot(bad_type),
         std::runtime_error);
 
     std::vector<std::uint8_t> bad_length = bytes;
     bad_length[2] = 0;
     bad_length[3] = 0;
     EXPECT_THROW(
-        (void)og::sim::deserialize_snapshot(bad_length.data(), bad_length.size()),
+        (void)og::sim::deserialize_snapshot(bad_length),
         std::runtime_error);
 
     const std::size_t payload_length = payload_length_from_header_for_test(bytes);
@@ -2017,7 +2018,7 @@ TEST(WorldSnapshot, deserialize_snapshot_rejects_bad_headers_and_format_version)
 
     try
     {
-        (void)og::sim::deserialize_snapshot(bad_format.data(), bad_format.size());
+        (void)og::sim::deserialize_snapshot(bad_format);
         FAIL() << "expected snapshot format mismatch";
     }
     catch (const std::runtime_error& error)
@@ -2029,7 +2030,7 @@ TEST(WorldSnapshot, deserialize_snapshot_rejects_bad_headers_and_format_version)
     std::vector<std::uint8_t> truncated = bytes;
     truncated.pop_back();
     EXPECT_THROW(
-        (void)og::sim::deserialize_snapshot(truncated.data(), truncated.size()),
+        (void)og::sim::deserialize_snapshot(truncated),
         std::runtime_error);
 }
 
@@ -2043,20 +2044,20 @@ TEST(WorldSnapshot, deserialize_delta_rejects_bad_headers_and_malformed_payloads
     std::vector<std::uint8_t> bad_protocol = bytes;
     bad_protocol[0] = static_cast<std::uint8_t>(og::sim::kSnapshotProtocolVersion + 1);
     EXPECT_THROW(
-        (void)og::sim::deserialize_delta(bad_protocol.data(), bad_protocol.size()),
+        (void)og::sim::deserialize_delta(bad_protocol),
         std::runtime_error);
 
     std::vector<std::uint8_t> bad_type = bytes;
     bad_type[1] = og::sim::kSnapshotMessageType;
     EXPECT_THROW(
-        (void)og::sim::deserialize_delta(bad_type.data(), bad_type.size()),
+        (void)og::sim::deserialize_delta(bad_type),
         std::runtime_error);
 
     std::vector<std::uint8_t> bad_length = bytes;
     bad_length[2] = 0;
     bad_length[3] = 0;
     EXPECT_THROW(
-        (void)og::sim::deserialize_delta(bad_length.data(), bad_length.size()),
+        (void)og::sim::deserialize_delta(bad_length),
         std::runtime_error);
 
     const bool payload_is_uncompressed =
@@ -2080,13 +2081,13 @@ TEST(WorldSnapshot, deserialize_delta_rejects_bad_headers_and_malformed_payloads
     bad_format.insert(bad_format.end(),
                       corrupted_payload.begin(), corrupted_payload.end());
     EXPECT_THROW(
-        (void)og::sim::deserialize_delta(bad_format.data(), bad_format.size()),
+        (void)og::sim::deserialize_delta(bad_format),
         std::runtime_error);
 
     std::vector<std::uint8_t> truncated = bytes;
     truncated.pop_back();
     EXPECT_THROW(
-        (void)og::sim::deserialize_delta(truncated.data(), truncated.size()),
+        (void)og::sim::deserialize_delta(truncated),
         std::runtime_error);
 }
 
@@ -2113,8 +2114,7 @@ TEST(WorldSnapshot, deserialize_snapshot_and_delta_reject_oversized_payloads_and
                               oversized_compressed.begin(),
                               oversized_compressed.end());
     EXPECT_THROW(
-        (void)og::sim::deserialize_snapshot(oversized_snapshot.data(),
-                                            oversized_snapshot.size()),
+        (void)og::sim::deserialize_snapshot(oversized_snapshot),
         std::runtime_error);
 
     og::sim::WorldSnapshot delta;
@@ -2144,8 +2144,7 @@ TEST(WorldSnapshot, deserialize_snapshot_and_delta_reject_oversized_payloads_and
     bad_count_delta.insert(bad_count_delta.end(),
                            raw_payload.begin(), raw_payload.end());
     EXPECT_THROW(
-        (void)og::sim::deserialize_delta(bad_count_delta.data(),
-                                         bad_count_delta.size()),
+        (void)og::sim::deserialize_delta(bad_count_delta),
         std::runtime_error);
 }
 
@@ -2201,38 +2200,35 @@ TEST(WorldSnapshot, event_batch_roundtrip_and_rejects_malformed_frames)
     const std::vector<std::uint8_t> bytes =
         og::sim::serialize_sim_event_batch(batch);
     const og::sim::SimEventBatch decoded =
-        og::sim::deserialize_sim_event_batch(bytes.data(), bytes.size());
+        og::sim::deserialize_sim_event_batch(bytes);
     EXPECT_EQ(batch.sequence, decoded.sequence);
     EXPECT_EQ(batch.events, decoded.events);
 
     const std::vector<std::uint8_t> flow_bytes =
         og::sim::serialize_game_flow_event_batch(batch);
     const og::sim::SimEventBatch decoded_flow =
-        og::sim::deserialize_game_flow_event_batch(flow_bytes.data(),
-                                                   flow_bytes.size());
+        og::sim::deserialize_game_flow_event_batch(flow_bytes);
     EXPECT_EQ(batch.events, decoded_flow.events);
 
-    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(nullptr, 0),
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
+                     std::span<const std::uint8_t>{}),
                  std::runtime_error);
 
     std::vector<std::uint8_t> bad_protocol = bytes;
     bad_protocol[0] =
         static_cast<std::uint8_t>(og::sim::kSnapshotProtocolVersion + 1);
-    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
-                     bad_protocol.data(), bad_protocol.size()),
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(bad_protocol),
                  std::runtime_error);
 
     std::vector<std::uint8_t> bad_type = bytes;
     bad_type[1] = og::sim::kGameFlowEventBatchMessageType;
-    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
-                     bad_type.data(), bad_type.size()),
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(bad_type),
                  std::runtime_error);
 
     std::vector<std::uint8_t> bad_length = bytes;
     bad_length[2] = 0;
     bad_length[3] = 0;
-    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
-                     bad_length.data(), bad_length.size()),
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(bad_length),
                  std::runtime_error);
 
     std::vector<std::uint8_t> too_many_events_payload;
@@ -2242,8 +2238,7 @@ TEST(WorldSnapshot, event_batch_roundtrip_and_rejects_malformed_frames)
         frame_event_batch_payload_for_test(
             og::sim::kSimEventBatchMessageType,
             too_many_events_payload);
-    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
-                     too_many_events.data(), too_many_events.size()),
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(too_many_events),
                  std::runtime_error);
 
     std::vector<std::uint8_t> oversized_string_payload;
@@ -2259,8 +2254,7 @@ TEST(WorldSnapshot, event_batch_roundtrip_and_rejects_malformed_frames)
         frame_event_batch_payload_for_test(
             og::sim::kSimEventBatchMessageType,
             oversized_string_payload);
-    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
-                     oversized_string.data(), oversized_string.size()),
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(oversized_string),
                  std::runtime_error);
 
     std::vector<std::uint8_t> truncated_string_payload;
@@ -2277,8 +2271,7 @@ TEST(WorldSnapshot, event_batch_roundtrip_and_rejects_malformed_frames)
         frame_event_batch_payload_for_test(
             og::sim::kSimEventBatchMessageType,
             truncated_string_payload);
-    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
-                     truncated_string.data(), truncated_string.size()),
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(truncated_string),
                  std::runtime_error);
 
     std::vector<std::uint8_t> trailing_payload;
@@ -2289,8 +2282,7 @@ TEST(WorldSnapshot, event_batch_roundtrip_and_rejects_malformed_frames)
         frame_event_batch_payload_for_test(
             og::sim::kSimEventBatchMessageType,
             trailing_payload);
-    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(
-                     trailing.data(), trailing.size()),
+    EXPECT_THROW((void)og::sim::deserialize_sim_event_batch(trailing),
                  std::runtime_error);
 
     og::sim::SimEventBatch huge_text;
@@ -2403,7 +2395,7 @@ TEST(WorldSnapshot, apply_delta_with_all_fields_dirty_matches_current_world_stat
         og::sim::consume_delta_snapshot_for_client(client_state, current);
     const std::vector<std::uint8_t> bytes = og::sim::serialize_delta(delta);
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_delta(bytes.data(), bytes.size());
+        og::sim::deserialize_delta(bytes);
 
     og::sim::apply_delta(client_baseline, decoded);
     const og::sim::WorldSnapshot source_keyframe =
@@ -2453,7 +2445,7 @@ TEST(WorldSnapshot, consume_delta_snapshot_for_client_accumulates_grid_tiles_acr
 
     const std::vector<std::uint8_t> bytes = og::sim::serialize_delta(delta);
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_delta(bytes.data(), bytes.size());
+        og::sim::deserialize_delta(bytes);
 
     EXPECT_TRUE(decoded.grid_dirty);
     EXPECT_FALSE(decoded.grid_full_resend);
@@ -2523,7 +2515,7 @@ TEST(WorldSnapshot, consume_delta_snapshot_for_client_keeps_later_grid_tiles_aft
 
     const std::vector<std::uint8_t> bytes = og::sim::serialize_delta(delta);
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_delta(bytes.data(), bytes.size());
+        og::sim::deserialize_delta(bytes);
 
     EXPECT_TRUE(decoded.grid_dirty);
     EXPECT_TRUE(decoded.grid_full_resend);
@@ -2600,7 +2592,7 @@ TEST(WorldSnapshot, apply_delta_reorders_entity_lists_even_without_field_changes
     const og::sim::WorldSnapshot delta = og::sim::capture_snapshot(source);
     const std::vector<std::uint8_t> bytes = og::sim::serialize_delta(delta);
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_delta(bytes.data(), bytes.size());
+        og::sim::deserialize_delta(bytes);
 
     og::sim::apply_delta(client_baseline, decoded);
     const og::sim::WorldSnapshot source_keyframe =
@@ -2645,7 +2637,7 @@ TEST(WorldSnapshot,
 
     const std::vector<std::uint8_t> bytes = og::sim::serialize_delta(delta);
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_delta(bytes.data(), bytes.size());
+        og::sim::deserialize_delta(bytes);
 
     og::sim::apply_delta(client_baseline, decoded);
     expect_world_snapshot_eq(current, client_baseline, false);
@@ -2711,7 +2703,7 @@ TEST(WorldSnapshot, apply_delta_accumulates_multi_tick_changes_with_spawn_and_re
         og::sim::consume_delta_snapshot_for_client(client_state, tick_three);
     const std::vector<std::uint8_t> bytes = og::sim::serialize_delta(delta);
     const og::sim::WorldSnapshot decoded =
-        og::sim::deserialize_delta(bytes.data(), bytes.size());
+        og::sim::deserialize_delta(bytes);
 
     EXPECT_NE(decoded.removed_entity_ids.end(),
               std::find(decoded.removed_entity_ids.begin(),

--- a/tests/unit/test_world_snapshot.cpp
+++ b/tests/unit/test_world_snapshot.cpp
@@ -1603,6 +1603,46 @@ TEST(WorldSnapshot, apply_snapshot_works_for_attached_external_worlds)
     EXPECT_NE(nullptr, mirror_level.world().find_by_id(actor_id));
 }
 
+TEST(WorldSnapshot, apply_snapshot_clamps_out_of_range_family_and_special)
+{
+    // Security: family/current_special arrive straight off the wire and are used
+    // to index per-family/per-special tables across the sim. A malicious peer can
+    // put any value here, so apply_snapshot must clamp them into range.
+    og::sim::WorldSnapshot snapshot;
+    std::uint32_t actor_id = 0;
+    {
+        TestGameWorld source_fx;
+        GameWorld& source = source_fx.world();
+        configure_snapshot_test_services(source);
+        walker* actor = source.add_ob(Order::Living, FAMILY_SOLDIER);
+        ASSERT_NE(nullptr, actor);
+        actor->setworldxy(64.0f, 96.0f);
+        actor_id = actor->entity_id();
+        snapshot = og::sim::capture_snapshot(source);
+    }
+    ASSERT_EQ(1u, snapshot.oblist.size());
+    // Forge attacker-controlled out-of-range indices.
+    snapshot.oblist[0].family = static_cast<std::int8_t>(99);
+    snapshot.oblist[0].current_special = static_cast<std::int8_t>(99);
+
+    TestGameWorld mirror_fx;
+    GameWorld& mirror = mirror_fx.world();
+    configure_snapshot_test_services(mirror);
+    GameplayContext* const previous_game = current_game;
+    current_game = nullptr;
+    og::sim::apply_snapshot(mirror, snapshot);
+    current_game = previous_game;
+
+    walker* applied = mirror.find_by_id(actor_id);
+    ASSERT_NE(nullptr, applied) << "entity should still be applied";
+    EXPECT_GE(static_cast<int>(applied->family()), 0);
+    EXPECT_LT(static_cast<int>(applied->family()), NUM_FAMILIES)
+        << "out-of-range family must be clamped";
+    EXPECT_GE(static_cast<int>(applied->current_special()), 0);
+    EXPECT_LT(static_cast<int>(applied->current_special()), NUM_SPECIALS)
+        << "out-of-range current_special must be clamped";
+}
+
 TEST(WorldSnapshot, apply_snapshot_keeps_dead_players_out_of_obmap)
 {
     TestGameWorld source_fx;


### PR DESCRIPTION
This `sec` branch combines two bodies of work: the original network/CI **security hardening**, and a subsequent **full-codebase memory-safety modernization** pass driven by a line-by-line audit. All GitHub CI checks are green (CI, Coverage, WASM E2E, Fuzz, Nightly).

---

## Part 1 — Network & CI security hardening

### Summary
- Add receive limits for native/Emscripten WebSocket transports and relay control messages
- Validate campaign IDs, save slots, scenario resource names, PNG/sidecar sizes, and zip extraction limits
- Harden malformed lobby packet handling, reconnect session tokens, direct WebSocket defaults, CI permissions, deploy/helper scripts, and npm dependencies
- Fix an ASan stack-use-after-scope in the zip test; add security-guard tests

### Notes
- Relay tooling now requires Node >=22, matching current Wrangler/Cloudflare test tooling
- Public relay room listing/join semantics and owner-token-in-query compatibility are left for a follow-up product/protocol decision

---

## Part 2 — Full-codebase memory-safety modernization

A line-by-line audit of all first-party `src/` + `include/` (~100k LOC), followed by surgical, behavior-preserving refactors that replace memory-unsafe patterns with modern C++. Every change in the deterministic sim/serialization path was kept byte-for-byte identical (the `og_test_parity` gate stays green).

### Highlights by class
- **Null-guard entity-factory returns before dereference** across the walker families (`add_ob` / `summon_entity` / `guy_create_and_add_walker`) — the factories only return null on allocation/registry failure that never occurs in normal play, so behavior is identical.
- **Unchecked indexing of snapshot/save/file-controlled data**: `ani_count` upper-bound (mirrors `walker::animate`), `ani` null-guard, save-file team/campaign/level **size caps with early reject**, bounds + divide-by-zero guards in the team-build UI.
- **RAII for owning raw handles**: `FILE*` and `addrinfo*` deleters; `=delete` copy/move on classes owning SDL / `Mix_Chunk` pointers; `std::make_unique` in factory paths.
- **Lifetime / dangling fixes**: `smoother::mygrid` raw pointer → `std::span`; removed redundant `PixieData::free()` (RAII); refreshed a stale radar viewscreen pointer; switched the level-editor text-input path to the safe `std::optional<std::string>` wrapper.
- **Type / UB hardening**: bounded `calculate_exp` iteration (untrusted recursion depth); `name.clear()` (fixes `operator[]` on an empty `std::string`); type-exact libyaml trampolines (removing function-pointer `reinterpret_cast`); `std::memcpy` byte extraction; `fire_check` loop counter widened (was infinite-loopable on a hostile snapshot); clamped narrowing casts.
- **Initialization / encapsulation**: default member initializers (pixie/pixien/view/walker/button/TroopResult/sdl_soundob); `inline constexpr` on a header-defined array (ODR); `SeededRandom::state_` private behind a `seed()`; `static_assert FIELD_COUNT <= dirty_mask_` capacity.

### Deliberately skipped
Refactors that would change deterministic outputs or churn broadly: signed-char `waver` / potion-duration overflows (parity value changes), `get_cfg_item` / `fill_help_array` signature changes, `std::array` migrations that would trigger `-Wconversion` floods, and `std::bit_cast` (unavailable on the ctest Emscripten libc++).

### Follow-up fixes (in this branch)
- **WASM**: reverted `get_asset_path()` to the raw `readlink("/proc/self/exe")` syscall — Emscripten's virtual FS supports it but `std::filesystem::read_symlink()` fails there, spamming the WASM console at startup. (The local build test only *compiles* WASM, so the Playwright run caught it.)
- **Coverage**: collapsed the new factory-null guards to single-line form (keeps the line covered) and wrapped genuinely-unreachable validation/wrap-guard blocks with `GCOVR_EXCL`. Line coverage back over the 90% gate (90.0% line / 96.4% function).

---

## Verification
- `cmake --build --preset ci-test && ctest --preset ci-test` — **43/43 pass**, including the `og_test_parity` determinism gate and `emscripten_build_test`
- Coverage build (`ci-coverage`): **44/44 tests pass**, line 90.0% / function 96.4% (both gates pass)
- Original security verification (npm audit, relay tsc/vitest, script lint) as listed in Part 1
- All GitHub Actions checks green on the head commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
