### PR TITLE
Fix 3-player iPad arrow latch: last-press priority, focus reset, key cross-talk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2025,6 +2025,7 @@ _openglad_require_imported_target(\"${OG_IXWEBSOCKET_TARGET}\" \"IXWebSocket\")
             ${CMAKE_SOURCE_DIR}/tests/test_help_smoke.cpp
             ${CMAKE_SOURCE_DIR}/tests/test_input_keybinds.cpp
             ${CMAKE_SOURCE_DIR}/tests/test_input_direction_grace.cpp
+            ${CMAKE_SOURCE_DIR}/tests/test_input_latch.cpp
             ${CMAKE_SOURCE_DIR}/tests/test_walker_pathing.cpp
             ${CMAKE_SOURCE_DIR}/tests/test_external_yaml_more.cpp
             ${CMAKE_SOURCE_DIR}/tests/test_external_physfs_ops.cpp
@@ -2423,6 +2424,7 @@ _openglad_require_imported_target(\"${OG_IXWEBSOCKET_TARGET}\" \"IXWebSocket\")
             test_input.cpp
             test_input_direction_grace.cpp
             test_input_event_dispatch.cpp
+            test_input_latch.cpp
             test_input_joystick.cpp
             test_input_keybinds.cpp
             test_input_more.cpp

--- a/include/openglad/interface/input.h
+++ b/include/openglad/interface/input.h
@@ -586,6 +586,11 @@ void assignKeyFromWaitEvent(int player_num, int key_enum);
 const char* query_key_name(int keycode);
 
 void clear_keyboard();
+// Drops ALL transient held input: SDL keyboard state (via a keyboard
+// reset), the touch held-key seam, and the per-player direction shaping
+// state. Called on window focus/visibility loss, where any release can
+// happen without us ever seeing the event (missed-keyup latch protection).
+void clear_transient_input_state();
 void wait_for_key(int somekey);
 inline short query_key_press_event() { return input_key_press_event_ref(); }
 inline void clear_key_press_event() { input_key_press_event_ref() = 0; }

--- a/include/openglad/interface/input_direction_grace.h
+++ b/include/openglad/interface/input_direction_grace.h
@@ -39,3 +39,43 @@ struct DirectionGraceState
 // deterministic: same timeline of raw masks -> same outputs.
 std::uint8_t coalesce_direction_release(std::uint8_t raw_mask,
                                         DirectionGraceState& state);
+
+// ---------------------------------------------------------------------------
+// Opposite-direction re-assert (missed-keyup resilience).
+//
+// Browsers on some devices swallow keyup events outright — iPad Safari
+// around system gestures and the Globe/Cmd HUD, shared-keyboard mashing —
+// and no later event corrects the record. The sampled keyboard state then
+// keeps the key down forever ("latched"). Because held[] is re-derived from
+// that state every sample, a latched UP alone walks the character up
+// constantly, and a REAL press of the opposite direction nets to zero in
+// PlayerInput::move_x()/move_y(): the whole axis looks dead while the other
+// axis keeps working (the 3-player iPad arrow-seat bug).
+//
+// resolve_opposing_directions() gives the fresh press priority: while both
+// sides of an axis are held, the side whose key rose most recently wins and
+// the stale side is suppressed from the reported mask. Both sides rising in
+// the same sample keep the legacy cancellation; releasing either side ends
+// the conflict; a correctly-delivered keyup behaves exactly as before.
+// Suppression is group-level: a suppressed stale diagonal (e.g. UP_LEFT
+// vs. a fresh DOWN) stops contributing to BOTH axes — it is presumed
+// phantom.
+//
+// This runs in the client input sampling (input_state_from_sdl) BEFORE
+// coalesce_direction_release, so the wire format and the sim are untouched
+// and the result is deterministic per input timeline.
+
+// Per-player conflict state. prev_raw is a bitmask over the eight direction
+// key slots KEY_UP(0)..KEY_UP_LEFT(7) (bit d == key slot d).
+struct DirectionConflictState
+{
+    std::uint8_t prev_raw = 0;  // raw direction mask from the previous sample
+    std::int8_t x_winner = 0;   // -1: left side wins, +1: right side, 0: none
+    std::int8_t y_winner = 0;   // -1: up side wins, +1: down side, 0: none
+};
+
+// Feed one raw direction-key sample; returns the mask to report (the stale
+// opposite side suppressed while a fresher press holds priority). Pure and
+// deterministic: same timeline of raw masks -> same outputs.
+std::uint8_t resolve_opposing_directions(std::uint8_t raw_mask,
+                                         DirectionConflictState& state);

--- a/include/openglad/interface/input_hardware_state.h
+++ b/include/openglad/interface/input_hardware_state.h
@@ -19,6 +19,9 @@ struct InputHardwareState {
     int player_mode_keys[4][2][17]{};  // [player][mode][key] — key dim == NUM_KEYS
     // Diagonal release retention (input_state_from_sdl); per player.
     DirectionGraceState direction_grace[4]{};
+    // Opposite-direction re-assert over stale holds (input_state_from_sdl);
+    // per player.
+    DirectionConflictState direction_conflict[4]{};
     std::int32_t mouse_buttons{0};
     bool picker_was_left_down{false};
     bool picker_was_right_down{false};

--- a/include/openglad/interface/native_input.h
+++ b/include/openglad/interface/native_input.h
@@ -122,6 +122,13 @@ const bool* keyboard_state();
 int scancode_from_key(int keycode);
 const char* key_name(int keycode);
 
+// Clears SDL's keyboard held-state (SDL synthesizes key-up events for every
+// key it believes is down). Used on focus/visibility loss: a release that
+// happened while another window/app had the keys — or that the browser
+// swallowed outright — never reaches us, and the key would stay latched
+// forever. Genuine holds re-assert on the next delivered key events.
+void reset_keyboard_state();
+
 using JoystickHandle = void*;
 int num_joysticks();
 JoystickHandle joystick_open(int index);

--- a/src/interface/input/input.cpp
+++ b/src/interface/input/input.cpp
@@ -1013,10 +1013,30 @@ void clear_keyboard()
     og::runtime::current_session->raw_text_input_.clear();
     
     og::runtime::current_session->input_continue_ = false;
-    
+
     #ifdef USE_TOUCH_INPUT
     hw().tapping = false;
     #endif
+}
+
+//
+// Focus/visibility loss: every "physically held" input we believe in may be
+// stale — the release can go to another window or app and never reach us,
+// and iPad Safari swallows keyups outright around system gestures. Drop all
+// transient held state; genuine holds re-assert on the next delivered
+// events. (This is what un-latches a key whose keyup was missed.)
+//
+void clear_transient_input_state()
+{
+    og::input_native::reset_keyboard_state();
+    for (int p = 0; p < 4; ++p)
+    {
+        hw().direction_grace[p] = {};
+        hw().direction_conflict[p] = {};
+        for (int k = 0; k < NUM_KEYS; ++k)
+            hw().touch_keystate[p][k] = false;
+    }
+    TRACE("input", "transient input cleared (focus/visibility loss)");
 }
 
 void wait_for_key(int somekey)

--- a/src/interface/input/input_state.cpp
+++ b/src/interface/input/input_state.cpp
@@ -162,8 +162,13 @@ constexpr int kDefaultEightDirKeys[4][NUM_KEYS] = {
         KEYCODE_BACKSLASH, KEYCODE_RSHIFT, KEYCODE_2, KEYCODE_F6,
         KEYCODE_RCTRL,                             // Look up (hold)
     },
-    {   // P3: clockwise I/O/L/./,/M/J/U, Yell=K
-        KEYCODE_i, KEYCODE_o, KEYCODE_l, KEYCODE_PERIOD,
+    {   // P3: clockwise I/O/L/?/,/M/J/U, Yell=K. DOWN-RIGHT starts unbound:
+        // its classic '.' is P2's FIRE in BOTH of P2's mode maps, so with
+        // three players on one keyboard P2 firing walked P3's character
+        // down-right (and vice versa). The diagonal still works as the
+        // L+',' (right+down) chord, and a dedicated key can be bound on the
+        // CONTROLS remap screen — the same policy as P4's unbound look-up.
+        KEYCODE_i, KEYCODE_o, KEYCODE_l, KEYCODE_UNKNOWN,
         KEYCODE_COMMA, KEYCODE_m, KEYCODE_j, KEYCODE_u,
         KEYCODE_SPACE, KEYCODE_SEMICOLON,
         KEYCODE_MINUS, KEYCODE_9,
@@ -303,6 +308,7 @@ bool compact_player_controls_after_removal(int removed_player_index, int active_
          player < active_player_count; ++player)
     {
         hw().direction_grace[player] = {};
+        hw().direction_conflict[player] = {};
         for (int k = 0; k < NUM_KEYS; ++k)
             hw().touch_keystate[player][k] = false;
     }
@@ -575,4 +581,71 @@ std::uint8_t coalesce_direction_release(std::uint8_t raw_mask,
         return prev;
     }
     return raw_mask;
+}
+
+// ---------------------------------------------------------------------------
+// Opposite-direction re-assert (see input_direction_grace.h for the
+// contract and the missed-keyup story behind it).
+// ---------------------------------------------------------------------------
+
+namespace
+{
+// The direction-key groups contributing to each half of each axis — the
+// same decode rules as PlayerInput::move_x()/move_y() above.
+constexpr std::uint8_t kUpSideMask =
+    static_cast<std::uint8_t>((1u << static_cast<int>(InputKey::Up)) |
+                              (1u << static_cast<int>(InputKey::UpLeft)) |
+                              (1u << static_cast<int>(InputKey::UpRight)));
+constexpr std::uint8_t kDownSideMask =
+    static_cast<std::uint8_t>((1u << static_cast<int>(InputKey::Down)) |
+                              (1u << static_cast<int>(InputKey::DownLeft)) |
+                              (1u << static_cast<int>(InputKey::DownRight)));
+constexpr std::uint8_t kLeftSideMask =
+    static_cast<std::uint8_t>((1u << static_cast<int>(InputKey::Left)) |
+                              (1u << static_cast<int>(InputKey::UpLeft)) |
+                              (1u << static_cast<int>(InputKey::DownLeft)));
+constexpr std::uint8_t kRightSideMask =
+    static_cast<std::uint8_t>((1u << static_cast<int>(InputKey::Right)) |
+                              (1u << static_cast<int>(InputKey::UpRight)) |
+                              (1u << static_cast<int>(InputKey::DownRight)));
+
+// One axis: while both sides are held, the side with the most recent rising
+// edge wins; a same-sample tie keeps the legacy cancellation (0); no
+// conflict means no priority. `previous` carries the winner across samples
+// where neither side has a fresh edge.
+std::int8_t axis_conflict_winner(std::uint8_t raw_mask, std::uint8_t rose,
+                                 std::uint8_t neg_side, std::uint8_t pos_side,
+                                 std::int8_t previous)
+{
+    if ((raw_mask & neg_side) == 0 || (raw_mask & pos_side) == 0)
+        return 0;
+    const bool neg_rose = (rose & neg_side) != 0;
+    const bool pos_rose = (rose & pos_side) != 0;
+    if (neg_rose == pos_rose)
+        return neg_rose ? std::int8_t{0} : previous;
+    return neg_rose ? std::int8_t{-1} : std::int8_t{1};
+}
+} // namespace
+
+std::uint8_t resolve_opposing_directions(std::uint8_t raw_mask,
+                                         DirectionConflictState& state)
+{
+    const std::uint8_t rose =
+        static_cast<std::uint8_t>(raw_mask & static_cast<std::uint8_t>(~state.prev_raw));
+    state.y_winner = axis_conflict_winner(
+        raw_mask, rose, kUpSideMask, kDownSideMask, state.y_winner);
+    state.x_winner = axis_conflict_winner(
+        raw_mask, rose, kLeftSideMask, kRightSideMask, state.x_winner);
+    state.prev_raw = raw_mask;
+
+    std::uint8_t out = raw_mask;
+    if (state.y_winner < 0)
+        out = static_cast<std::uint8_t>(out & static_cast<std::uint8_t>(~kDownSideMask));
+    else if (state.y_winner > 0)
+        out = static_cast<std::uint8_t>(out & static_cast<std::uint8_t>(~kUpSideMask));
+    if (state.x_winner < 0)
+        out = static_cast<std::uint8_t>(out & static_cast<std::uint8_t>(~kRightSideMask));
+    else if (state.x_winner > 0)
+        out = static_cast<std::uint8_t>(out & static_cast<std::uint8_t>(~kLeftSideMask));
+    return out;
 }

--- a/src/interface/sdl_context_services.cpp
+++ b/src/interface/sdl_context_services.cpp
@@ -55,18 +55,26 @@ void input_state_from_sdl(InputState& out)
                 input_hw.touch_keystate[p][KEY_UP_LEFT];
         }
 
-        // Diagonal release retention: a sloppy two-key diagonal release
-        // (one key clearing 1-3 samples before the other) keeps reporting
-        // the diagonal for a short grace window so the control walker's
-        // facing does not snap to the surviving cardinal. Client-side
-        // shaping only — the InputState wire format and the sim are
-        // untouched. See input_direction_grace.h.
+        // Two client-side direction shapers; the InputState wire format and
+        // the sim are untouched. See input_direction_grace.h for both
+        // contracts.
+        //
+        // 1. Opposite-direction re-assert: a fresh press must beat a STALE
+        //    opposite hold. A browser-swallowed keyup (iPad Safari around
+        //    system gestures) otherwise latches the old direction forever
+        //    and every real opposite press nets the axis to zero.
+        // 2. Diagonal release retention: a sloppy two-key diagonal release
+        //    (one key clearing 1-3 samples before the other) keeps
+        //    reporting the diagonal for a short grace window so the control
+        //    walker's facing does not snap to the surviving cardinal.
         std::uint8_t raw_mask = 0;
         for (int d = KEY_UP; d <= KEY_UP_LEFT; d++)
             if (out.players[p].held[d])
                 raw_mask = static_cast<std::uint8_t>(raw_mask | (1u << d));
+        const std::uint8_t resolved = resolve_opposing_directions(
+            raw_mask, input_hardware_state().direction_conflict[p]);
         const std::uint8_t shaped = coalesce_direction_release(
-            raw_mask, input_hardware_state().direction_grace[p]);
+            resolved, input_hardware_state().direction_grace[p]);
         if (shaped != raw_mask)
             for (int d = KEY_UP; d <= KEY_UP_LEFT; d++)
                 out.players[p].held[d] = (shaped & (1u << d)) != 0;

--- a/src/platform/sdl/input_event_bridge.cpp
+++ b/src/platform/sdl/input_event_bridge.cpp
@@ -147,6 +147,17 @@ void handle_window_event(const void* native_event)
                 reapply_world_zoom_after_window_change(*s);
             }
             break;
+        case SDL_EVENT_WINDOW_FOCUS_LOST:
+        case SDL_EVENT_WINDOW_HIDDEN:
+            // A key released while focus is elsewhere (or while the page is
+            // hidden — on the web, visibilitychange delivers only HIDDEN
+            // and SDL's own blur-time keyboard reset never runs) would
+            // never reach us: the key would stay latched and, if it is a
+            // direction, walk that player's character forever. Drop all
+            // transient held input; genuine holds re-assert on the next
+            // delivered key events.
+            clear_transient_input_state();
+            break;
     }
 }
 

--- a/src/platform/sdl/native_input.cpp
+++ b/src/platform/sdl/native_input.cpp
@@ -444,6 +444,16 @@ int scancode_from_key(int keycode)
     return static_cast<int>(SDL_GetScancodeFromKey(static_cast<SDL_Keycode>(keycode), nullptr));
 }
 
+void reset_keyboard_state()
+{
+    SDL_ResetKeyboard();
+#ifdef __EMSCRIPTEN__
+    // The mirror follows SDL's array through key events; a reset must be
+    // visible to keystate consumers before the next pump as well.
+    refresh_web_keyboard_state();
+#endif
+}
+
 const char* key_name(int keycode)
 {
     return SDL_GetKeyName(static_cast<SDL_Keycode>(keycode));

--- a/tests/test_input_latch.cpp
+++ b/tests/test_input_latch.cpp
@@ -1,0 +1,663 @@
+// Missed-keyup latch resilience (the 3-player iPad arrow-key bug).
+//
+// User repro, real device: 3-player split-screen in the browser build on an
+// iPad with a shared hardware keyboard. The arrow-key seat's UP and DOWN
+// stop responding after a while (LEFT/RIGHT keep working); separately the
+// same seat was once seen stuck walking UP with no key held.
+//
+// Mechanism (one bug, two moments): iPad Safari can swallow a keyup (system
+// gestures, the Globe/Cmd HUD, shared-keyboard mashing). SDL's keyboard-state
+// array then keeps the scancode down forever, and held[] is re-derived from
+// that array every sample, so:
+//   - a latched UP alone     -> constant walkstep(0,-1): "stuck walking up";
+//   - latched UP + real DOWN -> PlayerInput::move_y() nets -1+1 == 0: DOWN
+//     looks dead, and re-pressing UP changes nothing (state already down),
+//     so UP looks dead too;
+//   - LEFT/RIGHT live on the independent X axis: they keep working.
+//
+// These tests pin the two recovery behaviors:
+//   1. last-press priority: a fresh opposite press must win over a stale
+//      opposite hold instead of netting to zero (both axes), while
+//      correctly-delivered keyups and simultaneous-press cancellation keep
+//      their existing semantics;
+//   2. focus/visibility loss clears all transient input (SDL keyboard state,
+//      the touch seam, direction shaping state).
+//
+// The keystate timelines poke SDL's real keyboard-state array (the exact
+// state a swallowed browser keyup leaves behind) and sample through the real
+// input_state_from_sdl pipeline.
+
+#include <openglad/gameplay/input_state.h>
+#include <openglad/gameplay/sim_input_handler.h>
+#include <openglad/gameplay/sim_event_log.h>
+#include <openglad/gameplay/walker.h>
+#include <openglad/gameplay/statistics.h>
+#include <openglad/gameplay/guy.h>
+#include <openglad/interface/game_context.h>
+#include <openglad/interface/input.h>
+#include <openglad/interface/input_direction_grace.h>
+#include <openglad/interface/native_input.h>
+#include <openglad/interface/screen.h>
+#include <openglad/interface/session_state.h>
+#include <openglad/platform/game_session.h>
+#include <openglad/resources/gloader.h>
+#include <openglad/legacy/base.h>
+#include <gtest/gtest.h>
+#include <SDL3/SDL.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace
+{
+// Borrowed from test_input_keybinds.cpp: scoped raw SDL keyboard state poke.
+// set(true) with no later set(false) is EXACTLY the state a swallowed
+// browser keyup leaves behind: SDL believes the key is still down.
+struct KeyStateGuard
+{
+    SDL_Scancode sc;
+    bool old_value;
+    int numkeys;
+    bool* keys;
+
+    explicit KeyStateGuard(SDL_Scancode sc_)
+        : sc(sc_), old_value(false), numkeys(0), keys(nullptr)
+    {
+        const bool* read_only = SDL_GetKeyboardState(&numkeys);
+        keys = const_cast<bool*>(read_only);
+        if (keys && sc >= 0 && sc < numkeys)
+            old_value = keys[sc];
+    }
+
+    void set(bool pressed)
+    {
+        if (keys && sc >= 0 && sc < numkeys)
+            keys[sc] = pressed;
+    }
+
+    ~KeyStateGuard()
+    {
+        if (keys && sc >= 0 && sc < numkeys)
+            keys[sc] = old_value;
+    }
+};
+
+struct KeyBindingGuard
+{
+    int player;
+    int key_enum;
+    int old;
+
+    KeyBindingGuard(int player_, int key_enum_, int new_key)
+        : player(player_), key_enum(key_enum_),
+          old(og::runtime::current_session->player_keys_[player_][key_enum_])
+    {
+        og::runtime::current_session->player_keys_[player][key_enum] = new_key;
+    }
+
+    ~KeyBindingGuard()
+    {
+        og::runtime::current_session->player_keys_[player][key_enum] = old;
+    }
+};
+
+struct ControlModeGuard
+{
+    int player;
+    int old_mode;
+
+    explicit ControlModeGuard(int player_)
+        : player(player_), old_mode(get_player_control_mode(player_))
+    {}
+
+    ~ControlModeGuard()
+    {
+        set_player_control_mode(player, old_mode);
+    }
+};
+
+// Zeroes the per-player direction shaping state on entry and exit so
+// scripted timelines are deterministic and no state leaks between tests.
+struct GraceStateGuard
+{
+    GraceStateGuard() { reset(); }
+    ~GraceStateGuard() { reset(); }
+    static void reset()
+    {
+        for (auto& g : input_hardware_state().direction_grace)
+            g = DirectionGraceState{};
+    }
+};
+
+// Clears the touch-overlay held-key seam on scope exit.
+struct TouchKeystateGuard
+{
+    ~TouchKeystateGuard()
+    {
+        InputHardwareState& hw = input_hardware_state();
+        for (int p = 0; p < 4; ++p)
+            for (int k = 0; k < NUM_KEYS; ++k)
+                hw.touch_keystate[p][k] = false;
+    }
+};
+
+// Borrowed from test_input_keybinds.cpp: snapshot/restore of the complete
+// per-player control configuration (used by the tests that reset to factory
+// defaults).
+struct FullControlSnapshotGuard
+{
+    int modes[4];
+    int default_profiles[4];
+    int mode4[4][NUM_KEYS];
+    int mode8[4][NUM_KEYS];
+    int active[4][NUM_KEYS];
+    JoyData joy[4];
+    DirectionGraceState direction_grace[4];
+    bool touch_keystate[4][NUM_KEYS];
+
+    FullControlSnapshotGuard()
+    {
+        InputHardwareState& hw = input_hardware_state();
+        for (int p = 0; p < 4; ++p)
+        {
+            modes[p] = get_player_control_mode(p);
+            default_profiles[p] = hw.player_control_default_profiles[p];
+            joy[p] = player_joy[p];
+            direction_grace[p] = hw.direction_grace[p];
+            for (int k = 0; k < NUM_KEYS; ++k)
+            {
+                mode4[p][k] = get_player_key_binding_for_mode(
+                    p, static_cast<int>(ControlDirectionMode::FourDirection), k);
+                mode8[p][k] = get_player_key_binding_for_mode(
+                    p, static_cast<int>(ControlDirectionMode::EightDirection), k);
+                active[p][k] =
+                    og::runtime::current_session->player_keys_[p][k];
+                touch_keystate[p][k] = hw.touch_keystate[p][k];
+            }
+        }
+    }
+
+    void restore()
+    {
+        InputHardwareState& hw = input_hardware_state();
+        for (int p = 0; p < 4; ++p)
+        {
+            hw.player_control_default_profiles[p] = default_profiles[p];
+            set_player_control_mode(p, static_cast<int>(ControlDirectionMode::FourDirection));
+            for (int k = 0; k < NUM_KEYS; ++k)
+                set_player_key_binding(p, k, mode4[p][k]);
+            set_player_control_mode(p, static_cast<int>(ControlDirectionMode::EightDirection));
+            for (int k = 0; k < NUM_KEYS; ++k)
+                set_player_key_binding(p, k, mode8[p][k]);
+            set_player_control_mode(p, modes[p]);
+            for (int k = 0; k < NUM_KEYS; ++k)
+            {
+                og::runtime::current_session->player_keys_[p][k] = active[p][k];
+                hw.touch_keystate[p][k] = touch_keystate[p][k];
+            }
+            player_joy[p] = joy[p];
+            hw.direction_grace[p] = direction_grace[p];
+        }
+    }
+
+    ~FullControlSnapshotGuard() { restore(); }
+};
+
+SDL_Scancode scan_of(SDL_Keycode key)
+{
+    return SDL_GetScancodeFromKey(key, nullptr);
+}
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Last-press priority over a stale opposite hold (the recovery the iPad
+// player needs when a keyup was swallowed and no focus event will arrive).
+// ---------------------------------------------------------------------------
+
+TEST(InputLatch, fresh_down_press_beats_stale_up_latch_full_arc)
+{
+    disablePlayerJoystick(0);
+    GraceStateGuard grace;
+    ControlModeGuard mode_guard(0);
+    set_player_control_mode(0, static_cast<int>(ControlDirectionMode::FourDirection));
+    KeyBindingGuard bind_up(0, KEY_UP, SDLK_W);
+    KeyBindingGuard bind_down(0, KEY_DOWN, SDLK_S);
+
+    KeyStateGuard ks_w(scan_of(SDLK_W));
+    KeyStateGuard ks_s(scan_of(SDLK_S));
+    ks_w.set(false);
+    ks_s.set(false);
+
+    InputState input{};
+    input.clear();
+    input_state_from_sdl(input); // settle: all released
+
+    // UP goes down; its keyup is swallowed (ks_w is never set false below
+    // until the very end). The character walks up every sample: the
+    // observed "stuck walking up" moment.
+    ks_w.set(true);
+    for (int t = 0; t < 3; ++t)
+    {
+        input_state_from_sdl(input);
+        ASSERT_EQ(-1, input.players[0].move_y())
+            << "latched UP alone must walk up (stuck-walking-up shape), tick " << t;
+        ASSERT_EQ(0, input.players[0].move_x());
+    }
+
+    // The player presses DOWN (a real, delivered keydown). Today this nets
+    // -1+1 == 0 — "DOWN is dead". A fresh press must beat the stale hold.
+    ks_s.set(true);
+    input_state_from_sdl(input);
+    ASSERT_EQ(1, input.players[0].move_y())
+        << "fresh DOWN press must override the stale UP latch, not cancel";
+    ASSERT_TRUE(input.players[0].pressed[KEY_DOWN])
+        << "the fresh DOWN press should edge normally";
+
+    // Priority persists while DOWN stays physically held.
+    for (int t = 0; t < 3; ++t)
+    {
+        input_state_from_sdl(input);
+        ASSERT_EQ(1, input.players[0].move_y())
+            << "DOWN must keep winning while held, tick " << t;
+    }
+
+    // DOWN released (delivered keyup): the stale UP latch resumes walking
+    // up. That residual is expected — it is healed by the focus-loss reset
+    // or the web shell's stale-key release, not by this layer.
+    ks_s.set(false);
+    input_state_from_sdl(input);
+    ASSERT_EQ(-1, input.players[0].move_y())
+        << "with only the stale UP left, the latch resumes (documented residual)";
+
+    // Re-asserting DOWN works every time.
+    ks_s.set(true);
+    input_state_from_sdl(input);
+    ASSERT_EQ(1, input.players[0].move_y())
+        << "re-pressing DOWN must re-assert priority";
+
+    // The swallowed UP keyup finally arrives (delivered): normal keyup
+    // semantics — DOWN, still held, keeps moving down.
+    ks_w.set(false);
+    input_state_from_sdl(input);
+    ASSERT_EQ(1, input.players[0].move_y())
+        << "a delivered UP keyup must leave the held DOWN in effect";
+
+    ks_s.set(false);
+    input_state_from_sdl(input);
+    ASSERT_EQ(0, input.players[0].move_y());
+}
+
+TEST(InputLatch, fresh_up_press_beats_stale_down_latch)
+{
+    disablePlayerJoystick(0);
+    GraceStateGuard grace;
+    ControlModeGuard mode_guard(0);
+    set_player_control_mode(0, static_cast<int>(ControlDirectionMode::FourDirection));
+    KeyBindingGuard bind_up(0, KEY_UP, SDLK_W);
+    KeyBindingGuard bind_down(0, KEY_DOWN, SDLK_S);
+
+    KeyStateGuard ks_w(scan_of(SDLK_W));
+    KeyStateGuard ks_s(scan_of(SDLK_S));
+    ks_w.set(false);
+    ks_s.set(false);
+
+    InputState input{};
+    input.clear();
+    input_state_from_sdl(input);
+
+    ks_s.set(true); // DOWN latches (keyup swallowed)
+    for (int t = 0; t < 3; ++t)
+    {
+        input_state_from_sdl(input);
+        ASSERT_EQ(1, input.players[0].move_y());
+    }
+
+    ks_w.set(true); // fresh UP press
+    input_state_from_sdl(input);
+    ASSERT_EQ(-1, input.players[0].move_y())
+        << "fresh UP press must override the stale DOWN latch";
+}
+
+TEST(InputLatch, x_axis_priority_and_cross_axis_independence)
+{
+    disablePlayerJoystick(0);
+    GraceStateGuard grace;
+    ControlModeGuard mode_guard(0);
+    set_player_control_mode(0, static_cast<int>(ControlDirectionMode::FourDirection));
+    KeyBindingGuard bind_up(0, KEY_UP, SDLK_W);
+    KeyBindingGuard bind_left(0, KEY_LEFT, SDLK_A);
+    KeyBindingGuard bind_right(0, KEY_RIGHT, SDLK_D);
+
+    KeyStateGuard ks_w(scan_of(SDLK_W));
+    KeyStateGuard ks_a(scan_of(SDLK_A));
+    KeyStateGuard ks_d(scan_of(SDLK_D));
+    ks_w.set(false);
+    ks_a.set(false);
+    ks_d.set(false);
+
+    InputState input{};
+    input.clear();
+    input_state_from_sdl(input);
+
+    // The same latch on the X axis: LEFT stuck, fresh RIGHT must win.
+    ks_a.set(true); // LEFT latches
+    for (int t = 0; t < 3; ++t)
+    {
+        input_state_from_sdl(input);
+        ASSERT_EQ(-1, input.players[0].move_x());
+    }
+    ks_d.set(true); // fresh RIGHT press
+    input_state_from_sdl(input);
+    ASSERT_EQ(1, input.players[0].move_x())
+        << "fresh RIGHT press must override the stale LEFT latch";
+    ks_d.set(false);
+    ks_a.set(false);
+    input_state_from_sdl(input);
+    ASSERT_EQ(0, input.players[0].move_x());
+
+    // Cross-axis independence: while UP is latched, LEFT/RIGHT keep
+    // working (the reported symptom's other half).
+    ks_w.set(true); // UP latches
+    input_state_from_sdl(input);
+    ASSERT_EQ(-1, input.players[0].move_y());
+    ks_d.set(true); // RIGHT pressed: rides the stuck UP as a diagonal
+    input_state_from_sdl(input);
+    ASSERT_EQ(1, input.players[0].move_x())
+        << "X axis must stay live while UP is latched";
+    ASSERT_EQ(-1, input.players[0].move_y());
+}
+
+TEST(InputLatch, simultaneous_opposite_presses_still_cancel)
+{
+    // Legacy semantics pin: two genuinely simultaneous opposite presses
+    // (same sample) cancel, exactly as before the latch fix — priority only
+    // engages when one side is fresh and the other stale.
+    disablePlayerJoystick(0);
+    GraceStateGuard grace;
+    ControlModeGuard mode_guard(0);
+    set_player_control_mode(0, static_cast<int>(ControlDirectionMode::FourDirection));
+    KeyBindingGuard bind_up(0, KEY_UP, SDLK_W);
+    KeyBindingGuard bind_down(0, KEY_DOWN, SDLK_S);
+
+    KeyStateGuard ks_w(scan_of(SDLK_W));
+    KeyStateGuard ks_s(scan_of(SDLK_S));
+    ks_w.set(false);
+    ks_s.set(false);
+
+    InputState input{};
+    input.clear();
+    input_state_from_sdl(input);
+
+    ks_w.set(true);
+    ks_s.set(true); // both rise in the same sample
+    for (int t = 0; t < 3; ++t)
+    {
+        input_state_from_sdl(input);
+        ASSERT_EQ(0, input.players[0].move_y())
+            << "simultaneous opposite presses must cancel, tick " << t;
+    }
+
+    // A correctly-delivered keyup then leaves the survivor in effect.
+    ks_w.set(false);
+    input_state_from_sdl(input);
+    ASSERT_EQ(1, input.players[0].move_y())
+        << "releasing UP must leave the held DOWN walking";
+    ks_s.set(false);
+    input_state_from_sdl(input);
+    ASSERT_EQ(0, input.players[0].move_y());
+}
+
+TEST(InputLatch, arrow_seat_default_bindings_recover_up_down)
+{
+    // The reported seat exactly: seat index 1 (P2) whose factory default
+    // profile is the arrow cluster. UP's keyup is swallowed; DOWN must
+    // still respond on the real default bindings.
+    FullControlSnapshotGuard controls;
+    reset_default_player_controls();
+    disablePlayerJoystick(1);
+    GraceStateGuard grace;
+    TouchKeystateGuard touch;
+
+    KeyStateGuard ks_up(scan_of(SDLK_UP));
+    KeyStateGuard ks_down(scan_of(SDLK_DOWN));
+    ks_up.set(false);
+    ks_down.set(false);
+
+    InputState input{};
+    input.clear();
+    input_state_from_sdl(input);
+
+    ks_up.set(true); // UP latches (keyup swallowed)
+    for (int t = 0; t < 3; ++t)
+    {
+        input_state_from_sdl(input);
+        ASSERT_EQ(-1, input.players[1].move_y())
+            << "arrow seat: latched UP walks up, tick " << t;
+    }
+
+    ks_down.set(true); // the player hammers DOWN
+    input_state_from_sdl(input);
+    ASSERT_EQ(1, input.players[1].move_y())
+        << "arrow seat: fresh DOWN must recover control from the stale UP";
+}
+
+// ---------------------------------------------------------------------------
+// Focus/visibility loss clears transient input (the other recovery path:
+// system gestures and app switches that DO produce a window event).
+// ---------------------------------------------------------------------------
+
+namespace
+{
+void send_window_event(Uint32 type)
+{
+    SDL_Event event;
+    SDL_memset(&event, 0, sizeof(event));
+    event.type = type;
+    handle_window_event(static_cast<const void*>(&event));
+}
+} // namespace
+
+TEST(InputLatch, focus_loss_clears_latched_keyboard_touch_and_grace)
+{
+    disablePlayerJoystick(0);
+    GraceStateGuard grace;
+    ControlModeGuard mode_guard(0);
+    set_player_control_mode(0, static_cast<int>(ControlDirectionMode::FourDirection));
+    KeyBindingGuard bind_up(0, KEY_UP, SDLK_W);
+    TouchKeystateGuard touch;
+
+    KeyStateGuard ks_w(scan_of(SDLK_W));
+    ks_w.set(false);
+
+    InputState input{};
+    input.clear();
+    input_state_from_sdl(input);
+
+    // Latch UP, hold FIRE on the touch seam, and give the direction-grace
+    // shaper some retained state.
+    ks_w.set(true);
+    input_state_from_sdl(input);
+    ASSERT_TRUE(input.players[0].held[KEY_UP]);
+    input_hardware_state().touch_keystate[0][KEY_FIRE] = true;
+    input_hardware_state().direction_grace[0].hold_mask = 0x03;
+    input_hardware_state().direction_grace[0].ticks_left = 2;
+
+    send_window_event(SDL_EVENT_WINDOW_FOCUS_LOST);
+
+    ASSERT_TRUE(!isPlayerHoldingKey(0, KEY_UP))
+        << "focus loss must clear SDL's latched keyboard state";
+    ASSERT_TRUE(!input_hardware_state().touch_keystate[0][KEY_FIRE])
+        << "focus loss must clear the touch held-key seam";
+    ASSERT_EQ(0, static_cast<int>(input_hardware_state().direction_grace[0].hold_mask))
+        << "focus loss must drop direction-grace retention";
+
+    input_state_from_sdl(input);
+    ASSERT_TRUE(!input.players[0].held[KEY_UP])
+        << "after focus loss nothing should be reported held";
+    ASSERT_EQ(0, input.players[0].move_y());
+}
+
+TEST(InputLatch, visibility_hidden_clears_latched_keyboard)
+{
+    disablePlayerJoystick(0);
+    GraceStateGuard grace;
+    ControlModeGuard mode_guard(0);
+    set_player_control_mode(0, static_cast<int>(ControlDirectionMode::FourDirection));
+    KeyBindingGuard bind_up(0, KEY_UP, SDLK_W);
+
+    KeyStateGuard ks_w(scan_of(SDLK_W));
+    ks_w.set(false);
+
+    InputState input{};
+    input.clear();
+    input_state_from_sdl(input);
+
+    ks_w.set(true);
+    input_state_from_sdl(input);
+    ASSERT_TRUE(input.players[0].held[KEY_UP]);
+
+    // On the web, visibilitychange delivers only HIDDEN (no blur, so SDL's
+    // own blur-reset never runs). The app must clear held state itself.
+    send_window_event(SDL_EVENT_WINDOW_HIDDEN);
+
+    input_state_from_sdl(input);
+    ASSERT_TRUE(!input.players[0].held[KEY_UP])
+        << "WINDOW_HIDDEN must clear latched keyboard state";
+    ASSERT_EQ(0, input.players[0].move_y());
+}
+
+// ---------------------------------------------------------------------------
+// Sim linkage: the latched-UP walker really walks, and the DOWN re-assert
+// really turns the walk around (walkstep intent via lastx/lasty).
+// ---------------------------------------------------------------------------
+
+TEST(InputLatch, sim_stuck_walking_up_recovers_on_down_press)
+{
+    loader* l = og::runtime::current_session->myscreen_->myloader;
+    ASSERT_TRUE(l != nullptr);
+    auto w = l->create_walker_owned(Order::Living, FAMILY_SOLDIER);
+    ASSERT_TRUE(w != nullptr);
+    w->set_team_num(0);
+    w->set_real_team_num(255);
+    w->set_dead(0);
+    w->set_user(0);
+    w->setxy(100, 100);
+    w->set_act_type(ACT_CONTROL);
+    walker* control = w.get();
+    og::runtime::current_session->myscreen_->world().oblist.push_back(std::move(w));
+
+    disablePlayerJoystick(0);
+    GraceStateGuard grace;
+    ControlModeGuard mode_guard(0);
+    set_player_control_mode(0, static_cast<int>(ControlDirectionMode::FourDirection));
+    KeyBindingGuard bind_up(0, KEY_UP, SDLK_W);
+    KeyBindingGuard bind_down(0, KEY_DOWN, SDLK_S);
+
+    KeyStateGuard ks_w(scan_of(SDLK_W));
+    KeyStateGuard ks_s(scan_of(SDLK_S));
+    ks_w.set(false);
+    ks_s.set(false);
+
+    InputState input{};
+    input.clear();
+    input_state_from_sdl(input);
+
+    SimInputDebounce debounce = {};
+    std::string special_names[NUM_FAMILIES][NUM_SPECIALS];
+    og::sim::SimEventLog log;
+
+    // Latched UP: the sim walks the character up (stuck-walking-up).
+    ks_w.set(true);
+    input_state_from_sdl(input);
+    sim_process_player_input(
+        input.players[0], control, og::runtime::current_session->myscreen_->world(),
+        0, 0, debounce, special_names, &log);
+    ASSERT_TRUE(control->lasty() < 0.0f)
+        << "latched UP must produce an upward walkstep";
+
+    // The player presses DOWN. Today move_y() nets to 0, walkstep is never
+    // called, and the character just stands: "DOWN is dead".
+    control->set_lastx(0.0f);
+    control->set_lasty(0.0f);
+    ks_s.set(true);
+    input_state_from_sdl(input);
+    sim_process_player_input(
+        input.players[0], control, og::runtime::current_session->myscreen_->world(),
+        0, 0, debounce, special_names, &log);
+    ASSERT_TRUE(control->lasty() > 0.0f)
+        << "fresh DOWN must walk the character down despite the stale UP latch";
+
+    if (og::runtime::current_session->myscreen_)
+        og::runtime::current_session->myscreen_->world().delete_objects();
+}
+
+// ---------------------------------------------------------------------------
+// Factory default keymaps: no cross-player key collisions. On a shared
+// keyboard every player's bindings are live at once (modes are per-player,
+// so any 4-dir/8-dir combination can be active). A shared keycode makes one
+// player's action drive another player's character.
+// ---------------------------------------------------------------------------
+
+TEST(InputKeybindDefaults, no_undocumented_cross_player_default_key_collisions)
+{
+    FullControlSnapshotGuard controls;
+    reset_default_player_controls();
+
+    struct Binding
+    {
+        int player;
+        int mode;
+        int key_enum;
+        int keycode;
+    };
+    std::vector<Binding> bindings;
+    const int kModes[2] = {
+        static_cast<int>(ControlDirectionMode::FourDirection),
+        static_cast<int>(ControlDirectionMode::EightDirection),
+    };
+    for (int p = 0; p < 4; ++p)
+        for (int mode : kModes)
+            for (int k = 0; k < NUM_KEYS; ++k)
+            {
+                const int kc = get_player_key_binding_for_mode(p, mode, k);
+                if (kc != KEYCODE_UNKNOWN)
+                    bindings.push_back(Binding{p, mode, k, kc});
+            }
+
+    // The single documented exemption: P1's look-up hold 'v' (present in
+    // both of P1's mode maps) overlaps P4's 8-direction DOWN-LEFT 'v' — a
+    // known pre-existing quirk (see the KEY_LOOKUP default comment in
+    // input_state.cpp). Everything else must be unique across players.
+    const auto is_documented_v_quirk = [](const Binding& a, const Binding& b) {
+        const auto matches = [](const Binding& p1, const Binding& p4) {
+            return p1.player == 0 && p1.key_enum == KEY_LOOKUP &&
+                   p1.keycode == KEYCODE_v &&
+                   p4.player == 3 && p4.key_enum == KEY_DOWN_LEFT &&
+                   p4.mode == static_cast<int>(ControlDirectionMode::EightDirection) &&
+                   p4.keycode == KEYCODE_v;
+        };
+        return matches(a, b) || matches(b, a);
+    };
+
+    for (std::size_t i = 0; i < bindings.size(); ++i)
+        for (std::size_t j = i + 1; j < bindings.size(); ++j)
+        {
+            const Binding& a = bindings[i];
+            const Binding& b = bindings[j];
+            if (a.player == b.player || a.keycode != b.keycode)
+                continue;
+            if (is_documented_v_quirk(a, b))
+                continue;
+            ADD_FAILURE()
+                << "cross-player default key collision: key '"
+                << og::input_native::key_name(a.keycode)
+                << "' (keycode " << a.keycode << ") is player "
+                << (a.player + 1) << " mode " << a.mode << " key-slot "
+                << a.key_enum << " AND player " << (b.player + 1)
+                << " mode " << b.mode << " key-slot " << b.key_enum
+                << " — one player's press drives another player's character "
+                << "on a shared keyboard";
+        }
+}

--- a/tests/test_input_latch.cpp
+++ b/tests/test_input_latch.cpp
@@ -594,6 +594,105 @@ TEST(InputLatch, sim_stuck_walking_up_recovers_on_down_press)
 }
 
 // ---------------------------------------------------------------------------
+// Pure resolver timelines (resolve_opposing_directions), including the
+// group semantics the end-to-end samples cannot isolate: diagonal keys are
+// suppressed with their whole side, and any key of a side re-asserts it.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+constexpr std::uint8_t bit_of(int key_slot)
+{
+    return static_cast<std::uint8_t>(1u << key_slot);
+}
+constexpr std::uint8_t kUpBit = bit_of(KEY_UP);
+constexpr std::uint8_t kDownBit = bit_of(KEY_DOWN);
+constexpr std::uint8_t kLeftBit = bit_of(KEY_LEFT);
+constexpr std::uint8_t kUpLeftBit = bit_of(KEY_UP_LEFT);
+constexpr std::uint8_t kUpRightBit = bit_of(KEY_UP_RIGHT);
+constexpr std::uint8_t kDownRightBit = bit_of(KEY_DOWN_RIGHT);
+} // namespace
+
+TEST(InputLatch, resolver_fresh_press_wins_and_release_restores)
+{
+    DirectionConflictState state;
+
+    // UP latches; a lone side passes through untouched.
+    for (int t = 0; t < 3; ++t)
+        ASSERT_EQ(kUpBit, resolve_opposing_directions(kUpBit, state));
+
+    // Fresh DOWN suppresses the stale UP for as long as it is held.
+    ASSERT_EQ(kDownBit, resolve_opposing_directions(
+        static_cast<std::uint8_t>(kUpBit | kDownBit), state));
+    ASSERT_EQ(kDownBit, resolve_opposing_directions(
+        static_cast<std::uint8_t>(kUpBit | kDownBit), state));
+
+    // DOWN released: conflict over, the (still latched) UP passes again.
+    ASSERT_EQ(kUpBit, resolve_opposing_directions(kUpBit, state));
+
+    // Full release resets everything.
+    ASSERT_EQ(0, resolve_opposing_directions(0, state));
+    ASSERT_EQ(0, static_cast<int>(state.y_winner));
+}
+
+TEST(InputLatch, resolver_same_sample_tie_keeps_cancellation)
+{
+    DirectionConflictState state;
+    const std::uint8_t both = static_cast<std::uint8_t>(kUpBit | kDownBit);
+    // Both rise in one sample: legacy cancellation (mask passes through and
+    // move_y() nets it to zero), and it stays canceled while held.
+    ASSERT_EQ(both, resolve_opposing_directions(both, state));
+    ASSERT_EQ(both, resolve_opposing_directions(both, state));
+    // Releasing one side leaves the other in effect.
+    ASSERT_EQ(kDownBit, resolve_opposing_directions(kDownBit, state));
+}
+
+TEST(InputLatch, resolver_suppresses_stale_diagonal_with_its_whole_side)
+{
+    DirectionConflictState state;
+
+    // A latched UP_LEFT is presumed phantom once DOWN arrives fresh: it
+    // must stop contributing to BOTH axes (no leftover LEFT drift).
+    resolve_opposing_directions(kUpLeftBit, state);
+    ASSERT_EQ(kDownBit, resolve_opposing_directions(
+        static_cast<std::uint8_t>(kUpLeftBit | kDownBit), state));
+
+    // Double conflict: latched UP_LEFT vs a fresh DOWN_RIGHT press — the
+    // fresh key wins both axes.
+    state = DirectionConflictState{};
+    resolve_opposing_directions(kUpLeftBit, state);
+    ASSERT_EQ(kDownRightBit, resolve_opposing_directions(
+        static_cast<std::uint8_t>(kUpLeftBit | kDownRightBit), state));
+}
+
+TEST(InputLatch, resolver_any_key_of_a_side_reasserts_it)
+{
+    DirectionConflictState state;
+
+    // UP latched, DOWN fresh: down side wins.
+    resolve_opposing_directions(kUpBit, state);
+    ASSERT_EQ(kDownBit, resolve_opposing_directions(
+        static_cast<std::uint8_t>(kUpBit | kDownBit), state));
+
+    // UP_RIGHT pressed (a different key of the up side): the up side is
+    // fresh again and takes the axis back; its RIGHT contribution stays.
+    const std::uint8_t all = static_cast<std::uint8_t>(kUpBit | kDownBit | kUpRightBit);
+    ASSERT_EQ(static_cast<std::uint8_t>(kUpBit | kUpRightBit),
+              resolve_opposing_directions(all, state));
+}
+
+TEST(InputLatch, resolver_x_axis_is_symmetric)
+{
+    DirectionConflictState state;
+    resolve_opposing_directions(kLeftBit, state); // LEFT latches
+    const std::uint8_t both = static_cast<std::uint8_t>(kLeftBit | bit_of(KEY_RIGHT));
+    ASSERT_EQ(bit_of(KEY_RIGHT), resolve_opposing_directions(both, state))
+        << "fresh RIGHT must suppress the stale LEFT";
+    ASSERT_EQ(kLeftBit, resolve_opposing_directions(kLeftBit, state))
+        << "releasing RIGHT restores the surviving LEFT";
+}
+
+// ---------------------------------------------------------------------------
 // Factory default keymaps: no cross-player key collisions. On a shared
 // keyboard every player's bindings are live at once (modes are per-player,
 // so any 4-dir/8-dir combination can be active). A shared keycode makes one

--- a/web/shell.html
+++ b/web/shell.html
@@ -801,6 +801,77 @@
         });
 
         // ------------------------------------------------------------------
+        // Hardware-keyboard keyup resilience.
+        //
+        // iPad Safari (and Cocoa browsers generally) can swallow keyup
+        // events: releases while Cmd/Globe is held, system HUD overlays,
+        // shared-keyboard mashing in multi-player. SDL then believes the
+        // key is held forever — a latched arrow key walks that player's
+        // character until a matching keyup finally arrives, and opposite
+        // presses net to a dead axis.
+        //
+        // This shell-level tracker runs BEFORE SDL's own listeners (these
+        // capture-phase hooks are registered while the wasm module is still
+        // loading) and synthesizes the missing keyups:
+        //  - page lifecycle (pagehide / blur / hidden): release everything
+        //    (SDL resets its keyboard on blur itself, but not on
+        //    visibilitychange, and the tracker must stay coherent);
+        //  - Meta released: Cocoa suppressed other keys' keyups while it
+        //    was down, and they will never arrive — release everything;
+        //  - a fresh (non-repeat) keydown for a key whose last delivered
+        //    event is old, while we still think it is down: that earlier
+        //    keyup was swallowed. Release it first so SDL sees a clean
+        //    re-press edge (the engine's last-press priority then rides it).
+        // Auto-repeat keeps a genuinely held key's timestamp fresh, so the
+        // age gate never misfires on real holds; non-repeating keys never
+        // produce a keydown while held at all.
+        // ------------------------------------------------------------------
+        (function keyupResilience() {
+            var STALE_HOLD_MS = 1500;
+            var down = Object.create(null); // event.code -> last event ms
+            function synthesizeKeyUp(code, keyValue) {
+                var e = new KeyboardEvent('keyup', {
+                    code: code,
+                    key: keyValue || '',
+                    bubbles: true,
+                    cancelable: true,
+                    view: window
+                });
+                window.dispatchEvent(e);
+            }
+            function releaseAll() {
+                for (var code in down) {
+                    synthesizeKeyUp(code);
+                    delete down[code];
+                }
+            }
+            window.addEventListener('keydown', function(e) {
+                if (!e.isTrusted || !e.code) { return; }
+                var now = Date.now();
+                var last = down[e.code];
+                if (last !== undefined && !e.repeat &&
+                        (now - last) > STALE_HOLD_MS) {
+                    synthesizeKeyUp(e.code, e.key);
+                }
+                down[e.code] = now;
+            }, true);
+            window.addEventListener('keyup', function(e) {
+                if (!e.isTrusted || !e.code) { return; }
+                delete down[e.code];
+                if (e.key === 'Meta' || e.key === 'OS') {
+                    releaseAll();
+                }
+            }, true);
+            window.addEventListener('pagehide', releaseAll);
+            window.addEventListener('blur', releaseAll);
+            document.addEventListener('visibilitychange', function() {
+                if (document.visibilityState === 'hidden') {
+                    releaseAll();
+                }
+            });
+        })();
+
+        // ------------------------------------------------------------------
         // Touch controls overlay.
         //
         // Two injection tiers into the engine (web_touch_bridge.cpp):


### PR DESCRIPTION
## The bug (real device)

3-player split-screen in the browser/wasm build on an iPad with one shared hardware keyboard: the arrow-key seat's **UP and DOWN stop responding** after a while, while LEFT/RIGHT keep working. Separately observed once: the **same seat stuck walking UP**. These are one bug seen at two moments.

## Mechanism

iPad Safari swallows keyups around system gestures, the Globe/Cmd HUD, and shared-keyboard mashing. When the UP keyup is lost:

1. SDL's keyboard-state array keeps the scancode down forever, and `held[]` is re-derived from that array on **every sample** in `input_state_from_sdl` (`src/interface/sdl_context_services.cpp:28`) — the latch never decays.
2. **Stuck-walking-up moment:** the latched UP alone walks the character up every tick (`src/gameplay/sim_input_handler.cpp:343` consumes the walkstep intent).
3. **Dead-axis moment:** when the player later presses DOWN for real, `PlayerInput::move_y()` (`src/interface/input/input_state.cpp:27`) nets `-1 + 1 == 0`. UP looks dead (already held, a keydown changes nothing) and DOWN looks dead (cancelled by the phantom UP) — the whole Y axis dies while the independent X axis stays live. Exactly the report.

Nothing ever cleared the latch: no focus/visibility handling existed, and `InputState::clear()` had no caller.

**Also found on the way:** an undocumented factory-keymap collision in `kDefaultEightDirKeys` (`src/interface/input/input_state.cpp:148`) that goes live exactly at 3 players — P3's 8-direction DOWN-RIGHT default was `.`, which is P2's FIRE in both of P2's mode maps, so P2 firing walked P3's character down-right.

## Tests first (commit 05ed4d79 — red before the fix)

`tests/test_input_latch.cpp`. Red run: `og_test_input --gtest_filter='InputLatch.*:InputKeybindDefaults.*'` => **8 failed / 1 passed** (the one green was the legacy-cancel pin). The pins cover:

- fresh opposite press must beat a stale opposite hold — both axes, both directions, on explicit bindings, on seat 1's factory arrow defaults, and end-to-end through `sim_process_player_input`'s walkstep intent (`sim_stuck_walking_up_recovers_on_down_press`);
- `WINDOW_FOCUS_LOST` / `WINDOW_HIDDEN` must clear all transient held input (SDL keyboard state, touch seam, direction-grace retention);
- factory default keymaps must have no cross-player collisions beyond the documented P1/P4 `v` quirk;
- legacy semantics pinned green so they can't drift: simultaneous opposite presses still cancel, delivered keyups behave exactly as before, and LEFT/RIGHT ride a latched UP as a diagonal.

Adversarial resolver timelines included: same-sample tie keeps the legacy cancellation, a stale diagonal is suppressed with its whole side, any key of a side re-asserts it, X-axis symmetry, and release restores the survivor.

## The fix (commit 4085e635 — three layers; none changes a correctly-delivered keyup)

1. **Last-press priority** (interface sampling): new `resolve_opposing_directions` (`src/interface/input/input_state.cpp:630`) suppresses the stale side of an axis while a fresher opposite press is held; per-player `DirectionConflictState` lives in `InputHardwareState` (reset on seat compaction) and runs before `coalesce_direction_release` in `input_state_from_sdl`. The `InputState` wire format and the sim are untouched; same-sample opposite presses keep the legacy cancellation. A physical re-press of the opposite arrow now heals a latched axis instead of deadlocking it.
2. **Focus/visibility reset:** `SDL_EVENT_WINDOW_FOCUS_LOST` / `WINDOW_HIDDEN` (`src/platform/sdl/input_event_bridge.cpp:150`) now call `clear_transient_input_state()` (`src/interface/input/input.cpp:1029`): `SDL_ResetKeyboard` via the `og::input_native` seam + the touch held-key seam + direction shaping state. On the web, `visibilitychange` delivers only HIDDEN, so SDL's own blur-time reset never covered it.
3. **Web shell keyup synthesis** (`web/shell.html`): a capture-phase tracker registered before SDL's listeners releases everything on `pagehide`/`blur`/`hidden` and on Meta release (Cocoa suppresses other keys' keyups while Meta is held), and synthesizes a release when a fresh non-repeat keydown arrives for a key whose last delivered event is older than 1.5s — a physical re-press of a stuck key gives the engine a clean edge.

Plus the keymap fix: P3's DOWN-RIGHT now starts unbound (the same policy as P4's unbound look-up — the L+`,` chord still walks the diagonal, and a key can be bound on the CONTROLS remap screen). The documented P1/P4 `v` look-up quirk is kept and pinned by test.

## Verification

- `og_test_input` InputLatch **13/13** + InputKeybindDefaults **1/1** (the red pins, now green); full group **114/114** — re-run at ship time
- `ctest --preset ci-test`: **52/52 passed** (+ `emscripten_build_test` skipped locally — no emsdk in the test env)
- wasm build verified separately: `./scripts/build_web.sh` exit 0
- `og_test_parity` **188/188** from the repo root — the direction shaping is interface-layer sampling; the sim boundary did not move

🤖 Generated with [Claude Code](https://claude.com/claude-code)
