### PR TITLE
Modernize: enum class, smart-pointer audit, C-array→std::array sweep

### DIFF
--- a/include/openglad/gameplay/families/family_descriptor.h
+++ b/include/openglad/gameplay/families/family_descriptor.h
@@ -20,7 +20,7 @@
 
 inline constexpr int FD_NUM_SPECIALS = 6;
 
-enum FamilyAnimationType {
+enum class FamilyAnimationType : std::uint8_t {
     FAMILY_ANIM_STANDARD = 0,       // animan (most livings)
     FAMILY_ANIM_MAGE,               // animage (mage, archmage)
     FAMILY_ANIM_SKELETON,           // aniskel (skeleton with grow/shrink)
@@ -121,7 +121,7 @@ struct FamilyDescriptor {
 
     // Graphics / loader data (replaces hardcoded gloader.cpp arrays)
     const char* pix_filename;          // "monk.png", "footman.png", etc.
-    int animation_type;                // FamilyAnimationType enum
+    FamilyAnimationType animation_type;  // FamilyAnimationType enum
     int ai_line_of_sight;              // AI's understanding of ranged attack range
 
     // UI / picker data (replaces hardcoded switch statements)

--- a/include/openglad/gameplay/world_snapshot.h
+++ b/include/openglad/gameplay/world_snapshot.h
@@ -461,7 +461,7 @@ constexpr bool entity_snapshot_field_table_is_valid()
         return false;
     }
 
-    bool seen_bits[og::dirty::FIELD_COUNT] = {};
+    std::array<bool, og::dirty::FIELD_COUNT> seen_bits = {};
 
     for (std::size_t i = 0; i < kEntitySnapshotTableFieldCount; ++i) {
         const EntitySnapshotFieldDesc& field = kEntitySnapshotFields[i];

--- a/include/openglad/interface/native_input.h
+++ b/include/openglad/interface/native_input.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <cstddef>
 
@@ -45,7 +46,7 @@ struct EventData
     int key_mod = 0;
     bool key_repeat = false;
 
-    char text[32] = {};
+    std::array<char, 32> text = {};
 
     int wheel_y = 0;
 

--- a/include/openglad/interface/session_state.h
+++ b/include/openglad/interface/session_state.h
@@ -68,8 +68,8 @@ struct SessionState {
     std::array<std::unique_ptr<::vbutton, VButtonDeleter>, kMaxButtons> owned_buttons_{};
 
     // Render/palette state (Batch 6) — moved from pal32.cpp/video.cpp.
-    unsigned char curpal_[768] = {};
-    unsigned char temppal_[768] = {};
+    std::array<unsigned char, 768> curpal_ = {};
+    std::array<unsigned char, 768> temppal_ = {};
     unsigned char* videoptr_ = nullptr;
 
     // Game speed + debug state (Batch 7) — moved from util.cpp/walker.cpp/obmap.cpp.
@@ -96,7 +96,7 @@ struct SessionState {
 
     // Entity-layer state (Phase 4) — moved from guy.cpp and cheat_handler.cpp.
     int guy_id_counter_ = 0;
-    short changedteam_[6] = {};
+    std::array<short, 6> changedteam_ = {};
 
     // Keybinding storage (Phase 5) — moved from view.cpp allkeys global.
     int allkeys_[4][kNumKeys] = {};

--- a/include/openglad/interface/ui/picker_common.h
+++ b/include/openglad/interface/ui/picker_common.h
@@ -218,9 +218,9 @@ struct ScenarioRosterReport {
     short your_team = 0;            // 0 when allied, else save.my_team
     int cp_count = 0;
     int capture_limit = 0;          // effective: requested > map > default
-    bool team_has_flag[4] = {};
-    bool team_active[4] = {};       // mirror of the init clamp
-    int team_anchor_count[4] = {};
+    std::array<bool, 4> team_has_flag = {};
+    std::array<bool, 4> team_active = {}; // mirror of the init clamp
+    std::array<int, 4> team_anchor_count = {};
     std::vector<ScenarioRosterRow> rows; // grouped, team-major
     bool any_troops_off = false;
     bool any_inactive = false;

--- a/src/fuzz/fuzz_savefile.cpp
+++ b/src/fuzz/fuzz_savefile.cpp
@@ -39,6 +39,7 @@
 // SaveData::load() without touching the filesystem or game state.
 
 #include <SDL2/SDL.h>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 
@@ -56,8 +57,8 @@ static void fuzz_parse_savefile(const uint8_t *data, size_t size)
         return;
 
     // Read and validate GTL header
-    char header[4] = {};
-    if (!rw_read_exact(rw, header, 3, 1))
+    std::array<char, 4> header = {};
+    if (!rw_read_exact(rw, header.data(), 3, 1))
     {
         SDL_RWclose(rw);
         return;
@@ -89,8 +90,8 @@ static void fuzz_parse_savefile(const uint8_t *data, size_t size)
     // Version 2+: saved game name
     if (version >= 2)
     {
-        char savedgame[40] = {};
-        if (!rw_read_exact(rw, savedgame, 40, 1))
+        std::array<char, 40> savedgame = {};
+        if (!rw_read_exact(rw, savedgame.data(), 40, 1))
         {
             SDL_RWclose(rw);
             return;
@@ -106,8 +107,8 @@ static void fuzz_parse_savefile(const uint8_t *data, size_t size)
     // Version 8+: campaign ID
     if (version >= 8)
     {
-        char campaign[41] = {};
-        if (!rw_read_exact(rw, campaign, 1, 40))
+        std::array<char, 41> campaign = {};
+        if (!rw_read_exact(rw, campaign.data(), 1, 40))
         {
             SDL_RWclose(rw);
             return;
@@ -179,8 +180,8 @@ static void fuzz_parse_savefile(const uint8_t *data, size_t size)
     }
 
     // Reserved (31 bytes)
-    char filler[31] = {};
-    if (!rw_read_exact(rw, filler, 31, 1))
+    std::array<char, 31> filler = {};
+    if (!rw_read_exact(rw, filler.data(), 31, 1))
     {
         SDL_RWclose(rw);
         return;
@@ -191,18 +192,18 @@ static void fuzz_parse_savefile(const uint8_t *data, size_t size)
     {
         uint8_t order = 0;
         char family = 0;
-        char name[12] = {};
+        std::array<char, 12> name = {};
         int16_t str = 0, dex = 0, con = 0, intel = 0, arm = 0, lev = 0;
         uint32_t exp = 0;
         int16_t kills = 0;
         int32_t level_kills = 0;
         int32_t td = 0, th = 0, ts = 0;
         int16_t teamnum = 0;
-        char reserved[8] = {};
+        std::array<char, 8> reserved = {};
 
         if (!rw_read_exact(rw, &order, 1, 1) ||
             !rw_read_exact(rw, &family, 1, 1) ||
-            !rw_read_exact(rw, name, 12, 1) ||
+            !rw_read_exact(rw, name.data(), 12, 1) ||
             !rw_read_exact(rw, &str, 2, 1) ||
             !rw_read_exact(rw, &dex, 2, 1) ||
             !rw_read_exact(rw, &con, 2, 1) ||
@@ -216,7 +217,7 @@ static void fuzz_parse_savefile(const uint8_t *data, size_t size)
             !rw_read_exact(rw, &th, 4, 1) ||
             !rw_read_exact(rw, &ts, 4, 1) ||
             !rw_read_exact(rw, &teamnum, 2, 1) ||
-            !rw_read_exact(rw, reserved, 8, 1))
+            !rw_read_exact(rw, reserved.data(), 8, 1))
         {
             SDL_RWclose(rw);
             return;
@@ -241,11 +242,11 @@ static void fuzz_parse_savefile(const uint8_t *data, size_t size)
 
         for (int16_t i = 0; i < num_campaigns; i++)
         {
-            char campaign[41] = {};
+            std::array<char, 41> campaign = {};
             int16_t current_level = 0;
             int16_t num_levels = 0;
 
-            if (!rw_read_exact(rw, campaign, 1, 40) ||
+            if (!rw_read_exact(rw, campaign.data(), 1, 40) ||
                 !rw_read_exact(rw, &current_level, 2, 1) ||
                 !rw_read_exact(rw, &num_levels, 2, 1))
             {
@@ -273,8 +274,8 @@ static void fuzz_parse_savefile(const uint8_t *data, size_t size)
     else if (version >= 5)
     {
         // Versions 5-7: flat 500-byte level status array
-        char levelstatus[500] = {};
-        if (!rw_read_exact(rw, levelstatus, 500, 1))
+        std::array<char, 500> levelstatus = {};
+        if (!rw_read_exact(rw, levelstatus.data(), 500, 1))
         {
             SDL_RWclose(rw);
             return;
@@ -283,8 +284,8 @@ static void fuzz_parse_savefile(const uint8_t *data, size_t size)
     else
     {
         // Versions 2-4: flat 200-byte level status array
-        char levelstatus[200] = {};
-        rw_read_exact(rw, levelstatus, 200, 1);
+        std::array<char, 200> levelstatus = {};
+        rw_read_exact(rw, levelstatus.data(), 200, 1);
     }
 
     SDL_RWclose(rw);

--- a/src/fuzz/fuzz_scenario.cpp
+++ b/src/fuzz/fuzz_scenario.cpp
@@ -28,6 +28,7 @@
 // load_scenario_version() without creating game entities.
 
 #include <SDL2/SDL.h>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -45,8 +46,8 @@ static void fuzz_parse_scenario(const uint8_t *data, size_t size)
         return;
 
     // Read and validate FSS header
-    char header[4] = {};
-    if (!rw_read_exact(rw, header, 1, 3))
+    std::array<char, 4> header = {};
+    if (!rw_read_exact(rw, header.data(), 1, 3))
     {
         SDL_RWclose(rw);
         return;
@@ -70,8 +71,8 @@ static void fuzz_parse_scenario(const uint8_t *data, size_t size)
     }
 
     // Read grid name (8 bytes)
-    char gridname[9] = {};
-    if (!rw_read_exact(rw, gridname, 8, 1))
+    std::array<char, 9> gridname = {};
+    if (!rw_read_exact(rw, gridname.data(), 8, 1))
     {
         SDL_RWclose(rw);
         return;
@@ -123,11 +124,11 @@ static void fuzz_parse_scenario(const uint8_t *data, size_t size)
         if (version >= 6)
         {
             uint8_t level = 0;
-            char name[12] = {};
-            char reserved[10] = {};
+            std::array<char, 12> name = {};
+            std::array<char, 10> reserved = {};
             if (!rw_read_exact(rw, &level, 1, 1) ||
-                !rw_read_exact(rw, name, 12, 1) ||
-                !rw_read_exact(rw, reserved, 10, 1))
+                !rw_read_exact(rw, name.data(), 12, 1) ||
+                !rw_read_exact(rw, reserved.data(), 10, 1))
             {
                 SDL_RWclose(rw);
                 return;
@@ -136,8 +137,8 @@ static void fuzz_parse_scenario(const uint8_t *data, size_t size)
         else if (version >= 4)
         {
             // v4-5: extra reserved
-            char reserved[11] = {};
-            if (!rw_read_exact(rw, reserved, 11, 1))
+            std::array<char, 11> reserved = {};
+            if (!rw_read_exact(rw, reserved.data(), 11, 1))
             {
                 SDL_RWclose(rw);
                 return;
@@ -165,12 +166,12 @@ static void fuzz_parse_scenario(const uint8_t *data, size_t size)
             }
 
             // Read and discard line content
-            char buf[256];
+            std::array<char, 256> buf;
             int remaining = width;
             while (remaining > 0)
             {
-                int chunk = remaining < static_cast<int>(sizeof(buf)) ? remaining : static_cast<int>(sizeof(buf));
-                if (!rw_read_exact(rw, buf, static_cast<size_t>(chunk), 1))
+                int chunk = remaining < static_cast<int>(buf.size()) ? remaining : static_cast<int>(buf.size());
+                if (!rw_read_exact(rw, buf.data(), static_cast<size_t>(chunk), 1))
                 {
                     SDL_RWclose(rw);
                     return;

--- a/src/gameplay/ctf/ctf.cpp
+++ b/src/gameplay/ctf/ctf.cpp
@@ -21,6 +21,8 @@
 #include <openglad/gameplay/walker.h>
 
 #include <algorithm>
+#include <array>
+#include <cstddef>
 #include <cstdlib>
 #include <format>
 #include <string>
@@ -375,19 +377,19 @@ void run_respawn_timers(GameWorld& world)
     if (ctf.respawn_queue.empty())
         return;
 
-    bool team_owns_cp[4] = {};
+    std::array<bool, 4> team_owns_cp = {};
     for (int i = 0; i < ctf.cp_count; ++i)
     {
         const std::int8_t owner = ctf.cps[i].owner;
         if (owner >= 0 && owner < 4)
-            team_owns_cp[owner] = true;
+            team_owns_cp[static_cast<std::size_t>(owner)] = true;
     }
 
     for (std::size_t i = 0; i < ctf.respawn_queue.size();)
     {
         CtfRespawnEntry& entry = ctf.respawn_queue[i];
         const std::uint16_t dec =
-            (entry.team < 4 && team_owns_cp[entry.team]) ? 2 : 1;
+            (entry.team < 4 && team_owns_cp[static_cast<std::size_t>(entry.team)]) ? 2 : 1;
         entry.ticks_left -= std::min<std::uint16_t>(dec, entry.ticks_left);
         if (entry.ticks_left > 0)
         {
@@ -540,7 +542,7 @@ void run_control_points(GameWorld& world)
         CtfControlPoint& cp = ctf.cps[i];
         const std::int32_t radius = cp.radius_tiles * GRID_SIZE;
 
-        int present[4] = {};
+        std::array<int, 4> present = {};
         for (const auto& uptr : world.oblist)
         {
             walker* w = uptr.get();
@@ -552,7 +554,7 @@ void run_control_points(GameWorld& world)
             const std::int32_t dx = w->xpos() - cp.x;
             const std::int32_t dy = w->ypos() - cp.y;
             if (dx * dx + dy * dy <= radius * radius)
-                present[team]++;
+                present[static_cast<std::size_t>(team)]++;
         }
 
         // Majority-occupancy contender: the strongest team contests the
@@ -565,10 +567,10 @@ void run_control_points(GameWorld& world)
         int total_present = 0;
         for (int t = 0; t < 4; ++t)
         {
-            total_present += present[t];
-            if (present[t] > strongest_count)
+            total_present += present[static_cast<std::size_t>(t)];
+            if (present[static_cast<std::size_t>(t)] > strongest_count)
             {
-                strongest_count = present[t];
+                strongest_count = present[static_cast<std::size_t>(t)];
                 strongest = t;
             }
         }
@@ -713,8 +715,8 @@ void run_win_check(GameWorld& world)
 
 void spawn_bot_squad(GameWorld& world, int team)
 {
-    static constexpr int kSquad[5] = {FAMILY_SOLDIER, FAMILY_ARCHER,
-                                      FAMILY_ELF, FAMILY_MAGE, FAMILY_THIEF};
+    static constexpr std::array<int, 5> kSquad = {FAMILY_SOLDIER, FAMILY_ARCHER,
+                                                  FAMILY_ELF, FAMILY_MAGE, FAMILY_THIEF};
     const std::int32_t level = std::max(1, world.difficulty / 100 + 1);
     for (int member : kSquad)
     {
@@ -882,7 +884,7 @@ void ctf_initialize_for_level(GameWorld& world)
     // themselves are never stripped.
     if (world.ctf_requested_strip_scenario_troops != 0)
     {
-        bool team_has_myguy[4] = {};
+        std::array<bool, 4> team_has_myguy = {};
         for (const auto& uptr : world.oblist)
         {
             walker* w = uptr.get();
@@ -893,7 +895,7 @@ void ctf_initialize_for_level(GameWorld& world)
             }
             const unsigned char team = w->team_num();
             if (is_score_team(team))
-                team_has_myguy[team] = true;
+                team_has_myguy[static_cast<std::size_t>(team)] = true;
         }
         for (const auto& uptr : world.oblist)
         {
@@ -907,7 +909,7 @@ void ctf_initialize_for_level(GameWorld& world)
                 continue;
             const unsigned char team = w->team_num();
             if (!is_score_team(team) || !ctf.team_active[team] ||
-                !team_has_myguy[team])
+                !team_has_myguy[static_cast<std::size_t>(team)])
             {
                 continue;
             }
@@ -939,19 +941,19 @@ void ctf_initialize_for_level(GameWorld& world)
     ctf.team_count = static_cast<std::uint8_t>(active_count);
 
     // Bot squads for active teams that field no livings.
-    int living_per_team[4] = {};
+    std::array<int, 4> living_per_team = {};
     for (const auto& uptr : world.oblist)
     {
         walker* w = uptr.get();
         if (w != nullptr && !w->dead() && w->query_order() == Order::Living &&
             is_score_team(w->team_num()))
         {
-            living_per_team[w->team_num()]++;
+            living_per_team[static_cast<std::size_t>(w->team_num())]++;
         }
     }
     for (int t = 0; t < 4; ++t)
     {
-        if (ctf.team_active[t] && living_per_team[t] == 0)
+        if (ctf.team_active[t] && living_per_team[static_cast<std::size_t>(t)] == 0)
             spawn_bot_squad(world, t);
     }
 

--- a/src/gameplay/families/family_archer.cpp
+++ b/src/gameplay/families/family_archer.cpp
@@ -154,7 +154,7 @@ const FamilyDescriptor& describe_family_archer()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "archer.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 12,
         .description = "Archers are fleet of foot,\n"
                        "and their arrows have a   \n"

--- a/src/gameplay/families/family_archmage.cpp
+++ b/src/gameplay/families/family_archmage.cpp
@@ -520,7 +520,7 @@ const FamilyDescriptor& describe_family_archmage()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "archmage.png",
-        .animation_type = FAMILY_ANIM_MAGE,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_MAGE,
         .ai_line_of_sight = 10,
         .description = "An Archmage takes the     \n"
                        "learnings of the Magi one \n"

--- a/src/gameplay/families/family_barbarian.cpp
+++ b/src/gameplay/families/family_barbarian.cpp
@@ -111,7 +111,7 @@ const FamilyDescriptor& describe_family_barbarian()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "barby.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 12,
         .description = "Barbarians are powerful   \n"
                        "and resist some magic     \n"

--- a/src/gameplay/families/family_big_orc.cpp
+++ b/src/gameplay/families/family_big_orc.cpp
@@ -62,7 +62,7 @@ const FamilyDescriptor& describe_family_big_orc()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "orc2.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 25,
         .description = "Orcs captains are stronger\n"
                        "and smarter than the basic\n"

--- a/src/gameplay/families/family_cleric.cpp
+++ b/src/gameplay/families/family_cleric.cpp
@@ -361,7 +361,7 @@ const FamilyDescriptor& describe_family_cleric()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "cleric.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 4,
         .description = "Clerics, like mages, are  \n"
                        "slow, but have a stronger \n"

--- a/src/gameplay/families/family_druid.cpp
+++ b/src/gameplay/families/family_druid.cpp
@@ -202,7 +202,7 @@ const FamilyDescriptor& describe_family_druid()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "druid.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 10,
         .description = "Druids are the magicians  \n"
                        "of nature, and have power \n"

--- a/src/gameplay/families/family_elf.cpp
+++ b/src/gameplay/families/family_elf.cpp
@@ -161,7 +161,7 @@ const FamilyDescriptor& describe_family_elf()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "elf.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 8,
         .description = "Elves are small and weak, \n"
                        "but are harder to hit than\n"

--- a/src/gameplay/families/family_faerie.cpp
+++ b/src/gameplay/families/family_faerie.cpp
@@ -65,7 +65,7 @@ const FamilyDescriptor& describe_family_faerie()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "faerie.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 8,
         .description = "The faerie are small,     \n"
                        "flying above friends and  \n"

--- a/src/gameplay/families/family_fire_elemental.cpp
+++ b/src/gameplay/families/family_fire_elemental.cpp
@@ -127,7 +127,7 @@ const FamilyDescriptor& describe_family_fire_elemental()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "firelem.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 10,
         .description = "Strong and quick, fire    \n"
                        "elementals can expel      \n"

--- a/src/gameplay/families/family_ghost.cpp
+++ b/src/gameplay/families/family_ghost.cpp
@@ -76,7 +76,7 @@ const FamilyDescriptor& describe_family_ghost()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "ghost.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 12,
         .description = "Ghosts can pass through   \n"
                        "walls, trees, and anything\n"

--- a/src/gameplay/families/family_giant_skeleton.cpp
+++ b/src/gameplay/families/family_giant_skeleton.cpp
@@ -53,7 +53,7 @@ const FamilyDescriptor& describe_family_giant_skeleton()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "gs1.png",
-        .animation_type = FAMILY_ANIM_GIANT_SKELETON,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_GIANT_SKELETON,
         .ai_line_of_sight = 20,
         .description = nullptr,
         .name_pool = nullptr,

--- a/src/gameplay/families/family_golem.cpp
+++ b/src/gameplay/families/family_golem.cpp
@@ -61,7 +61,7 @@ const FamilyDescriptor& describe_family_golem()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "golem1.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 20,
         .description = nullptr,
         .name_pool = nullptr,

--- a/src/gameplay/families/family_mage.cpp
+++ b/src/gameplay/families/family_mage.cpp
@@ -314,7 +314,7 @@ const FamilyDescriptor& describe_family_mage()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "mage.png",
-        .animation_type = FAMILY_ANIM_MAGE,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_MAGE,
         .ai_line_of_sight = 7,
         .description = "Mages are slow, can't     \n"
                        "stand much damage, and are\n"

--- a/src/gameplay/families/family_orc.cpp
+++ b/src/gameplay/families/family_orc.cpp
@@ -161,7 +161,7 @@ const FamilyDescriptor& describe_family_orc()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "orc.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 20,
         .description = "Orcs are a basic 'grunt'; \n"
                        "strong and hard to hurt,  \n"

--- a/src/gameplay/families/family_skeleton.cpp
+++ b/src/gameplay/families/family_skeleton.cpp
@@ -91,7 +91,7 @@ const FamilyDescriptor& describe_family_skeleton()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "skeleton.png",
-        .animation_type = FAMILY_ANIM_SKELETON,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_SKELETON,
         .ai_line_of_sight = 7,
         .description = "Skeletons are the pathetic\n"
                        "remains of those who once \n"

--- a/src/gameplay/families/family_slime.cpp
+++ b/src/gameplay/families/family_slime.cpp
@@ -189,7 +189,7 @@ const FamilyDescriptor& describe_family_slime()
         .on_ani_complete = slime_on_ani_complete,
         .on_melee_hit = nullptr,
         .pix_filename = "amoeba3.png",
-        .animation_type = FAMILY_ANIM_SLIME,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_SLIME,
         .ai_line_of_sight = 4,
         .description = "Slimes are patches of ooze\n"
                        "which grow and split into \n"
@@ -249,7 +249,7 @@ const FamilyDescriptor& describe_family_small_slime()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "s_slime.png",
-        .animation_type = FAMILY_ANIM_SMALL_SLIME,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_SMALL_SLIME,
         .ai_line_of_sight = 2,
         .description = "Slimes are patches of ooze\n"
                        "which grow and split into \n"
@@ -309,7 +309,7 @@ const FamilyDescriptor& describe_family_medium_slime()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "m_slime.png",
-        .animation_type = FAMILY_ANIM_SMALL_SLIME,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_SMALL_SLIME,
         .ai_line_of_sight = 3,
         .description = "Slimes are patches of ooze\n"
                        "which grow and split into \n"

--- a/src/gameplay/families/family_soldier.cpp
+++ b/src/gameplay/families/family_soldier.cpp
@@ -202,7 +202,7 @@ const FamilyDescriptor& describe_family_soldier()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "footman.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 7,
         .description = "Your basic grunt, can     \n"
                        "absorb and deal damage and\n"

--- a/src/gameplay/families/family_thief.cpp
+++ b/src/gameplay/families/family_thief.cpp
@@ -225,7 +225,7 @@ const FamilyDescriptor& describe_family_thief()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "thief.png",
-        .animation_type = FAMILY_ANIM_STANDARD,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STANDARD,
         .ai_line_of_sight = 10,
         .description = "Thieves are fast, though  \n"
                        "not so potent as the      \n"

--- a/src/gameplay/families/family_tower1.cpp
+++ b/src/gameplay/families/family_tower1.cpp
@@ -53,7 +53,7 @@ const FamilyDescriptor& describe_family_tower1()
         .on_ani_complete = nullptr,
         .on_melee_hit = nullptr,
         .pix_filename = "towersm1.png",
-        .animation_type = FAMILY_ANIM_STATIC,
+        .animation_type = FamilyAnimationType::FAMILY_ANIM_STATIC,
         .ai_line_of_sight = 10,
         .description = nullptr,
         .name_pool = nullptr,

--- a/src/gameplay/smooth.cpp
+++ b/src/gameplay/smooth.cpp
@@ -134,19 +134,19 @@ static constexpr auto make_pix_to_genre() {
 static constexpr auto PIX_to_genre = make_pix_to_genre();
 
 // Random variant lookup tables for smooth()
-static constexpr Sint32 grass_variants[] = {PIX_GRASS1, PIX_GRASS2, PIX_GRASS3, PIX_GRASS4};
-static constexpr Sint32 grass_dark_variants[] = {PIX_GRASS_DARK_1, PIX_GRASS_DARK_2, PIX_GRASS_DARK_3, PIX_GRASS_DARK_4};
-static constexpr Sint32 grass_dark_right[] = {PIX_GRASS_DARK_R1, PIX_GRASS_DARK_R2};
-static constexpr Sint32 grass_dark_bottom[] = {PIX_GRASS_DARK_B1, PIX_GRASS_DARK_B2};
-static constexpr Sint32 water_variants[] = {PIX_WATER1, PIX_WATER2, PIX_WATER3};
-static constexpr Sint32 watergrass_up[] = {PIX_WATERGRASS_LL, PIX_WATERGRASS_LR};
-static constexpr Sint32 watergrass_down[] = {PIX_WATERGRASS_UL, PIX_WATERGRASS_UR};
-static constexpr Sint32 watergrass_left[] = {PIX_WATERGRASS_UR, PIX_WATERGRASS_LR};
-static constexpr Sint32 watergrass_right[] = {PIX_WATERGRASS_UL, PIX_WATERGRASS_LL};
-static constexpr Sint32 cobble_variants[] = {PIX_COBBLE_1, PIX_COBBLE_2, PIX_COBBLE_3, PIX_COBBLE_4};
+static constexpr std::array<Sint32, 4> grass_variants = {PIX_GRASS1, PIX_GRASS2, PIX_GRASS3, PIX_GRASS4};
+static constexpr std::array<Sint32, 4> grass_dark_variants = {PIX_GRASS_DARK_1, PIX_GRASS_DARK_2, PIX_GRASS_DARK_3, PIX_GRASS_DARK_4};
+static constexpr std::array<Sint32, 2> grass_dark_right = {PIX_GRASS_DARK_R1, PIX_GRASS_DARK_R2};
+static constexpr std::array<Sint32, 2> grass_dark_bottom = {PIX_GRASS_DARK_B1, PIX_GRASS_DARK_B2};
+static constexpr std::array<Sint32, 3> water_variants = {PIX_WATER1, PIX_WATER2, PIX_WATER3};
+static constexpr std::array<Sint32, 2> watergrass_up = {PIX_WATERGRASS_LL, PIX_WATERGRASS_LR};
+static constexpr std::array<Sint32, 2> watergrass_down = {PIX_WATERGRASS_UL, PIX_WATERGRASS_UR};
+static constexpr std::array<Sint32, 2> watergrass_left = {PIX_WATERGRASS_UR, PIX_WATERGRASS_LR};
+static constexpr std::array<Sint32, 2> watergrass_right = {PIX_WATERGRASS_UL, PIX_WATERGRASS_LL};
+static constexpr std::array<Sint32, 4> cobble_variants = {PIX_COBBLE_1, PIX_COBBLE_2, PIX_COBBLE_3, PIX_COBBLE_4};
 
 // Directional lookup tables: surround value (0-15) → PIX tile
-static constexpr Sint32 carpet_by_surround[] = {
+static constexpr std::array<Sint32, 16> carpet_by_surround = {
 	PIX_CARPET_SMALL_TINY,   // 0: all alone
 	PIX_CARPET_SMALL_CUP,    // 1: bottom cup
 	PIX_CARPET_SMALL_LEFT,   // 2: left edge
@@ -165,7 +165,7 @@ static constexpr Sint32 carpet_by_surround[] = {
 	PIX_CARPET_M,             // 15: surrounded
 };
 
-static constexpr Sint32 grass_light_by_surround[] = {
+static constexpr std::array<Sint32, 16> grass_light_by_surround = {
 	PIX_GRASS_LIGHT_RIGHT,          // 0: all alone
 	PIX_GRASS_LIGHT_RIGHT_BOTTOM,   // 1: bottom cup
 	PIX_GRASS_LIGHT_LEFT_TOP,       // 2: left edge
@@ -184,7 +184,7 @@ static constexpr Sint32 grass_light_by_surround[] = {
 	PIX_GRASS_LIGHT_1,              // 15: surrounded
 };
 
-static constexpr Sint32 dirt_by_surround[] = {
+static constexpr std::array<Sint32, 16> dirt_by_surround = {
 	PIX_DIRT_1,          // 0: all alone
 	PIX_DIRT_1,          // 1: TO_UP
 	PIX_DIRT_1,          // 2: TO_RIGHT
@@ -203,7 +203,7 @@ static constexpr Sint32 dirt_by_surround[] = {
 	PIX_DIRT_1,          // 15: all around
 };
 
-static constexpr Sint32 dirt_dark_by_surround[] = {
+static constexpr std::array<Sint32, 16> dirt_dark_by_surround = {
 	PIX_DIRT_DARK_1,          // 0: all alone
 	PIX_DIRT_DARK_1,          // 1: TO_UP
 	PIX_DIRT_DARK_1,          // 2: TO_RIGHT
@@ -445,10 +445,10 @@ Sint32 smoother::smooth(Sint32 x, Sint32 y)
 				newvalue = PIX_GRASS_DARK_1; // default case
 			break;
 		case TYPE_CARPET:
-			newvalue = carpet_by_surround[around];
+			newvalue = carpet_by_surround[static_cast<std::size_t>(around)];
 			break; // end of carpet case
 		case TYPE_GRASS_LIGHT:
-			newvalue = grass_light_by_surround[around];
+			newvalue = grass_light_by_surround[static_cast<std::size_t>(around)];
 			break; // end of light grass case
 		case TYPE_WALL:
 			if (herepix == PIX_WALL_ARROW_GRASS ||
@@ -605,10 +605,10 @@ Sint32 smoother::smooth(Sint32 x, Sint32 y)
 				newvalue = PIX_TREE_B1; // default case
 			break;
 		case TYPE_DIRT:
-			newvalue = dirt_by_surround[around];
+			newvalue = dirt_by_surround[static_cast<std::size_t>(around)];
 			break; // end of dirt cases
 		case TYPE_DIRT_DARK:
-			newvalue = dirt_dark_by_surround[around];
+			newvalue = dirt_dark_by_surround[static_cast<std::size_t>(around)];
 			break; // end of dark dirt cases
 		case TYPE_COBBLE: // cobblestone
 			newvalue = cobble_variants[next_random(4)];

--- a/src/interface/input/input.cpp
+++ b/src/interface/input/input.cpp
@@ -182,7 +182,7 @@ void handle_text_event(const void* native_event)
     og::input_native::EventData event;
     if (!as_event_data(native_event, event))
         return;
-    og::runtime::current_session->raw_text_input_ = event.text;
+    og::runtime::current_session->raw_text_input_ = event.text.data();
     og::runtime::current_session->text_input_event_ = 1;
 }
 

--- a/src/interface/input/input_state.cpp
+++ b/src/interface/input/input_state.cpp
@@ -5,6 +5,7 @@
 #include <openglad/interface/session_state.h>
 #include <openglad/core/util.h>
 
+#include <array>
 #include <format>
 #include <string>
 
@@ -158,7 +159,7 @@ constexpr int kDefaultEightDirKeys[4][NUM_KEYS] = {
         KEYCODE_g, KEYCODE_8, KEYCODE_4, KEYCODE_F8,
     }
 };
-constexpr int kDefaultControlModes[4] = {
+constexpr std::array<int, 4> kDefaultControlModes = {
     static_cast<int>(ControlDirectionMode::FourDirection),
     static_cast<int>(ControlDirectionMode::FourDirection),
     static_cast<int>(ControlDirectionMode::FourDirection),
@@ -197,9 +198,9 @@ void reset_default_player_controls()
             hw().player_mode_keys[p][kModeFourIndex][k] = kDefaultFourDirKeys[p][k];
             hw().player_mode_keys[p][kModeEightIndex][k] = kDefaultEightDirKeys[p][k];
         }
-        hw().player_control_modes[p] = kDefaultControlModes[p];
+        hw().player_control_modes[p] = kDefaultControlModes[static_cast<std::size_t>(p)];
         // Activate the default mode's keymap into player_keys
-        const int idx = control_mode_keymap_index(kDefaultControlModes[p]);
+        const int idx = control_mode_keymap_index(kDefaultControlModes[static_cast<std::size_t>(p)]);
         for (int k = 0; k < NUM_KEYS; ++k)
             og::runtime::current_session->player_keys_[p][k] = hw().player_mode_keys[p][idx][k];
     }

--- a/src/interface/render/text.cpp
+++ b/src/interface/render/text.cpp
@@ -20,6 +20,7 @@
 #include <openglad/interface/input.h>
 #include <openglad/interface/native_input.h>
 #include <openglad/interface/base.h>
+#include <array>
 #include <cstdarg>
 #include <cstring>
 #include <span>
@@ -135,39 +136,39 @@ Sint32 text::write_formatted(Sint32 x, Sint32 y, const char* str,
     return center ? 1 : static_cast<Sint32>(len) * static_cast<Sint32>(sizex + 1);
 }
 
-#define TEXT_VFORMAT()                                                     \
-    char text_buffer[256];                                                 \
-    do {                                                                   \
-        if (!formatted_string) return 0;                                   \
-        va_list lst;                                                       \
-        va_start(lst, formatted_string);                                   \
-        vsnprintf(text_buffer, sizeof(text_buffer), formatted_string, lst);\
-        va_end(lst);                                                       \
+#define TEXT_VFORMAT()                                                          \
+    std::array<char, 256> text_buffer;                                          \
+    do {                                                                        \
+        if (!formatted_string) return 0;                                        \
+        va_list lst;                                                            \
+        va_start(lst, formatted_string);                                        \
+        vsnprintf(text_buffer.data(), text_buffer.size(), formatted_string, lst);\
+        va_end(lst);                                                            \
     } while(0)
 
 Sint32 text::write_xy(Sint32 x, Sint32 y, unsigned char color, const char* formatted_string, ...) {
     TEXT_VFORMAT();
-    return write_formatted(x, y, text_buffer, color, false, false, false, 0);
+    return write_formatted(x, y, text_buffer.data(), color, false, false, false, 0);
 }
 
 Sint32 text::write_xy_shadow(Sint32 x, Sint32 y, unsigned char color, const char* formatted_string, ...) {
     TEXT_VFORMAT();
-    return write_formatted(x, y, text_buffer, color, false, true, false, 0);
+    return write_formatted(x, y, text_buffer.data(), color, false, true, false, 0);
 }
 
 Sint32 text::write_xy_center(Sint32 x, Sint32 y, unsigned char color, const char* formatted_string, ...) {
     TEXT_VFORMAT();
-    return write_formatted(x, y, text_buffer, color, true, false, false, 0);
+    return write_formatted(x, y, text_buffer.data(), color, true, false, false, 0);
 }
 
 Sint32 text::write_xy_center_alpha(Sint32 x, Sint32 y, unsigned char color, Uint8 alpha, const char* formatted_string, ...) {
     TEXT_VFORMAT();
-    return write_formatted(x, y, text_buffer, color, true, false, true, alpha);
+    return write_formatted(x, y, text_buffer.data(), color, true, false, true, alpha);
 }
 
 Sint32 text::write_xy_center_shadow(Sint32 x, Sint32 y, unsigned char color, const char* formatted_string, ...) {
     TEXT_VFORMAT();
-    return write_formatted(x, y, text_buffer, color, true, true, false, 0);
+    return write_formatted(x, y, text_buffer.data(), color, true, true, false, 0);
 }
 
 #undef TEXT_VFORMAT

--- a/src/interface/render/view.cpp
+++ b/src/interface/render/view.cpp
@@ -48,6 +48,7 @@
 #include <format>
 #include <openglad/interface/view_sizes.h>
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <memory>
 #include <openglad/core/test_trace.h>
@@ -72,7 +73,7 @@ inline constexpr int VIEW_TEAM_RIGHT = 280;
 // Zardus: these were originally static chars but are now ints
 // Now define the arrays with their default values
 
-const int key1[] = {
+static constexpr std::array<int, 16> key1 = {
                  KEYCODE_w, KEYCODE_e, KEYCODE_d, KEYCODE_c,  // movements
                  KEYCODE_x, KEYCODE_z, KEYCODE_a, KEYCODE_q,
                  KEYCODE_LCTRL, KEYCODE_LALT,                    // fire & special
@@ -85,8 +86,8 @@ const int key1[] = {
 };
 
 void timed_dialog(const char* message, float delay_seconds = 3.0f);
-             
-const int key2[] = {
+
+static constexpr std::array<int, 16> key2 = {
                  KEYCODE_KP_8, KEYCODE_KP_9, KEYCODE_KP_6, KEYCODE_KP_3,  // movements
                  KEYCODE_KP_2, KEYCODE_KP_1, KEYCODE_KP_4, KEYCODE_KP_7,
                  KEYCODE_KP_0, KEYCODE_KP_ENTER,                    // fire & special
@@ -98,7 +99,7 @@ const int key2[] = {
                  KEYCODE_F8,                                    // Cheat key
              };
 
-const int key3[] = {
+static constexpr std::array<int, 16> key3 = {
                  KEYCODE_i, KEYCODE_o, KEYCODE_l, KEYCODE_PERIOD,  // movements
                  KEYCODE_COMMA, KEYCODE_m, KEYCODE_j, KEYCODE_u,
                  KEYCODE_SPACE, KEYCODE_SEMICOLON,                    // fire & special
@@ -110,7 +111,7 @@ const int key3[] = {
                  KEYCODE_F7,                                 // Cheat key
              };
 
-const int key4[] = {
+static constexpr std::array<int, 16> key4 = {
                  KEYCODE_t, KEYCODE_y, KEYCODE_h, KEYCODE_n,  // movements
                  KEYCODE_b, KEYCODE_v, KEYCODE_f, KEYCODE_r,
                  KEYCODE_5, KEYCODE_6,                    // fire & special
@@ -134,7 +135,8 @@ inline constexpr const char* KEY_FILE = "keyprefs.dat";
 // This only exists so we can use the array constructor
 //   for our prefs object (grumble grumble)
 // Zardus: these used to be static chars too
-const int *normalkeys[] = {key1,key2,key3,key4};
+static constexpr std::array<const int*, 4> normalkeys = {
+    key1.data(), key2.data(), key3.data(), key4.data()};
 // Zardus: keys is a sys var (apparently) so we'll use allkeys
 // allkeys now lives in GameSession::allkeys_ (Phase 5 migration).
 // File-local accessor for convenience.
@@ -1576,7 +1578,7 @@ Sint32 viewscreen::change_gamma(Sint32 whichway)
 void init_allkeys(int allkeys[][16])
 {
 	for (int i = 0; i < 4; i++)
-		std::copy_n(normalkeys[i], 16, allkeys[i]);
+		std::copy_n(normalkeys[static_cast<std::size_t>(i)], 16, allkeys[i]);
 
 	og::io::OgFilePtr infile = og::io::og_open_read(KEY_FILE);
 	if (!infile)

--- a/src/interface/score_panel.cpp
+++ b/src/interface/score_panel.cpp
@@ -24,6 +24,7 @@
 
 #include <openglad/interface/game_context.h>
 
+#include <array>
 #include <cmath>
 #include <format>
 #include <string>
@@ -137,29 +138,29 @@ static void draw_ctf_panel(screen* s, walker* control, Sint32 lm, Sint32 tm,
     {
         // Full-width pane: one "<caps><flag-glyph>" segment per active team
         // in its team ramp color, 6px apart.
-        std::string segments[4];
+        std::array<std::string, 4> segments;
         Sint32 total_width = 0;
         for (int team = 0; team < 4; ++team)
         {
             if (!ctf.team_active[team])
                 continue;
-            segments[team] = std::format(
+            segments[static_cast<std::size_t>(team)] = std::format(
                 "{}{}",
                 ctf.captures[team],
                 ctf_flag_state_glyph(ctf.flags[team]));
             if (total_width > 0)
                 total_width += 6;
-            total_width += static_cast<Sint32>(segments[team].size()) * 6;
+            total_width += static_cast<Sint32>(segments[static_cast<std::size_t>(team)].size()) * 6;
         }
         Sint32 x = rm - 60 - total_width;
         for (int team = 0; team < 4; ++team)
         {
-            if (segments[team].empty())
+            if (segments[static_cast<std::size_t>(team)].empty())
                 continue;
-            mytext.write_xy(x, tm + 4, segments[team].c_str(),
+            mytext.write_xy(x, tm + 4, segments[static_cast<std::size_t>(team)].c_str(),
                             static_cast<unsigned char>(team * 16 + 40),
                             static_cast<short>(1));
-            x += static_cast<Sint32>(segments[team].size()) * 6 + 6;
+            x += static_cast<Sint32>(segments[static_cast<std::size_t>(team)].size()) * 6 + 6;
         }
     }
     else if (s->numviews == 2)
@@ -168,8 +169,8 @@ static void draw_ctf_panel(screen* s, walker* control, Sint32 lm, Sint32 tm,
         // compact digits-only group ("2:1:0:3", counts in team ramp colors,
         // neutral separators) on the tm+28 row, clear of the name and the
         // HP/MP rows. The carrier's FLAG! stays left at lm+2 on that row.
-        std::string pieces[7];
-        unsigned char piece_colors[7];
+        std::array<std::string, 7> pieces;
+        std::array<unsigned char, 7> piece_colors;
         int piece_count = 0;
         Sint32 total_width = 0;
         for (int team = 0; team < 4; ++team)
@@ -178,24 +179,25 @@ static void draw_ctf_panel(screen* s, walker* control, Sint32 lm, Sint32 tm,
                 continue;
             if (piece_count > 0)
             {
-                pieces[piece_count] = ":";
-                piece_colors[piece_count] = WHITE;
+                pieces[static_cast<std::size_t>(piece_count)] = ":";
+                piece_colors[static_cast<std::size_t>(piece_count)] = WHITE;
                 total_width += 6;
                 ++piece_count;
             }
-            pieces[piece_count] = std::format("{}", ctf.captures[team]);
-            piece_colors[piece_count] =
+            pieces[static_cast<std::size_t>(piece_count)] = std::format("{}", ctf.captures[team]);
+            piece_colors[static_cast<std::size_t>(piece_count)] =
                 static_cast<unsigned char>(team * 16 + 40);
             total_width +=
-                static_cast<Sint32>(pieces[piece_count].size()) * 6;
+                static_cast<Sint32>(pieces[static_cast<std::size_t>(piece_count)].size()) * 6;
             ++piece_count;
         }
         Sint32 x = rm - 60 - total_width;
         for (int i = 0; i < piece_count; ++i)
         {
-            mytext.write_xy(x, tm + 28, pieces[i].c_str(), piece_colors[i],
+            mytext.write_xy(x, tm + 28, pieces[static_cast<std::size_t>(i)].c_str(),
+                            piece_colors[static_cast<std::size_t>(i)],
                             static_cast<short>(1));
-            x += static_cast<Sint32>(pieces[i].size()) * 6;
+            x += static_cast<Sint32>(pieces[static_cast<std::size_t>(i)].size()) * 6;
         }
     }
 
@@ -280,7 +282,7 @@ short new_score_panel(screen* s, short /*do_it*/)
         };
 
     Uint32 myscore;
-    static Uint32 scorecountup[SCORE_TEAM_COUNT] = {
+    static std::array<Uint32, SCORE_TEAM_COUNT> scorecountup = {
         s->world_.m_score[0],
         s->world_.m_score[1],
         s->world_.m_score[2],

--- a/src/interface/screen.cpp
+++ b/src/interface/screen.cpp
@@ -50,6 +50,7 @@
 #include <openglad/interface/platform_bridge.h>
 #include <openglad/resources/level_data_hooks.h>
 #include <algorithm>
+#include <array>
 #include <string>
 #include <cstring>
 #include <format>
@@ -1277,9 +1278,9 @@ short screen::endgame(short ending, short nextlevel)
 	}
 	else if (ending == 0) // we won
 	{
-		Uint32 bonuscash[4] = {0, 0, 0, 0};
+		std::array<Uint32, 4> bonuscash = {0, 0, 0, 0};
 		Uint32 allbonuscash = 0;
-		
+
 		// Update all the money!
 		for (int i=0; i < 4; i++)
 		{
@@ -1289,14 +1290,14 @@ short screen::endgame(short ending, short nextlevel)
 		}
 		for (int i=0; i < 4; i++)
 		{
-            bonuscash[i] = get_time_bonus(i);
-			save_data.m_totalcash[i] += bonuscash[i];
-			allbonuscash += bonuscash[i];
+            bonuscash[static_cast<std::size_t>(i)] = get_time_bonus(i);
+			save_data.m_totalcash[i] += bonuscash[static_cast<std::size_t>(i)];
+			allbonuscash += bonuscash[static_cast<std::size_t>(i)];
 		}
 		if (save_data.is_level_completed(save_data.scen_num)) // already won, no bonus
 		{
 			for (int i=0; i < 4; i++)
-				bonuscash[i] = 0;
+				bonuscash[static_cast<std::size_t>(i)] = 0;
 			allbonuscash = 0;
 		}
 	    
@@ -1368,13 +1369,13 @@ screen::ScenarioTitleError screen::get_scen_title_with_error(const char *filenam
 const char* screen::get_scen_title(const char *filename, screen *master)
 {
     (void)master;
-    static char buffer[31] = {};
+    static std::array<char, 31> buffer = {};
     std::string out_title;
     const ScenarioTitleError err = get_scen_title_with_error(filename, out_title);
     if(err != ScenarioTitleError::None)
         out_title = "none";
-    std::snprintf(buffer, sizeof(buffer), "%s", out_title.c_str());
-    return buffer;
+    std::snprintf(buffer.data(), buffer.size(), "%s", out_title.c_str());
+    return buffer.data();
 
 }
 

--- a/src/interface/sdl_context_services.cpp
+++ b/src/interface/sdl_context_services.cpp
@@ -20,6 +20,9 @@
 #include <openglad/resources/gloader.h>
 #include <openglad/resources/gloader_ctf.h>
 
+#include <array>
+#include <cstddef>
+
 // myscreen and theprefs are now macros defined in base.h / view.h
 
 void input_state_from_sdl(InputState& out)
@@ -27,15 +30,15 @@ void input_state_from_sdl(InputState& out)
     out.timer_wait_request = kNoTimerWaitRequest;
     for (int p = 0; p < MAX_PLAYERS; p++) {
         // Save previous held state to detect press edges
-        bool was_held[NUM_INPUT_KEYS];
+        std::array<bool, NUM_INPUT_KEYS> was_held;
         for (int k = 0; k < NUM_INPUT_KEYS; k++)
-            was_held[k] = out.players[p].held[k];
+            was_held[static_cast<std::size_t>(k)] = out.players[p].held[k];
 
         // Sample current held state from SDL
         for (int k = 0; k < NUM_INPUT_KEYS; k++) {
             out.players[p].held[k] = isPlayerHoldingKey(p, k);
             // Pressed = held now but wasn't held last frame
-            out.players[p].pressed[k] = out.players[p].held[k] && !was_held[k];
+            out.players[p].pressed[k] = out.players[p].held[k] && !was_held[static_cast<std::size_t>(k)];
         }
 
         if (!player_allows_diagonal_movement(p))

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -41,6 +41,7 @@
 #include <openglad/interface/ui/level_editor_state.h>
 #include <openglad/interface/session_state.h>
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <format>
@@ -171,7 +172,7 @@ bool Rectf::contains(float X, float Y) const
     return (x <= X && x + w >= X && y + h <= Y && y >= Y);
 }
 
-static constexpr Sint32 kDefaultBackgrounds[] = {
+static constexpr std::array<Sint32, 100> kDefaultBackgrounds = {
                          PIX_GRASS1, PIX_GRASS2, PIX_GRASS_DARK_1, PIX_GRASS_DARK_2,
                          //PIX_GRASS_DARK_B1, PIX_GRASS_DARK_BR, PIX_GRASS_DARK_R1, PIX_GRASS_DARK_R2,
                          PIX_BOULDER_1, PIX_GRASS_DARK_LL, PIX_GRASS_DARK_UR, PIX_GRASS_RUBBLE,
@@ -231,9 +232,6 @@ static constexpr Sint32 kDefaultBackgrounds[] = {
                          PIX_CLIFF_LEFT, PIX_CLIFF_BOTTOM, PIX_CLIFF_TOP, PIX_CLIFF_RIGHT,
                          PIX_CLIFF_LEFT, PIX_CLIFF_TOP_L, PIX_CLIFF_TOP_R, PIX_CLIFF_RIGHT,
                      };
-static constexpr std::size_t kNumBackgrounds =
-    sizeof(kDefaultBackgrounds) / sizeof(kDefaultBackgrounds[0]);
-
 static inline auto& backgrounds()
 {
     return eds().backgrounds;
@@ -2817,8 +2815,8 @@ int level_editor_test_exercise_internal_helpers()
     check(data.level != nullptr);
     if (data.level != nullptr)
     {
-        backgrounds().assign(kDefaultBackgrounds,
-                             kDefaultBackgrounds + kNumBackgrounds);
+        backgrounds().assign(kDefaultBackgrounds.begin(),
+                             kDefaultBackgrounds.end());
         object_pane().clear();
         object_pane().push_back({Order::Living, FAMILY_SOLDIER});
         object_pane().push_back({Order::Generator, FAMILY_TENT});
@@ -3515,7 +3513,7 @@ Sint32 level_editor()
     
     // Initialize palette for cycling
     load_and_set_palette("our.pal", eds().scenpalette);
-    backgrounds().assign(kDefaultBackgrounds, kDefaultBackgrounds + kNumBackgrounds);
+    backgrounds().assign(kDefaultBackgrounds.begin(), kDefaultBackgrounds.end());
     eds().maxrows = static_cast<std::int32_t>(backgrounds().size() / 4);
     
     if(data.reloadCampaign())

--- a/src/interface/ui/picker_sdl_defs.h
+++ b/src/interface/ui/picker_sdl_defs.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <cstdint>
 
 // Menu loop return value flags (bitmask).
@@ -106,10 +107,10 @@ struct TeamsMenuWiring
     bool show_ctf = false;        // CTF campaign + lobby host
     bool networked = false;       // genuine networked session (READY shown)
     bool guy_row = false;         // local session with a non-empty roster
-    bool join_visible[4] = {false, false, false, false};
+    std::array<bool, 4> join_visible = {false, false, false, false};
     // Per-team member pager ('>' at the row's right edge): shown only when
     // the team's detail line does not fit one slice.
-    bool pager_visible[4] = {false, false, false, false};
+    std::array<bool, 4> pager_visible = {false, false, false, false};
 };
 
 // Deterministically rewires the TEAMS subscreen nav graph so every visible

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -2460,7 +2460,7 @@ std::string get_saved_name(const char * filename)
 {
 	std::string temp_filename;
 
-	char temptext[4] = {};
+	std::array<char, 4> temptext{};
     std::array<char, 40> savedgame{};
 	char temp_version = 1;
 	short temp_registered = 0;
@@ -2485,7 +2485,7 @@ std::string get_saved_name(const char * filename)
 	}
 
 	// Read id header
-	if (!og::io::og_read_exact(*infile, temptext, 1, 3) || std::string(temptext, 3) != "GTL")
+	if (!og::io::og_read_exact(*infile, temptext.data(), 1, 3) || std::string(temptext.data(), 3) != "GTL")
 	{
 		return std::string("EMPTY SLOT");
 	}

--- a/src/interface/ui/results_screen.cpp
+++ b/src/interface/ui/results_screen.cpp
@@ -22,6 +22,7 @@
 #include <openglad/core/test_trace.h>
 #include <openglad/gameplay/ctf/ctf_state.h>
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <format>
@@ -492,25 +493,25 @@ bool results_screen(int ending, int nextlevel, std::map<int, guy*>& before, std:
 
 	text& mytext = og::runtime::current_session->myscreen_->text_normal;
 	text& bigtext = og::runtime::current_session->myscreen_->text_big;
-	Uint32 bonuscash[4] = {0, 0, 0, 0};
+	std::array<Uint32, 4> bonuscash = {0, 0, 0, 0};
 	Uint32 allscore = 0, allbonuscash = 0;
 
 	for(int i = 0; i < 4; i++)
 		allscore += save_data.m_score[i];
-	
+
 	if(ending == 0)  // we won
 	{
 	    // Calculate bonuses
 		for (int i = 0; i < 4; i++)
 		{
-			bonuscash[i] = get_time_bonus(i);
-			
-			allbonuscash += bonuscash[i];
+			bonuscash[static_cast<std::size_t>(i)] = get_time_bonus(i);
+
+			allbonuscash += bonuscash[static_cast<std::size_t>(i)];
 		}
 		if (save_data.is_level_completed(save_data.scen_num)) // already won, no bonus
 		{
 			for(int i = 0; i < 4; i++)
-				bonuscash[i] = 0;
+				bonuscash[static_cast<std::size_t>(i)] = 0;
 			allbonuscash = 0;
 		}
 	}

--- a/src/platform/curses/curses_game_runtime.cpp
+++ b/src/platform/curses/curses_game_runtime.cpp
@@ -266,6 +266,7 @@ std::unique_ptr<LocalCursesSession> LocalCursesSession::create(SaveData& save,
         return nullptr;
     };
 
+    // factory: private ctor — make_unique not applicable
     std::unique_ptr<LocalCursesSession> s(new LocalCursesSession(save));
     og::server::copy_headless_server_save_data(s->server_save_, save);
     og::server::copy_headless_server_save_data(s->client_save_, save);

--- a/src/platform/curses/curses_network.cpp
+++ b/src/platform/curses/curses_network.cpp
@@ -506,6 +506,7 @@ std::unique_ptr<HostCursesSession> HostCursesSession::create(
     if (!server_transport || !host_client_transport)
         return set_error("host session: missing transport");
 
+    // factory: private ctor — make_unique not applicable
     std::unique_ptr<HostCursesSession> s(new HostCursesSession());
     s->server_transport_ = std::move(server_transport);
     s->host_client_transport_ = std::move(host_client_transport);
@@ -716,6 +717,7 @@ std::unique_ptr<JoinCursesSession> JoinCursesSession::create(
     if (!transport)
         return set_error("join session: missing transport");
 
+    // factory: private ctor — make_unique not applicable
     std::unique_ptr<JoinCursesSession> s(new JoinCursesSession());
     s->transport_ = std::move(transport);
     s->local_player_index_ = local_player_index;

--- a/src/platform/curses/curses_terminal.cpp
+++ b/src/platform/curses/curses_terminal.cpp
@@ -17,6 +17,7 @@
 #include <openglad/platform/curses/kitty_keys.h>
 #include <openglad/platform/curses/text_util.h>
 
+#include <array>
 #include <atomic>
 #include <cerrno>
 #include <clocale>
@@ -131,11 +132,11 @@ bool detect_kitty_support(int in_fd, int out_fd)
         }
         if (pr == 0)
             break; // no (more) data within this slice
-        char tmp[256];
-        const ssize_t n = ::read(in_fd, tmp, sizeof(tmp));
+        std::array<char, 256> tmp;
+        const ssize_t n = ::read(in_fd, tmp.data(), tmp.size());
         if (n <= 0)
             break;
-        reply.append(tmp, static_cast<std::size_t>(n));
+        reply.append(tmp.data(), static_cast<std::size_t>(n));
         supported = kitty::response_indicates_support(reply, done);
     }
     return supported;
@@ -305,10 +306,10 @@ Key CursesTerminal::poll_key(bool block)
                 return Key::none(); // nothing ready and not blocking
             continue;               // blocking: keep waiting
         }
-        char tmp[256];
-        const ssize_t n = ::read(impl_->in_fd, tmp, sizeof(tmp));
+        std::array<char, 256> tmp;
+        const ssize_t n = ::read(impl_->in_fd, tmp.data(), tmp.size());
         if (n > 0) {
-            impl_->decoder.feed(std::string_view(tmp, static_cast<std::size_t>(n)));
+            impl_->decoder.feed(std::string_view(tmp.data(), static_cast<std::size_t>(n)));
             continue; // try to decode what we just read
         }
         if (n == 0)

--- a/src/platform/sdl/demo.cpp
+++ b/src/platform/sdl/demo.cpp
@@ -77,7 +77,7 @@ static const std::array<int, 20> SCENARIO_POOL = {
 };
 
 // Playable families for random team generation.
-static constexpr int PLAYABLE_FAMILIES[] = {
+static constexpr std::array<int, 14> PLAYABLE_FAMILIES = {
     FAMILY_SOLDIER, FAMILY_ELF, FAMILY_ARCHER, FAMILY_MAGE,
     FAMILY_SKELETON, FAMILY_CLERIC, FAMILY_FIREELEMENTAL, FAMILY_FAERIE,
     FAMILY_SLIME, FAMILY_THIEF, FAMILY_GHOST, FAMILY_DRUID,
@@ -127,7 +127,7 @@ static void spawn_random_player_team(screen* s, std::mt19937& rng)
     std::uniform_int_distribution<int> fam_dist(0, NUM_PLAYABLE - 1);
 
     for (int enemy_level : enemy_levels) {
-        int fam = PLAYABLE_FAMILIES[fam_dist(rng)];
+        int fam = PLAYABLE_FAMILIES[static_cast<std::size_t>(fam_dist(rng))];
         guy g(fam);
         g.teamnum = 0;
         if (enemy_level > g.level)

--- a/src/platform/sdl/game_session.cpp
+++ b/src/platform/sdl/game_session.cpp
@@ -58,6 +58,7 @@ PlatformBridge make_sdl_platform_bridge()
     bridge.stop_music = [] {};
 
     bridge.create_surface = [](int, int) -> video* {
+        // ownership transferred to caller's RAII immediately
         return new sdl_video(true);
     };
 
@@ -204,7 +205,7 @@ GameSession::GameSession(const Config& session_cfg)
         // demo sub-sessions).  Copy the authoritative palette here so that
         // rendering with this session active uses correct colors.
         std::copy(screen_owner_->ourpalette.begin(),
-                  screen_owner_->ourpalette.end(), curpal_);
+                  screen_owner_->ourpalette.end(), curpal_.begin());
     }
 
     // Create per-session render surface for sub-sessions sharing a display.

--- a/src/platform/sdl/glad.cpp
+++ b/src/platform/sdl/glad.cpp
@@ -73,6 +73,8 @@ namespace {
 std::unique_ptr<og::runtime::GameSession> g_web_session;
 bool g_web_boot_started = false;
 std::optional<og::ui::PickerLobbyGameStartConfig> g_web_game_start_config;
+// Mutable C-array kept on purpose: it backs a char* argv[] handed to the C-style
+// io_init(argc, argv) entry point, so it must decay to a writable char*.
 char g_web_arg0[] = "/play.html";
 char* g_web_argv[] = {g_web_arg0, nullptr};
 } // namespace

--- a/src/platform/sdl/local_transport_shadow.cpp
+++ b/src/platform/sdl/local_transport_shadow.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 short load_saved_game(const char* filename, screen* scr);
@@ -41,7 +42,7 @@ struct LocalTransportClient {
     bool drives_display = false;
 };
 
-constexpr char kPauseOverlayEscHint[] = "ESC again: Quit?";
+constexpr std::string_view kPauseOverlayEscHint = "ESC again: Quit?";
 
 walker* resolve_control_from_entity_id(GameWorld& world, std::uint32_t entity_id);
 

--- a/src/platform/sdl/native_input.cpp
+++ b/src/platform/sdl/native_input.cpp
@@ -67,7 +67,7 @@ bool decode_event(const void* native_event, EventData& out)
         out.key_repeat = e.key.repeat != 0;
         break;
     case SDL_TEXTINPUT:
-        std::memcpy(out.text, e.text.text, sizeof(out.text));
+        std::memcpy(out.text.data(), e.text.text, out.text.size());
         break;
     case SDL_MOUSEWHEEL:
         out.wheel_y = e.wheel.y;

--- a/src/platform/sdl/picker_lobby_network_client.cpp
+++ b/src/platform/sdl/picker_lobby_network_client.cpp
@@ -201,7 +201,7 @@ EM_JS(char*, current_browser_hostname_js, (), {
 
 std::string url_encode_component(std::string_view text)
 {
-    constexpr char hex_digits[] = "0123456789ABCDEF";
+    constexpr std::string_view hex_digits = "0123456789ABCDEF";
 
     std::string encoded;
     encoded.reserve(text.size());
@@ -216,8 +216,8 @@ std::string url_encode_component(std::string_view text)
         }
 
         encoded.push_back('%');
-        encoded.push_back(hex_digits[(ch >> 4) & 0x0f]);
-        encoded.push_back(hex_digits[ch & 0x0f]);
+        encoded.push_back(hex_digits[static_cast<std::size_t>((ch >> 4) & 0x0f)]);
+        encoded.push_back(hex_digits[static_cast<std::size_t>(ch & 0x0f)]);
     }
     return encoded;
 }
@@ -1247,10 +1247,11 @@ std::string detect_lan_ipv4_address()
         if (!is_usable_ipv4(address))
             return std::nullopt;
 
-        char buffer[INET_ADDRSTRLEN] = {};
-        if (inet_ntop(AF_INET, &address, buffer, sizeof(buffer)) == nullptr)
+        std::array<char, INET_ADDRSTRLEN> buffer = {};
+        if (inet_ntop(AF_INET, &address, buffer.data(),
+                      static_cast<socklen_t>(buffer.size())) == nullptr)
             return std::nullopt;
-        return std::string(buffer);
+        return std::string(buffer.data());
     };
 
     const auto detect_via_udp_socket = [&]() -> std::optional<std::string> {
@@ -1292,10 +1293,10 @@ std::string detect_lan_ipv4_address()
     };
 
     const auto detect_via_hostname = [&]() -> std::optional<std::string> {
-        char hostname[256] = {};
+        std::array<char, 256> hostname = {};
         // Reserve the final byte: POSIX leaves NUL-termination unspecified when
         // the name is truncated, but the zero-initialized buffer keeps [255]=='\0'.
-        if (gethostname(hostname, sizeof(hostname) - 1) != 0 || hostname[0] == '\0')
+        if (gethostname(hostname.data(), hostname.size() - 1) != 0 || hostname[0] == '\0')
             return std::nullopt;
 
         addrinfo hints = {};
@@ -1303,7 +1304,7 @@ std::string detect_lan_ipv4_address()
         hints.ai_socktype = SOCK_DGRAM;
 
         addrinfo* results = nullptr;
-        if (getaddrinfo(hostname, nullptr, &hints, &results) != 0 ||
+        if (getaddrinfo(hostname.data(), nullptr, &hints, &results) != 0 ||
             results == nullptr)
         {
             return std::nullopt;

--- a/src/platform/sdl/sai2x.cpp
+++ b/src/platform/sdl/sai2x.cpp
@@ -503,7 +503,7 @@ void Super2xSaI_ex(unsigned char *src, Uint32 src_pitch, unsigned char *unused, 
 	(void)unused;
 	//int j;
 	unsigned int x, y;
-	Uint32 color[16];
+	std::array<Uint32, 16> color{};
 
 	/* Point to the first 3 lines. */
 	src_line[0] = src;

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -25,6 +25,7 @@
 #include <openglad/legacy/base.h>
 #include <openglad/core/test_trace.h>
 #include <openglad/resources/io.h>
+#include <array>
 #include <format>
 #include <cstring>
 #include <openglad/platform/game_context.h>
@@ -775,8 +776,8 @@ void sdl_video::do_cycle(Sint32 curmode, Sint32 maxmode)
 {
 	Sint32 i;
 	//buffers: PORT: changed these two arrays to ints
-	int tempcol[3];
-	int curcol[3];
+	std::array<int, 3> tempcol{};
+	std::array<int, 3> curcol{};
 
 	curmode %= maxmode;   // avoid over-runs
 

--- a/src/platform/text/platform_headless.cpp
+++ b/src/platform/text/platform_headless.cpp
@@ -17,6 +17,7 @@
 #include <openglad/interface/session_state.h>
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <mutex>
 #include <cstdint>
@@ -62,10 +63,10 @@ std::string get_user_path()
     }
 
 #ifdef _WIN32
-    char path[MAX_PATH];
-    HRESULT hr = SHGetFolderPath(0, CSIDL_LOCAL_APPDATA, 0, 0, path);
+    std::array<char, MAX_PATH> path;
+    HRESULT hr = SHGetFolderPath(0, CSIDL_LOCAL_APPDATA, 0, 0, path.data());
     if (SUCCEEDED(hr)) {
-        std::string s = path;
+        std::string s = path.data();
         size_t pos = 0;
         do {
             pos = s.find_first_of('\\', pos);
@@ -88,17 +89,17 @@ std::string get_asset_path()
     return "";
 #else
     constexpr size_t maxPathSize = 512;
-    char path[maxPathSize];
-    std::fill_n(path, maxPathSize, '\0');
+    std::array<char, maxPathSize> path;
+    std::fill_n(path.data(), maxPathSize, '\0');
 
-    const ssize_t read_len = readlink("/proc/self/exe", path, maxPathSize - 1);
+    const ssize_t read_len = readlink("/proc/self/exe", path.data(), maxPathSize - 1);
     if (read_len < 0) {
         LogError("get_asset_path: readlink(/proc/self/exe) failed\n");
         return "./";
     }
     path[static_cast<size_t>(read_len)] = '\0';
 
-    std::string s = path;
+    std::string s = path.data();
     size_t slash = s.find_last_of('/');
     if (slash != std::string::npos)
         s = s.substr(0, slash);

--- a/src/platform/text/text_protocol.cpp
+++ b/src/platform/text/text_protocol.cpp
@@ -49,7 +49,7 @@ static void json_entity(std::ostream& os, const walker* w, int index)
 
 static void json_string(std::ostream& os, std::string_view value)
 {
-    static constexpr char kHex[] = "0123456789abcdef";
+    static constexpr std::string_view kHex = "0123456789abcdef";
 
     os << '"';
     for (unsigned char c : value) {
@@ -77,7 +77,8 @@ static void json_string(std::ostream& os, std::string_view value)
             break;
         default:
             if (c < 0x20) {
-                os << "\\u00" << kHex[c >> 4] << kHex[c & 0x0f];
+                os << "\\u00" << kHex[static_cast<std::size_t>(c >> 4)]
+                   << kHex[static_cast<std::size_t>(c & 0x0f)];
             } else {
                 os << static_cast<char>(c);
             }

--- a/src/resources/gloader.cpp
+++ b/src/resources/gloader.cpp
@@ -33,6 +33,7 @@
 #include <openglad/gameplay/weap.h>
 #include <openglad/gameplay/effect.h>
 #include <algorithm>
+#include <array>
 #include <cstring>
 
 #define SIZE_ORDERS 7 // see constants.h
@@ -46,92 +47,92 @@ static inline Order sanitize_order(Order order)
 }
 
 // These are for monsters and us
-const signed char bit1[] = {static_cast<char>(1),static_cast<char>(5),static_cast<char>(1),static_cast<char>(9),static_cast<signed char>(-1)};     // up
-const signed char bit2[] = {static_cast<char>(13),static_cast<char>(17),static_cast<char>(13),static_cast<char>(21),static_cast<signed char>(-1)}; // up-right
-const signed char bit3[] = {static_cast<char>(2),static_cast<char>(6),static_cast<char>(2),static_cast<char>(10),static_cast<signed char>(-1)};    // right
-const signed char bit4[] = {static_cast<char>(14),static_cast<char>(18),static_cast<char>(14),static_cast<char>(22),static_cast<signed char>(-1)}; // down-right
-const signed char bit5[] = {static_cast<char>(0),static_cast<char>(4),static_cast<char>(0),static_cast<char>(8),static_cast<signed char>(-1)};     // down
-const signed char bit6[] = {static_cast<char>(12),static_cast<char>(16),static_cast<char>(12),static_cast<char>(20),static_cast<signed char>(-1)}; // down-left
-const signed char bit7[] = {static_cast<char>(3),static_cast<char>(7),static_cast<char>(3),static_cast<char>(11),static_cast<signed char>(-1)};    // left
-const signed char bit8[] = {static_cast<char>(15),static_cast<char>(19),static_cast<char>(15),static_cast<char>(23),static_cast<signed char>(-1)}; // up-left
+static constexpr std::array<signed char, 5> bit1 = {static_cast<char>(1),static_cast<char>(5),static_cast<char>(1),static_cast<char>(9),static_cast<signed char>(-1)};     // up
+static constexpr std::array<signed char, 5> bit2 = {static_cast<char>(13),static_cast<char>(17),static_cast<char>(13),static_cast<char>(21),static_cast<signed char>(-1)}; // up-right
+static constexpr std::array<signed char, 5> bit3 = {static_cast<char>(2),static_cast<char>(6),static_cast<char>(2),static_cast<char>(10),static_cast<signed char>(-1)};    // right
+static constexpr std::array<signed char, 5> bit4 = {static_cast<char>(14),static_cast<char>(18),static_cast<char>(14),static_cast<char>(22),static_cast<signed char>(-1)}; // down-right
+static constexpr std::array<signed char, 5> bit5 = {static_cast<char>(0),static_cast<char>(4),static_cast<char>(0),static_cast<char>(8),static_cast<signed char>(-1)};     // down
+static constexpr std::array<signed char, 5> bit6 = {static_cast<char>(12),static_cast<char>(16),static_cast<char>(12),static_cast<char>(20),static_cast<signed char>(-1)}; // down-left
+static constexpr std::array<signed char, 5> bit7 = {static_cast<char>(3),static_cast<char>(7),static_cast<char>(3),static_cast<char>(11),static_cast<signed char>(-1)};    // left
+static constexpr std::array<signed char, 5> bit8 = {static_cast<char>(15),static_cast<char>(19),static_cast<char>(15),static_cast<char>(23),static_cast<signed char>(-1)}; // up-left
 
-const signed char att1[] = {1,5,1,-1};       // up
-const signed char att2[] = {13,17,13,-1};    // up-right
-const signed char att3[] = {2,6,2,-1};       // right
-const signed char att4[] = {14,18,14,-1};    // down-right
-const signed char att5[] = {0,4,0,-1};       // down
-const signed char att6[] = {12,16,12,-1};    // down-left
-const signed char att7[] = {3,7,3,-1};       // left
-const signed char att8[] = {15,19,15,-1};    // up-left
+static constexpr std::array<signed char, 4> att1 = {1,5,1,-1};       // up
+static constexpr std::array<signed char, 4> att2 = {13,17,13,-1};    // up-right
+static constexpr std::array<signed char, 4> att3 = {2,6,2,-1};       // right
+static constexpr std::array<signed char, 4> att4 = {14,18,14,-1};    // down-right
+static constexpr std::array<signed char, 4> att5 = {0,4,0,-1};       // down
+static constexpr std::array<signed char, 4> att6 = {12,16,12,-1};    // down-left
+static constexpr std::array<signed char, 4> att7 = {3,7,3,-1};       // left
+static constexpr std::array<signed char, 4> att8 = {15,19,15,-1};    // up-left
 
-const signed char bitm2[] = {21,25,21,29,-1};  // up-right
-const signed char bitm4[] = {22,26,22,30,-1};  // down-right
-const signed char bitm6[] = {20,24,20,28,-1};  // down-left
-const signed char bitm8[] = {23,27,23,31,-1};  // up-left
+static constexpr std::array<signed char, 5> bitm2 = {21,25,21,29,-1};  // up-right
+static constexpr std::array<signed char, 5> bitm4 = {22,26,22,30,-1};  // down-right
+static constexpr std::array<signed char, 5> bitm6 = {20,24,20,28,-1};  // down-left
+static constexpr std::array<signed char, 5> bitm8 = {23,27,23,31,-1};  // up-left
 
-const signed char mageatt1[] = {5,17,1,-1};    // up
-const signed char mageatt2[] = {25,33,21,-1};  // up-right
-const signed char mageatt3[] = {6,18,2,-1};    // right
-const signed char mageatt4[] = {26,34,22,-1};  // down-right
-const signed char mageatt5[] = {4,16,0,-1};    // down
-const signed char mageatt6[] = {24,32,20,-1};  // down-left
-const signed char mageatt7[] = {7,19,3,-1};    // left
-const signed char mageatt8[] = {27,35,23,-1};  // up-left
+static constexpr std::array<signed char, 4> mageatt1 = {5,17,1,-1};    // up
+static constexpr std::array<signed char, 4> mageatt2 = {25,33,21,-1};  // up-right
+static constexpr std::array<signed char, 4> mageatt3 = {6,18,2,-1};    // right
+static constexpr std::array<signed char, 4> mageatt4 = {26,34,22,-1};  // down-right
+static constexpr std::array<signed char, 4> mageatt5 = {4,16,0,-1};    // down
+static constexpr std::array<signed char, 4> mageatt6 = {24,32,20,-1};  // down-left
+static constexpr std::array<signed char, 4> mageatt7 = {7,19,3,-1};    // left
+static constexpr std::array<signed char, 4> mageatt8 = {27,35,23,-1};  // up-left
 
 
-const signed char tele_out1[] = {12,13,14,15,-1};
-const signed char tele_in1[] = {15,14,13,12,1,-1};  // up
-const signed char tele_in2[] = {15,14,13,12,2,-1};  // right
-const signed char tele_in3[] = {15,14,13,12,0,-1};  // down
-const signed char tele_in4[] = {15,14,13,12,3,-1};  // left
+static constexpr std::array<signed char, 5> tele_out1 = {12,13,14,15,-1};
+static constexpr std::array<signed char, 6> tele_in1 = {15,14,13,12,1,-1};  // up
+static constexpr std::array<signed char, 6> tele_in2 = {15,14,13,12,2,-1};  // right
+static constexpr std::array<signed char, 6> tele_in3 = {15,14,13,12,0,-1};  // down
+static constexpr std::array<signed char, 6> tele_in4 = {15,14,13,12,3,-1};  // left
 
 // Big skeleton, who is currently different ...
-const signed char gs_down[] = {0, 1, 2, 3, -1}; // true "down"
-const signed char gs_up[] = {3, 2, 1, 0, -1}; // faked up :)
+static constexpr std::array<signed char, 5> gs_down = {0, 1, 2, 3, -1}; // true "down"
+static constexpr std::array<signed char, 5> gs_up = {3, 2, 1, 0, -1}; // faked up :)
 
 // Skeleton growing
-const signed char skel_grow[] =   {27, 26, 25, 24, 0, -1};
-const signed char skel_shrink[] = {0, 24, 25, 26, 27, -1};
+static constexpr std::array<signed char, 6> skel_grow =   {27, 26, 25, 24, 0, -1};
+static constexpr std::array<signed char, 6> skel_shrink = {0, 24, 25, 26, 27, -1};
 
 // For slime unidirectional movement
-const signed char slime_pulse[] = { 0, 0, 1, 1, 2, 2, 1, 1, -1 };
+static constexpr std::array<signed char, 9> slime_pulse = { 0, 0, 1, 1, 2, 2, 1, 1, -1 };
 
-const signed char slime_split[] = { 8, 8, 9, 9, 10, 10,
+static constexpr std::array<signed char, 13> slime_split = { 8, 8, 9, 9, 10, 10,
                               11,11,12,12, 13, 13, -1 };
 
-const signed char small_slime[] = { 0, 0, 1, 1, 2, 2, 3, 3,
+static constexpr std::array<signed char, 29> small_slime = { 0, 0, 1, 1, 2, 2, 3, 3,
                               4, 4, 5, 5, 6, 6, 7, 7,
                               6, 6, 5, 5, 4 ,4, 3, 3,
                               2, 2, 1, 1, -1 };
 
 // These are for the 'effect' objects
-const signed char series_8[] = {0, 1, 2, 3, 4, 5, 6, 7, -1};
-const signed char * const aniexpand8[] = { series_8, series_8, series_8, series_8,
-                               series_8, series_8, series_8, series_8,
-                               series_8, series_8, series_8, series_8,
-                               series_8, series_8, series_8, series_8 };
+static constexpr std::array<signed char, 9> series_8 = {0, 1, 2, 3, 4, 5, 6, 7, -1};
+static constexpr std::array<const signed char*, 16> aniexpand8 = { series_8.data(), series_8.data(), series_8.data(), series_8.data(),
+                               series_8.data(), series_8.data(), series_8.data(), series_8.data(),
+                               series_8.data(), series_8.data(), series_8.data(), series_8.data(),
+                               series_8.data(), series_8.data(), series_8.data(), series_8.data() };
 
 //signed char series_16[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, -1};
-const signed char series_16[] = {0, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, -1};
-const signed char * const ani16[] = {series_16, series_16, series_16, series_16,
-                        series_16, series_16, series_16, series_16,
-                        series_16, series_16, series_16, series_16,
-                        series_16, series_16, series_16, series_16};
+static constexpr std::array<signed char, 17> series_16 = {0, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, -1};
+static constexpr std::array<const signed char*, 16> ani16 = {series_16.data(), series_16.data(), series_16.data(), series_16.data(),
+                        series_16.data(), series_16.data(), series_16.data(), series_16.data(),
+                        series_16.data(), series_16.data(), series_16.data(), series_16.data(),
+                        series_16.data(), series_16.data(), series_16.data(), series_16.data()};
 
-const signed char bomb1[] = {0, 1, 0, 1, 0, 1, 0, 1, 2, 3, 2, 3, 2, 3, 2, 3,
+static constexpr std::array<signed char, 51> bomb1 = {0, 1, 0, 1, 0, 1, 0, 1, 2, 3, 2, 3, 2, 3, 2, 3,
                        4, 5, 4, 5, 4, 5, 4, 5, 6, 7, 6, 7, 6, 7, 6, 7,
                        8, 9, 8, 9, 8, 9, 8, 9, 10, 11, 10, 11, 10, 11, 10, 11,
                        12, 12, -1};
-const signed char * const anibomb1[] = {bomb1, bomb1, bomb1, bomb1,
-                            bomb1, bomb1, bomb1, bomb1,
-                            bomb1, bomb1, bomb1, bomb1,
-                            bomb1, bomb1, bomb1, bomb1 };
+static constexpr std::array<const signed char*, 16> anibomb1 = {bomb1.data(), bomb1.data(), bomb1.data(), bomb1.data(),
+                            bomb1.data(), bomb1.data(), bomb1.data(), bomb1.data(),
+                            bomb1.data(), bomb1.data(), bomb1.data(), bomb1.data(),
+                            bomb1.data(), bomb1.data(), bomb1.data(), bomb1.data() };
 
-const signed char explosion1[] = {0, 1, 2, -1};
-const signed char * const aniexplosion1[] = {explosion1, explosion1, explosion1, explosion1,
-                                 explosion1, explosion1, explosion1, explosion1,
-                                 explosion1, explosion1, explosion1, explosion1,
-                                 explosion1, explosion1, explosion1, explosion1 };
+static constexpr std::array<signed char, 4> explosion1 = {0, 1, 2, -1};
+static constexpr std::array<const signed char*, 16> aniexplosion1 = {explosion1.data(), explosion1.data(), explosion1.data(), explosion1.data(),
+                                 explosion1.data(), explosion1.data(), explosion1.data(), explosion1.data(),
+                                 explosion1.data(), explosion1.data(), explosion1.data(), explosion1.data(),
+                                 explosion1.data(), explosion1.data(), explosion1.data(), explosion1.data() };
 
 /*
 How do animations work?
@@ -142,209 +143,206 @@ The animation can be directional due to the use of curdir.
 The signed char[] are the actual frame indices for the animation.  -1 means to end the animation.
 */
 
-const signed char hit1[] = {0, 1, -1};
-const signed char hit2[] = {0, 2, -1};
-const signed char hit3[] = {0, 3, -1};
-const signed char * const anihit[] = {hit1, hit1, hit1, hit1,
-                                 hit1, hit1, hit1, hit1,
-                                 hit1, hit1, hit1, hit1,
-                                 hit1, hit1, hit1, hit1,
-                                 hit2, hit2, hit2, hit2,
-                                 hit2, hit2, hit2, hit2,
-                                 hit3, hit3, hit3, hit3,
-                                 hit3, hit3, hit3, hit3 };
+static constexpr std::array<signed char, 3> hit1 = {0, 1, -1};
+static constexpr std::array<signed char, 3> hit2 = {0, 2, -1};
+static constexpr std::array<signed char, 3> hit3 = {0, 3, -1};
+static constexpr std::array<const signed char*, 32> anihit = {hit1.data(), hit1.data(), hit1.data(), hit1.data(),
+                                 hit1.data(), hit1.data(), hit1.data(), hit1.data(),
+                                 hit1.data(), hit1.data(), hit1.data(), hit1.data(),
+                                 hit1.data(), hit1.data(), hit1.data(), hit1.data(),
+                                 hit2.data(), hit2.data(), hit2.data(), hit2.data(),
+                                 hit2.data(), hit2.data(), hit2.data(), hit2.data(),
+                                 hit3.data(), hit3.data(), hit3.data(), hit3.data(),
+                                 hit3.data(), hit3.data(), hit3.data(), hit3.data() };
 
-const signed char cloud_cycle[] = {0, 1, 2, 3, 2, 1, -1};
-const signed char * const anicloud[] = {cloud_cycle, cloud_cycle, cloud_cycle, cloud_cycle,
-                           cloud_cycle, cloud_cycle, cloud_cycle, cloud_cycle,
-                           cloud_cycle, cloud_cycle, cloud_cycle, cloud_cycle,
-                           cloud_cycle, cloud_cycle, cloud_cycle, cloud_cycle};
+static constexpr std::array<signed char, 7> cloud_cycle = {0, 1, 2, 3, 2, 1, -1};
+static constexpr std::array<const signed char*, 16> anicloud = {cloud_cycle.data(), cloud_cycle.data(), cloud_cycle.data(), cloud_cycle.data(),
+                           cloud_cycle.data(), cloud_cycle.data(), cloud_cycle.data(), cloud_cycle.data(),
+                           cloud_cycle.data(), cloud_cycle.data(), cloud_cycle.data(), cloud_cycle.data(),
+                           cloud_cycle.data(), cloud_cycle.data(), cloud_cycle.data(), cloud_cycle.data()};
 
-const signed char marker_cycle[] = {0, 1, 2, 3, 4,      // mage TP marker
+static constexpr std::array<signed char, 21> marker_cycle = {0, 1, 2, 3, 4,      // mage TP marker
                               5, 6, 7, 8, 9,
                               10,11,12,13,14,
                               15,16,17,18,19,-1};
-const signed char * const animarker[] = {marker_cycle, marker_cycle, marker_cycle, marker_cycle,
-                            marker_cycle, marker_cycle, marker_cycle, marker_cycle,
-                            marker_cycle, marker_cycle, marker_cycle, marker_cycle,
-                            marker_cycle, marker_cycle, marker_cycle, marker_cycle };
+static constexpr std::array<const signed char*, 16> animarker = {marker_cycle.data(), marker_cycle.data(), marker_cycle.data(), marker_cycle.data(),
+                            marker_cycle.data(), marker_cycle.data(), marker_cycle.data(), marker_cycle.data(),
+                            marker_cycle.data(), marker_cycle.data(), marker_cycle.data(), marker_cycle.data(),
+                            marker_cycle.data(), marker_cycle.data(), marker_cycle.data(), marker_cycle.data() };
 
 // These are for livings now
-const signed char * const animan[] = {
-                             bit1, bit2, bit3, bit4, bit5, bit6, bit7, bit8,
-                             att1, att2, att3, att4, att5, att6, att7, att8,
+static constexpr std::array<const signed char*, 16> animan = {
+                             bit1.data(), bit2.data(), bit3.data(), bit4.data(), bit5.data(), bit6.data(), bit7.data(), bit8.data(),
+                             att1.data(), att2.data(), att3.data(), att4.data(), att5.data(), att6.data(), att7.data(), att8.data(),
                          };
 
-const signed char * const aniskel[] = {
-                              bit1, bit2, bit3, bit4,
-                              bit5, bit6, bit7, bit8,
-                              att1, att2, att3, att4,
-                              att5, att6, att7, att8,
-                              skel_shrink, skel_shrink, skel_shrink, skel_shrink,  // == tele_out
-                              skel_shrink, skel_shrink, skel_shrink, skel_shrink,
-                              skel_grow, skel_grow, skel_grow, skel_grow, // grow from ground (tele-in)
-                              skel_grow, skel_grow, skel_grow, skel_grow,
+static constexpr std::array<const signed char*, 32> aniskel = {
+                              bit1.data(), bit2.data(), bit3.data(), bit4.data(),
+                              bit5.data(), bit6.data(), bit7.data(), bit8.data(),
+                              att1.data(), att2.data(), att3.data(), att4.data(),
+                              att5.data(), att6.data(), att7.data(), att8.data(),
+                              skel_shrink.data(), skel_shrink.data(), skel_shrink.data(), skel_shrink.data(),  // == tele_out
+                              skel_shrink.data(), skel_shrink.data(), skel_shrink.data(), skel_shrink.data(),
+                              skel_grow.data(), skel_grow.data(), skel_grow.data(), skel_grow.data(), // grow from ground (tele-in)
+                              skel_grow.data(), skel_grow.data(), skel_grow.data(), skel_grow.data(),
 
                           };
 
-const signed char * const animage[] = {
-                              bit1, bitm2, bit3, bitm4,
-                              bit5, bitm6, bit7, bitm8,
-                              mageatt1, mageatt2, mageatt3, mageatt4,       // 8 == attack
-                              mageatt5, mageatt6, mageatt7, mageatt8,
-                              tele_out1, tele_out1, tele_out1, tele_out1,   // 16 == tele_out
-                              tele_out1, tele_out1, tele_out1, tele_out1,
-                              tele_in1, tele_in1, tele_in2, tele_in2,       // 24 == tele_in
-                              tele_in3, tele_in3, tele_in4, tele_in4,
+static constexpr std::array<const signed char*, 32> animage = {
+                              bit1.data(), bitm2.data(), bit3.data(), bitm4.data(),
+                              bit5.data(), bitm6.data(), bit7.data(), bitm8.data(),
+                              mageatt1.data(), mageatt2.data(), mageatt3.data(), mageatt4.data(),       // 8 == attack
+                              mageatt5.data(), mageatt6.data(), mageatt7.data(), mageatt8.data(),
+                              tele_out1.data(), tele_out1.data(), tele_out1.data(), tele_out1.data(),   // 16 == tele_out
+                              tele_out1.data(), tele_out1.data(), tele_out1.data(), tele_out1.data(),
+                              tele_in1.data(), tele_in1.data(), tele_in2.data(), tele_in2.data(),       // 24 == tele_in
+                              tele_in3.data(), tele_in3.data(), tele_in4.data(), tele_in4.data(),
                           };
 
 // giant skeleton ..
-const signed char * const anigs[] = {
-                           gs_down, gs_up, gs_down, gs_up,
-                           gs_down, gs_up, gs_down, gs_up,
-                           gs_down, gs_up, gs_down, gs_up,
-                           gs_down, gs_up, gs_down, gs_up,
+static constexpr std::array<const signed char*, 16> anigs = {
+                           gs_down.data(), gs_up.data(), gs_down.data(), gs_up.data(),
+                           gs_down.data(), gs_up.data(), gs_down.data(), gs_up.data(),
+                           gs_down.data(), gs_up.data(), gs_down.data(), gs_up.data(),
+                           gs_down.data(), gs_up.data(), gs_down.data(), gs_up.data(),
                        };
 
-const signed char * const anislime[] = {
-                               slime_pulse, slime_pulse, slime_pulse, slime_pulse, // 0 == walk
-                               slime_pulse, slime_pulse, slime_pulse, slime_pulse,
-                               slime_pulse, slime_pulse, slime_pulse, slime_pulse, // 8 == attack
-                               slime_pulse, slime_pulse, slime_pulse, slime_pulse,
-                               slime_pulse, slime_pulse, slime_pulse, slime_pulse, // 16 == tele_out (ignored)
-                               slime_pulse, slime_pulse, slime_pulse, slime_pulse,
+static constexpr std::array<const signed char*, 40> anislime = {
+                               slime_pulse.data(), slime_pulse.data(), slime_pulse.data(), slime_pulse.data(), // 0 == walk
+                               slime_pulse.data(), slime_pulse.data(), slime_pulse.data(), slime_pulse.data(),
+                               slime_pulse.data(), slime_pulse.data(), slime_pulse.data(), slime_pulse.data(), // 8 == attack
+                               slime_pulse.data(), slime_pulse.data(), slime_pulse.data(), slime_pulse.data(),
+                               slime_pulse.data(), slime_pulse.data(), slime_pulse.data(), slime_pulse.data(), // 16 == tele_out (ignored)
+                               slime_pulse.data(), slime_pulse.data(), slime_pulse.data(), slime_pulse.data(),
                                nullptr, nullptr, nullptr, nullptr,                             // 24 == tele_in (ignored)
                                nullptr, nullptr, nullptr, nullptr,
-                               slime_split, slime_split, slime_split, slime_split, // 32 == slime splits
-                               slime_split, slime_split, slime_split, slime_split,
+                               slime_split.data(), slime_split.data(), slime_split.data(), slime_split.data(), // 32 == slime splits
+                               slime_split.data(), slime_split.data(), slime_split.data(), slime_split.data(),
                            };
 
-const signed char * const ani_small_slime[] = {
-                                      small_slime, small_slime, small_slime, small_slime,
-                                      small_slime, small_slime, small_slime, small_slime,
-                                      small_slime, small_slime, small_slime, small_slime,
-                                      small_slime, small_slime, small_slime, small_slime,
+static constexpr std::array<const signed char*, 16> ani_small_slime = {
+                                      small_slime.data(), small_slime.data(), small_slime.data(), small_slime.data(),
+                                      small_slime.data(), small_slime.data(), small_slime.data(), small_slime.data(),
+                                      small_slime.data(), small_slime.data(), small_slime.data(), small_slime.data(),
+                                      small_slime.data(), small_slime.data(), small_slime.data(), small_slime.data(),
                                   };
 
 
 // These are for the knives
-const signed char kni1[] = {7,6,5,4,3,2,1,0,-1};  // clockwise?
-const signed char kni2[] = {0,1,2,3,4,5,6,7,-1};  // counter?
-const signed char * const anikni[] = { kni2, kni2, kni1, kni1,
-                           kni1, kni1, kni2, kni2,
-                           kni2, kni2, kni1, kni1,
-                           kni1, kni1, kni2, kni2 };
+static constexpr std::array<signed char, 9> kni1 = {7,6,5,4,3,2,1,0,-1};  // clockwise?
+static constexpr std::array<signed char, 9> kni2 = {0,1,2,3,4,5,6,7,-1};  // counter?
+static constexpr std::array<const signed char*, 16> anikni = { kni2.data(), kni2.data(), kni1.data(), kni1.data(),
+                           kni1.data(), kni1.data(), kni2.data(), kni2.data(),
+                           kni2.data(), kni2.data(), kni1.data(), kni1.data(),
+                           kni1.data(), kni1.data(), kni2.data(), kni2.data() };
 
 // These are for the rocks
-const signed char rock1[] = {0, -1};
-const signed char * const anirock[] = { rock1, rock1, rock1, rock1,
-                            rock1, rock1, rock1, rock1,
-                            rock1, rock1, rock1, rock1,
-                            rock1, rock1, rock1, rock1 };
+static constexpr std::array<signed char, 2> rock1 = {0, -1};
+static constexpr std::array<const signed char*, 16> anirock = { rock1.data(), rock1.data(), rock1.data(), rock1.data(),
+                            rock1.data(), rock1.data(), rock1.data(), rock1.data(),
+                            rock1.data(), rock1.data(), rock1.data(), rock1.data(),
+                            rock1.data(), rock1.data(), rock1.data(), rock1.data() };
 
-const signed char grow1[] = {4, 3, 2, 1, 0, -1};
-const signed char * const anitree[] = { rock1, rock1, rock1, rock1,
-                            rock1, rock1, rock1, rock1,
-                            grow1, grow1, grow1, grow1,
-                            grow1, grow1, grow1, grow1 };
+static constexpr std::array<signed char, 6> grow1 = {4, 3, 2, 1, 0, -1};
+static constexpr std::array<const signed char*, 16> anitree = { rock1.data(), rock1.data(), rock1.data(), rock1.data(),
+                            rock1.data(), rock1.data(), rock1.data(), rock1.data(),
+                            grow1.data(), grow1.data(), grow1.data(), grow1.data(),
+                            grow1.data(), grow1.data(), grow1.data(), grow1.data() };
 
-const signed char door1[] = {0, -1};
-const signed char door2[] = {1, -1};
-const signed char * const anidoor[] = { door1, door1, door2, door2,
-                           door1, door1, door2, door2,
-                           door1, door1, door2, door2,
-                           door1, door1, door2, door2 };
+static constexpr std::array<signed char, 2> door1 = {0, -1};
+static constexpr std::array<signed char, 2> door2 = {1, -1};
+static constexpr std::array<const signed char*, 16> anidoor = { door1.data(), door1.data(), door2.data(), door2.data(),
+                           door1.data(), door1.data(), door2.data(), door2.data(),
+                           door1.data(), door1.data(), door2.data(), door2.data(),
+                           door1.data(), door1.data(), door2.data(), door2.data() };
 
 
-const signed char dooropen1[] = {0, 2, 3, 4, 1, -1};
-const signed char dooropen2[] = {1, 4, 3, 2, 0, -1};
-const signed char * const anidooropen[] = { door2, door2, door1, door1,
-                               door2, door2, door1, door1,
-                               dooropen1, dooropen1, dooropen2, dooropen2,
-                               dooropen1, dooropen1, dooropen2, dooropen2 };
+static constexpr std::array<signed char, 6> dooropen1 = {0, 2, 3, 4, 1, -1};
+static constexpr std::array<signed char, 6> dooropen2 = {1, 4, 3, 2, 0, -1};
+static constexpr std::array<const signed char*, 16> anidooropen = { door2.data(), door2.data(), door1.data(), door1.data(),
+                               door2.data(), door2.data(), door1.data(), door1.data(),
+                               dooropen1.data(), dooropen1.data(), dooropen2.data(), dooropen2.data(),
+                               dooropen1.data(), dooropen1.data(), dooropen2.data(), dooropen2.data() };
 
-const signed char arrow1[] = {1, -1}; // up
-const signed char arrow2[] = {5, -1}; // up-right
-const signed char arrow3[] = {2, -1}; // right
-const signed char arrow4[] = {6, -1}; // down-right
-const signed char arrow5[] = {0, -1}; // down
-const signed char arrow6[] = {4, -1}; // down-left
-const signed char arrow7[] = {3, -1}; // left
-const signed char arrow8[] = {7, -1}; // up-left
-const signed char * const aniarrow[] = { arrow1, arrow2, arrow3, arrow4,
-                             arrow5, arrow6, arrow7, arrow8,
-                             arrow1, arrow2, arrow3, arrow4,
-                             arrow5, arrow6, arrow7, arrow8 };
+static constexpr std::array<signed char, 2> arrow1 = {1, -1}; // up
+static constexpr std::array<signed char, 2> arrow2 = {5, -1}; // up-right
+static constexpr std::array<signed char, 2> arrow3 = {2, -1}; // right
+static constexpr std::array<signed char, 2> arrow4 = {6, -1}; // down-right
+static constexpr std::array<signed char, 2> arrow5 = {0, -1}; // down
+static constexpr std::array<signed char, 2> arrow6 = {4, -1}; // down-left
+static constexpr std::array<signed char, 2> arrow7 = {3, -1}; // left
+static constexpr std::array<signed char, 2> arrow8 = {7, -1}; // up-left
+static constexpr std::array<const signed char*, 16> aniarrow = { arrow1.data(), arrow2.data(), arrow3.data(), arrow4.data(),
+                             arrow5.data(), arrow6.data(), arrow7.data(), arrow8.data(),
+                             arrow1.data(), arrow2.data(), arrow3.data(), arrow4.data(),
+                             arrow5.data(), arrow6.data(), arrow7.data(), arrow8.data() };
 
 // These are for the slimes' blobs
-const signed char blob1[] = {0, 1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1, 0, -1};
-const signed char * const aniblob1[] = { blob1, blob1, blob1, blob1,
-                             blob1, blob1, blob1, blob1,
-                             blob1, blob1, blob1, blob1,
-                             blob1, blob1, blob1, blob1 };
+static constexpr std::array<signed char, 14> blob1 = {0, 1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1, 0, -1};
+static constexpr std::array<const signed char*, 16> aniblob1 = { blob1.data(), blob1.data(), blob1.data(), blob1.data(),
+                             blob1.data(), blob1.data(), blob1.data(), blob1.data(),
+                             blob1.data(), blob1.data(), blob1.data(), blob1.data(),
+                             blob1.data(), blob1.data(), blob1.data(), blob1.data() };
 
-const signed char none1[] = {0, -1};
-const signed char * const aninone[] = { none1, none1, none1, none1,
-                            none1, none1, none1, none1,
-                            none1, none1, none1, none1,
-                            none1, none1, none1, none1 };
+static constexpr std::array<signed char, 2> none1 = {0, -1};
+static constexpr std::array<const signed char*, 16> aninone = { none1.data(), none1.data(), none1.data(), none1.data(),
+                            none1.data(), none1.data(), none1.data(), none1.data(),
+                            none1.data(), none1.data(), none1.data(), none1.data(),
+                            none1.data(), none1.data(), none1.data(), none1.data() };
 
 // for the tower generator
-const signed char towerglow1[] = { 1,1,1,2,2,0,-1 };
-const signed char * const anitower[] = { none1, none1, none1, none1,
-                            none1, none1, none1, none1,
-                            towerglow1, towerglow1, towerglow1, towerglow1,
-                            towerglow1, towerglow1, towerglow1, towerglow1 };
+static constexpr std::array<signed char, 7> towerglow1 = { 1,1,1,2,2,0,-1 };
+static constexpr std::array<const signed char*, 16> anitower = { none1.data(), none1.data(), none1.data(), none1.data(),
+                            none1.data(), none1.data(), none1.data(), none1.data(),
+                            towerglow1.data(), towerglow1.data(), towerglow1.data(), towerglow1.data(),
+                            towerglow1.data(), towerglow1.data(), towerglow1.data(), towerglow1.data() };
 
 // for tent generator
-const signed char tent1[] = { 1,1,1,2,2,2,3,3,3,4,4,4,0,-1 };
-const signed char * const anitent[] = { none1, none1, none1, none1,
-                           none1, none1, none1, none1,
-                           tent1, tent1, tent1, tent1,
-                           tent1, tent1, tent1, tent1 };
+static constexpr std::array<signed char, 14> tent1 = { 1,1,1,2,2,2,3,3,3,4,4,4,0,-1 };
+static constexpr std::array<const signed char*, 16> anitent = { none1.data(), none1.data(), none1.data(), none1.data(),
+                           none1.data(), none1.data(), none1.data(), none1.data(),
+                           tent1.data(), tent1.data(), tent1.data(), tent1.data(),
+                           tent1.data(), tent1.data(), tent1.data(), tent1.data() };
 
-const signed char blood1[] = {3,2,1,0,-1};
-const signed char * const aniblood[] = { rock1, rock1, rock1, rock1,
-                             rock1, rock1, rock1, rock1,
-                             blood1, blood1, blood1, blood1,
-                             blood1, blood1, blood1, blood1, };
+static constexpr std::array<signed char, 5> blood1 = {3,2,1,0,-1};
+static constexpr std::array<const signed char*, 16> aniblood = { rock1.data(), rock1.data(), rock1.data(), rock1.data(),
+                             rock1.data(), rock1.data(), rock1.data(), rock1.data(),
+                             blood1.data(), blood1.data(), blood1.data(), blood1.data(),
+                             blood1.data(), blood1.data(), blood1.data(), blood1.data(), };
 
 // These are for the cleric's glow thing
-const signed char glowgrow[] = {0, 1, 2, 3, -1};
-const signed char glowpulse[] = {4, 5, 6, 7, 8, 9, 8, 7, 6, 5, -1};
-const signed char * const aniglowgrow[] = { rock1, rock1, rock1, rock1,
-                                rock1, rock1, rock1, rock1,
-                                glowgrow, glowgrow, glowgrow, glowgrow,
-                                glowgrow, glowgrow, glowgrow, glowgrow,
-                                glowpulse, glowpulse, glowpulse, glowpulse,
-                                glowpulse, glowpulse, glowpulse, glowpulse, };
+static constexpr std::array<signed char, 5> glowgrow = {0, 1, 2, 3, -1};
+static constexpr std::array<signed char, 11> glowpulse = {4, 5, 6, 7, 8, 9, 8, 7, 6, 5, -1};
+static constexpr std::array<const signed char*, 24> aniglowgrow = { rock1.data(), rock1.data(), rock1.data(), rock1.data(),
+                                rock1.data(), rock1.data(), rock1.data(), rock1.data(),
+                                glowgrow.data(), glowgrow.data(), glowgrow.data(), glowgrow.data(),
+                                glowgrow.data(), glowgrow.data(), glowgrow.data(), glowgrow.data(),
+                                glowpulse.data(), glowpulse.data(), glowpulse.data(), glowpulse.data(),
+                                glowpulse.data(), glowpulse.data(), glowpulse.data(), glowpulse.data(), };
 
 // Treasure animations
 
-const signed char food1[] = {0, -1};
-const signed char * const anifood[] = { food1, food1, food1, food1,
-                            food1, food1, food1, food1,
-                            food1, food1, food1, food1,
-                            food1, food1, food1, food1 };
+static constexpr std::array<signed char, 2> food1 = {0, -1};
+static constexpr std::array<const signed char*, 16> anifood = { food1.data(), food1.data(), food1.data(), food1.data(),
+                            food1.data(), food1.data(), food1.data(), food1.data(),
+                            food1.data(), food1.data(), food1.data(), food1.data(),
+                            food1.data(), food1.data(), food1.data(), food1.data() };
 
 // Animation table lookup from FamilyAnimationType enum
-static const signed char * const * animation_for_type(int anim_type)
+static const signed char * const * animation_for_type(FamilyAnimationType anim_type)
 {
     switch (anim_type)
     {
-        case FAMILY_ANIM_STANDARD:        return animan;
-        case FAMILY_ANIM_MAGE:            return animage;
-        case FAMILY_ANIM_SKELETON:        return aniskel;
-        case FAMILY_ANIM_GIANT_SKELETON:  return anigs;
-        case FAMILY_ANIM_SLIME:           return anislime;
-        case FAMILY_ANIM_SMALL_SLIME:     return ani_small_slime;
-        case FAMILY_ANIM_STATIC:          return anifood;
-        default:                          return animan;
+        case FamilyAnimationType::FAMILY_ANIM_STANDARD:        return animan.data();
+        case FamilyAnimationType::FAMILY_ANIM_MAGE:            return animage.data();
+        case FamilyAnimationType::FAMILY_ANIM_SKELETON:        return aniskel.data();
+        case FamilyAnimationType::FAMILY_ANIM_GIANT_SKELETON:  return anigs.data();
+        case FamilyAnimationType::FAMILY_ANIM_SLIME:           return anislime.data();
+        case FamilyAnimationType::FAMILY_ANIM_SMALL_SLIME:     return ani_small_slime.data();
+        case FamilyAnimationType::FAMILY_ANIM_STATIC:          return anifood.data();
+        default:                                               return animan.data();
     }
 }
-
-template <typename T, std::size_t N>
-static constexpr int array_len(const T (&)[N]) { return static_cast<int>(N); }
 
 // Returns the number of (facing x ani_type) pointer entries in an animation
 // table, or 0 for nullptr / an unrecognized table. Animation tables vary in
@@ -357,32 +355,32 @@ static int anim_table_count(const signed char * const * t)
         return 0;
     struct Entry { const signed char * const * table; int count; };
     static const Entry kRegistry[] = {
-        { anihit,         array_len(anihit) },
-        { anicloud,       array_len(anicloud) },
-        { animarker,      array_len(animarker) },
-        { animan,         array_len(animan) },
-        { aniskel,        array_len(aniskel) },
-        { animage,        array_len(animage) },
-        { anigs,          array_len(anigs) },
-        { anislime,       array_len(anislime) },
-        { ani_small_slime,array_len(ani_small_slime) },
-        { anikni,         array_len(anikni) },
-        { anirock,        array_len(anirock) },
-        { anitree,        array_len(anitree) },
-        { anidoor,        array_len(anidoor) },
-        { anidooropen,    array_len(anidooropen) },
-        { aniarrow,       array_len(aniarrow) },
-        { aniblob1,       array_len(aniblob1) },
-        { aninone,        array_len(aninone) },
-        { anitower,       array_len(anitower) },
-        { anitent,        array_len(anitent) },
-        { aniblood,       array_len(aniblood) },
-        { aniglowgrow,    array_len(aniglowgrow) },
-        { anifood,        array_len(anifood) },
-        { aniexpand8,     array_len(aniexpand8) },
-        { ani16,          array_len(ani16) },
-        { anibomb1,       array_len(anibomb1) },
-        { aniexplosion1,  array_len(aniexplosion1) },
+        { anihit.data(),         static_cast<int>(anihit.size()) },
+        { anicloud.data(),       static_cast<int>(anicloud.size()) },
+        { animarker.data(),      static_cast<int>(animarker.size()) },
+        { animan.data(),         static_cast<int>(animan.size()) },
+        { aniskel.data(),        static_cast<int>(aniskel.size()) },
+        { animage.data(),        static_cast<int>(animage.size()) },
+        { anigs.data(),          static_cast<int>(anigs.size()) },
+        { anislime.data(),       static_cast<int>(anislime.size()) },
+        { ani_small_slime.data(),static_cast<int>(ani_small_slime.size()) },
+        { anikni.data(),         static_cast<int>(anikni.size()) },
+        { anirock.data(),        static_cast<int>(anirock.size()) },
+        { anitree.data(),        static_cast<int>(anitree.size()) },
+        { anidoor.data(),        static_cast<int>(anidoor.size()) },
+        { anidooropen.data(),    static_cast<int>(anidooropen.size()) },
+        { aniarrow.data(),       static_cast<int>(aniarrow.size()) },
+        { aniblob1.data(),       static_cast<int>(aniblob1.size()) },
+        { aninone.data(),        static_cast<int>(aninone.size()) },
+        { anitower.data(),       static_cast<int>(anitower.size()) },
+        { anitent.data(),        static_cast<int>(anitent.size()) },
+        { aniblood.data(),       static_cast<int>(aniblood.size()) },
+        { aniglowgrow.data(),    static_cast<int>(aniglowgrow.size()) },
+        { anifood.data(),        static_cast<int>(anifood.size()) },
+        { aniexpand8.data(),     static_cast<int>(aniexpand8.size()) },
+        { ani16.data(),          static_cast<int>(ani16.size()) },
+        { anibomb1.data(),       static_cast<int>(anibomb1.size()) },
+        { aniexplosion1.data(),  static_cast<int>(aniexplosion1.size()) },
     };
     for (const auto& e : kRegistry)
         if (e.table == t)
@@ -457,65 +455,65 @@ loader::loader(EntityFactory entity_factory)
 	static const EntityDef defs[] = {
 		// Weapon entities (BLOOD pix handled separately for gore toggle)
 		//                                                       hp  act         anim           step los  dmg freq
-		{Order::Weapon, FAMILY_KNIFE,             "knife.png",    6, ACT_FIRE, anikni,          5,  7,  6, 0},
-		{Order::Weapon, FAMILY_ROCK,              "rock.png",     4, ACT_FIRE, anirock,         5,  8,  4, 0},
-		{Order::Weapon, FAMILY_ARROW,             "arrow.png",    5, ACT_FIRE, aniarrow,        8, 12,  5, 0},
-		{Order::Weapon, FAMILY_FIRE_ARROW,        "farrow.png",   7, ACT_FIRE, aniarrow,        8, 12,  7, 0},
-		{Order::Weapon, FAMILY_FIREBALL,          "fire.png",     8, ACT_FIRE, aniarrow,        6,  7, 10, 0},
-		{Order::Weapon, FAMILY_TREE,              "tree.png",    50, ACT_SIT,  anitree,         0,  1,  0, 0},
-		{Order::Weapon, FAMILY_METEOR,            "meteor.png",  12, ACT_FIRE, aniarrow,        7,  9, 12, 0},
-		{Order::Weapon, FAMILY_SPRINKLE,          "sparkle.png",  1, ACT_FIRE, anikni,          6, 10,  1, 0},
-		{Order::Weapon, FAMILY_BLOOD,             nullptr,        0, ACT_DIE,  aniblood,        0,  1,  0, 0},
-		{Order::Weapon, FAMILY_BONE,              "bone1.png",    5, ACT_FIRE, anikni,          6,  6,  5, 0},
-		{Order::Weapon, FAMILY_BLOB,              "sl_ball.png",  1, ACT_FIRE, aniblob1,        2, 11,  1, 2},
-		{Order::Weapon, FAMILY_LIGHTNING,         "lightnin.png",60, ACT_FIRE, aniarrow,        9, 13,  6, 0},
-		{Order::Weapon, FAMILY_GLOW,              "clerglow.png",50, ACT_SIT,  aniglowgrow,    0,   1,  0, 0},
-		{Order::Weapon, FAMILY_WAVE,              "wave.png",    50, ACT_FIRE, aniarrow,        6,  3, 16, 0},
-		{Order::Weapon, FAMILY_WAVE2,             "wave2.png",   50, ACT_RANDOM, aniarrow,      4,  4, 12, 0},
-		{Order::Weapon, FAMILY_WAVE3,             "wave3.png",   50, ACT_FIRE, aniarrow,        3,  6, 10, 0},
-		{Order::Weapon, FAMILY_CIRCLE_PROTECTION, "wave2.png",   50, ACT_SIT,  anifood,         1,110,  0, 0},
-		{Order::Weapon, FAMILY_HAMMER,            "hammer.png",  10, ACT_FIRE, aniarrow,        6,  4,  9, 0},
-		{Order::Weapon, FAMILY_DOOR,              "door.png",  5000, ACT_SIT,  anidoor,         0,  1,  0, 0},
-		{Order::Weapon, FAMILY_BOULDER,           "boulder1.png",50, ACT_FIRE, aninone,        10,  9, 25, 0},
+		{Order::Weapon, FAMILY_KNIFE,             "knife.png",    6, ACT_FIRE, anikni.data(),          5,  7,  6, 0},
+		{Order::Weapon, FAMILY_ROCK,              "rock.png",     4, ACT_FIRE, anirock.data(),         5,  8,  4, 0},
+		{Order::Weapon, FAMILY_ARROW,             "arrow.png",    5, ACT_FIRE, aniarrow.data(),        8, 12,  5, 0},
+		{Order::Weapon, FAMILY_FIRE_ARROW,        "farrow.png",   7, ACT_FIRE, aniarrow.data(),        8, 12,  7, 0},
+		{Order::Weapon, FAMILY_FIREBALL,          "fire.png",     8, ACT_FIRE, aniarrow.data(),        6,  7, 10, 0},
+		{Order::Weapon, FAMILY_TREE,              "tree.png",    50, ACT_SIT,  anitree.data(),         0,  1,  0, 0},
+		{Order::Weapon, FAMILY_METEOR,            "meteor.png",  12, ACT_FIRE, aniarrow.data(),        7,  9, 12, 0},
+		{Order::Weapon, FAMILY_SPRINKLE,          "sparkle.png",  1, ACT_FIRE, anikni.data(),          6, 10,  1, 0},
+		{Order::Weapon, FAMILY_BLOOD,             nullptr,        0, ACT_DIE,  aniblood.data(),        0,  1,  0, 0},
+		{Order::Weapon, FAMILY_BONE,              "bone1.png",    5, ACT_FIRE, anikni.data(),          6,  6,  5, 0},
+		{Order::Weapon, FAMILY_BLOB,              "sl_ball.png",  1, ACT_FIRE, aniblob1.data(),        2, 11,  1, 2},
+		{Order::Weapon, FAMILY_LIGHTNING,         "lightnin.png",60, ACT_FIRE, aniarrow.data(),        9, 13,  6, 0},
+		{Order::Weapon, FAMILY_GLOW,              "clerglow.png",50, ACT_SIT,  aniglowgrow.data(),    0,   1,  0, 0},
+		{Order::Weapon, FAMILY_WAVE,              "wave.png",    50, ACT_FIRE, aniarrow.data(),        6,  3, 16, 0},
+		{Order::Weapon, FAMILY_WAVE2,             "wave2.png",   50, ACT_RANDOM, aniarrow.data(),      4,  4, 12, 0},
+		{Order::Weapon, FAMILY_WAVE3,             "wave3.png",   50, ACT_FIRE, aniarrow.data(),        3,  6, 10, 0},
+		{Order::Weapon, FAMILY_CIRCLE_PROTECTION, "wave2.png",   50, ACT_SIT,  anifood.data(),         1,110,  0, 0},
+		{Order::Weapon, FAMILY_HAMMER,            "hammer.png",  10, ACT_FIRE, aniarrow.data(),        6,  4,  9, 0},
+		{Order::Weapon, FAMILY_DOOR,              "door.png",  5000, ACT_SIT,  anidoor.data(),         0,  1,  0, 0},
+		{Order::Weapon, FAMILY_BOULDER,           "boulder1.png",50, ACT_FIRE, aninone.data(),        10,  9, 25, 0},
 
 		// Treasure entities (STAIN pix handled by gore toggle; data_copy entries have nullptr pix)
-		{Order::Treasure, FAMILY_STAIN,                nullptr,       0, ACT_CONTROL, aniblood, 0, 0, 0, 0},
-		{Order::Treasure, FAMILY_DRUMSTICK,            "food1.png",  10, ACT_CONTROL, anifood,  5, 0, 0, 0},
-		{Order::Treasure, FAMILY_GOLD_BAR,             "bar1.png", 1000, ACT_CONTROL, anifood,  0, 0, 0, 0},
-		{Order::Treasure, FAMILY_SILVER_BAR,           nullptr,     100, ACT_CONTROL, anifood,  0, 0, 0, 0},
-		{Order::Treasure, FAMILY_MAGIC_POTION,         "bottle.png",  0, ACT_CONTROL, anifood,  0, 0, 0, 0},
-		{Order::Treasure, FAMILY_INVIS_POTION,         nullptr,       0, ACT_CONTROL, anifood,  0, 0, 0, 0},
-		{Order::Treasure, FAMILY_INVULNERABLE_POTION,  nullptr,       0, ACT_CONTROL, anifood,  0, 0, 0, 0},
-		{Order::Treasure, FAMILY_FLIGHT_POTION,        nullptr,       0, ACT_CONTROL, anifood,  0, 0, 0, 0},
-		{Order::Treasure, FAMILY_EXIT,                 "16exit1.png", 0, ACT_CONTROL, anifood,  0, 0, 0, 0},
-		{Order::Treasure, FAMILY_TELEPORTER,           "teleport.png",0, ACT_CONTROL, anifood,  0, 0, 0, 0},
-		{Order::Treasure, FAMILY_LIFE_GEM,             "lifegem.png", 0, ACT_CONTROL, anifood,  0, 0, 0, 0},
-		{Order::Treasure, FAMILY_KEY,                  "key.png",     0, ACT_CONTROL, anifood,  0, 0, 0, 0},
-		{Order::Treasure, FAMILY_SPEED_POTION,         nullptr,       0, ACT_CONTROL, anifood,  0, 0, 0, 0},
+		{Order::Treasure, FAMILY_STAIN,                nullptr,       0, ACT_CONTROL, aniblood.data(), 0, 0, 0, 0},
+		{Order::Treasure, FAMILY_DRUMSTICK,            "food1.png",  10, ACT_CONTROL, anifood.data(),  5, 0, 0, 0},
+		{Order::Treasure, FAMILY_GOLD_BAR,             "bar1.png", 1000, ACT_CONTROL, anifood.data(),  0, 0, 0, 0},
+		{Order::Treasure, FAMILY_SILVER_BAR,           nullptr,     100, ACT_CONTROL, anifood.data(),  0, 0, 0, 0},
+		{Order::Treasure, FAMILY_MAGIC_POTION,         "bottle.png",  0, ACT_CONTROL, anifood.data(),  0, 0, 0, 0},
+		{Order::Treasure, FAMILY_INVIS_POTION,         nullptr,       0, ACT_CONTROL, anifood.data(),  0, 0, 0, 0},
+		{Order::Treasure, FAMILY_INVULNERABLE_POTION,  nullptr,       0, ACT_CONTROL, anifood.data(),  0, 0, 0, 0},
+		{Order::Treasure, FAMILY_FLIGHT_POTION,        nullptr,       0, ACT_CONTROL, anifood.data(),  0, 0, 0, 0},
+		{Order::Treasure, FAMILY_EXIT,                 "16exit1.png", 0, ACT_CONTROL, anifood.data(),  0, 0, 0, 0},
+		{Order::Treasure, FAMILY_TELEPORTER,           "teleport.png",0, ACT_CONTROL, anifood.data(),  0, 0, 0, 0},
+		{Order::Treasure, FAMILY_LIFE_GEM,             "lifegem.png", 0, ACT_CONTROL, anifood.data(),  0, 0, 0, 0},
+		{Order::Treasure, FAMILY_KEY,                  "key.png",     0, ACT_CONTROL, anifood.data(),  0, 0, 0, 0},
+		{Order::Treasure, FAMILY_SPEED_POTION,         nullptr,       0, ACT_CONTROL, anifood.data(),  0, 0, 0, 0},
 
 		// Generator entities
-		{Order::Generator, FAMILY_TENT,      "tent.png",    100, ACT_GENERATE, anitent,  0, 0, 0, 0},
-		{Order::Generator, FAMILY_TOWER,     "tower4.png",    0, ACT_GENERATE, anitower, 0, 0, 0, 0},
-		{Order::Generator, FAMILY_BONES,     "bonepile.png",  0, ACT_GENERATE, aninone,  0, 0, 2, 0},
-		{Order::Generator, FAMILY_TREEHOUSE, "bigtree.png",   0, ACT_GENERATE, aninone,  0, 0, 0, 0},
+		{Order::Generator, FAMILY_TENT,      "tent.png",    100, ACT_GENERATE, anitent.data(),  0, 0, 0, 0},
+		{Order::Generator, FAMILY_TOWER,     "tower4.png",    0, ACT_GENERATE, anitower.data(), 0, 0, 0, 0},
+		{Order::Generator, FAMILY_BONES,     "bonepile.png",  0, ACT_GENERATE, aninone.data(),  0, 0, 2, 0},
+		{Order::Generator, FAMILY_TREEHOUSE, "bigtree.png",   0, ACT_GENERATE, aninone.data(),  0, 0, 0, 0},
 
 		// Special
 		{Order::Special, FAMILY_RESERVED_TEAM, "team.png", 0, ACT_RANDOM, nullptr, 0, 0, 0, 0},
 
 		// FX entities
-		{Order::FX, FAMILY_EXPAND,       "expand8.png",    0, ACT_RANDOM, aniexpand8,    0,  0,  0, 0},
-		{Order::FX, FAMILY_GHOST_SCARE,  "expand8.png",    0, ACT_RANDOM, aniexpand8,    0,  0,  0, 0},
-		{Order::FX, FAMILY_BOMB,         "bomb1.png",      0, ACT_RANDOM, anibomb1,      0,  0,  0, 0},
-		{Order::FX, FAMILY_EXPLOSION,    "boom1.png",      0, ACT_RANDOM, aniexplosion1, 0,  0,  0, 0},
-		{Order::FX, FAMILY_FLASH,        "telflash.png",   0, ACT_RANDOM, aniexpand8,    0,  0,  0, 0},
-		{Order::FX, FAMILY_MAGIC_SHIELD, "mshield.png",  100, ACT_RANDOM, anikni,        0,  0, 10, 0},
-		{Order::FX, FAMILY_KNIFE_BACK,   "knife.png",      0, ACT_RANDOM, anikni,        0,  0,  0, 0},
-		{Order::FX, FAMILY_CLOUD,        "cloud.png",      0, ACT_RANDOM, anicloud,      4,  0, 20, 0},
-		{Order::FX, FAMILY_MARKER,       "marker.png",     0, ACT_RANDOM, animarker,     0,  0,  0, 0},
-		{Order::FX, FAMILY_BOOMERANG,    "boomer.png",    50, ACT_RANDOM, ani16,         0,  0,  8, 0},
-		{Order::FX, FAMILY_CHAIN,        "lightnin.png",   0, ACT_RANDOM, aniarrow,     12, 15,  0, 0},
-		{Order::FX, FAMILY_DOOR_OPEN,    "door.png",       0, ACT_RANDOM, anidooropen,   0,  0,  0, 0},
-		{Order::FX, FAMILY_HIT,          "hit.png",        0, ACT_RANDOM, anihit,        0,  0,  0, 0},
+		{Order::FX, FAMILY_EXPAND,       "expand8.png",    0, ACT_RANDOM, aniexpand8.data(),    0,  0,  0, 0},
+		{Order::FX, FAMILY_GHOST_SCARE,  "expand8.png",    0, ACT_RANDOM, aniexpand8.data(),    0,  0,  0, 0},
+		{Order::FX, FAMILY_BOMB,         "bomb1.png",      0, ACT_RANDOM, anibomb1.data(),      0,  0,  0, 0},
+		{Order::FX, FAMILY_EXPLOSION,    "boom1.png",      0, ACT_RANDOM, aniexplosion1.data(), 0,  0,  0, 0},
+		{Order::FX, FAMILY_FLASH,        "telflash.png",   0, ACT_RANDOM, aniexpand8.data(),    0,  0,  0, 0},
+		{Order::FX, FAMILY_MAGIC_SHIELD, "mshield.png",  100, ACT_RANDOM, anikni.data(),        0,  0, 10, 0},
+		{Order::FX, FAMILY_KNIFE_BACK,   "knife.png",      0, ACT_RANDOM, anikni.data(),        0,  0,  0, 0},
+		{Order::FX, FAMILY_CLOUD,        "cloud.png",      0, ACT_RANDOM, anicloud.data(),      4,  0, 20, 0},
+		{Order::FX, FAMILY_MARKER,       "marker.png",     0, ACT_RANDOM, animarker.data(),     0,  0,  0, 0},
+		{Order::FX, FAMILY_BOOMERANG,    "boomer.png",    50, ACT_RANDOM, ani16.data(),         0,  0,  8, 0},
+		{Order::FX, FAMILY_CHAIN,        "lightnin.png",   0, ACT_RANDOM, aniarrow.data(),     12, 15,  0, 0},
+		{Order::FX, FAMILY_DOOR_OPEN,    "door.png",       0, ACT_RANDOM, anidooropen.data(),   0,  0,  0, 0},
+		{Order::FX, FAMILY_HIT,          "hit.png",        0, ACT_RANDOM, anihit.data(),        0,  0,  0, 0},
 
 		// Button graphics (no gameplay properties)
 		{Order::Button1, FAMILY_NORMAL1, "normal1.png",  0, ACT_RANDOM, nullptr, 0, 0, 0, 0},

--- a/src/resources/gparser.cpp
+++ b/src/resources/gparser.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <string_view>
 #include <set>
 #include <cstdlib>
 #include <cstdio>
@@ -194,7 +195,7 @@ bool cfg_store::save_settings()
 
 void cfg_store::commandline(int &argc, char **&argv)
 {
-	const char helpmsg[] =
+	static constexpr std::string_view helpmsg =
 "Usage: openglad [-d -f ...]\n"
 "  -s		Turn sound on\n"
 "  -S		Turn sound off\n"
@@ -207,7 +208,7 @@ void cfg_store::commandline(int &argc, char **&argv)
 "  -v		Print the version number\n"
 "  --show-fps   Overlay render FPS in the top-right corner\n";
 
-	const char versmsg[] = "openglad version " OPENGLAD_VERSION_STRING "\n";
+	static constexpr std::string_view versmsg = "openglad version " OPENGLAD_VERSION_STRING "\n";
 
 	// Begin changes by David Storey (Deathifier)
 	// FIX: Handle mutually exclusive arguments being used at the same time?

--- a/src/resources/level_file_io.cpp
+++ b/src/resources/level_file_io.cpp
@@ -112,7 +112,7 @@ bool read_level_body(og::io::OgFile& infile, short version, GameWorld& world,
     char templevel = 0;
     short shortlevel = 0;
     short listsize = 0;
-    char newgrid[9] = "grid";
+    std::array<char, 9> newgrid = {'g', 'r', 'i', 'd'};
     char new_scen_type = 0;
     std::array<char, 80> oneline{};
     char numlines = 0;
@@ -132,12 +132,12 @@ bool read_level_body(og::io::OgFile& infile, short version, GameWorld& world,
         }                                                                       \
     } while (0)
 
-    READ_OR_FAIL(newgrid, 8, 1);
+    READ_OR_FAIL(newgrid.data(), 8, 1);
     newgrid[8] = '\0';
     // Zardus: FIX: make sure they're lowercased
     //buffers: PORT: make sure grid name is lowercase
-    lowercase(newgrid);
-    metadata.grid_file = newgrid;
+    lowercase(newgrid.data());
+    metadata.grid_file = newgrid.data();
     if (!is_safe_virtual_basename(metadata.grid_file, 32))
     {
         LogError("Rejected unsafe scenario grid file name: {}\n",
@@ -289,7 +289,7 @@ bool read_level_body(og::io::OgFile& infile, short version, GameWorld& world,
         }
     }
 
-    const std::string gridpix = ensure_png_extension(newgrid);
+    const std::string gridpix = ensure_png_extension(newgrid.data());
     world.grid = read_pixie_file(gridpix.c_str());
     if (!world.grid.valid())
     {
@@ -371,15 +371,15 @@ bool load_level(const std::string& path,
         return false;
     }
 
-    char header[4] = {};
+    std::array<char, 4> header = {};
     char versionnumber = 0;
-    if (!rw_read_exact_or_log(*infile, header, 1, 3))
+    if (!rw_read_exact_or_log(*infile, header.data(), 1, 3))
     {
         set_error(out_error, LevelFileIoError::ParseFailed);
         return false;
     }
 
-    if (std::string(header, 3) != "FSS")
+    if (std::string(header.data(), 3) != "FSS")
     {
         LogError("File {} is not a valid scenario!\n", path);
         set_error(out_error, LevelFileIoError::InvalidHeader);
@@ -455,21 +455,22 @@ bool write_scenario_payload(og::io::OgFile& outfile,
         return true;
     };
 
-    const char header[3] = {'F', 'S', 'S'};
+    const std::array<char, 3> header = {'F', 'S', 'S'};
     char temp_version = kScenarioVersion;
-    char temp_grid[20] = {};
-    char scentitle[30] = {};
-    char filler[20] = "MSTRMSTRMSTRMSTR";
+    std::array<char, 20> temp_grid = {};
+    std::array<char, 30> scentitle = {};
+    std::array<char, 20> filler = {'M', 'S', 'T', 'R', 'M', 'S', 'T', 'R',
+                                   'M', 'S', 'T', 'R', 'M', 'S', 'T', 'R'};
 
-    if (!write_field(header, 3, 1) || !write_field(&temp_version, 1, 1))
+    if (!write_field(header.data(), 3, 1) || !write_field(&temp_version, 1, 1))
         return false;
 
-    fill_fixed_field(temp_grid, 8, metadata.grid_file, "grid_file");
-    if (!write_field(temp_grid, 8, 1))
+    fill_fixed_field(temp_grid.data(), 8, metadata.grid_file, "grid_file");
+    if (!write_field(temp_grid.data(), 8, 1))
         return false;
 
-    fill_fixed_field(scentitle, 30, world.title, "title");
-    if (!write_field(scentitle, 30, 1))
+    fill_fixed_field(scentitle.data(), 30, world.title, "title");
+    if (!write_field(scentitle.data(), 30, 1))
         return false;
 
     char temp_scen_type = world.type;
@@ -523,8 +524,8 @@ bool write_scenario_payload(og::io::OgFile& outfile,
             char tempfacing = ob->curdir();
             char tempcommand = static_cast<char>(ob->act_type());
             short shortlevel = static_cast<short>(ob->stats()->level());
-            char tempname[12] = {};
-            snprintf(tempname, sizeof(tempname), "%s", ob->stats()->name.c_str());
+            std::array<char, 12> tempname = {};
+            snprintf(tempname.data(), tempname.size(), "%s", ob->stats()->name.c_str());
 
             if (!write_field(&temporder, 1, 1) ||
                 !write_field(&tempfamily, 1, 1) ||
@@ -534,8 +535,8 @@ bool write_scenario_payload(og::io::OgFile& outfile,
                 !write_field(&tempfacing, 1, 1) ||
                 !write_field(&tempcommand, 1, 1) ||
                 !write_field(&shortlevel, 2, 1) ||
-                !write_field(tempname, 12, 1) ||
-                !write_field(filler, 10, 1))
+                !write_field(tempname.data(), 12, 1) ||
+                !write_field(filler.data(), 10, 1))
             {
                 return false;
             }
@@ -719,24 +720,24 @@ LevelFileIoError load_scenario_title_with_error(const char* filename,
     if (!infile)
         return LevelFileIoError::OpenReadFailed;
 
-    char header[4] = {};
+    std::array<char, 4> header = {};
     char versionnumber = 0;
-    char gridname[8] = {};
-    char buffer[31] = {};
+    std::array<char, 8> gridname = {};
+    std::array<char, 31> buffer = {};
 
-    if (!rw_read_exact_or_log(*infile, header, 1, 3))
+    if (!rw_read_exact_or_log(*infile, header.data(), 1, 3))
         return LevelFileIoError::ParseFailed;
-    if (std::string(header, 3) != "FSS")
+    if (std::string(header.data(), 3) != "FSS")
         return LevelFileIoError::InvalidHeader;
     if (!rw_read_exact_or_log(*infile, &versionnumber, 1, 1))
         return LevelFileIoError::ParseFailed;
     if (versionnumber < 6)
         return LevelFileIoError::UnsupportedVersion;
-    if (!rw_read_exact_or_log(*infile, gridname, 1, 8))
+    if (!rw_read_exact_or_log(*infile, gridname.data(), 1, 8))
         return LevelFileIoError::ParseFailed;
-    if (!rw_read_exact_or_log(*infile, buffer, 1, 30))
+    if (!rw_read_exact_or_log(*infile, buffer.data(), 1, 30))
         return LevelFileIoError::ParseFailed;
-    out_title = std::string(buffer);
+    out_title = std::string(buffer.data());
     return LevelFileIoError::None;
 }
 

--- a/src/resources/platform_io.cpp
+++ b/src/resources/platform_io.cpp
@@ -176,10 +176,10 @@ std::string get_asset_path()
     // WASM console with errors at startup. The buffer is bounded and always
     // explicitly null-terminated, so there is no overflow.
     constexpr size_t maxPathSize = 512;
-    char path[maxPathSize];
-    std::fill_n(path, maxPathSize, '\0');
+    std::array<char, maxPathSize> path;
+    std::fill_n(path.data(), maxPathSize, '\0');
 
-    const ssize_t read_len = readlink("/proc/self/exe", path, maxPathSize - 1);
+    const ssize_t read_len = readlink("/proc/self/exe", path.data(), maxPathSize - 1);
     if (read_len < 0)
     {
         LogError("get_asset_path: readlink(/proc/self/exe) failed\n");
@@ -187,7 +187,7 @@ std::string get_asset_path()
     }
     path[static_cast<size_t>(read_len)] = '\0';
 
-    std::string s = path;
+    std::string s = path.data();
     size_t slash = s.find_last_of('/');
     if(slash != std::string::npos)
     {
@@ -423,10 +423,10 @@ NewFileIoError create_new_map_pix_with_error(const std::string& filename, int w,
 
     static thread_local std::mt19937 grass_rng{std::random_device{}()};
     std::uniform_int_distribution<int> grass_dist(0, 3);
-    const unsigned char grass_tiles[] = {PIX_GRASS1, PIX_GRASS2, PIX_GRASS3, PIX_GRASS4};
+    const std::array<unsigned char, 4> grass_tiles = {PIX_GRASS1, PIX_GRASS2, PIX_GRASS3, PIX_GRASS4};
     for(int i = 0; i < size; i++)
     {
-        grid.data[i] = grass_tiles[grass_dist(grass_rng)];
+        grid.data[i] = grass_tiles[static_cast<size_t>(grass_dist(grass_rng))];
     }
 
     if (!write_pixie_png(filename.c_str(), grid))

--- a/src/resources/save_data.cpp
+++ b/src/resources/save_data.cpp
@@ -27,6 +27,7 @@
 #include <openglad/resources/io_common.h>
 #include <openglad/resources/og_file.h>
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <iterator>
@@ -103,13 +104,16 @@ bool SaveData::load(const std::string& filename)
         last_io_error_ = SaveDataIoError::OpenReadFailed;
         return false;
     }
-	char filler[50] = "GTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTL"; // for RESERVED
+	std::array<char, 50> filler = {'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T', 'L',
+		'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T',
+		'L', 'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T', 'L', 'G',
+		'T', 'L', 'G', 'T', 'L'}; // for RESERVED
 
-	char temptext[10] = "GTL";
-	char savedgame[41];
-	std::fill_n(savedgame, std::size(savedgame), '\0');
-	char temp_campaign[41];
-	snprintf(temp_campaign, sizeof(temp_campaign), "org.openglad.gladiator");
+	std::array<char, 10> temptext = {'G', 'T', 'L'};
+	std::array<char, 41> savedgame;
+	std::fill_n(savedgame.data(), savedgame.size(), '\0');
+	std::array<char, 41> temp_campaign;
+	snprintf(temp_campaign.data(), temp_campaign.size(), "org.openglad.gladiator");
 	temp_campaign[40] = '\0';
 	std::uint8_t temp_version = 9;
 	std::uint32_t newcash;
@@ -117,8 +121,8 @@ bool SaveData::load(const std::string& filename)
 	//  short numguys;
 	std::int16_t listsize = 0;
 
-	char tempname[12] = "FRED";
-	char guyname[12] = "JOE";
+	std::array<char, 12> tempname = {'F', 'R', 'E', 'D'};
+	std::array<char, 12> guyname = {'J', 'O', 'E'};
 	std::uint8_t temp_order = 0;
 	char temp_family;
 	std::int16_t temp_str = 0;
@@ -215,8 +219,8 @@ bool SaveData::load(const std::string& filename)
     team_size = 0;
 
 	// Read id header
-	READ_OR_FAIL(temptext, 3, 1);
-	if ( std::string(temptext) != "GTL")
+	READ_OR_FAIL(temptext.data(), 3, 1);
+	if ( std::string(temptext.data()) != "GTL")
 	{
 		LogError("Selected file is not a GTL file: {}\n", filename);
         last_io_error_ = SaveDataIoError::InvalidHeader;
@@ -237,7 +241,7 @@ bool SaveData::load(const std::string& filename)
 		{
 			if (temp_version >= 2)
 			{
-				READ_OR_FAIL(savedgame, 40, 1); // load save name from fixed-width (40-byte) field
+				READ_OR_FAIL(savedgame.data(), 40, 1); // load save name from fixed-width (40-byte) field
 				savedgame[40] = '\0';
 			}
 		else
@@ -247,14 +251,14 @@ bool SaveData::load(const std::string& filename)
 			return 0;
 		}
 	}
-	save_name = savedgame;
+	save_name = savedgame.data();
 
     // Read campaign ID
 	if (temp_version >= 8)
 	{
-		READ_OR_FAIL(temp_campaign, 1, 40);
+		READ_OR_FAIL(temp_campaign.data(), 1, 40);
 		temp_campaign[40] = '\0';
-        const std::string loaded_campaign = temp_campaign;
+        const std::string loaded_campaign = temp_campaign.data();
 		if(loaded_campaign.size() > 3 && is_safe_campaign_id(loaded_campaign))
             current_campaign = loaded_campaign;
         else
@@ -320,7 +324,7 @@ bool SaveData::load(const std::string& filename)
 	numplayers = temp_numplayers;
 
 	// Read the reserved area, 31 bytes
-	READ_OR_FAIL(filler, 31, 1);
+	READ_OR_FAIL(filler.data(), 31, 1);
 
 	// Okay, we've read header .. now read the team list data ..
     for(int i = 0; i < listsize; i++)
@@ -337,12 +341,12 @@ bool SaveData::load(const std::string& filename)
 		// Get temp values to be read
 		temp_order = static_cast<unsigned char>(Order::Living); // may be changed later
 		// Read name of current guy...
-		std::fill_n(guyname, 12, '\0');
-		snprintf(guyname, sizeof(guyname), "%s", tempname);
+		std::fill_n(guyname.data(), 12, '\0');
+		snprintf(guyname.data(), guyname.size(), "%s", tempname.data());
 		// Now write all those values
 		READ_OR_FAIL(&temp_order, 1, 1);
 		READ_OR_FAIL(&temp_family,1, 1);
-		READ_OR_FAIL(guyname, 12, 1);
+		READ_OR_FAIL(guyname.data(), 12, 1);
 		READ_OR_FAIL(&temp_str, 2, 1);
 		READ_OR_FAIL(&temp_dex, 2, 1);
 		READ_OR_FAIL(&temp_con, 2, 1);
@@ -360,12 +364,12 @@ bool SaveData::load(const std::string& filename)
 		READ_OR_FAIL(&temp_teamnum, 2, 1); // team number
 
 		// And the filler
-		READ_OR_FAIL(filler, 8, 1);
+		READ_OR_FAIL(filler.data(), 8, 1);
 			// Now set the values ..
             if (temp_guy_ptr != nullptr)
             {
 			    temp_guy_ptr->family       = temp_family;
-			    temp_guy_ptr->name.assign(guyname, strnlen(guyname, sizeof(guyname)));
+			    temp_guy_ptr->name.assign(guyname.data(), strnlen(guyname.data(), guyname.size()));
 			    temp_guy_ptr->strength     = temp_str;
 			    temp_guy_ptr->dexterity    = temp_dex;
 			    temp_guy_ptr->constitution = temp_con;
@@ -438,7 +442,7 @@ bool SaveData::load(const std::string& filename)
     else
     {
         short num_campaigns = 0;
-        char campaign[41];
+        std::array<char, 41> campaign;
         short num_levels = 0;
         constexpr short kMaxSavedCampaigns = 128;
         constexpr short kMaxSavedLevels = 1000;
@@ -456,11 +460,11 @@ bool SaveData::load(const std::string& filename)
         for(int i = 0; i < num_campaigns; i++)
         {
             // Get the campaign ID (40 chars)
-            READ_OR_FAIL(campaign, 1, 40);
+            READ_OR_FAIL(campaign.data(), 1, 40);
             campaign[40] = '\0';
-            if (!is_safe_campaign_id(campaign))
+            if (!is_safe_campaign_id(campaign.data()))
             {
-                LogError("Rejected unsafe campaign id in save: {}\n", campaign);
+                LogError("Rejected unsafe campaign id in save: {}\n", campaign.data());
                 last_io_error_ = SaveDataIoError::ReadFailed;
                 return false;
             }
@@ -468,7 +472,7 @@ bool SaveData::load(const std::string& filename)
             short index = 1;
             // Get the current level for this campaign
             READ_OR_FAIL(&index, 2, 1);
-            current_levels[campaign] = index;
+            current_levels[campaign.data()] = index;
 
             // Get the number of cleared levels
             READ_OR_FAIL(&num_levels, 2, 1);
@@ -487,7 +491,7 @@ bool SaveData::load(const std::string& filename)
                 READ_OR_FAIL(&index, 2, 1);
 
                 // Add it to our list
-                add_level_completed(campaign, index);
+                add_level_completed(campaign.data(), index);
             }
         }
     }
@@ -663,13 +667,16 @@ bool SaveData::save(const std::string& filename)
         last_io_error_ = SaveDataIoError::OpenWriteFailed;
         return false;
     }
-	char filler[50] = "GTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTLGTL"; // for RESERVED
-	char savedgame[41];
-	std::fill_n(savedgame, std::size(savedgame), '\0');
-	char temp_campaign[41];
-	std::fill_n(temp_campaign, std::size(temp_campaign), '\0');
+	std::array<char, 50> filler = {'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T', 'L',
+		'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T',
+		'L', 'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T', 'L', 'G', 'T', 'L', 'G',
+		'T', 'L', 'G', 'T', 'L'}; // for RESERVED
+	std::array<char, 41> savedgame;
+	std::fill_n(savedgame.data(), savedgame.size(), '\0');
+	std::array<char, 41> temp_campaign;
+	std::fill_n(temp_campaign.data(), temp_campaign.size(), '\0');
 
-	char temptext[10] = "GTL";
+	std::array<char, 10> temptext = {'G', 'T', 'L'};
 	std::uint8_t temp_version = 11;
 
 	std::uint32_t newcash = totalcash;
@@ -677,7 +684,7 @@ bool SaveData::save(const std::string& filename)
 	//  short numguys;
 	std::int16_t listsize = 0;
 
-	char guyname[12] = "JOE";
+	std::array<char, 12> guyname = {'J', 'O', 'E'};
 	std::uint8_t temp_order = 0;
 	char temp_family;
 	std::int16_t temp_str = 0;
@@ -767,7 +774,7 @@ bool SaveData::save(const std::string& filename)
     } while(0)
 
 	// Write id header
-	WRITE_OR_FAIL(temptext, 3, 1);
+	WRITE_OR_FAIL(temptext.data(), 3, 1);
 
 	// Write version number
 	WRITE_OR_FAIL(&temp_version, 1, 1);
@@ -777,8 +784,8 @@ bool SaveData::save(const std::string& filename)
 	WRITE_OR_FAIL(&temp_registered, 2, 1);
 
 	// Write the name
-	snprintf(savedgame, sizeof(savedgame), "%s", save_name.c_str());
-	WRITE_OR_FAIL(savedgame, 40, 1);
+	snprintf(savedgame.data(), savedgame.size(), "%s", save_name.c_str());
+	WRITE_OR_FAIL(savedgame.data(), 40, 1);
 
 	// Write current campaign
     if (!is_safe_campaign_id(current_campaign))
@@ -789,8 +796,8 @@ bool SaveData::save(const std::string& filename)
         return false;
     }
 	Log("Saving campaign status: {}\n", current_campaign);
-	snprintf(temp_campaign, sizeof(temp_campaign), "%s", current_campaign.c_str());
-	WRITE_OR_FAIL(temp_campaign, 40, 1);
+	snprintf(temp_campaign.data(), temp_campaign.size(), "%s", current_campaign.c_str());
+	WRITE_OR_FAIL(temp_campaign.data(), 40, 1);
 
 	// Write scenario number
 	short temp_scenario = scen_num;
@@ -824,7 +831,7 @@ bool SaveData::save(const std::string& filename)
 	WRITE_OR_FAIL(&numplayers_to_save, 1, 1);
 
 	// Write the reserved area, 31 bytes
-	WRITE_OR_FAIL(filler, 31, 1);
+	WRITE_OR_FAIL(filler.data(), 31, 1);
 
 	// Okay, we've written header .. now dump the data ..
 	for(int team_idx = 0; team_idx < team_size; team_idx++)
@@ -835,8 +842,8 @@ bool SaveData::save(const std::string& filename)
         temp_order = static_cast<unsigned char>(Order::Living);
         temp_family= temp_guy->family;
         // Write name of current guy...
-        std::fill_n(guyname, 12, '\0');
-        snprintf(guyname, sizeof(guyname), "%s", temp_guy->name.c_str());
+        std::fill_n(guyname.data(), 12, '\0');
+        snprintf(guyname.data(), guyname.size(), "%s", temp_guy->name.c_str());
         temp_str = temp_guy->strength;
         temp_dex = temp_guy->dexterity;
         temp_con = temp_guy->constitution;
@@ -858,7 +865,7 @@ bool SaveData::save(const std::string& filename)
         // Now write all those values
         WRITE_OR_FAIL(&temp_order, 1, 1);
         WRITE_OR_FAIL(&temp_family,1, 1);
-        WRITE_OR_FAIL(guyname, 12, 1);
+        WRITE_OR_FAIL(guyname.data(), 12, 1);
         WRITE_OR_FAIL(&temp_str, 2, 1);
         WRITE_OR_FAIL(&temp_dex, 2, 1);
         WRITE_OR_FAIL(&temp_con, 2, 1);
@@ -873,7 +880,7 @@ bool SaveData::save(const std::string& filename)
         WRITE_OR_FAIL(&temp_ts, 4, 1);
         WRITE_OR_FAIL(&temp_teamnum, 2, 1);
         // And the filler
-        WRITE_OR_FAIL(filler, 8, 1);
+        WRITE_OR_FAIL(filler.data(), 8, 1);
 	}
 
 	// Write the completed levels
@@ -911,10 +918,10 @@ bool SaveData::save(const std::string& filename)
             return false;
         }
         // Campaign ID
-        char campaign[41];
-        std::fill_n(campaign, std::size(campaign), '\0');
-        snprintf(campaign, sizeof(campaign), "%s", e->first.c_str());
-        WRITE_OR_FAIL(campaign, 1, 40);
+        std::array<char, 41> campaign;
+        std::fill_n(campaign.data(), campaign.size(), '\0');
+        snprintf(campaign.data(), campaign.size(), "%s", e->first.c_str());
+        WRITE_OR_FAIL(campaign.data(), 1, 40);
 
 	        short index = 1;
 	        auto g = current_levels.find(e->first);

--- a/tests/test_input_keybinds.cpp
+++ b/tests/test_input_keybinds.cpp
@@ -249,7 +249,7 @@ TEST(InputKeybinds, native_input_decode_event_covers_non_keyboard_variants)
     SDL_strlcpy(e.text.text, "abc", sizeof(e.text.text));
     ASSERT_TRUE(og::input_native::decode_event(&e, out)) << "decode_event should accept text input";
     ASSERT_EQ((int)og::input_native::EventType::TextInput, (int)out.type) << "text input type should decode";
-    ASSERT_STREQ("abc", out.text) << "text payload should decode";
+    ASSERT_STREQ("abc", out.text.data()) << "text payload should decode";
 
     e = SDL_Event{};
     e.type = SDL_MOUSEWHEEL;


### PR DESCRIPTION
Completes the three deferred modernization refactors. Local `ci-test` build is warning-clean on touched files and full `ctest` is green (43/43, including parity #24 and `emscripten_build_test` #43).

## 1. enum → enum class
`FamilyAnimationType` — the last remaining plain enum (the other 48 enums were already `enum class`) — is now `enum class FamilyAnimationType : std::uint8_t`. The `FamilyDescriptor::animation_type` field, all 21 family `.animation_type = …` designated-initializers, and `gloader.cpp`'s `animation_for_type` dispatch are scoped. Enumerator names/values/order are unchanged; the field is loader-only metadata (never serialized), so pinning the underlying type is behavior-neutral.

## 2. raw new/delete → smart pointers
Audited every `new`/`delete` site. They were **already RAII** and are left intact (with intent comments where useful), because forcing `make_unique`/`make_shared` would be wrong:
- custom-deleter `unique_ptr` (`vbutton`, picker `pixie`) — `make_unique` has no custom-deleter overload;
- private-ctor factory `shared_ptr`/`unique_ptr` (`InProcessTransport`, `LocalCursesSession`/`HostCursesSession`/`JoinCursesSession`) — `make_unique`/`make_shared` cannot reach a private ctor;
- the `sdl_video` factory whose raw owning pointer is adopted into the caller's RAII immediately.

## 3. C-array → std::array (the bulk)
Converted ~50 file-local arrays, `constexpr` lookup tables, and `char` serialization buffers, plus the contained header member arrays:
- **gloader animation tables**: 73 sentinel-terminated leaf tables → `static constexpr std::array<signed char, N>` and 26 pointer-aggregator tables → `std::array<const signed char*, N>` (consumers use `.data()`; pointer identity preserved so the `ani_count` clamp still works). Parity gate (#24) confirms byte-for-byte behavior.
- **serialization buffers** (`level_file_io`, `save_data`, `fuzz/*`): identical `N`, `.data()`/`.size()` at every `fread`/`fwrite`/`memcpy` boundary — byte-exact (level test #18 green).
- **header member arrays**: 768-byte palette buffers, picker report/wiring flag arrays, native-input text, snapshot validation bitmap.

### Deliberately kept as C-arrays (documented, principled)
- Parity-serialized struct members (`CtfState`, `WorldSnapshot`, `FamilyDescriptor` POD stats) — fixed-size + zero-init, already memory-safe; converting is churn in the determinism path with no safety gain.
- The hot input `held[]`/`pressed[]` arrays — 49 cross-file signed-index sites in serialization/parity code.
- 2D keybind/anchor tables.

## Validation
- `cmake --build --preset ci-test`: 0 warnings on touched files.
- `ctest --preset ci-test --repeat until-pass:3`: **43/43 passed**, parity + CTF + level + emscripten + sim all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)