### PR TITLE
Ball games always respawn; the Sea Wizard ward survives real play

### DIFF
--- a/campaigns/modes/packs/modes.core/lib/mode_basketball_impl.lua
+++ b/campaigns/modes/packs/modes.core/lib/mode_basketball_impl.lua
@@ -2354,7 +2354,7 @@ end
 -- logic this tick (§9 #13).
 local function on_mode_tick(level, tick)
   local obs = og.oblist()
-  match.run_death_scan(anchors, obs, og.mode_get(S.TEAM_MASK), og.mode_get(S.RESPAWN_TICKS))
+  match.schedule_dead(obs, og.mode_get(S.TEAM_MASK), og.mode_get(S.RESPAWN_TICKS))
   local livings = {}
   local gens = {}
   local spawn_count = { 0, 0, 0, 0, 0, 0, 0, 0 }

--- a/campaigns/modes/packs/modes.core/lib/mode_match.lua
+++ b/campaigns/modes/packs/modes.core/lib/mode_match.lua
@@ -449,10 +449,28 @@ local function strip_inactive_teams(obs, mask)
   end
 end
 
+-- The L1 ring cell at index i (0 .. 4*r-1) of tile radius r, clockwise
+-- from due north — the deterministic ring-walk idiom shared with the
+-- ball games' landing-legality re-spot.
+local function ring_offset(i, r)
+  local edge = og.div(i, r)
+  local k = og.mod(i, r)
+  if edge == 0 then
+    return k, k - r
+  elseif edge == 1 then
+    return r - k, k
+  elseif edge == 2 then
+    return -k, r - k
+  end
+  return k - r, -k
+end
+
 -- Anchor rotation placement (DECISIONS D1): the mode-var cursor +
 -- probe-eats-safe checks. Deterministic and zero-RNG on the respawn path;
 -- init-time bot placement passes allow_teleport (the one blessed RNG
--- fallback, same as the CTF port).
+-- fallback, same as the CTF port). When every anchor is blocked — a
+-- camped spawn line must never stall respawns — a bounded ring walk
+-- around each anchor in index order takes the first clear tile instead.
 local function place_at_anchor(w, team, cursor_slot, allow_teleport)
   local final_x = -1
   local final_y = 0
@@ -467,6 +485,30 @@ local function place_at_anchor(w, team, cursor_slot, allow_teleport)
           final_x = ax
           final_y = ay
           break
+        end
+      end
+      if final_x < 0 then
+        -- Ring fallback, RNG-free and probe-eats-safe like the rotation
+        -- above. Rings cap at 3 tiles: past that the caller's own
+        -- fallback (engine revive-in-place, or the blocked-fire retry
+        -- cadence) is the honest answer.
+        for r = 1, 3 do
+          for a = 0, count - 1 do
+            local ax, ay = og.respawn_anchor(team, a)
+            for i = 0, 4 * r - 1 do
+              if final_x < 0 then
+                local dx, dy = ring_offset(i, r)
+                local px = ax + dx * 16
+                local py = ay + dy * 16
+                if px >= 0 and py >= 0 then
+                  if og.spawn_spot_clear(w, px, py) then
+                    final_x = px
+                    final_y = py
+                  end
+                end
+              end
+            end
+          end
         end
       end
     end
@@ -645,51 +687,6 @@ local function schedule_dead(obs, mask, delay)
   end
 end
 
--- Corpse eligibility mirroring the classic difficulty-submenu semantics
--- the engine applies on non-scripted maps (0 off, 1 heroes, 2 everyone,
--- 3 Team-1 heroes; ctf.cpp classic_respawn_corpse_eligible), minus the
--- spawn-point gate no binding exposes: an "everyone" AI corpse respawns
--- while it has no live owner. This is the SUBMENU-HONORING scan a ball
--- game wants. CTF and Onslaught keep their own — neither reads the
--- submenu, and Onslaught halves the delay off a held waypoint — so the
--- three variants stay separate on purpose.
---
--- `anchors` is the caller's mode_anchors module. og.use is load-time only
--- and rejects cycles, and mode_anchors already uses THIS module, so the
--- score-team read arrives as an argument rather than an import.
-local function run_death_scan(anchors, obs, mask, ticks)
-  local mode = og.match_setting("respawn_mode")
-  if mode == 0 then
-    return
-  end
-  for k = 1, #obs do
-    local w = obs[k]
-    if w:dead() ~= 0 then
-      if w:order() == C.ORDER_LIVING then
-        local team = anchors.score_team(w)
-        if team < C.SCORE_TEAM_COUNT then
-          if core.mask_has(mask, team) then
-            local eligible = false
-            if w:has_guy() then
-              eligible = true
-              if mode == 3 then
-                eligible = team == 0
-              end
-            elseif mode == 2 then
-              eligible = w:owner() == nil
-            end
-            if eligible then
-              if not og.respawn_pending(w) then
-                og.respawn_schedule(w, ticks)
-              end
-            end
-          end
-        end
-      end
-    end
-  end
-end
-
 -- The neutral-reset backstop (soccer's design §6.3 kickoff rule, shared):
 -- an active team with zero live Livings comes back at every re-spot,
 -- whatever the difficulty submenu says — respawn
@@ -700,7 +697,9 @@ end
 -- so a wiped bot side whose bodies are already gone is reprovisioned with
 -- a fresh squad — the same spawn path init uses for empty active teams —
 -- unless revives are already in flight. `anchors` is the caller's
--- mode_anchors module, an argument for the reason run_death_scan gives.
+-- mode_anchors module: og.use is load-time only and rejects cycles, and
+-- mode_anchors already uses THIS module, so the score-team read arrives
+-- as an argument rather than an import.
 local function revive_wiped_teams(anchors, mask, ticks, cursor_slot)
   local obs = og.oblist()
   local live = { 0, 0, 0, 0 }
@@ -846,7 +845,6 @@ return {
   spawn_bots = spawn_bots,
   owns_its_life = owns_its_life,
   schedule_dead = schedule_dead,
-  run_death_scan = run_death_scan,
   revive_wiped_teams = revive_wiped_teams,
   foe_scores = foe_scores,
   nearest_enemy = nearest_enemy,

--- a/campaigns/modes/packs/modes.core/lib/mode_soccer_impl.lua
+++ b/campaigns/modes/packs/modes.core/lib/mode_soccer_impl.lua
@@ -1,4 +1,4 @@
--- Soccer rules + AI director — N-team ball game over manifest goal rects (D7): fixed-point ball physics (kick/shot impulses, wall bounces, contact damage, rolling spin), last-toucher scoring where a self-goal still puts a point on the board, submenu-honoring respawns, chaser/goalie roles (cookbook: docs/lua-classpacks-design.md §3).
+-- Soccer rules + AI director — N-team ball game over manifest goal rects (D7): fixed-point ball physics (kick/shot impulses, wall bounces, contact damage, rolling spin), last-toucher scoring where a self-goal still puts a point on the board, always-on respawns (a ball game never strands a side), chaser/goalie roles (cookbook: docs/lua-classpacks-design.md §3).
 -- Copyright (C) 1995-2002 FSGames; ported by Sean Ford and Yan Shosh.
 
 local C = og.C
@@ -925,7 +925,7 @@ end
 -- and owns the win-latch short-circuit).
 local function on_mode_tick(level, tick)
   local obs = og.oblist()
-  match.run_death_scan(anchors, obs, og.mode_get(S.TEAM_MASK), og.mode_get(S.RESPAWN_TICKS))
+  match.schedule_dead(obs, og.mode_get(S.TEAM_MASK), og.mode_get(S.RESPAWN_TICKS))
   local livings = {}
   local gens = {}
   local spawn_count = { 0, 0, 0, 0, 0, 0, 0, 0 }

--- a/src/gameplay/walker_combat.cpp
+++ b/src/gameplay/walker_combat.cpp
@@ -198,6 +198,14 @@ void walker::do_hit_effects(walker* attacker, walker* target, short tempdamage)
 
 void walker::do_combat_damage(walker* attacker, walker* target, short tempdamage)
 {
+    // Every damage sink honors the ward. attack() gates earlier (its
+    // early-out also skips retaliation and score), but a caller reaching
+    // this sink directly — turn-undead's scripted arm — must not pierce
+    // BIT_INVINCIBLE or a running invulnerability.
+    if (target->stats()->query_bit_flags(BIT_INVINCIBLE) ||
+        target->invulnerable_left() != 0)
+        return;
+
     // Record damage done for records ..
     if (attacker && attacker->myguy && target->query_order() == Order::Living)  // hit a living
     {

--- a/src/gameplay/walker_specials.cpp
+++ b/src/gameplay/walker_specials.cpp
@@ -333,7 +333,13 @@ std::int32_t walker::turn_undead(std::int32_t range, [[maybe_unused]] std::int32
     for(auto* w : deadlist)
 	{
 		const auto* target_fd = w ? get_family_descriptor(w->family()) : nullptr;
-		if (w && target_fd && target_fd->is_undead)
+		// A warded (BIT_INVINCIBLE / invulnerable) undead is skipped before
+		// the resistance rolls: turning is damage, and both classic arms
+		// below kill without ever entering walker::attack's gate.
+		const bool warded =
+		    w != nullptr && (w->stats()->query_bit_flags(BIT_INVINCIBLE) ||
+		                     w->invulnerable_left() != 0);
+		if (w && target_fd && target_fd->is_undead && !warded)
 		{
 			if (current_game->world->rng_.next(static_cast<std::uint32_t>(range*40)) > current_game->world->rng_.next(static_cast<std::uint32_t>(w->stats()->level()*10)) )
 			{

--- a/src/gameplay/world_snapshot.cpp
+++ b/src/gameplay/world_snapshot.cpp
@@ -2837,7 +2837,16 @@ bool apply_snapshot(GameWorld& world, const WorldSnapshot& snapshot)
     SimEventLogSuppressGuard event_guard(*gameplay_context.sim_events);
 
     world.tick_count_ = snapshot.tick_count;
-    world.set_level_tick_count(snapshot.level_tick_count);
+    // A MID-level snapshot claims the level-change latch so the restored
+    // counter survives the next tick (set_level_tick_count's contract). A
+    // level-START seed (tick 0 — the transport-shadow installs seed the
+    // authoritative world this way) must instead leave the latch armed:
+    // the world's first tick still owes the level on_load dispatch, and a
+    // tick-0 counter has nothing to protect from the latch's zeroing.
+    if (snapshot.level_tick_count > 0)
+        world.set_level_tick_count(snapshot.level_tick_count);
+    else
+        world.reset_level_progress();
 
     world.level_done = snapshot.level_done;
     world.game_ended = snapshot.game_ended;

--- a/tests/parity/scenario_table.h
+++ b/tests/parity/scenario_table.h
@@ -1101,14 +1101,14 @@ inline constexpr FactPredicate kFacts_family_tower1_scen99[] = {
 // family-specific behavior and data.
 
 inline constexpr Mutation kMut_combat_damage = {
-    "src/gameplay/walker_combat.cpp", 210,
+    "src/gameplay/walker_combat.cpp", 218,
     "target->stats()->set_hitpoints(target->stats()->hitpoints() - tempdamage);",
     "target->stats()->set_hitpoints(target->stats()->hitpoints() - 0);",
     "Zeroes the per-hit damage applied to combat targets in walker::do_combat_damage; for any scenario that actually exercises melee combat this leaves the target alive and flips WalkerDiedByFinal and team-alive predicates."
 };
 
 inline constexpr Mutation kMut_walker_ai_wander = {
-    "src/gameplay/walker_combat.cpp", 322,
+    "src/gameplay/walker_combat.cpp", 330,
     "do_combat_damage(attacker, target, tempdamage_i);",
     "do_combat_damage(attacker, target, 0);",
     "Forces the walker_combat dispatch site to pass tempdamage=0 into do_combat_damage; in AI-driven combat scenarios the target takes no damage so AI walkers don't lose HP. Distinct from kMut_combat_damage (line 189) which mutates the target HP decrement inside the do_combat_damage body."
@@ -3220,7 +3220,7 @@ inline constexpr FactPredicate kFacts_event_end_game_emission_scen99[] = {
 };
 
 inline constexpr Mutation kMut_event_end_game_emission = {
-    "src/gameplay/walker_combat.cpp", 210,
+    "src/gameplay/walker_combat.cpp", 218,
     "target->stats()->set_hitpoints(target->stats()->hitpoints() - tempdamage);",
     "target->stats()->set_hitpoints(target->stats()->hitpoints() - 0);",
     "Zeroes per-hit damage in walker::do_combat_damage; the lone-player-vs-three-enemies arena no longer kills the player so end_game (which fires when the last team-0 walker dies) is never reached."
@@ -4788,7 +4788,7 @@ inline constexpr FactPredicate kFacts_midcombat_partial_hp_scen99[] = {
     pred::EventKindAtLeast(/*play_sound*/1, 4),
 };
 inline constexpr Mutation kMut_midcombat_partial_hp_scen99 = {
-    "src/gameplay/walker_combat.cpp", 210,
+    "src/gameplay/walker_combat.cpp", 218,
     "    target->stats()->set_hitpoints(target->stats()->hitpoints() - tempdamage);",
     "    target->stats()->set_hitpoints(target->stats()->hitpoints() - 0);",
     "Zeroes the central per-hit combat-damage write in walker::do_combat_damage; neither soldier takes damage and both finish at full HP (12000), leaving no FAMILY_SOLDIER in the WalkerHpRangeAtFinalTick band -- flipping it."

--- a/tests/unit/test_imaginations_levels.cpp
+++ b/tests/unit/test_imaginations_levels.cpp
@@ -28,6 +28,7 @@
 #include <openglad/gameplay/sim_event_log.h>
 #include <openglad/gameplay/statistics.h>
 #include <openglad/gameplay/walker.h>
+#include <openglad/gameplay/world_snapshot.h>
 #include <openglad/interface/level_runtime_data.h>
 #include <openglad/interface/game_context.h>
 #include <openglad/resources/gloader.h>
@@ -277,6 +278,17 @@ TEST_F(ImaginationsCampaignTest, watchtower_ward_arc_plays_out)
     EXPECT_TRUE(wizard->stats()->query_bit_flags(BIT_INVINCIBLE))
         << "the ward holds while the watchtowers stand";
 
+    // The ward must block a LIVE attack, not just wear the flag: a raider
+    // whose blow demonstrably lands once the ward drops deals nothing now.
+    const float warded_hp = wizard->stats()->hitpoints();
+    walker* raider = world.add_ob(Order::Living, FAMILY_SOLDIER);
+    ASSERT_NE(nullptr, raider);
+    raider->set_team_num(0);
+    raider->set_damage(50);
+    raider->attack(wizard);
+    EXPECT_EQ(warded_hp, wizard->stats()->hitpoints())
+        << "the warded wizard shrugs off a landed blow";
+
     // Fell both towers through the sim's death path so on_entity_death
     // dispatches for each (first: one remains; second: the ward fails).
     for (walker* tower : towers)
@@ -288,6 +300,9 @@ TEST_F(ImaginationsCampaignTest, watchtower_ward_arc_plays_out)
     }
     EXPECT_FALSE(wizard->stats()->query_bit_flags(BIT_INVINCIBLE))
         << "both towers down must drop the ward";
+    raider->attack(wizard);
+    EXPECT_LT(wizard->stats()->hitpoints(), warded_hp)
+        << "the same blow lands once the ward is down";
 
     // The throne falls: the dream-won fanfare fires via the per-entity
     // death hook.
@@ -302,6 +317,40 @@ TEST_F(ImaginationsCampaignTest, watchtower_ward_arc_plays_out)
             ev.text.find("Dream won") != std::string::npos)
             dream_won = true;
     EXPECT_TRUE(dream_won) << "the wizard's death narrates the win";
+
+    for (const auto& err : world.scripts().host().errors())
+        ADD_FAILURE() << err.where << ": " << err.message;
+}
+
+// Real play seeds the authoritative world from a level-START keyframe
+// (the transport-shadow installs: reset_level_progress, apply_snapshot,
+// then the first tick). apply_snapshot used to claim the level-change
+// latch even for a tick-0 seed, so isle.lua's on_load never ran in the
+// SDL flow and the Sea Wizard spawned unwarded — while the unlatched
+// on_tick / on_entity_death hooks still fired, masking the breakage.
+TEST_F(ImaginationsCampaignTest, ward_survives_the_level_start_snapshot_seed)
+{
+    LoadedImaginationsLevel fx(1);
+    ASSERT_TRUE(fx.loaded);
+    GameWorld& world = fx.world();
+    const og::sim::WorldSnapshot seed =
+        og::sim::capture_keyframe_snapshot(world);
+    ASSERT_EQ(0u, seed.level_tick_count) << "a level-start keyframe";
+    world.reset_level_progress();
+    ASSERT_TRUE(og::sim::apply_snapshot(world, seed));
+    world.tick();
+
+    walker* wizard = nullptr;
+    for (const auto& uptr : world.oblist)
+    {
+        walker* ob = uptr.get();
+        if (ob != nullptr && ob->query_order() == Order::Living &&
+            ob->team_num() == 1 && ob->family() == FAMILY_MAGE)
+            wizard = ob;
+    }
+    ASSERT_NE(nullptr, wizard);
+    EXPECT_TRUE(wizard->stats()->query_bit_flags(BIT_INVINCIBLE))
+        << "a level-start seed must leave on_load armed";
 
     for (const auto& err : world.scripts().host().errors())
         ADD_FAILURE() << err.where << ": " << err.message;

--- a/tests/unit/test_modes_basketball.cpp
+++ b/tests/unit/test_modes_basketball.cpp
@@ -1612,21 +1612,26 @@ TEST_F(ModesBasketball, dead_ball_resets_and_revives_wiped_team)
             << "post-reset freeze armed";
     }
     // Wipe arm: an ATTENDED free ball still resets when a team is wiped
-    // (D25 — the watchdog ignores attendance), and the reset's backstop
-    // refields the wiped side.
+    // (D25 — the watchdog ignores attendance). Under always-on respawns
+    // the revive normally owns the comeback, so the watchdog arms only
+    // for a side with zero live AND zero pending — drain the entry to
+    // exercise exactly that backstop.
     {
         BballCourt fx;
-        fx.world().respawn_mode = 0;
         fx.tick(1);
         ASSERT_TRUE(fx.basketball_active());
         fx.thaw();
         fx.red->setxy(292, 452);  // center (300,460): 40 px from the ball —
                                   // attending, but NOT on it (no pickup)
         fx.green->set_dead(1);
-        fx.tick(598);
-        EXPECT_EQ(0, count_notifications(fx.events, "BALL RESET"));
+        fx.tick(1);
         ASSERT_EQ(0, alive_on_team(fx.world(), 1));
-        fx.tick(5);
+        EXPECT_EQ(1, ai_entries_for_team(fx.world(), 1))
+            << "the corpse scheduled the tick it fell — always-on";
+        fx.world().respawn.respawn_queue.clear();
+        fx.tick(597);
+        EXPECT_EQ(0, count_notifications(fx.events, "BALL RESET"));
+        fx.tick(6);
         EXPECT_EQ(1, count_notifications(fx.events, "BALL RESET"))
             << "attendance cannot stall the wipe watchdog";
         EXPECT_EQ(5, alive_on_team(fx.world(), 1))
@@ -1904,9 +1909,10 @@ struct BballRespawnCourt : BballCourt
 
 }  // namespace
 
-TEST_F(ModesBasketball, respawn_honors_submenu)
+TEST_F(ModesBasketball, respawn_ignores_submenu_everyone_returns)
 {
-    // Off: nobody comes back.
+    // Off: everyone still comes back — the submenu no longer gates a
+    // ball game.
     {
         BballRespawnCourt fx;
         fx.world().respawn_mode = 0;
@@ -1914,12 +1920,13 @@ TEST_F(ModesBasketball, respawn_honors_submenu)
         ASSERT_TRUE(fx.basketball_active());
         fx.kill_both();
         fx.tick(3);
-        EXPECT_FALSE(player_revive_pending(fx.world(), fx.hero->entity_id()));
-        EXPECT_EQ(0, ai_entries_for_team(fx.world(), 0));
+        EXPECT_TRUE(player_revive_pending(fx.world(), fx.hero->entity_id()));
+        EXPECT_EQ(1, ai_entries_for_team(fx.world(), 0));
         fx.tick(70);
-        EXPECT_TRUE(fx.hero->dead());
+        EXPECT_FALSE(fx.hero->dead()) << "Off no longer keeps anyone down";
     }
-    // Heroes: the roster corpse revives at its own anchors; AI stays down.
+    // Heroes: scheduling identical to Off; the roster corpse still lands
+    // on its own anchors.
     {
         BballRespawnCourt fx;
         fx.world().respawn_mode = 1;
@@ -1928,7 +1935,8 @@ TEST_F(ModesBasketball, respawn_honors_submenu)
         fx.kill_both();
         fx.tick(2);
         EXPECT_TRUE(player_revive_pending(fx.world(), fx.hero->entity_id()));
-        EXPECT_EQ(0, ai_entries_for_team(fx.world(), 0));
+        EXPECT_EQ(1, ai_entries_for_team(fx.world(), 0))
+            << "the AI corpse is scheduled regardless of the choice";
         fx.tick(70);  // respawn_ticks 60 + slack
         EXPECT_FALSE(fx.hero->dead());
         const bool at_anchor =
@@ -1938,9 +1946,8 @@ TEST_F(ModesBasketball, respawn_honors_submenu)
             << "on_respawn places at a team-0 anchor, got ("
             << fx.hero->xpos() << "," << fx.hero->ypos() << ")";
         EXPECT_GT(fx.var(kBbAnchorCursor), 0) << "anchor cursor rotated";
-        EXPECT_TRUE(fx.bot->dead());
     }
-    // Everyone: the unowned AI corpse is scheduled too.
+    // Everyone: the same always-on semantics, spelled by the submenu.
     {
         BballRespawnCourt fx;
         fx.world().respawn_mode = 2;
@@ -3126,7 +3133,6 @@ TEST_F(ModesBasketball, moving_receiver_pass_completes)
 TEST_F(ModesBasketball, wipe_watchdog_resets_and_revives)
 {
     BballCourt fx;
-    fx.world().respawn_mode = 0;
     fx.tick(1);
     ASSERT_TRUE(fx.basketball_active());
     fx.give_ball(fx.red, 350, 480);
@@ -3136,9 +3142,13 @@ TEST_F(ModesBasketball, wipe_watchdog_resets_and_revives)
         static_cast<std::int32_t>(fx.world().tick_count_) + 5000;
     fx.green->set_dead(1);
     fx.tick(1);
+    ASSERT_EQ(0, alive_on_team(fx.world(), 1));
+    // The always-on revive would own this comeback; drain it — the
+    // watchdog arms only for a side with zero live AND zero pending.
+    fx.world().respawn.respawn_queue.clear();
+    fx.tick(1);
     const std::int32_t since = fx.var(kBbStallSince);
     ASSERT_GT(since, 0) << "the wipe watchdog armed";
-    ASSERT_EQ(0, alive_on_team(fx.world(), 1));
 
     while (static_cast<std::int32_t>(fx.world().tick_count_) <
            since + kDeadBallTicks - 1)
@@ -4205,7 +4215,6 @@ TEST_F(ModesBasketball, wipe_watchdog_refields_a_matched_team_at_strength)
 {
     BballSoloRosterCourt fx(4);
     arm_matched(fx.world());
-    fx.world().respawn_mode = 0;
     fx.tick(1);
     ASSERT_TRUE(fx.basketball_active());
     const std::vector<int> at_init = team_levels_sorted(fx.world(), 1);
@@ -4222,8 +4231,11 @@ TEST_F(ModesBasketball, wipe_watchdog_refields_a_matched_team_at_strength)
             w->query_order() == Order::Living && w->team_num() == 1)
             w->set_dead(1);
     }
-    fx.tick(2);  // the engine sweeps the unscheduled AI corpses
+    fx.tick(2);  // corpses sweep; their revive entries ride the queue
     ASSERT_EQ(0, alive_on_team(fx.world(), 1));
+    // The D39 reprovision arm guards the drained-queue edge: clear the
+    // in-flight revives so the watchdog reset refields from the plan.
+    fx.world().respawn.respawn_queue.clear();
 
     fx.tick(598);
     for (int i = 0;

--- a/tests/unit/test_modes_soccer.cpp
+++ b/tests/unit/test_modes_soccer.cpp
@@ -1231,21 +1231,24 @@ TEST_F(ModesSoccer, goal_kickoff_reprovisions_a_wiped_bot_team)
 {
     SoccerWorld fx;
     walker* red_extra = fx.spawn_living(FAMILY_SOLDIER, 0, 160, 448, ACT_GUARD);
-    fx.world().respawn_mode = 0;  // permadeath submenu
+    fx.world().respawn_mode = 0;  // the submenu no longer gates a ball game
     fx.tick(1);
     ASSERT_TRUE(fx.soccer_active());
     fx.thaw_kickoff();
-    // Team 1 is wiped; team 0 loses a member but keeps red alive. The
-    // engine sweeps the unscheduled AI corpses at the end of this tick.
+    // Team 1 is wiped; team 0 loses a member but keeps red alive. Every
+    // corpse schedules the tick it falls — submenu Off included.
     fx.green->set_dead(1);
     red_extra->set_dead(1);
     fx.tick(2);
-    EXPECT_EQ(0, ai_entries_for_team(fx.world(), 1))
-        << "Off keeps mid-play corpses down (no policy change)";
+    EXPECT_EQ(1, ai_entries_for_team(fx.world(), 1))
+        << "always-on scheduling covers the wiped side";
+    EXPECT_EQ(1, ai_entries_for_team(fx.world(), 0))
+        << "and the non-wiped side's corpse too";
     ASSERT_EQ(0, alive_on_team(fx.world(), 1));
 
-    // A goal kickoff brings the wiped side back — its corpses are gone,
-    // so the backstop reprovisions the init-style bot squad (B1).
+    // The B1 reprovision arm still guards the no-revives-in-flight edge
+    // (evicted or flushed entries): drain the queue, then score.
+    fx.world().respawn.respawn_queue.clear();
     fx.world().mode.vars[kSocLastTouch1] = 1;  // team 0 touched last
     fx.set_ball(600, 464, 4 * 256, 0);         // into team 1's strip
     fx.tick(1);
@@ -1254,8 +1257,6 @@ TEST_F(ModesSoccer, goal_kickoff_reprovisions_a_wiped_bot_team)
         << "the kickoff backstop refields the wiped team (B1)";
     EXPECT_EQ(1, alive_on_team(fx.world(), 0))
         << "a team with a live member is left alone";
-    EXPECT_EQ(0, ai_entries_for_team(fx.world(), 0))
-        << "no revival entries for the non-wiped team";
     EXPECT_EQ(0u, og::script::hooks::hook_failures().count);
 }
 
@@ -1281,24 +1282,27 @@ TEST_F(ModesSoccer, kickoff_revive_schedules_corpses_and_skips_summons)
     fx.tick(1);
 
     EXPECT_TRUE(player_revive_pending(fx.world(), hero->entity_id()))
-        << "roster corpses ride the kickoff backstop";
+        << "roster corpses are scheduled the tick they fall";
     EXPECT_EQ(1, ai_entries_for_team(fx.world(), 1))
         << "the unowned AI corpse is scheduled; the summon stays down";
     EXPECT_EQ(0, alive_on_team(fx.world(), 1))
         << "revives in flight: no bot-squad reprovision on top";
-    EXPECT_EQ(0, ai_entries_for_team(fx.world(), 0))
-        << "a non-wiped team's corpse stays down at kickoff";
+    EXPECT_EQ(1, ai_entries_for_team(fx.world(), 0))
+        << "the non-wiped team's corpse is scheduled too — always-on";
     fx.tick(70);  // respawn_ticks 60 + slack
     EXPECT_FALSE(hero->dead()) << "the hero is back for the kickoff";
     EXPECT_EQ(2, alive_on_team(fx.world(), 1))
         << "hero + AI replacement return; the summon does not";
-    EXPECT_TRUE(red_extra->dead()) << "the non-wiped team's dead stay down";
+    EXPECT_EQ(2, alive_on_team(fx.world(), 0))
+        << "red + the fallen extra's replacement";
 }
 
 TEST_F(ModesSoccer, unattended_dead_ball_resets_after_600_ticks)
 {
     SoccerWorld fx;
-    fx.world().respawn_mode = 0;
+    // Hold the wiped side's revive past the whole stall window so the
+    // dead-ball clock (not the respawn delay) is what this test times.
+    fx.world().ctf_requested_respawn_ticks = 1200;
     fx.tick(1);
     ASSERT_TRUE(fx.soccer_active());
     // Both parked livings sit L1 > 160 px from the kickoff spot, so the
@@ -1314,8 +1318,10 @@ TEST_F(ModesSoccer, unattended_dead_ball_resets_after_600_ticks)
     EXPECT_EQ(320, fx.ball_cx());
     EXPECT_EQ(464, fx.ball_cy());
     EXPECT_GT(fx.var(kSocKickoffUntil), 600) << "post-reset freeze armed";
-    EXPECT_EQ(5, alive_on_team(fx.world(), 1))
-        << "the dead-ball kickoff refields the wiped side too";
+    EXPECT_EQ(0, alive_on_team(fx.world(), 1))
+        << "the revive rides its long delay — no squad reprovision on top";
+    EXPECT_EQ(1, ai_entries_for_team(fx.world(), 1))
+        << "the wiped side's revive stays in flight";
 }
 
 TEST_F(ModesSoccer, a_nearby_living_clears_the_stall_clock)
@@ -1336,7 +1342,8 @@ TEST_F(ModesSoccer, a_nearby_living_clears_the_stall_clock)
 }
 
 // ===========================================================================
-// Respawns honor the difficulty submenu (og.match_setting("respawn_mode"))
+// Respawns are always on: a ball game ignores the difficulty submenu's
+// respawn choice — every corpse that owns its life comes back.
 // ===========================================================================
 
 namespace {
@@ -1363,7 +1370,7 @@ struct SoccerRespawnWorld : SoccerWorld
 
 }  // namespace
 
-TEST_F(ModesSoccer, respawn_mode_off_schedules_nothing)
+TEST_F(ModesSoccer, submenu_off_still_schedules_everyone)
 {
     SoccerRespawnWorld fx;
     fx.world().respawn_mode = 0;
@@ -1371,13 +1378,15 @@ TEST_F(ModesSoccer, respawn_mode_off_schedules_nothing)
     ASSERT_TRUE(fx.soccer_active());
     fx.kill_both();
     fx.tick(3);
-    EXPECT_FALSE(player_revive_pending(fx.world(), fx.hero->entity_id()));
-    EXPECT_EQ(0, ai_entries_for_team(fx.world(), 0));
+    EXPECT_TRUE(player_revive_pending(fx.world(), fx.hero->entity_id()));
+    EXPECT_EQ(1, ai_entries_for_team(fx.world(), 0));
     fx.tick(70);
-    EXPECT_TRUE(fx.hero->dead()) << "Off means nobody comes back";
+    EXPECT_FALSE(fx.hero->dead()) << "Off no longer keeps anyone down";
+    EXPECT_EQ(3, alive_on_team(fx.world(), 0))
+        << "red + hero + the bot's replacement";
 }
 
-TEST_F(ModesSoccer, respawn_mode_heroes_revives_heroes_at_anchors)
+TEST_F(ModesSoccer, hero_revives_on_anchor_whatever_the_submenu_says)
 {
     SoccerRespawnWorld fx;
     fx.world().respawn_mode = 1;
@@ -1386,8 +1395,8 @@ TEST_F(ModesSoccer, respawn_mode_heroes_revives_heroes_at_anchors)
     fx.kill_both();
     fx.tick(2);
     EXPECT_TRUE(player_revive_pending(fx.world(), fx.hero->entity_id()));
-    EXPECT_EQ(0, ai_entries_for_team(fx.world(), 0))
-        << "Heroes mode never schedules AI corpses";
+    EXPECT_EQ(1, ai_entries_for_team(fx.world(), 0))
+        << "the AI corpse is scheduled regardless of the Heroes choice";
     fx.tick(70);  // delay 60 + slack
     EXPECT_FALSE(fx.hero->dead());
     const bool at_anchor =
@@ -1396,7 +1405,6 @@ TEST_F(ModesSoccer, respawn_mode_heroes_revives_heroes_at_anchors)
     EXPECT_TRUE(at_anchor) << "revive lands on a team-0 anchor, got ("
                            << fx.hero->xpos() << "," << fx.hero->ypos() << ")";
     EXPECT_GT(fx.var(kSocAnchorCursor), 0) << "anchor cursor rotated";
-    EXPECT_TRUE(fx.bot->dead());
 }
 
 TEST_F(ModesSoccer, respawn_mode_everyone_includes_unowned_ai)
@@ -1409,10 +1417,10 @@ TEST_F(ModesSoccer, respawn_mode_everyone_includes_unowned_ai)
     fx.tick(2);
     EXPECT_TRUE(player_revive_pending(fx.world(), fx.hero->entity_id()));
     EXPECT_EQ(1, ai_entries_for_team(fx.world(), 0))
-        << "Everyone mode schedules the unowned AI corpse too";
+        << "the always-on scan matches the old Everyone semantics";
 }
 
-TEST_F(ModesSoccer, respawn_mode_team_one_heroes_gates_by_team)
+TEST_F(ModesSoccer, submenu_team_gate_is_ignored_every_hero_returns)
 {
     SoccerRespawnWorld fx;
     walker* green_hero = fx.spawn_hero(FAMILY_SOLDIER, 1, 560, 448, 8);
@@ -1422,11 +1430,48 @@ TEST_F(ModesSoccer, respawn_mode_team_one_heroes_gates_by_team)
     fx.kill_both();
     green_hero->set_dead(1);
     fx.tick(2);
-    EXPECT_TRUE(player_revive_pending(fx.world(), fx.hero->entity_id()))
-        << "Team 1 (internal team 0) heroes respawn";
-    EXPECT_FALSE(player_revive_pending(fx.world(), green_hero->entity_id()))
-        << "other teams' heroes stay down";
-    EXPECT_EQ(0, ai_entries_for_team(fx.world(), 0));
+    EXPECT_TRUE(player_revive_pending(fx.world(), fx.hero->entity_id()));
+    EXPECT_TRUE(player_revive_pending(fx.world(), green_hero->entity_id()))
+        << "the Team 1-only choice no longer strands other teams";
+    EXPECT_EQ(1, ai_entries_for_team(fx.world(), 0));
+}
+
+TEST_F(ModesSoccer, camped_anchors_cannot_stall_a_respawn)
+{
+    SoccerRespawnWorld fx;
+    // Campers parked EXACTLY on both team-0 anchors: the rotation probe
+    // fails everywhere, and before the ring fallback the revive stayed
+    // wherever the corpse fell. Wildlife team (outside the score range)
+    // so neither the strip nor the AI director ever moves them — a
+    // Living blocks a spawn probe whatever its team.
+    fx.tick(1);
+    ASSERT_TRUE(fx.soccer_active());
+    // Spawn the campers AFTER init (mid-match camping): init-time census
+    // and stripping never see them.
+    walker* c1 = fx.spawn_living(FAMILY_SOLDIER, 4, 96, 448, ACT_SIT);
+    walker* c2 = fx.spawn_living(FAMILY_SOLDIER, 4, 96, 480, ACT_SIT);
+    ASSERT_NE(nullptr, c1);
+    ASSERT_NE(nullptr, c2);
+    fx.hero->setxy(400, 300);  // die far from the spawn line
+    fx.hero->set_dead(1);
+    fx.tick(2);
+    ASSERT_EQ(0, c1->dead()) << "the camper holds its post";
+    ASSERT_EQ(0, c2->dead()) << "the camper holds its post";
+    ASSERT_TRUE(player_revive_pending(fx.world(), fx.hero->entity_id()));
+    fx.tick(70);  // delay 60 + slack
+    ASSERT_FALSE(fx.hero->dead());
+    ASSERT_EQ(0, c1->dead()) << "the camper still holds the anchor";
+    ASSERT_EQ(0, c2->dead()) << "the camper still holds the anchor";
+    // The ring walk lands on a clear tile within 3 tiles (48 px L1) of an
+    // anchor — never at the corpse spot, and never merely at the hero's
+    // own 64-px-away recorded home (the engine's revive-home move).
+    const int d1 = std::abs(fx.hero->xpos() - 96) +
+                   std::abs(fx.hero->ypos() - 448);
+    const int d2 = std::abs(fx.hero->xpos() - 96) +
+                   std::abs(fx.hero->ypos() - 480);
+    EXPECT_LE(std::min(d1, d2), 48)
+        << "revive lands beside the camped spawn line, got ("
+        << fx.hero->xpos() << "," << fx.hero->ypos() << ")";
 }
 
 // ===========================================================================
@@ -2103,8 +2148,13 @@ TEST_F(ModesSoccer, kickoff_reprovisions_a_wiped_matched_team_at_strength)
             w->query_order() == Order::Living && w->team_num() == 1)
             w->set_dead(1);
     }
-    fx.tick(2);  // the engine sweeps the unscheduled AI corpses
+    fx.tick(2);  // corpses sweep; their revive entries ride the queue
     ASSERT_EQ(0, alive_on_team(fx.world(), 1));
+    EXPECT_EQ(1, ai_entries_for_team(fx.world(), 1))
+        << "always-on scheduling covers the matched bot too";
+    // The D39 reprovision arm still guards the no-revives-in-flight edge
+    // (evicted or flushed entries): drain the queue, then score.
+    fx.world().respawn.respawn_queue.clear();
 
     fx.world().mode.vars[kSocLastTouch1] = 1;  // team 0 touched last
     fx.set_ball(600, 464, 4 * 256, 0);         // into team 1's strip
@@ -2155,12 +2205,15 @@ TEST_F(ModesSoccer, kickoff_backstop_matches_a_wiped_human_team_to_target)
     fx.thaw_kickoff();
     park_away(red_hero);
     // The green hero falls AND loses its guy record (a destroyed-corpse
-    // stand-in): the engine sweeps the now-guyless unscheduled corpse, so
-    // the kickoff backstop finds zero live, zero pending, zero corpses.
+    // stand-in): the engine sweeps the now-guyless corpse this tick.
     green_hero->set_dead(1);
     green_hero->clear_myguy();
     fx.tick(2);
     ASSERT_EQ(0, alive_on_team(fx.world(), 1));
+    // The guyless corpse scheduled as a plain AI revive under the
+    // always-on scan; the D24 measure-and-solve arm guards the
+    // drained-queue edge — clear it so the backstop refields.
+    fx.world().respawn.respawn_queue.clear();
 
     fx.world().mode.vars[kSocLastTouch1] = 1;
     fx.set_ball(600, 464, 4 * 256, 0);


### PR DESCRIPTION
Two fixes from family game night.

## Basketball & Soccer: respawns are now always on

Basketball and Soccer were the only two modes wired to the difficulty submenu's respawn choice, which defaults to **Off** — so in a default session nobody respawned at all, and only the wiped-team backstop at goal/center resets ever brought a side back. (The cleric's glow carpets were innocent: glow patches are non-blocking weapons, and the spawn probe never sees them.)

- Both ball games now schedule every corpse that owns its life through `match.schedule_dead` — the same always-on scan TDM and Mutant already use, and the same stance CTF and Onslaught take. The submenu-honoring `run_death_scan` is retired.
- Belt-and-braces for the "spawn points taken up" case: when every anchor probe is blocked (a camped spawn line), `place_at_anchor` falls back to a bounded deterministic ring walk around the anchors — RNG-free, probe-eats-safe, 3-tile cap.

## Imaginations: the Sea Wizard ward never applied in real play

The isle script stamps `BIT_INVINCIBLE` on the Sea Wizard in `on_load` while either watchtower stands — and the flag, the script, and the shipped archive are all correct. The break was dispatch: the transport-shadow installs seed the authoritative world from a level-start keyframe, and `apply_snapshot` claimed the level-change latch even for a tick-0 seed — so `on_load` never ran in the SDL flow. The unlatched `on_tick`/`on_entity_death` hooks kept narrating the dream-log, masking the breakage; the mapgen self-check and unit test tick a freshly loaded world (latch open), which is why they stayed green.

- `apply_snapshot` now claims the latch only for genuinely mid-level snapshots (`level_tick_count > 0`); a level-start seed leaves the first tick's `on_load` dispatch armed. This un-breaks `on_load` for **every** campaign's level scripts in real play, not just the isle.
- Hardening from the damage-path audit: `do_combat_damage` and turn-undead now honor `BIT_INVINCIBLE`/invulnerability (the sink was only protected when reached through `attack()`; turn-undead was the one real caller-side bypass). The four `walker_combat.cpp` mutation pins are repinned to the shifted lines.

## Tests

- Ball-game suites re-pin the new contract: every submenu choice schedules everyone; the wipe watchdog and squad-reprovision arms keep coverage via drained-queue setups (the watchdog arms only for a side with zero live AND zero pending — revives now own the normal comeback).
- New `camped_anchors_cannot_stall_a_respawn`: campers parked exactly on both anchors; proven red with the ring fallback neutered (revive stranded at the corpse spot), green with it.
- New `ward_survives_the_level_start_snapshot_seed`: reproduces the real-play seed flow (`reset_level_progress` + `apply_snapshot` + tick); red before the latch fix, green after.
- `watchtower_ward_arc_plays_out` now pins **damage immunity under a live attack** (and that the same blow lands once the ward drops), not just the flag value.

## Verification

- ctest ci-test suite: 57/58 (the one red is `emscripten_build_test`, which fails on this machine's system emscripten 3.1.6/clang-15 with libc++ sysroot mismatches while compiling vendored lodepng/Lua — input-independent of this diff; the CI emsdk wasm build is the authoritative gate)
- `og_test_parity`: 256/256 goldens byte-identical
- `check_mutation_pins.py`: 217/217 anchors valid
- Lua statement lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)