### PR TITLE
Deploy production on every push to master

### DIFF
--- a/.github/workflows/wasm-e2e.yml
+++ b/.github/workflows/wasm-e2e.yml
@@ -10,9 +10,12 @@ permissions:
   deployments: write
 
 # Only the newest revision of a PR should be able to update its stable preview
-# alias. Push runs keep their unique run IDs and are not cancelled here.
+# alias, and only the newest master push should be able to update production —
+# without a shared group, an older master run finishing late could overwrite a
+# newer deploy. Pushes to other branches keep their unique run IDs and are not
+# cancelled here.
 concurrency:
-  group: wasm-e2e-${{ github.event.pull_request.number || github.run_id }}
+  group: wasm-e2e-${{ github.event.pull_request.number || (github.event_name == 'push' && github.ref == 'refs/heads/master' && 'master') || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -140,6 +143,55 @@ jobs:
             echo
             echo "Immutable deployment: ${IMMUTABLE_URL}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Production deploy: every same-repository push to master ships the
+      # exact dist/ the Playwright suite above just validated. The relay
+      # worker (rooms + cloud-save vault) deploys first so a Durable Object
+      # migration is always live before any client that needs it — the same
+      # ordering nightly.yml uses. The nightly workflow's own web deploy
+      # stays as an idempotent backstop. The relay requires Node >= 22
+      # (relay/package.json engines), hence the second setup-node.
+      - name: Set up Node.js for relay deploy
+        if: >-
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/master' &&
+          github.repository == 'openglad/openglad'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: relay/package-lock.json
+
+      - name: Install relay npm dependencies
+        if: >-
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/master' &&
+          github.repository == 'openglad/openglad'
+        working-directory: relay
+        run: npm ci
+
+      - name: Deploy relay worker
+        if: >-
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/master' &&
+          github.repository == 'openglad/openglad'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: relay
+          command: deploy
+
+      - name: Deploy production to Cloudflare Pages
+        if: >-
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/master' &&
+          github.repository == 'openglad/openglad'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=openglad
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -906,8 +906,10 @@ The main GitHub Actions workflow (`.github/workflows/test.yml`) runs:
 5. **tsan** — ThreadSanitizer build and test
 
 Alongside it: `coverage.yml` (the line/function coverage gate), `fuzz.yml`,
-`nightly.yml` (nightly build + Cloudflare Pages production deploy), and
-`wasm-e2e.yml` (Playwright WebAssembly end-to-end tests + PR preview deploys).
+`nightly.yml` (nightly native builds + release, plus a backstop Cloudflare
+Pages production deploy), and `wasm-e2e.yml` (Playwright WebAssembly
+end-to-end tests + PR preview deploys, and the production deploy — relay
+worker then Pages — on every push to master).
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -179,10 +179,22 @@ test, but are not deployed: repository Cloudflare credentials are never made
 available to their code, and their artifacts are not promoted by a privileged
 follow-up workflow.
 
+### Production Deployment
+
+Every push or merge to `master` deploys production from the same workflow,
+after the WASM Playwright tests pass: the relay Worker (rooms + cloud-save
+vault) first, then the exact `dist/` the tests validated goes to
+`https://openglad.pages.dev`. Rapid successive pushes cancel older in-flight
+master runs so the newest commit always deploys last. The Nightly Release
+workflow also redeploys production on its 2am UTC schedule as a backstop,
+alongside the nightly native binaries.
+
 Maintainer setup for `.github/workflows/wasm-e2e.yml`:
 
 - Configure the `CLOUDFLARE_API_TOKEN` Actions secret with Account /
-  Cloudflare Pages / Edit permission.
+  Cloudflare Pages / Edit permission. The production relay deploy additionally
+  needs Workers Scripts / Edit on the same token (already required by
+  `nightly.yml`).
 - Configure the `CLOUDFLARE_ACCOUNT_ID` Actions secret for the account that
   owns the `openglad` Pages project.
 - Keep preview deployments enabled for that project. CI deploys the synthetic


### PR DESCRIPTION
## Summary

Production (`openglad.pages.dev` + the relay worker) previously deployed only from the nightly 2am UTC cron, so merges sat undeployed for up to a day (today's CLOUD button from #159 being the live example).

The WASM E2E workflow already builds `dist/` and validates it with Playwright on every push, so the production deploy now lives there:

- On every same-repository push to `master`, after the Playwright suite passes: deploy the relay worker first (so Durable Object migrations are live before any client needs them — same ordering as `nightly.yml`), then ship the **exact tested** `dist/` to Cloudflare Pages production.
- Master pushes now share a concurrency group with cancel-in-progress, so an older run finishing late cannot overwrite a newer deploy.
- The nightly workflow's web deploy remains as an idempotent backstop; nightly native builds/releases are unchanged.
- A second `setup-node` (22) precedes the relay deploy — the relay's `engines` requires Node ≥ 22 while the Playwright toolchain in this job runs Node 20.

No new secrets: the same `CLOUDFLARE_API_TOKEN` already carries Workers Scripts / Edit for the nightly relay deploy. Docs updated (`docs/INSTALL.md`, `docs/ARCHITECTURE.md`).

## Test plan

- [x] YAML validated
- [ ] CI green on this PR (deploy steps are inert here — they gate on push-to-master)
- [ ] After merge: this PR's own merge commit triggers the first push deploy; verify the run's deploy steps execute and openglad.pages.dev serves the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)