### PR TITLE
Create the preview log directory in the post-commit hook

### DIFF
--- a/scripts/refresh_web_preview.sh
+++ b/scripts/refresh_web_preview.sh
@@ -33,8 +33,15 @@ if [[ "${1:-}" == "--install-hook" ]]; then
 #!/usr/bin/env bash
 # Refresh the local web preview in the background after every commit.
 # Log: ~/.local/state/openglad-preview/refresh.log
+#
+# The log directory is created HERE, not in refresh_web_preview.sh: the shell
+# evaluates the redirect below before the script runs, so the script's own
+# mkdir is too late to create its own log file's parent. Without this, every
+# commit prints "No such file or directory" and the preview never refreshes.
+LOG_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/openglad-preview"
+mkdir -p "$LOG_DIR"
 nohup "$(git rev-parse --show-toplevel)/scripts/refresh_web_preview.sh" \
-    >> "${XDG_STATE_HOME:-$HOME/.local/state}/openglad-preview/refresh.log" 2>&1 &
+    >> "$LOG_DIR/refresh.log" 2>&1 &
 HOOKEOF
     chmod +x "$HOOK"
     echo "post-commit hook installed: $HOOK"


### PR DESCRIPTION
The post-commit hook installed by `scripts/refresh_web_preview.sh --install-hook` redirects into `$XDG_STATE_HOME/openglad-preview/refresh.log`, but nothing ever created that directory.

`refresh_web_preview.sh` does `mkdir -p "$LOG_DIR"` at line 28 — too late. The shell evaluates the hook's `>>` redirect *before* the script it invokes starts, so the script cannot create its own log file's parent. On a machine that had never run the script in the foreground first, every commit printed

```
.git/hooks/post-commit: line 4: /home/…/.local/state/openglad-preview/refresh.log: No such file or directory
```

and the preview silently never refreshed.

The fix creates the directory in the hook itself, ahead of the redirect, and reuses the variable for the log path so the two can't drift.

**Verified:** deleted `~/.local/state/openglad-preview/`, reinstalled the hook, and committed — the directory and log are recreated and the commit is silent. `bash -n` clean on both the script and the generated hook.

Found while cleaning up the repository layout (#184); unrelated to that diff, so it's on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)