### PR TITLE
Agent skills: session-history friction mined into shared Claude+Codex playbooks

### DIFF
--- a/.claude/skills/openglad-campaign-design/SKILL.md
+++ b/.claude/skills/openglad-campaign-design/SKILL.md
@@ -90,6 +90,22 @@ fully deterministic too — scripts/make_glad.py pins order, mtimes, method).
   conceals (forestwalk + LOS decay) — keep it off battle lanes or smoke bounds
   shift. Writer downgrades v11→v10/v9 when all decor planes are empty.
 
+## Twitchers (units jammed in place, spinning)
+
+Two distinct jam classes — do not misdiagnose one as the other:
+(a) a hunter whose beeline crosses impassable terrain (water, wall)
+jams at the boundary; (b) a woken posted guard in ACT_RANDOM whose
+target left jams mid-field against scenery or other units. Cures:
+re-post disengaged hostiles from the level script; never place a roamer
+where its straight line to a likely foe crosses a barrier.
+
+The unattended-sim regression test is MANDATORY for every new level:
+run ~1800 ticks with the player crew parked, assert no living has
+near-zero net displacement while alive, and include a phase that wakes
+the garrison and then walks away. Copy the shape of
+tests/unit/test_imaginations_twitchers.cpp (ships with the Imaginations
+campaign; the recipe above is complete on its own).
+
 ## Story rules (the "story bible" discipline)
 
 One narrative voice across all briefings; briefings are the ONLY narrative

--- a/.claude/skills/openglad-campaign-design/SKILL.md
+++ b/.claude/skills/openglad-campaign-design/SKILL.md
@@ -106,17 +106,18 @@ the garrison and then walks away. Copy the shape of
 tests/unit/test_imaginations_twitchers.cpp (ships with the Imaginations
 campaign; the recipe above is complete on its own).
 
-## Unit-class lifecycle audit (the twitcher postmortem)
+## Verify behavior rules per construction path
 
-Any level/script rule that touches AI act types must be verified per
-UNIT CLASS, not per rule: placed livings, generator spawns
-(customize_spawn runs at birth — derived stats may not match placed
-units), delayed-wave walkers, defectors/team-changed units, and
-woken-then-re-posted hunters each walk a different path through
-born -> posted -> wake (lineofsight stat + clear ray + find_near_foe
-target) -> hunt -> blocked. The wake-guarantee shape: for every hostile
-class, an enemy 2 tiles away on open grass must produce an attack
-within 300 ticks, proven RED on the broken tree before the fix ships.
+Entities that belong to one category can be built by different paths
+(authored placement, runtime generation, delayed activation, team
+conversion, state conversion), and the paths do NOT share guarantees —
+derived stats, hook timing, and AI state can all differ. Any rule that
+targets a category ("all X behave like Y") must be validated against
+EVERY path that produces members of that category, with a behavioral
+test per path proven red on a broken tree before the rule ships. A rule
+proven on one construction path and assumed for the rest is the
+standard way levels ship invisible statues, dead triggers, and
+unreachable objectives.
 
 ## Story rules (the "story bible" discipline)
 

--- a/.claude/skills/openglad-campaign-design/SKILL.md
+++ b/.claude/skills/openglad-campaign-design/SKILL.md
@@ -90,21 +90,31 @@ fully deterministic too — scripts/make_glad.py pins order, mtimes, method).
   conceals (forestwalk + LOS decay) — keep it off battle lanes or smoke bounds
   shift. Writer downgrades v11→v10/v9 when all decor planes are empty.
 
-## Twitchers (units jammed in place, spinning)
+## The hunt AI does not pathfind — design for it
 
-Two distinct jam classes — do not misdiagnose one as the other:
-(a) a hunter whose beeline crosses impassable terrain (water, wall)
-jams at the boundary; (b) a woken posted guard in ACT_RANDOM whose
-target left jams mid-field against scenery or other units. Cures:
-re-post disengaged hostiles from the level script; never place a roamer
-where its straight line to a likely foe crosses a barrier.
+ACT_RANDOM hunters walk a STRAIGHT line at their acquired foe
+(walker::act_random -> walkstep with wall-slide only); there is no
+routing. Consequences for every level layout:
 
-The unattended-sim regression test is MANDATORY for every new level:
-run ~1800 ticks with the player crew parked, assert no living has
-near-zero net displacement while alive, and include a phase that wakes
-the garrison and then walks away. Copy the shape of
-tests/unit/test_imaginations_twitchers.cpp (ships with the Imaginations
-campaign; the recipe above is complete on its own).
+- Any impassable band (water, walls, tree lines) between two forces
+  turns approaching units into visible statues grinding at the
+  boundary. Either keep opposing forces' likely sight lines free of
+  barriers, or provide crossings wide and frequent enough that the
+  slide finds one within a couple of tiles from any angle.
+- A woken guard hunts forever; if its target leaves, it jams against
+  whatever stands where it happens to be. Levels that post guards need
+  a level-script rule that stands disengaged hunters back down (the
+  engine's own act_guard sight test then re-wakes them honestly).
+- Every AI unit follows these rules regardless of origin — placed,
+  generator-spawned, or script-converted.
+
+Every level whose layout puts ANY blocker between opposing forces must
+ship an unattended-sim stationarity test: run the level headless for
+~1800+ ticks under the scenarios players actually create (crew parked
+near the front line; garrison woken then abandoned), and fail on any
+living with near-zero displacement that is neither posted nor in
+contact with an enemy. Prove the test red on a layout that jams before
+trusting it green.
 
 ## Verify behavior rules per construction path
 

--- a/.claude/skills/openglad-campaign-design/SKILL.md
+++ b/.claude/skills/openglad-campaign-design/SKILL.md
@@ -106,6 +106,18 @@ the garrison and then walks away. Copy the shape of
 tests/unit/test_imaginations_twitchers.cpp (ships with the Imaginations
 campaign; the recipe above is complete on its own).
 
+## Unit-class lifecycle audit (the twitcher postmortem)
+
+Any level/script rule that touches AI act types must be verified per
+UNIT CLASS, not per rule: placed livings, generator spawns
+(customize_spawn runs at birth — derived stats may not match placed
+units), delayed-wave walkers, defectors/team-changed units, and
+woken-then-re-posted hunters each walk a different path through
+born -> posted -> wake (lineofsight stat + clear ray + find_near_foe
+target) -> hunt -> blocked. The wake-guarantee shape: for every hostile
+class, an enemy 2 tiles away on open grass must produce an attack
+within 300 ticks, proven RED on the broken tree before the fix ships.
+
 ## Story rules (the "story bible" discipline)
 
 One narrative voice across all briefings; briefings are the ONLY narrative

--- a/.claude/skills/openglad-menus/SKILL.md
+++ b/.claude/skills/openglad-menus/SKILL.md
@@ -143,6 +143,57 @@ GO / SET LEVEL / SET CAMPAIGN.
 - Coverage gate: every new `src/` line needs ~90% execution; pure helpers in
   `picker_common` are cheap to cover, SDL screens need an injector flow.
 
+## Visual verification (a green suite says nothing about layout)
+
+Any menu/HUD/render change: capture a PNG (scripts/media/capture_showcase.sh
+or `save_screenshot()` into gitignored build/media/), then READ the image
+back and describe what you see BEFORE claiming success. Playwright pixel
+assertions are not visual verification. Gotcha: capture must follow the
+single real `SDL_RenderPresent` — a second present eats the HUD overlay;
+test builds emit BMP/PPM, convert losslessly before viewing.
+
+Restoring or matching a legacy screen: never reconstruct it from memory,
+docs, or code reading. (1) `git worktree add` the pre-migration commit,
+(2) build it and dump SETTLED frames through its own render loop (the
+async screenshot probe captures mid-fade), (3) capture the current screen
+at the same 320x200 through the same hook, (4) crop-compare the
+must-be-unchanged regions and require RMSE 0, (5) capture a NON-full data
+state too (e.g. 4 of 10 saves — that is what exposed the missing EMPTY
+SLOT rows). For "make it look like X" tasks generally: capture the
+master-branch reference shot and put both images side by side in one
+message.
+
+## Setting scope: TEAMS/SEATS vs TROOPS/SCENARIO
+
+Before adding any cycler value, ask "does this change with the map or
+with the players?" TEAMS/SEATS settings describe who is sitting at the
+game (per-machine, host-owned, packed into header slots 2/3/4).
+TROOPS and other SCENARIO settings describe what the level contains.
+Smell test: if your new value needs a special case to behave identically
+to an existing one, it is on the wrong axis. Getting this wrong costs a
+save migration — sentinel values persist in saves (MATCH shipped as
+TEAMS team_count=5 and had to be moved to TROOPS).
+
+## Teams are authoritative (the team/seat test matrix)
+
+Company/save ownership NEVER implies friendliness: same team can never
+damage each other, different teams are always hostile, a player can
+never take control of a foreign-team character. These call sites all
+independently re-derive teams and must agree: melee/attack predicate, AI
+targeting, collision auto-attack, projectile/summon owner chains, mage
+freeze-time, SAVE_ALL scoping, remaining-foes/victory counting,
+results/MVP, kill+XP+score credit, respawn accounting, replay
+reconstruction.
+
+Team assignment changes are never "a small UI change". Required matrix,
+driven through the REAL Base Camp → seat-assignment launch path (never a
+hand-built launch struct): {1,2,4 seats} × {ally, pvp} × {team
+assignments 1..4, incl. a seat with no team-1 character}, asserting
+(a) every roster character spawns, (b) at ITS OWN team's spawn point,
+(c) same-team can't damage / cross-team can, (d) no character dropped
+from the save on launch, (e) remove-and-re-add a seat yields disjoint
+key mappings.
+
 ## Checklist: adding one menu entry
 
 1. menu_model item (id + command) + `test_menu_model` resolution case.

--- a/.claude/skills/openglad-pr-workflow/SKILL.md
+++ b/.claude/skills/openglad-pr-workflow/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: openglad-pr-workflow
+description: Definition of done for any OpenGlad branch or PR — riding CI to green, completion-report honesty, pre-merge sweeps (nostalgic comments, doc litter), and the web preview delivery paths. Use whenever you push, open a PR, report a task complete, or answer "is CI green" / "which build am I playing".
+---
+
+# OpenGlad PR workflow
+
+## Definition of done (non-negotiable)
+
+A turn that pushed code ends only when every check on that push has
+CONCLUDED. Block on `gh pr checks <n> --watch` (or poll `gh run list
+--commit <sha>`); report the final counts. "CI is running" is not a
+completion report.
+
+- Expected wall-clock: ASan+UBSan ~35 min, Coverage ~21–34 min, Campaign
+  Regeneration Drift ~2 min. Slower than that is "slow", not "stuck" —
+  keep waiting.
+- Every push to a PR branch produces DUPLICATE push-triggered and
+  pull_request-triggered runs on the same SHA; concurrency rules cancel
+  the redundant one. Dedupe by SHA + workflow name. A canceled duplicate
+  is NOT a failure — never report it as one.
+- Known flake: the wasm-jitter E2E on PR runs. Remedy: `gh run rerun <id>
+  --failed`, then PROVE it green. A flake explained away is a red check.
+- Report on state change only (first red, final verdict) — not a
+  narration of every poll.
+
+## Banned dispositions
+
+"Deferred", "out of scope", "follow-up issue", "deliberate limitation",
+"acceptable for now" are NOT valid outcomes for anything the user named.
+A gate turned off, defaulted off, or narrowed is not a fixed gate. If a
+named item looks infeasible, ask IN THE TURN YOU DISCOVER IT, with a cost
+estimate — never in the completion report. Completion reports list every
+user-named item as done/not-done; not-done requires the user's prior
+sign-off, quoted.
+
+## Pre-merge sweep (before opening or squash-merging any PR)
+
+1. Nostalgic comments: original Gladiator-era comments (signed initials,
+   dated notes, jokes, "this is a hack because…") are load-bearing
+   heritage. When code moves, is rewritten, or is ported (including
+   C++ → Lua), the comment moves with it verbatim. Check:
+   `git diff master...HEAD -- '*.cpp' '*.h' '*.lua' | grep '^-.*//'`
+   and review every deleted comment line. BEFORE the merge, not after.
+2. Doc litter: agent-facing artifacts (plans, phase reports, audit
+   summaries, handoff notes) never live in the tree — scratchpad only.
+   Check `git diff --stat master...HEAD -- '*.md'`; anything named
+   *_PLAN.md, *_REPORT.md, *_SUMMARY.md, PHASE*, HANDOFF* is deleted.
+   A doc worth keeping goes to docs/ as a human-facing document.
+3. `git status --porcelain` is empty of surprises.
+
+## Web preview delivery paths (know which build the user is playing)
+
+| URL | Built by | Trigger |
+|---|---|---|
+| openglad.pages.dev | wasm-e2e.yml (production deploy step) | master pushes only |
+| pr-<n>.openglad.pages.dev | wasm-e2e.yml (PR preview step) | every push to an open same-repo PR |
+| local tunnel | scripts/refresh_web_preview.sh + cloudflared | manual |
+
+Before explaining why a user "sees the old build": read the git-hash
+stamp on the main menu of the build THEY named and compare to branch
+HEAD. Never reason about caching from first principles. Always hand back
+preview URLs with the commit SHA they serve.

--- a/.claude/skills/openglad-pr-workflow/SKILL.md
+++ b/.claude/skills/openglad-pr-workflow/SKILL.md
@@ -24,6 +24,39 @@ completion report.
 - Report on state change only (first red, final verdict) — not a
   narration of every poll.
 
+## Playtest-report response protocol (paid for by four failed twitcher fixes)
+
+A human report of in-game misbehavior ("units stuck twitching") is an
+OBSERVATION, not a diagnosis. The four-round fumble pattern to never
+repeat: theorize from code reading -> patch the theory -> build a test
+around the same theory -> pass -> declare victory -> user sees the same
+bug. Rules:
+
+1. REPRODUCE UNDER OBSERVATION FIRST. Before any fix: dump live entity
+   state at the reported spot (openglad_text --protocol `state`), or
+   pixel-diff capture frames there. The cheap observability tools find
+   in seconds what hypothesis-stacking misses for days.
+2. PIN THE OBSERVATION. If the report is ambiguous, ask ONE question up
+   front — which units (color/family), where, doing what — instead of
+   burning a fix-deploy-playtest round per guess. "Yellow guys sitting
+   in open grass ignoring an adjacent enemy" identified in one sentence
+   what four patches never touched.
+3. THE REGRESSION TEST MUST FAIL FIRST — on the tree the user reported
+   against, reproducing THEIR scenario (their position, crew shape,
+   timing), not a scenario shaped by your current theory. A net that
+   passes pre-fix has proven it does not cover the bug; do not ship the
+   fix it "validates". Teeth are red-then-green, nothing less.
+4. NO EXTINCTION CLAIMS. Never state a bug class "cannot recur" from
+   tests that never reproduced the user's report. Completion reports
+   state what the test actually exercises.
+5. EPICYCLE ALARM. If a fix needs a fix that needs a fix (posted ->
+   re-post cycle -> distance carve-out -> geometry), stop patching and
+   map the full state machine you are scripting around — every
+   transition and its INPUTS — then verify each input for EVERY unit
+   class you touch. Placed and generator-spawned units differ in
+   derived stats; a rule proven on one class silently fails on the
+   other.
+
 ## Banned dispositions
 
 "Deferred", "out of scope", "follow-up issue", "deliberate limitation",

--- a/.claude/skills/openglad-pr-workflow/SKILL.md
+++ b/.claude/skills/openglad-pr-workflow/SKILL.md
@@ -24,38 +24,31 @@ completion report.
 - Report on state change only (first red, final verdict) — not a
   narration of every poll.
 
-## Playtest-report response protocol (paid for by four failed twitcher fixes)
+## Responding to bug reports
 
-A human report of in-game misbehavior ("units stuck twitching") is an
-OBSERVATION, not a diagnosis. The four-round fumble pattern to never
-repeat: theorize from code reading -> patch the theory -> build a test
-around the same theory -> pass -> declare victory -> user sees the same
-bug. Rules:
+A human report of misbehavior is an OBSERVATION, not a diagnosis. The
+anti-pattern: theorize from code reading, patch the theory, build a
+test around the same theory, pass, declare victory, bug survives.
+Rules, in order:
 
-1. REPRODUCE UNDER OBSERVATION FIRST. Before any fix: dump live entity
-   state at the reported spot (openglad_text --protocol `state`), or
-   pixel-diff capture frames there. The cheap observability tools find
-   in seconds what hypothesis-stacking misses for days.
-2. PIN THE OBSERVATION. If the report is ambiguous, ask ONE question up
-   front — which units (color/family), where, doing what — instead of
-   burning a fix-deploy-playtest round per guess. "Yellow guys sitting
-   in open grass ignoring an adjacent enemy" identified in one sentence
-   what four patches never touched.
-3. THE REGRESSION TEST MUST FAIL FIRST — on the tree the user reported
-   against, reproducing THEIR scenario (their position, crew shape,
-   timing), not a scenario shaped by your current theory. A net that
-   passes pre-fix has proven it does not cover the bug; do not ship the
-   fix it "validates". Teeth are red-then-green, nothing less.
-4. NO EXTINCTION CLAIMS. Never state a bug class "cannot recur" from
-   tests that never reproduced the user's report. Completion reports
-   state what the test actually exercises.
-5. EPICYCLE ALARM. If a fix needs a fix that needs a fix (posted ->
-   re-post cycle -> distance carve-out -> geometry), stop patching and
-   map the full state machine you are scripting around — every
-   transition and its INPUTS — then verify each input for EVERY unit
-   class you touch. Placed and generator-spawned units differ in
-   derived stats; a rule proven on one class silently fails on the
-   other.
+1. Observe before hypothesizing. Reproduce the reported behavior under
+   instrumentation (live state dumps, frame captures, logs) before
+   changing anything. Cheap observability beats clever inference.
+2. Pin ambiguity with one question. If the report underdetermines the
+   subject (which component, which entity, where, when), ask once up
+   front. One question costs a message; a wrong guess costs a full
+   fix-deploy-verify round.
+3. The regression test must fail first — on the tree the report was
+   made against, reproducing the REPORTER's scenario, not a scenario
+   shaped by your hypothesis. A test that passes pre-fix does not cover
+   the bug; do not ship the fix it "validates". Teeth are
+   red-then-green, nothing less.
+4. Claim only what the tests exercise. Never state a bug class cannot
+   recur on the strength of tests that never reproduced the report.
+5. Epicycle alarm. When a fix needs a follow-up fix that needs another,
+   stop patching: model the underlying mechanism end to end (states,
+   transitions, and each transition's inputs), then verify every input
+   for every variant the change touches.
 
 ## Banned dispositions
 

--- a/.claude/skills/openglad-test-integrity/SKILL.md
+++ b/.claude/skills/openglad-test-integrity/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: openglad-test-integrity
+description: The rules that keep OpenGlad's test and coverage numbers honest — the coverage denominator invariant, banned assertion shapes, hang traps, and parity-golden authenticity. Use whenever a task touches coverage.yml, chases a coverage/function target, writes or audits tests, recaptures parity goldens, or debugs a hung/slow test run.
+---
+
+# OpenGlad test integrity
+
+## The honest-denominator invariant
+
+The coverage denominator is a pure function of repo contents. NEVER:
+- add a gcovr/lcov `--exclude` or `--filter` narrowing,
+- add a ctest `-E`/`-R` selection to the coverage workflow,
+- add or raise a `--repeat until-pass` retry to turn a red run green
+  (the `until-pass:3` pinned in test.yml and coverage.yml is deliberate
+  and moves only in lockstep across both; a test that fails every
+  attempt fails the gate, and a flake "fixed" by more retries is still
+  a flake to root-cause),
+- move a file out of src/, lower a threshold, or delete/disable/skip a
+  test to go green.
+
+One sanctioned exclusion list exists: `scripts/coverage/cpp_excluded.txt`
+— tracked src/ TUs the coverage build genuinely cannot measure
+(fuzz-only, emscripten-only), one per line with a mandatory reason,
+rot-checked in both directions by scripts/coverage/coverage_report.py.
+It makes an unmeasured TU an error instead of a silently smaller
+denominator; it is never a lever for dodging poorly covered code. Any
+coverage-gate PR reports the no-exclude numbers before and after and
+states "denominator unchanged" explicitly. Raising a CI floor is a
+separate, announced act — never a silent side effect. Read the current
+thresholds from coverage.yml; never trust remembered numbers. CI's
+retried runs can read slightly higher than a local single pass — judge
+local work by its before/after delta.
+
+## Banned assertion shapes
+
+An assertion an empty or broken result also satisfies is not a test:
+
+    ASSERT_TRUE(helper() > 0)          // banned
+    EXPECT_GE(score, 3)                // banned when total > 3
+    EXPECT_TRUE(x || !x); rc==0||rc==1 // banned tautologies
+    parse(...).size() <= 1             // banned
+    (void)call();                      // banned as the only "check"
+
+Internal exercisers assert an EXACT check count —
+`ASSERT_EQ(kExpectedChecks, helper())` — and each internal check asserts
+a postcondition, not that the call returned. Every test asserts a
+specific expected value or state transition. Before claiming a coverage
+number, self-audit your new tests against this list.
+
+## Tests that hang (the three known traps)
+
+1. Menu/prompt/picker paths need the injector-thread pattern
+   (`wait_for_interactable` + `SDL_Delay(750)` + `interact`). Never
+   drive a prompt from a TESTING exerciser — restrict exercisers to
+   non-blocking data/mode/draw paths.
+2. Never feed malformed YAML to gparser as a coverage target; it does
+   not return.
+3. Run ctest with stdin PIPED, never under a pty — headless clients
+   block on terminal input under a pty and mimic a 180s regression.
+
+Run long targets in the background or under a hard timeout; once stdin
+is closed you cannot interrupt them.
+
+## Proving a parity golden is authentic
+
+The companion worktree must be the baseline commit plus recorder-only
+commits. Verify: `git -C <companion> log --oneline <baseline>..HEAD` and
+confirm every entry touches only tools/parity_*. A matching
+`git merge-base` is NOT sufficient proof — never quote it as such.
+`tests/parity/scenario_table.h` and the companion copy must be
+byte-identical (`cmp`) before any recapture. "All N goldens matched
+after rebasing to a different baseline" is a red flag to investigate,
+never a success report.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,70 @@ agent, not just Claude.
 | Modding: class packs, Lua scripting, new classes/objects, level scripts | [.claude/skills/openglad-modding/SKILL.md](.claude/skills/openglad-modding/SKILL.md) — then the modding map below |
 | Campaign/level design, mapgen tooling, balance | [.claude/skills/openglad-campaign-design/SKILL.md](.claude/skills/openglad-campaign-design/SKILL.md) |
 | Picker/menu UI changes (buttons, subscreens, labels, menu tests) | [.claude/skills/openglad-menus/SKILL.md](.claude/skills/openglad-menus/SKILL.md) |
+| PR/branch definition of done: riding CI, completion reports, pre-merge sweeps, web previews | [.claude/skills/openglad-pr-workflow/SKILL.md](.claude/skills/openglad-pr-workflow/SKILL.md) |
+| Test and coverage honesty: denominator rules, banned assertions, hang traps, parity goldens | [.claude/skills/openglad-test-integrity/SKILL.md](.claude/skills/openglad-test-integrity/SKILL.md) |
 
 The skill files are plain markdown playbooks — they assume no Claude-specific
 tooling. Follow their checklists and gates exactly; the hard invariants
 (byte-identical parity via `og_test_parity`, coverage floors, vendor-header
 isolation) are enforced by CI and scripts under `scripts/`.
+
+## Environment and toolchain
+
+Every build/test/emcc/ctest command runs inside the nix dev shell:
+`nix develop --command bash -c '...'` (add
+`--extra-experimental-features 'nix-command flakes'` if nix refuses).
+Mandatory first command of any build task:
+`nix develop --command bash -c 'which cmake c++ emcc'`.
+A tool missing from PATH means you are OUTSIDE the shell, not that the
+tool is absent. Never source ~/emsdk, never apt/snap-install a tool,
+never patch a build script around a non-flake toolchain — if a tool is
+genuinely missing, `grep -n <tool> flake.nix`, then add it to flake.nix
+and say so. Never run `cmake -S . -B .`: an in-source configure drops a
+root CMakeCache.txt pinning /usr/bin/cc that poisons every later
+configure — if the wrong compiler appears, delete the root
+CMakeCache.txt/CMakeFiles/ first. Use only the presets.
+
+## Secrets
+
+Never print, cat, head, grep, or Read the contents of `env`, `.env`,
+`*secret*`, `*token*`, `*credential*`, or anything under ~/code/squad/.
+"Use the keys in `<file>`" means `set -a; . <file>; set +a` inside one
+non-echoing bash call, or `grep -oE '^[A-Z_]+=' <file>` to learn
+variable NAMES only. Never echo a variable sourced from such a file. To
+identify an unknown file use `file`/`wc -l`, not `cat`.
+
+## Autonomy and delegation
+
+Never stop at a partial checkpoint or ask "should I keep going" — the
+answer is always yes. A turn ends when the whole named task is done and
+its gates are green, or with a genuinely blocking question asked the
+moment it is discovered. On low context, write a handoff note and keep
+going.
+
+There is no such thing as a "pre-existing test failure" or "pre-existing
+flakiness": every failing test in a run you own is yours to fix, and the
+whole suite passes at all times, unless the user explicitly waives a
+specific failure.
+
+Delegation default (do not make the user restate it): design, level and
+scenario authoring, briefing prose, and hard debugging go to the
+stronger model; mechanical implementation, cleanup, and audits go to the
+cheaper one. On usage-limit exhaustion: checkpoint to a resume note and
+report — never silently downgrade the model mid-task.
+
+When proposing a mechanism (dependency pin, wrapper removal, migration),
+apply it to EVERY member of the class in the same change; "and leave X
+as-is" is not an option. Prefer deleting a first-party wrapper over
+keeping it when callers can use the upstream API directly.
+
+## Cross-tool handoff
+
+Every non-trivial multi-session branch keeps a gitignored
+`build/handoff.md` (or pinned PR comment): current goal, done, verified
+(and how), known-broken, exact next command. Update before yielding.
+Transcripts: codex at ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+(keyed by session_meta.cwd), Claude under ~/.claude/projects/.
 
 ## PR screenshots and proof media
 
@@ -33,6 +92,12 @@ The capture tooling stays here (`scripts/media/capture_showcase.sh`,
 `openglad_demo` frame dumps, `save_screenshot()`); it writes to the
 gitignored `build/media/`, and finished artifacts get committed to the
 screenshots repo.
+
+Before any merge: run the pre-merge sweep in
+[.claude/skills/openglad-pr-workflow/SKILL.md](.claude/skills/openglad-pr-workflow/SKILL.md)
+— restore any dropped Gladiator-era signed/nostalgic comments (they move
+with ported code, even cross-language) and delete agent-facing planning
+markdown from the tree.
 
 ## Modding map
 


### PR DESCRIPTION
Mined the repo's complete agent session history (19 Claude sessions, 315 MB; the 120 largest of 2,849 Codex sessions) with a multi-agent workflow: opus workers extracted 28 friction reports — corrections, repeated instructions, manual human labor, environment fights — and a synthesis pass collapsed them into the recurring, skill-preventable clusters.

**New skills** (readable by both agents; AGENTS.md routes Codex through the same files):
- `openglad-pr-workflow` — definition of done: ride CI to conclusion and report final counts, dedupe duplicate push/PR runs by SHA, known-flake remedies; banned weasel dispositions ("deferred", "out of scope" for user-named items); pre-merge sweep (nostalgic Gladiator-era comments move verbatim with code; agent-facing .md litter never enters the tree); web preview delivery table + the main-menu git-hash stamp check before any "stale build" theory.
- `openglad-test-integrity` — the honest coverage denominator (no excludes/filters/retries to go green), banned assertion shapes with examples, test-hang traps, parity-golden authenticity proof.

**Augmented**: `openglad-menus` (verify visuals by reading captures; legacy-screen comparison; seat/team launch matrix) and `openglad-campaign-design` (both stuck-twitcher jam classes + mandatory unattended-sim regression test).

**AGENTS.md**: new domain-table rows plus Environment/toolchain (nix shell mandatory), Secrets (never print env/token file contents), Autonomy (keep going; no "preexisting" test failures), and Cross-tool handoff sections — rules that previously lived only where Codex never saw them.

Implementation deviations from the mined plan were each reality-checked against the repo (e.g. the production web deploy is wasm-e2e.yml's master-push step, not nightly.yml; the sanctioned coverage-exclusion mechanism is scripts/coverage/cpp_excluded.txt) — details in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)