### PR TITLE
Second-pass modern-C++ idiom cleanup across src/ and include/

### DIFF
--- a/include/openglad/core/combat_math.h
+++ b/include/openglad/core/combat_math.h
@@ -14,23 +14,23 @@ using RandomU32 = std::uint32_t(*)(std::uint32_t);
 
 // Original behavior from walker.cpp:
 //   d - sqrt(d)/2 + random(floor(sqrt(d)))
-float compute_base_damage(float base_damage, RandomU32 rng);
+[[nodiscard]] float compute_base_damage(float base_damage, RandomU32 rng);
 
 // Original behavior from walker.cpp:
 //   reduction = armor/2, clamped to at most (damage - 1) so at least 1 gets through.
-float compute_damage_reduction(float incoming_damage, float target_armor);
+[[nodiscard]] float compute_damage_reduction(float incoming_damage, float target_armor);
 
 // Convenience helper.
-float compute_post_reduction_damage(float incoming_damage, float target_armor);
+[[nodiscard]] float compute_post_reduction_damage(float incoming_damage, float target_armor);
 
 // IRandom-based overload: allows injection via GameContext's RNG
-float compute_base_damage(float base_damage, IRandom& rng);
+[[nodiscard]] float compute_base_damage(float base_damage, IRandom& rng);
 
 // Compute faerie freeze duration on a target.
 // constitution: target's constitution stat (0 if no myguy)
 // level: attacker's level
 // Returns: freeze delay in ticks (clamped to >= 0)
-std::int32_t compute_freeze_duration(std::int32_t level, std::int32_t constitution, IRandom& rng);
+[[nodiscard]] std::int32_t compute_freeze_duration(std::int32_t level, std::int32_t constitution, IRandom& rng);
 
 // Compute cleric heal amount for one target.
 // magicpoints: caster's current MP
@@ -40,12 +40,12 @@ struct HealResult {
     std::int32_t amount;
     std::int32_t cost;
 };
-HealResult compute_heal_amount(std::int32_t magicpoints, std::int32_t level, IRandom& rng);
+[[nodiscard]] HealResult compute_heal_amount(std::int32_t magicpoints, std::int32_t level, IRandom& rng);
 
 // Compute charm duration.
 // level_diff: caster_level - target_level (can be negative)
 // Returns: charm duration in ticks
-std::int32_t compute_charm_duration(std::int32_t level_diff, IRandom& rng);
+[[nodiscard]] std::int32_t compute_charm_duration(std::int32_t level_diff, IRandom& rng);
 
 // Regeneration tick result.
 struct RegenTickResult {
@@ -58,7 +58,7 @@ struct RegenTickResult {
 // current_delay: current delay counter, max_delay: delay threshold for bonus +1.
 // frozen: if true, no regen occurs.
 // Returns new value and delay counter.
-RegenTickResult compute_regen_tick(float current, float max_val, float per_round,
+[[nodiscard]] RegenTickResult compute_regen_tick(float current, float max_val, float per_round,
                                    std::int32_t current_delay, std::int32_t max_delay, bool frozen);
 
 // Compute HP regen considering regen_delay (post-damage cooldown).
@@ -69,7 +69,7 @@ struct HpRegenResult {
     std::int32_t new_heal_delay;
     std::int32_t new_regen_delay;
 };
-HpRegenResult compute_hp_regen_tick(float current_hp, float max_hp, float heal_per_round,
+[[nodiscard]] HpRegenResult compute_hp_regen_tick(float current_hp, float max_hp, float heal_per_round,
                                      std::int32_t current_heal_delay, std::int32_t max_heal_delay,
                                      std::int32_t regen_delay, bool frozen);
 
@@ -77,10 +77,10 @@ HpRegenResult compute_hp_regen_tick(float current_hp, float max_hp, float heal_p
 // level_diff: attacker_level - target_level
 // damage: damage dealt
 // Returns: XP earned (clamped to >= 0)
-short compute_xp_from_attack(std::int32_t level_diff, float damage);
+[[nodiscard]] short compute_xp_from_attack(std::int32_t level_diff, float damage);
 
 // XP from killing a target (equivalent to dealing 20 damage worth of XP).
-short compute_xp_from_kill(std::int32_t level_diff);
+[[nodiscard]] short compute_xp_from_kill(std::int32_t level_diff);
 
 // XP action types for compute_xp_from_action.
 enum class ExpAction {
@@ -93,6 +93,6 @@ enum class ExpAction {
 // attacker_level/target_level: the relevant entity levels
 // value: action-specific value (damage for Attack, heal amount for Heal, etc.)
 // rng: needed only for Heal action
-short compute_xp_from_action(ExpAction action, std::int32_t attacker_level, std::int32_t target_level,
+[[nodiscard]] short compute_xp_from_action(ExpAction action, std::int32_t attacker_level, std::int32_t target_level,
                              short value, IRandom& rng);
 

--- a/include/openglad/core/frame_pacing.h
+++ b/include/openglad/core/frame_pacing.h
@@ -4,14 +4,14 @@
 
 namespace og::core {
 
-float render_tick_interval_ms(short timer_wait, float speed_factor);
+[[nodiscard]] float render_tick_interval_ms(short timer_wait, float speed_factor);
 
 // Returns the per-frame interval the browser pacer should target, derived from
 // the configured target_fps. The browser cannot present faster than the host
 // rAF cadence (~16 ms), so values below that floor are clamped up. When
 // `fps <= 0`, the legacy "fast mode" sentinel is preserved by returning 0,
 // which tells the pacer to run every callback without accumulating.
-std::uint32_t browser_frame_target_interval_ms(int fps);
+[[nodiscard]] std::uint32_t browser_frame_target_interval_ms(int fps);
 
 struct BrowserFramePacingResult
 {
@@ -26,7 +26,7 @@ struct BrowserFramePacingResult
     std::uint32_t accumulated_after_step_ms = 0;
 };
 
-BrowserFramePacingResult step_browser_frame_pacing(
+[[nodiscard]] BrowserFramePacingResult step_browser_frame_pacing(
     std::uint32_t accumulated_time_ms,
     std::uint32_t delta_ms,
     std::uint32_t sim_interval_ms);
@@ -45,7 +45,7 @@ public:
     void configure(std::uint32_t interval_ms, std::uint32_t now_ms);
     FrameDeadlineDecision tick(std::uint32_t now_ms);
     void reset(std::uint32_t now_ms);
-    std::uint32_t interval_ms() const { return interval_ms_; }
+    [[nodiscard]] std::uint32_t interval_ms() const { return interval_ms_; }
 
 private:
     std::uint32_t interval_ms_ = 0;

--- a/include/openglad/core/frame_rate_config.h
+++ b/include/openglad/core/frame_rate_config.h
@@ -21,7 +21,7 @@ inline constexpr int kMaxTargetFps = 240;
 // include sandbox. Callers (glad.cpp, tests) instantiate with cfg_store,
 // which is a complete type at the call site.
 template <typename Cfg>
-int target_fps_from_cfg(Cfg& cfg)
+[[nodiscard]] int target_fps_from_cfg(Cfg& cfg)
 {
     const std::string raw = cfg.get_setting("graphics", "target_fps");
     const auto parsed = parse_int_strict(raw);
@@ -38,7 +38,7 @@ void apply_target_fps_to_cfg(Cfg& cfg, int fps)
 }
 
 // Rounds half-up: 60 fps -> 17 ms, 120 fps -> 8 ms, 30 fps -> 33 ms. Always >= 1 ms.
-inline std::uint32_t target_frame_interval_ms(int fps)
+[[nodiscard]] inline std::uint32_t target_frame_interval_ms(int fps)
 {
     if (fps <= 0)
         return 1u;

--- a/include/openglad/core/sim_cadence.h
+++ b/include/openglad/core/sim_cadence.h
@@ -20,7 +20,7 @@ struct SimCadenceResult {
     const char*   trace_event;
 };
 
-inline SimCadenceResult compute_sim_interval_ms(const SimCadenceInputs& in)
+[[nodiscard]] inline SimCadenceResult compute_sim_interval_ms(const SimCadenceInputs& in)
 {
     if (!in.enable_frame_timing) {
         return { 0u, true, true, "schedule_external_timing" };

--- a/include/openglad/core/util.h
+++ b/include/openglad/core/util.h
@@ -115,7 +115,7 @@ inline void log_formatted(void (*sink)(const char*),
 
 namespace og::core {
 
-inline float rounded_render_tick_interval_ms(short timer_wait, float speed_factor)
+[[nodiscard]] inline float rounded_render_tick_interval_ms(short timer_wait, float speed_factor)
 {
     constexpr float kTimerWaitToMs = 13.6f;
 

--- a/include/openglad/gameplay/pathfinding_grid.h
+++ b/include/openglad/gameplay/pathfinding_grid.h
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <openglad/core/constants.h>
 
-#define MAP_WIDTH 400
+inline constexpr int MAP_WIDTH = 400;
 #define GET_STATE_X(state) (static_cast<std::int32_t>(reinterpret_cast<intptr_t>(state) % MAP_WIDTH) * GRID_SIZE)
 #define GET_STATE_Y(state) (static_cast<std::int32_t>(reinterpret_cast<intptr_t>(state) / MAP_WIDTH) * GRID_SIZE)
 

--- a/include/openglad/interface/level_runtime_data.h
+++ b/include/openglad/interface/level_runtime_data.h
@@ -194,9 +194,9 @@ public:
         SerializeFailed
     };
 
-    static const char TYPE_CAN_EXIT_WHENEVER = 0x1;  // Can exit without defeating all enemies
-    static const char TYPE_MUST_DESTROY_GENERATORS = 0x2;  // Must destroy generators to exit
-    static const char TYPE_MUST_PROTECT_NAMED_NPCS = 0x4;  // Must protect named NPCs or else you lose
+    static constexpr char TYPE_CAN_EXIT_WHENEVER = 0x1;  // Can exit without defeating all enemies
+    static constexpr char TYPE_MUST_DESTROY_GENERATORS = 0x2;  // Must destroy generators to exit
+    static constexpr char TYPE_MUST_PROTECT_NAMED_NPCS = 0x4;  // Must protect named NPCs or else you lose
 
     std::string grid_file;
     LevelDoneForwarder level_done;

--- a/include/openglad/resources/gloader.h
+++ b/include/openglad/resources/gloader.h
@@ -43,7 +43,7 @@ class loader
 {
 	public:
 		explicit loader(EntityFactory entity_factory = {});
-		virtual ~loader(void);
+		virtual ~loader();
 		loader(const loader&) = delete;
 		loader& operator=(const loader&) = delete;
 		loader(loader&&) = delete;

--- a/src/gameplay/ctf/ctf.cpp
+++ b/src/gameplay/ctf/ctf.cpp
@@ -47,7 +47,7 @@ const char* team_color_name(int team)
 
 void fire_ai_respawn(GameWorld& world, const CtfRespawnEntry& entry);
 
-bool is_score_team(unsigned char team)
+[[nodiscard]] bool is_score_team(unsigned char team)
 {
     return team < SCORE_TEAM_COUNT;
 }
@@ -111,8 +111,8 @@ void send_flag_home(GameWorld& world, int team)
 // ob_pass_check, whose treasure overlap dispatches eat_me — a probe must
 // never eat a drumstick or pick up a flag at a position the walker is not
 // actually placed at. Grid check plus a manual blocking-entity scan instead.
-bool spawn_spot_blocked_by(const walker* other, const walker* w,
-                           short x, short y)
+[[nodiscard]] bool spawn_spot_blocked_by(const walker* other, const walker* w,
+                                         short x, short y)
 {
     if (other == nullptr || other == w || other->dead())
         return false;
@@ -130,7 +130,7 @@ bool spawn_spot_blocked_by(const walker* other, const walker* w,
            y < other->ypos() + other->sizey();
 }
 
-bool spawn_spot_clear(GameWorld& world, walker* w, short x, short y)
+[[nodiscard]] bool spawn_spot_clear(GameWorld& world, walker* w, short x, short y)
 {
     if (!world.query_grid_passable(x, y, w))
         return false;
@@ -241,7 +241,7 @@ void revive_player_walker(GameWorld& world, walker* w, int team)
     place_at_anchor(world, w, team);
 }
 
-bool already_scheduled(const CtfState& ctf, std::uint32_t entity_id)
+[[nodiscard]] bool already_scheduled(const CtfState& ctf, std::uint32_t entity_id)
 {
     for (const auto& entry : ctf.respawn_queue)
     {
@@ -256,7 +256,7 @@ bool already_scheduled(const CtfState& ctf, std::uint32_t entity_id)
 // Guy ids are only unique per owning player (each client numbers its roster
 // from its own counter), so identity is the (id, owner) pair — owner tags
 // are kNoOwner for everyone in local play, where bare ids suffice.
-bool live_duplicate_exists(GameWorld& world, const walker* corpse)
+[[nodiscard]] bool live_duplicate_exists(GameWorld& world, const walker* corpse)
 {
     if (corpse->myguy == nullptr)
         return false;

--- a/src/gameplay/ctf/ctf_ai.cpp
+++ b/src/gameplay/ctf/ctf_ai.cpp
@@ -42,7 +42,7 @@ inline constexpr int kCtfDefendRadius = 96;
 
 // Manhattan distance, matching walker::distance_to_ob's metric so role
 // decisions agree with the chase logic they hand off to.
-int point_distance(const walker* w, int x, int y)
+[[nodiscard]] int point_distance(const walker* w, int x, int y)
 {
     return std::abs(static_cast<int>(w->xpos()) - x) +
            std::abs(static_cast<int>(w->ypos()) - y);
@@ -50,7 +50,7 @@ int point_distance(const walker* w, int x, int y)
 
 // Directable: a live, unfrozen AI living. Player-controlled walkers
 // (ACT_CONTROL or a bound user) are never touched.
-bool is_directable(const walker* w, int team)
+[[nodiscard]] bool is_directable(const walker* w, int team)
 {
     return w != nullptr && !w->dead() && w->query_order() == Order::Living &&
            w->team_num() == static_cast<unsigned char>(team) &&
@@ -58,7 +58,7 @@ bool is_directable(const walker* w, int team)
            w->stats() != nullptr && w->stats()->frozen_delay() <= 0;
 }
 
-bool carries_enemy_flag(const CtfState& ctf, int team, std::uint32_t entity_id)
+[[nodiscard]] bool carries_enemy_flag(const CtfState& ctf, int team, std::uint32_t entity_id)
 {
     for (int t = 0; t < kCtfMaxFlags; ++t)
     {
@@ -74,7 +74,7 @@ bool carries_enemy_flag(const CtfState& ctf, int team, std::uint32_t entity_id)
     return false;
 }
 
-bool leader_is_flag_entity(const CtfState& ctf, const walker* w)
+[[nodiscard]] bool leader_is_flag_entity(const CtfState& ctf, const walker* w)
 {
     const walker* leader = w->leader();
     if (leader == nullptr)

--- a/src/gameplay/effect.cpp
+++ b/src/gameplay/effect.cpp
@@ -52,7 +52,7 @@ effect::~effect()
 
 void orbit_offset(int drawcycle, float &xd, float &yd)
 {
-    static const float orbit_table[16][2] = {
+    static constexpr float orbit_table[16][2] = {
         {  0, -24}, { -9, -22}, {-17, -17}, {-22,  -9},
         {-24,   0}, {-22,   9}, {-17,  17}, { -9,  22},
         {  0,  24}, {  9,  22}, { 17,  17}, { 22,   9},

--- a/src/gameplay/families/family_archer.cpp
+++ b/src/gameplay/families/family_archer.cpp
@@ -14,7 +14,9 @@
 #include <openglad/core/constants.h>
 #include <openglad/core/util.h>
 
-#define BASE_GUY_HP 30
+#include <iterator>
+
+inline constexpr int BASE_GUY_HP = 30;
 
 static bool archer_do_special(walker* self)
 {
@@ -163,7 +165,7 @@ const FamilyDescriptor& describe_family_archer()
                        "\n"
                        "Special: Fire Arrows",
         .name_pool = archer_names,
-        .name_pool_size = sizeof(archer_names) / sizeof(archer_names[0]),
+        .name_pool_size = std::size(archer_names),
         .is_playable = true,
         .playable_order = 3,
     };

--- a/src/gameplay/families/family_barbarian.cpp
+++ b/src/gameplay/families/family_barbarian.cpp
@@ -13,7 +13,9 @@
 #include <openglad/core/util.h>
 #include <openglad/gameplay/statistics.h>
 
-#define BASE_GUY_HP 30
+#include <iterator>
+
+inline constexpr int BASE_GUY_HP = 30;
 
 static void barbarian_level_up(guy* self, std::int32_t level_diff)
 {
@@ -120,7 +122,7 @@ const FamilyDescriptor& describe_family_barbarian()
                        "iron hammers.             \n"
                        "Special: Hurl Boulder",
         .name_pool = barbarian_names,
-        .name_pool_size = sizeof(barbarian_names) / sizeof(barbarian_names[0]),
+        .name_pool_size = std::size(barbarian_names),
         .is_playable = true,
         .playable_order = 1,
     };

--- a/src/gameplay/families/family_druid.cpp
+++ b/src/gameplay/families/family_druid.cpp
@@ -19,6 +19,7 @@
 #include <openglad/gameplay/sim_emit.h>
 
 #include <format>
+#include <iterator>
 #include <string>
 #include <list>
 
@@ -212,7 +213,7 @@ const FamilyDescriptor& describe_family_druid()
                        "\n"
                        "Special: Plant Tree",
         .name_pool = druid_names,
-        .name_pool_size = sizeof(druid_names) / sizeof(druid_names[0]),
+        .name_pool_size = std::size(druid_names),
         .is_playable = true,
         .playable_order = 8,
     };

--- a/src/gameplay/families/family_elf.cpp
+++ b/src/gameplay/families/family_elf.cpp
@@ -16,6 +16,8 @@
 #include <openglad/core/util.h>
 #include <openglad/gameplay/statistics.h>
 
+#include <iterator>
+
 #define BASE_GUY_HP 30
 
 namespace
@@ -169,7 +171,7 @@ const FamilyDescriptor& describe_family_elf()
                        "\n"
                        "Special: Rocks",
         .name_pool = elf_names,
-        .name_pool_size = sizeof(elf_names) / sizeof(elf_names[0]),
+        .name_pool_size = std::size(elf_names),
         .is_playable = true,
         .playable_order = 2,
     };

--- a/src/gameplay/families/family_faerie.cpp
+++ b/src/gameplay/families/family_faerie.cpp
@@ -12,6 +12,8 @@
 #include <openglad/core/util.h>
 #include <openglad/gameplay/statistics.h>
 
+#include <iterator>
+
 #define BASE_GUY_HP 30
 
 static void faerie_level_up(guy* self, std::int32_t level_diff)
@@ -74,7 +76,7 @@ const FamilyDescriptor& describe_family_faerie()
                        "magic powder which freezes\n"
                        "their enemies.",
         .name_pool = faerie_names,
-        .name_pool_size = sizeof(faerie_names) / sizeof(faerie_names[0]),
+        .name_pool_size = std::size(faerie_names),
         .is_playable = true,
         .playable_order = 13,
     };

--- a/src/gameplay/families/family_fire_elemental.cpp
+++ b/src/gameplay/families/family_fire_elemental.cpp
@@ -14,6 +14,8 @@
 #include <openglad/core/util.h>
 #include <openglad/gameplay/statistics.h>
 
+#include <iterator>
+
 #define BASE_GUY_HP 30
 
 static bool fire_elemental_check_special_ai(living* self)
@@ -135,7 +137,7 @@ const FamilyDescriptor& describe_family_fire_elemental()
                        "\n"
                        "Special: Starburst",
         .name_pool = elemental_names,
-        .name_pool_size = sizeof(elemental_names) / sizeof(elemental_names[0]),
+        .name_pool_size = std::size(elemental_names),
         .is_playable = true,
         .playable_order = 11,
     };

--- a/src/gameplay/families/family_ghost.cpp
+++ b/src/gameplay/families/family_ghost.cpp
@@ -13,6 +13,8 @@
 #include <openglad/core/util.h>
 #include <openglad/gameplay/statistics.h>
 
+#include <iterator>
+
 #define BASE_GUY_HP 30
 
 static bool ghost_check_special_ai(living* self)
@@ -85,7 +87,7 @@ const FamilyDescriptor& describe_family_ghost()
                        "\n"
                        "Special: Scare",
         .name_pool = ghost_names,
-        .name_pool_size = sizeof(ghost_names) / sizeof(ghost_names[0]),
+        .name_pool_size = std::size(ghost_names),
         .is_playable = true,
         .playable_order = 14,
     };

--- a/src/gameplay/families/family_golem.cpp
+++ b/src/gameplay/families/family_golem.cpp
@@ -12,7 +12,7 @@
 #include <openglad/core/constants.h>
 #include <openglad/core/util.h>
 
-#define BASE_GUY_HP 30
+inline constexpr int BASE_GUY_HP = 30;
 
 static void golem_set_difficulty(living* self, std::uint32_t level)
 {

--- a/src/gameplay/families/family_mage.cpp
+++ b/src/gameplay/families/family_mage.cpp
@@ -30,7 +30,7 @@ static bool mage_handle_teleport(walker* self)
     return true;
 }
 
-#define BASE_GUY_HP 30
+inline constexpr int BASE_GUY_HP = 30;
 
 static bool mage_check_special_ai(living* self)
 {

--- a/src/gameplay/families/family_orc.cpp
+++ b/src/gameplay/families/family_orc.cpp
@@ -21,7 +21,7 @@
 #include <list>
 #include <string>
 
-#define BASE_GUY_HP 30
+inline constexpr int BASE_GUY_HP = 30;
 
 short exp_from_action(ExpAction action, walker* w, walker* target, short value);
 

--- a/src/gameplay/families/family_skeleton.cpp
+++ b/src/gameplay/families/family_skeleton.cpp
@@ -21,7 +21,7 @@ static bool skeleton_handle_teleport(walker* self)
     return true;
 }
 
-#define BASE_GUY_HP 30
+inline constexpr int BASE_GUY_HP = 30;
 
 static bool skeleton_check_special_ai(living* self)
 {

--- a/src/gameplay/families/family_slime.cpp
+++ b/src/gameplay/families/family_slime.cpp
@@ -17,7 +17,7 @@
 
 std::int32_t calculate_level(std::uint32_t temp_exp);
 
-#define BASE_GUY_HP 30
+inline constexpr int BASE_GUY_HP = 30;
 
 static bool slime_check_special_ai(living* self)
 {

--- a/src/gameplay/families/family_soldier.cpp
+++ b/src/gameplay/families/family_soldier.cpp
@@ -19,7 +19,7 @@
 
 #include <cmath>
 
-#define BASE_GUY_HP 30
+inline constexpr int BASE_GUY_HP = 30;
 
 // RNG now comes from current_game->world->rng_.
 

--- a/src/gameplay/families/family_thief.cpp
+++ b/src/gameplay/families/family_thief.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <list>
 
-#define BASE_GUY_HP 30
+inline constexpr int BASE_GUY_HP = 30;
 
 static bool thief_check_special_ai(living* self)
 {

--- a/src/gameplay/families/family_tower1.cpp
+++ b/src/gameplay/families/family_tower1.cpp
@@ -9,7 +9,7 @@
 #include <openglad/core/constants.h>
 #include <openglad/core/util.h>
 
-#define BASE_GUY_HP 30
+inline constexpr int BASE_GUY_HP = 30;
 
 const FamilyDescriptor& describe_family_tower1()
 {

--- a/src/gameplay/family_registry_base.h
+++ b/src/gameplay/family_registry_base.h
@@ -32,11 +32,11 @@ public:
         initialized_ = true;
     }
 
-    const Descriptor* get(int family_id) const {
+    [[nodiscard]] const Descriptor* get(int family_id) const {
         return (family_id >= 0 && family_id < NUM) ? &entries_[family_id] : nullptr;
     }
 
-    bool is_initialized() const { return initialized_; }
+    [[nodiscard]] bool is_initialized() const { return initialized_; }
 
 private:
     bool initialized_ = false;

--- a/src/gameplay/game_client.cpp
+++ b/src/gameplay/game_client.cpp
@@ -27,12 +27,12 @@ void clear_transport_only_world_state(GameWorld& world)
     world.clear_grid_dirty_tiles();
 }
 
-float clamp_alpha(float alpha)
+float clamp_alpha(float alpha) noexcept
 {
     return std::clamp(alpha, 0.0f, 1.0f);
 }
 
-float lerp(float start, float end, float alpha)
+float lerp(float start, float end, float alpha) noexcept
 {
     return start + (end - start) * alpha;
 }

--- a/src/gameplay/guy.cpp
+++ b/src/gameplay/guy.cpp
@@ -277,26 +277,7 @@ guy::guy(int whatfamily)
 }
 
 
-guy::guy(const guy& copy)
-    : family(copy.family)
-    , strength(copy.strength), dexterity(copy.dexterity), constitution(copy.constitution), intelligence(copy.intelligence)
-    , armor(copy.armor)
-    , exp(copy.exp), kills(copy.kills), level_kills(copy.level_kills)
-    , total_damage(copy.total_damage), total_hits(copy.total_hits), total_shots(copy.total_shots)
-    , teamnum(copy.teamnum)
-    , scen_damage(copy.scen_damage)
-    , scen_kills(copy.scen_kills)
-    , scen_damage_taken(copy.scen_damage_taken)
-    , scen_min_hp(copy.scen_min_hp)
-    , scen_shots(copy.scen_shots)
-    , scen_hits(copy.scen_hits)
-    , id(copy.id)
-    , level(copy.level)
-    , owner_player_index(copy.owner_player_index)
-    , owner_save_slot(copy.owner_save_slot)
-{
-    name = copy.name;
-}
+guy::guy(const guy& copy) = default;
 
 guy::~guy()
 {

--- a/src/gameplay/obmap.cpp
+++ b/src/gameplay/obmap.cpp
@@ -34,7 +34,7 @@ short collide(short x,  short y,  short xsize,  short ysize,
 
 //#define XRES GRID_SIZE
 //#define YRES GRID_SIZE
-#define OBRES 32 //GRID_SIZE
+inline constexpr int OBRES = 32; //GRID_SIZE
 
 // These are passed in as PIXEL coordinates now...
 obmap::obmap()

--- a/src/gameplay/stats.cpp
+++ b/src/gameplay/stats.cpp
@@ -42,7 +42,7 @@ static inline Uint32 rng(Uint32 max_exclusive) {
     return current_game->world->rng_.next(max_exclusive);
 }
 
-#define CHECK_STEP_SIZE 1 // (controller->stepsize()) // was 1
+inline constexpr int CHECK_STEP_SIZE = 1; // (controller->stepsize()) // was 1
 
 // COMMAND declarations defined at bottom
 
@@ -982,10 +982,10 @@ bool statistics::direct_walk()
 
 }
 
-#define PATHING_MIN_DISTANCE 100
+inline constexpr int PATHING_MIN_DISTANCE = 100;
 
 // Note that obmap::size() counts dead things too, which don't do pathfinding
-#define PATHING_SHORT_CIRCUIT_OBJECT_LIMIT 200
+inline constexpr int PATHING_SHORT_CIRCUIT_OBJECT_LIMIT = 200;
 
 bool statistics::walk_to_foe()
 {

--- a/src/interface/input/input.cpp
+++ b/src/interface/input/input.cpp
@@ -101,8 +101,8 @@ void update_overscan_setting()
     og::runtime::current_session->viewport_h_ = og::runtime::current_session->window_h_ * (1.0f - og::runtime::current_session->overscan_percentage_);
 }
 
-#define JOY_DEAD_ZONE 8000
-#define MAX_NUM_JOYSTICKS 10  // Just in case there are joysticks attached that are not useable (e.g. accelerometer)
+inline constexpr int JOY_DEAD_ZONE = 8000;
+inline constexpr int MAX_NUM_JOYSTICKS = 10;  // Just in case there are joysticks attached that are not useable (e.g. accelerometer)
 og::input_native::JoystickHandle joysticks[MAX_NUM_JOYSTICKS];
 
 namespace

--- a/src/interface/render/radar.cpp
+++ b/src/interface/render/radar.cpp
@@ -66,8 +66,8 @@ walker* sanitize_radar_control(viewscreen* view, LevelRuntimeData& level)
 }
 } // namespace
 
-#define RADAR_X 60  // These are the dimensions of the radar
-#define RADAR_Y 44  // viewport
+inline constexpr int RADAR_X = 60;  // These are the dimensions of the radar
+inline constexpr int RADAR_Y = 44;  // viewport
 
 // ************************************************************
 //  RADAR -- It's nothing like pixie, it just looks like it
@@ -164,9 +164,7 @@ void radar::sync_to_grid(LevelRuntimeData* data)
 
 
 // Destruct the radar and its variables
-radar::~radar()
-{
-}
+radar::~radar() = default;
 
 short radar::draw()
 {

--- a/src/interface/render/view.cpp
+++ b/src/interface/render/view.cpp
@@ -294,9 +294,7 @@ viewscreen::viewscreen(short x, short y, short width,
 }
 
 // Destruct the viewscreen and its variables
-viewscreen::~viewscreen()
-{
-}
+viewscreen::~viewscreen() = default;
 
 void viewscreen::clear()
 {

--- a/src/interface/render/walker_draw.cpp
+++ b/src/interface/render/walker_draw.cpp
@@ -400,8 +400,8 @@ void draw_small_health_bar(walker* w, viewscreen* view_buf)
     }
 }
 
-#define ATTACK_LUNGE_SIZE 5
-#define HIT_RECOIL_SIZE 3
+inline constexpr int ATTACK_LUNGE_SIZE = 5;
+inline constexpr int HIT_RECOIL_SIZE = 3;
 
 // In genuine networked play, same-team peers' characters get a team-color
 // outline so you can tell which are human-controlled. Local split-screen does

--- a/src/interface/score_panel.cpp
+++ b/src/interface/score_panel.cpp
@@ -104,9 +104,9 @@ void new_draw_value_bar(Sint32 left, Sint32 top,
 } // end of drawing routine ..
 
 #ifdef REDUCE_OVERSCAN
-#define OVERSCAN_PADDING 6
+inline constexpr int OVERSCAN_PADDING = 6;
 #else
-#define OVERSCAN_PADDING 0
+inline constexpr int OVERSCAN_PADDING = 0;
 #endif
 
 // Flag-state glyph for the per-team CTF readout: that team's flag is at

--- a/src/interface/ui/button.cpp
+++ b/src/interface/ui/button.cpp
@@ -157,10 +157,7 @@ vbutton::vbutton() //for pointers
     mypixie = nullptr;
 }
 
-vbutton::~vbutton()
-{
-    // No manual ownership; menu buttons are owned by `owned_buttons_` in GameSession.
-}
+vbutton::~vbutton() = default;
 
 void vbutton::set_graphic(char family)
 {

--- a/src/interface/ui/campaign_picker.cpp
+++ b/src/interface/ui/campaign_picker.cpp
@@ -39,7 +39,7 @@ bool no_or_yes_prompt(const char* title, const char* message, bool default_value
 
 bool prompt_for_string(const std::string& message, std::string& result);
 
-#define OG_OK 4
+inline constexpr int OG_OK = 4;
 void draw_highlight_interior(const button& b);
 void draw_highlight(const button& b);
 bool handle_menu_nav(button* buttons, int& highlighted_button, Sint32& retvalue, bool use_global_vbuttons = true);

--- a/src/interface/ui/help.cpp
+++ b/src/interface/ui/help.cpp
@@ -426,10 +426,10 @@ static const char* get_content_line(const TabContent& content, int index)
 }
 
 // Tab button dimensions
-#define TAB_Y 20
-#define TAB_HEIGHT 12
-#define TAB_WIDTH 58
-#define TAB_SPACING 2
+inline constexpr Sint32 TAB_Y = 20;
+inline constexpr Sint32 TAB_HEIGHT = 12;
+inline constexpr Sint32 TAB_WIDTH = 58;
+inline constexpr Sint32 TAB_SPACING = 2;
 inline constexpr Sint32 TAB_START_X = HELPTEXT_LEFT + 10;
 inline constexpr Sint32 CONTENT_TOP = TAB_Y + TAB_HEIGHT + 4;  // Content starts below tabs
 

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -57,7 +57,7 @@ void quit(Sint32 arg1);
  * 		Zardus: added scrolling-by-keyboard
  */
 
-#define OK 4 //this function was successful, continue normal operation
+inline constexpr Sint32 OK = 4; //this function was successful, continue normal operation
 
 #include <string>
 #include <vector>
@@ -65,13 +65,13 @@ void quit(Sint32 arg1);
 #define MINIMUM_TIME 0
 
 
-#define S_LEFT 1
-#define S_RIGHT 245
-#define S_UP 1
-#define S_DOWN 188
+inline constexpr Sint32 S_LEFT = 1;
+inline constexpr Sint32 S_RIGHT = 245;
+inline constexpr Sint32 S_UP = 1;
+inline constexpr Sint32 S_DOWN = 188;
 
 static constexpr char VERSION_NUM = 8; // save scenario type info
-#define SCROLLSIZE 8
+inline constexpr Sint32 SCROLLSIZE = 8;
 
 #define NUM_BACKGROUNDS PIX_MAX
 
@@ -793,9 +793,9 @@ bool LevelEditorData::saveLevelAs(int id)
 
 bool button_showing(const std::list<std::pair<SimpleButton*, std::set<SimpleButton*> > >& ls, SimpleButton* elem)
 {
-    for(std::list<std::pair<SimpleButton*, std::set<SimpleButton*> > >::const_iterator e = ls.begin(); e != ls.end(); e++)
+    for(const auto& e : ls)
     {
-        const std::set<SimpleButton*>& s = e->second;
+        const std::set<SimpleButton*>& s = e.second;
         if(s.find(elem) != s.end())
             return true;
     }
@@ -805,15 +805,15 @@ bool button_showing(const std::list<std::pair<SimpleButton*, std::set<SimpleButt
 // Wouldn't spatial partitioning be nice?  Too bad!
 bool LevelEditorData::mouse_on_menus(int mx, int my)
 {
-    for(std::set<SimpleButton*>::const_iterator e = menu_buttons.begin(); e != menu_buttons.end(); e++)
+    for(const SimpleButton* e : menu_buttons)
     {
-        if((*e)->contains(mx, my))
+        if(e->contains(mx, my))
             return true;
     }
-    
-    for(std::set<SimpleButton*>::const_iterator e = mode_buttons.begin(); e != mode_buttons.end(); e++)
+
+    for(const SimpleButton* e : mode_buttons)
     {
-        if((*e)->contains(mx, my))
+        if(e->contains(mx, my))
             return true;
     }
     
@@ -821,12 +821,12 @@ bool LevelEditorData::mouse_on_menus(int mx, int my)
     if(pan_buttons.size() > 0 && Rect(panLeftButton.area.x, panUpButton.area.y, panRightButton.area.x + panRightButton.area.w - panLeftButton.area.x, panDownButton.area.y + panDownButton.area.h - panUpButton.area.y).contains(mx, my))
         return true;
     
-    for(std::list<std::pair<SimpleButton*, std::set<SimpleButton*> > >::const_iterator e = current_menu.begin(); e != current_menu.end(); e++)
+    for(const auto& e : current_menu)
     {
-        const std::set<SimpleButton*>& s = e->second;
-        for(std::set<SimpleButton*>::const_iterator f = s.begin(); f != s.end(); f++)
+        const std::set<SimpleButton*>& s = e.second;
+        for(const SimpleButton* f : s)
         {
-            if((*f)->contains(mx, my))
+            if(f->contains(mx, my))
                 return true;
         }
     }
@@ -1690,9 +1690,9 @@ void LevelEditorData::mouse_motion(int mx, int my, int dx, int dy)
 
 bool is_in_selection(walker* w, const std::vector<SelectionInfo>& selection)
 {
-    for(std::vector<SelectionInfo>::const_iterator e = selection.begin(); e != selection.end(); e++)
+    for(const SelectionInfo& e : selection)
     {
-        if(e->target == w)
+        if(e.target == w)
             return true;
     }
     return false;

--- a/src/interface/ui/level_picker.cpp
+++ b/src/interface/ui/level_picker.cpp
@@ -53,7 +53,7 @@ bool prompt_for_string(const std::string& message, std::string& result);
 void popup_dialog(const char* title, const char* message);
 
 
-#define OK 4
+inline constexpr int OK = 4;
 void draw_highlight_interior(const button& b);
 void draw_highlight(const button& b);
 bool handle_menu_nav(button* buttons, int& highlighted_button, Sint32& retvalue, bool use_global_vbuttons = true);
@@ -291,8 +291,7 @@ BrowserEntry::BrowserEntry(screen* screenp, int index, int scen_num)
 }
 
 
-BrowserEntry::~BrowserEntry()
-{}
+BrowserEntry::~BrowserEntry() = default;
 
 void BrowserEntry::updateIndex(int index)
 {
@@ -345,7 +344,7 @@ void BrowserEntry::draw(screen* screenp)
 }
 
 
-#define NUM_BROWSE_RADARS 3
+inline constexpr int NUM_BROWSE_RADARS = 3;
 
 // Load a scenario...
 int pick_level(screen *screenp, int default_level, bool enable_delete)

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -36,11 +36,11 @@ static inline Uint32 rng(Uint32 max_exclusive) {
     return ctx().rng->next(max_exclusive);
 }
 
-#define VIDEO_BUFFER_WIDTH 320
-#define VIDEO_WIDTH 320
-#define VIDEO_SIZE 64000
-#define CX_SCREEN 320
-#define CY_SCREEN 200
+inline constexpr int VIDEO_BUFFER_WIDTH = 320;
+inline constexpr int VIDEO_WIDTH = 320;
+inline constexpr int VIDEO_SIZE = 64000;
+inline constexpr int CX_SCREEN = 320;
+inline constexpr int CY_SCREEN = 200;
 
 
 // videoptr lives in GameSession — access via current_session->videoptr_.

--- a/src/resources/gparser.cpp
+++ b/src/resources/gparser.cpp
@@ -52,18 +52,18 @@ void cfg_store::apply_override(const std::string& category, const std::string& s
 std::string cfg_store::get_setting(const std::string& category, const std::string& setting)
 {
 	// Transient overrides win over persisted settings and are never saved.
-	std::map<std::string, std::map<std::string, std::string> >::iterator o1 = overrides.find(category);
+	auto o1 = overrides.find(category);
 	if(o1 != overrides.end())
 	{
-		std::map<std::string, std::string>::iterator o2 = o1->second.find(setting);
+		auto o2 = o1->second.find(setting);
 		if(o2 != o1->second.end())
 			return o2->second;
 	}
 
-	std::map<std::string, std::map<std::string, std::string> >::iterator a1 = data.find(category);
+	auto a1 = data.find(category);
 	if(a1 != data.end())
 	{
-		std::map<std::string, std::string>::iterator a2 = a1->second.find(setting);
+		auto a2 = a1->second.find(setting);
 		if(a2 != a1->second.end())
 			return a2->second;
 	}

--- a/src/resources/io/platform_io_common.cpp
+++ b/src/resources/io/platform_io_common.cpp
@@ -216,7 +216,7 @@ std::list<int> list_levels()
 {
     std::list<std::string> ls = list_files("scen/");
     std::list<int> result;
-    for(std::list<std::string>::iterator e = ls.begin(); e != ls.end(); )
+    for(auto e = ls.begin(); e != ls.end(); )
     {
         size_t pos = e->rfind(".fss");
         if(pos == std::string::npos)
@@ -248,7 +248,7 @@ std::vector<int> list_levels_v()
 {
     std::list<std::string> ls = list_files("scen/");
     std::vector<int> result;
-    for(std::list<std::string>::iterator e = ls.begin(); e != ls.end(); )
+    for(auto e = ls.begin(); e != ls.end(); )
     {
         size_t pos = e->rfind(".fss");
         if(pos == std::string::npos)

--- a/src/resources/save_data.cpp
+++ b/src/resources/save_data.cpp
@@ -879,7 +879,7 @@ bool SaveData::save(const std::string& filename)
 	// Write the completed levels
 
 	// Make sure our current level is saved
-	std::map<std::string, int>::iterator cur = current_levels.find(current_campaign);
+	auto cur = current_levels.find(current_campaign);
 	if(cur != current_levels.end())
     {
         cur->second = scen_num;
@@ -901,7 +901,7 @@ bool SaveData::save(const std::string& filename)
 	}
 	short num_campaigns = static_cast<short>(raw_campaign_count);
     WRITE_OR_FAIL(&num_campaigns, 2, 1);
-	for(std::map<std::string, std::set<int> >::const_iterator e = completed_levels.begin(); e != completed_levels.end(); e++)
+	for(auto e = completed_levels.begin(); e != completed_levels.end(); e++)
     {
         if (!is_safe_campaign_id(e->first))
         {
@@ -917,7 +917,7 @@ bool SaveData::save(const std::string& filename)
         WRITE_OR_FAIL(campaign, 1, 40);
 
 	        short index = 1;
-	        std::map<std::string, int>::const_iterator g = current_levels.find(e->first);
+	        auto g = current_levels.find(e->first);
 	        if(g != current_levels.end())
 	            index = static_cast<short>(g->second);
 	        WRITE_OR_FAIL(&index, 2, 1);
@@ -934,7 +934,7 @@ bool SaveData::save(const std::string& filename)
 	        }
 	        short num_levels = static_cast<short>(raw_level_count);
 	        WRITE_OR_FAIL(&num_levels, 2, 1);
-        for(std::set<int>::const_iterator f = e->second.begin(); f != e->second.end(); f++)
+        for(auto f = e->second.begin(); f != e->second.end(); f++)
 	        {
 	            // Level index
 	            index = static_cast<short>(*f);
@@ -980,19 +980,19 @@ SaveDataIoError SaveData::save_with_error(const std::string& filename)
 
 bool SaveData::is_level_completed(int level_index) const
 {
-    std::map<std::string, std::set<int> >::const_iterator e = completed_levels.find(current_campaign);
+    auto e = completed_levels.find(current_campaign);
     // Campaign not found?  Then this level is not done.
     if(e == completed_levels.end())
         return false;
 
     // If the level is listed, then it is completed.
-    std::set<int>::const_iterator f = e->second.find(level_index);
+    auto f = e->second.find(level_index);
     return (f != e->second.end());
 }
 
 int SaveData::get_num_levels_completed(const std::string& campaign) const
 {
-    std::map<std::string, std::set<int> >::const_iterator e = completed_levels.find(campaign);
+    auto e = completed_levels.find(campaign);
     // Campaign not found?
     if(e == completed_levels.end())
         return 0;
@@ -1002,7 +1002,7 @@ int SaveData::get_num_levels_completed(const std::string& campaign) const
 
 void SaveData::add_level_completed(const std::string& campaign, int level_index)
 {
-    std::map<std::string, std::set<int> >::iterator e = completed_levels.find(campaign);
+    auto e = completed_levels.find(campaign);
 
     // Campaign not found?  Add it in.
     if(e == completed_levels.end())
@@ -1014,7 +1014,7 @@ void SaveData::add_level_completed(const std::string& campaign, int level_index)
 
 void SaveData::reset_campaign(const std::string& campaign)
 {
-    std::map<std::string, std::set<int> >::iterator e = completed_levels.find(campaign);
+    auto e = completed_levels.find(campaign);
 
     if(e != completed_levels.end())
         e->second.clear();


### PR DESCRIPTION
## Summary

A full line-by-line review of all **358 production translation units** (`src/` + `include/`, excluding only the two fuzz harnesses) for remaining non-idiomatic C++, applying **only low-risk, behavior-preserving** refactors. The prior audit (#124) handled `NULL`/`typedef`/most casts; this pass picks up the subtler items it left behind.

The review was done by a 26-group multi-agent sweep (each group a disjoint slice of the tree, audited then refactored), followed by per-diff human review and full local verification.

## What changed (45 files, all semantics-preserving)

- **`[[nodiscard]]`** on pure compute / predicate functions (combat_math, frame pacing, sim cadence, family registry, CTF helpers) so dropped results are flagged.
- **`#define` numeric/char constants → typed `inline constexpr`** (video, radar, input, help, walker_draw, score_panel, level editor/picker, stats, obmap, pathfinding_grid, families, …). Names and values unchanged; macros that reference them (`GET_STATE_X/Y`) still resolve.
- **`static const` tables/flags → `static constexpr`** (effect orbit table, level-class type flags).
- **Empty-body destructors and a fully-explicit `guy` copy constructor → `= default`** (verified the hand-written ctor copied every member).
- **Verbose explicit iterator loops → `auto` / range-based `for`** in hot read paths (save_data, gparser, platform_io_common, level_editor).
- **`sizeof(arr)/sizeof(arr[0])` → `std::size`** for family name pools.
- **`noexcept`** on pure float helpers; **`~loader(void)` → `~loader()`**.

Net **−14 lines**. No behavior, serialization layout, RNG/float, iteration-order, or public-signature changes. Anything riskier (enum→`enum class`, `new`/`delete`→smart pointers, C-array→`std::array`) was deliberately deferred.

## Verification

- Clean build with **zero new warnings** under `-Wall -Wextra -Wpedantic -Wconversion -Wshadow` (same 4 pre-existing test-file warnings as `master`, none in production code).
- **43/43 tests pass**, including `og_test_parity` (determinism), `og_test_snapshot_safety` / `og_test_snapshot_benchmark` (wire format), and `og_unit_sim`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)