### PR TITLE
Demo: 6x4 fullscreen grid, cover-scaled cells, whole-grid FPS overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -794,8 +794,8 @@ if(NOT EMSCRIPTEN)
     endif()
 
     # --- openglad_demo (multi-session demo) ---
-    # Runs 12 concurrent AI-controlled game sessions in a 4x3 grid,
-    # demonstrating the de-singletonized engine.
+    # Runs 24 concurrent AI-controlled game sessions in a 6x4 grid scaled to
+    # fill the display, demonstrating the de-singletonized engine.
     add_executable(openglad_demo ${SRC_DIR}/platform/sdl/demo.cpp)
     configure_openglad_library(openglad_demo)
     configure_openglad_sdl_target(openglad_demo)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -381,10 +381,30 @@ Composite all surfaces into grid
 SDL_RenderPresent (once)
 ```
 
-- Queries native display resolution to calculate grid size (e.g., 4×3 on 1280×600+)
+- Fixed 6×4 grid by default; each 320×200 session surface is cover-scaled into its display cell
 - 1 host session (owns SDL window) + N sub-sessions (headless render targets)
 - Each sub-session gets a unique random seed and random scenario assignment
 - All sessions run in spectator mode (0-player, fully AI-controlled)
+
+#### Environment knobs
+
+Every knob is opt-in: unset, the demo takes its production path.
+
+| Variable | Effect |
+|---|---|
+| `OPENGLAD_DEMO_GRID` | `COLSxROWS` grid topology (default `6x4`) |
+| `OPENGLAD_DEMO_ZOOM` | Extra magnification on top of the cover scale, clamped to ≥ 1.0 (default 1.1) |
+| `OPENGLAD_DEMO_SEED` | Unsigned seed for scenario shuffle and per-session RNG |
+| `OPENGLAD_DEMO_MAX_FRAMES` | Stop after N main-loop frames (0 = run forever) |
+| `OPENGLAD_DEMO_CAMPAIGN` | Campaign the scenarios are loaded from (default `gladiator`) |
+| `OPENGLAD_DEMO_SCENARIOS` | Comma-separated scenario ids assigned to cells in order, replacing the shuffled pool |
+| `OPENGLAD_DEMO_TEAM_SIZE` | Force the generated player team size |
+| `OPENGLAD_DEMO_SHOW_FPS` | One whole-grid FPS readout, top-right of the composite. Unset falls back to the `graphics`/`show_fps` setting (`--show-fps`); `0` or `off` disables. Never appears in capture frames |
+| `OPENGLAD_DEMO_COMPOSITE_DUMP` | BMP path for the final presented composite, written when the run ends via `OPENGLAD_DEMO_MAX_FRAMES` |
+| `OPENGLAD_DEMO_CAPTURE_DIR` | Enables showcase frame capture into this directory (indexed BMPs) |
+| `OPENGLAD_DEMO_CAPTURE_SESSION` | Cell index to capture, or `-1` for the whole grid at native cell resolution |
+| `OPENGLAD_DEMO_CAPTURE_FOCUS` | Capture camera: `player`, `boss` or `center` |
+| `OPENGLAD_DEMO_CAPTURE_EVERY` / `_START` / `_LIMIT` | Capture frame stride, first frame, and frame count cap |
 
 ### Spectator Mode (0-Player)
 

--- a/include/openglad/interface/fps_overlay.h
+++ b/include/openglad/interface/fps_overlay.h
@@ -1,6 +1,27 @@
 #pragma once
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
 class screen;
+
+// Sliding-window frame-rate estimator: one update() call per presented frame,
+// timestamps in SDL_GetTicks() milliseconds. Exposed here because the demo
+// compositor needs the same measurement for its whole-grid readout; keeping one
+// definition keeps the two overlays reporting the same quantity.
+struct FpsCounter {
+    static constexpr std::size_t kCap = 256;
+    static constexpr std::uint64_t kWindowMs = 500;
+    std::array<std::uint64_t, kCap> ts{};
+    std::size_t head = 0;
+    std::size_t size = 0;
+    std::uint64_t first_seen_ms = 0;
+    bool initialized = false;
+    // Returns frames per second over the trailing kWindowMs; during the first
+    // 250ms after the first call it extrapolates from the samples so far.
+    int update(std::uint64_t now_ms);
+};
 
 // Draws the measured render FPS at the top-right of the frame, one row below
 // the TEAM/FOES counter box. counter_bottom_y is the box's bottom edge in

--- a/scripts/test_demo_smoke.sh
+++ b/scripts/test_demo_smoke.sh
@@ -215,3 +215,96 @@ fi
 grep -Fq \
     "OPENGLAD_DEMO_SCENARIOS must be a comma-separated scenario id list" \
     <<<"$bad_scenarios_output"
+
+# --- Whole-grid FPS overlay -------------------------------------------------
+# These runs write composite dumps, so they must stay after the "no *.bmp with
+# capture disabled" check above. The overlay-on log line is matched with its
+# openglad_demo prefix because gparser logs a bare "FPS overlay on." for the
+# --show-fps command-line flag.
+fps_on_output=$(
+    env \
+        SDL_VIDEODRIVER=dummy \
+        SDL_AUDIODRIVER=dummy \
+        SDL_RENDER_DRIVER=software \
+        OPENGLAD_DEMO_GRID=2x1 \
+        OPENGLAD_DEMO_MAX_FRAMES=10 \
+        OPENGLAD_DEMO_SEED=5 \
+        OPENGLAD_DEMO_SHOW_FPS=1 \
+        OPENGLAD_DEMO_COMPOSITE_DUMP="$test_root/fps-on.bmp" \
+        OPENGLAD_CONFIG_DIR="$test_root/fps-on-config" \
+        "$demo_bin" 2>&1
+)
+printf '%s\n' "$fps_on_output"
+grep -Fq 'openglad_demo: FPS overlay on' <<<"$fps_on_output"
+
+# Unset knob with a fresh config dir: graphics/show_fps is off, so is the
+# overlay.
+fps_off_output=$(
+    env \
+        SDL_VIDEODRIVER=dummy \
+        SDL_AUDIODRIVER=dummy \
+        SDL_RENDER_DRIVER=software \
+        OPENGLAD_DEMO_GRID=2x1 \
+        OPENGLAD_DEMO_MAX_FRAMES=10 \
+        OPENGLAD_DEMO_SEED=5 \
+        OPENGLAD_DEMO_COMPOSITE_DUMP="$test_root/fps-off.bmp" \
+        OPENGLAD_CONFIG_DIR="$test_root/fps-off-config" \
+        "$demo_bin" 2>&1
+)
+printf '%s\n' "$fps_off_output"
+if grep -Fq 'openglad_demo: FPS overlay on' <<<"$fps_off_output"; then
+    printf 'openglad_demo enabled the FPS overlay without the knob\n' >&2
+    exit 1
+fi
+
+fps_zero_output=$(
+    env \
+        SDL_VIDEODRIVER=dummy \
+        SDL_AUDIODRIVER=dummy \
+        SDL_RENDER_DRIVER=software \
+        OPENGLAD_DEMO_GRID=1x1 \
+        OPENGLAD_DEMO_MAX_FRAMES=1 \
+        OPENGLAD_DEMO_SEED=5 \
+        OPENGLAD_DEMO_SHOW_FPS=0 \
+        OPENGLAD_CONFIG_DIR="$test_root/fps-zero-config" \
+        "$demo_bin" 2>&1
+)
+printf '%s\n' "$fps_zero_output"
+if grep -Fq 'openglad_demo: FPS overlay on' <<<"$fps_zero_output"; then
+    printf 'OPENGLAD_DEMO_SHOW_FPS=0 still enabled the FPS overlay\n' >&2
+    exit 1
+fi
+
+# Control for the pixel assertion below: with the overlay off, two runs of the
+# same seed, grid and frame count dump byte-identical composites. If that ever
+# stops holding, this fails first and the "on differs from off" comparison is
+# not silently reduced to a coin flip.
+env \
+    SDL_VIDEODRIVER=dummy \
+    SDL_AUDIODRIVER=dummy \
+    SDL_RENDER_DRIVER=software \
+    OPENGLAD_DEMO_GRID=2x1 \
+    OPENGLAD_DEMO_MAX_FRAMES=10 \
+    OPENGLAD_DEMO_SEED=5 \
+    OPENGLAD_DEMO_COMPOSITE_DUMP="$test_root/fps-off-again.bmp" \
+    OPENGLAD_CONFIG_DIR="$test_root/fps-off-again-config" \
+    "$demo_bin" >/dev/null 2>&1
+if ! cmp -s "$test_root/fps-off.bmp" "$test_root/fps-off-again.bmp"; then
+    printf 'composite dumps are not reproducible for a fixed seed\n' >&2
+    exit 1
+fi
+
+# The overlay is drawn into the presented composite, so it must change those
+# pixels. Only inequality is asserted: the readout itself varies run to run.
+# Both dumps must exist and be non-empty first — cmp exits 2 on a missing
+# operand, which the inequality branch would otherwise treat as a pass.
+for dump in "$test_root/fps-on.bmp" "$test_root/fps-off.bmp"; do
+    if [[ ! -s "$dump" ]]; then
+        printf 'missing composite dump: %s\n' "$dump" >&2
+        exit 1
+    fi
+done
+if cmp -s "$test_root/fps-on.bmp" "$test_root/fps-off.bmp"; then
+    printf 'FPS overlay left the presented composite unchanged\n' >&2
+    exit 1
+fi

--- a/src/interface/fps_overlay.cpp
+++ b/src/interface/fps_overlay.cpp
@@ -13,19 +13,6 @@
 #include <format>
 #include <string>
 
-namespace {
-
-struct FpsCounter {
-    static constexpr std::size_t kCap = 256;
-    static constexpr std::uint64_t kWindowMs = 500;
-    std::array<std::uint64_t, kCap> ts{};
-    std::size_t head = 0;
-    std::size_t size = 0;
-    std::uint64_t first_seen_ms = 0;
-    bool initialized = false;
-    int update(std::uint64_t now_ms);
-};
-
 int FpsCounter::update(std::uint64_t now_ms)
 {
     if (!initialized)
@@ -60,8 +47,6 @@ int FpsCounter::update(std::uint64_t now_ms)
     }
     return static_cast<int>(size * 1000 / kWindowMs);
 }
-
-} // namespace
 
 // new_score_panel draws the TEAM/FOES counter in the top-right corner of the
 // top viewport; counter_bottom_y is that box's bottom edge (it grows with the

--- a/src/platform/sdl/demo.cpp
+++ b/src/platform/sdl/demo.cpp
@@ -33,6 +33,7 @@
 #include <openglad/gameplay/gameplay_context.h>
 #include <openglad/gameplay/guy.h>
 #include <openglad/gameplay/walker.h>
+#include <openglad/interface/fps_overlay.h>
 #include <openglad/interface/input.h>
 #include <openglad/legacy/base.h>
 #include <openglad/resources/io.h>
@@ -49,6 +50,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cmath>
 #include <charconv>
 #include <chrono>
 #include <climits>
@@ -73,12 +75,26 @@
 void init_input();
 short load_saved_game(const char* filename, screen* scr);
 
-// Demo sessions are PINNED to the classic 320x200 canvas: the compositor
-// assumes every session surface is exactly one CELL_W x CELL_H cell, and demo
-// sessions never call Screen::set_world_canvas_size, so their world canvas
-// stays shared with the fixed-size UI canvas.
+// Demo sessions are PINNED to the classic 320x200 canvas: every session
+// surface is exactly CELL_W x CELL_H, and demo sessions never call
+// Screen::set_world_canvas_size, so their world canvas stays shared with the
+// fixed-size UI canvas. The compositor scales each surface into its display
+// cell (aspect-preserving cover + center crop), so cells need not be 320x200
+// on screen.
 inline constexpr int CELL_W = 320;
 inline constexpr int CELL_H = 200;
+
+// Extra magnification applied on top of the cover scale when compositing a
+// session into its display cell. Values above 1.0 crop deeper into the
+// 320x200 frame. Overridable via OPENGLAD_DEMO_ZOOM (clamped to >= 1.0; below
+// 1.0 the cell would no longer be filled).
+inline constexpr float DEFAULT_CELL_ZOOM = 1.1f;
+
+// Backing strip for the whole-grid FPS readout, in host-canvas pixels. Wide
+// enough for "FPS: 99999" at the 5x6 normal font (6px advance per glyph) with
+// a 2px inset, so the text is never clipped by the strip edge.
+inline constexpr int FPS_STRIP_W = 64;
+inline constexpr int FPS_STRIP_H = 10;
 
 // Scenario pool — diverse levels from the main campaign plus bonus maps.
 static const std::array<int, 20> SCENARIO_POOL = {
@@ -129,6 +145,22 @@ static int env_int(const char* name, int fallback, int minimum)
     if (parsed.ec != std::errc{} || parsed.ptr != text.data() + text.size()) {
         throw std::runtime_error(std::format(
             "{} must be an integer, got '{}'", name, text));
+    }
+    return std::max(minimum, value);
+}
+
+static float env_float(const char* name, float fallback, float minimum)
+{
+    const char* raw = env_or_null(name);
+    if (raw == nullptr)
+        return fallback;
+    const std::string_view text(raw);
+    float value = 0.0f;
+    const auto parsed = std::from_chars(
+        text.data(), text.data() + text.size(), value);
+    if (parsed.ec != std::errc{} || parsed.ptr != text.data() + text.size()) {
+        throw std::runtime_error(std::format(
+            "{} must be a number, got '{}'", name, text));
     }
     return std::max(minimum, value);
 }
@@ -268,8 +300,7 @@ public:
     // Writes `src` (the session's 32bpp canvas) to `path` as an 8-bit BMP,
     // using `pal6` (the session's live 6-bit palette) as the colour table.
     // `width`/`height` of 0 mean the whole surface; otherwise only that
-    // top-left region is written (the composite surface is display-sized but
-    // only its grid area carries sessions).
+    // top-left region is written.
     bool write(SDL_Surface* src, const std::array<unsigned char, 768>& pal6,
                const std::string& path, int width = 0, int height = 0)
     {
@@ -605,17 +636,37 @@ static void render_session_frame(screen& s, SDL_Surface* session_surface)
     }
 }
 
-// Blit a 320x200 session surface into a sub-region of the composite surface.
+// Blit a 320x200 session surface into its cell of the composite surface.
+// Cells split the composite evenly (per-index rounding, so the grid always
+// covers the full display with no seams). The source is cover-scaled: magnify
+// uniformly until the frame fills the cell in both dimensions, times the zoom
+// boost, then center-crop the excess.
 static void composite_session(SDL_Surface* dst, SDL_Surface* src,
-                              int grid_col, int grid_row)
+                              int grid_col, int grid_row,
+                              int grid_cols, int grid_rows, float zoom_boost)
 {
     if (!src || !dst) return;
     SDL_Rect dst_rect;
-    dst_rect.x = grid_col * CELL_W;
-    dst_rect.y = grid_row * CELL_H;
-    dst_rect.w = CELL_W;
-    dst_rect.h = CELL_H;
-    SDL_BlitSurface(src, nullptr, dst, &dst_rect);
+    dst_rect.x = grid_col * dst->w / grid_cols;
+    dst_rect.y = grid_row * dst->h / grid_rows;
+    dst_rect.w = (grid_col + 1) * dst->w / grid_cols - dst_rect.x;
+    dst_rect.h = (grid_row + 1) * dst->h / grid_rows - dst_rect.y;
+
+    const float cover = std::max(
+        static_cast<float>(dst_rect.w) / static_cast<float>(CELL_W),
+        static_cast<float>(dst_rect.h) / static_cast<float>(CELL_H));
+    const float zoom = cover * std::max(1.0f, zoom_boost);
+    SDL_Rect src_rect;
+    src_rect.w = std::clamp(
+        static_cast<int>(std::lround(static_cast<float>(dst_rect.w) / zoom)),
+        1, CELL_W);
+    src_rect.h = std::clamp(
+        static_cast<int>(std::lround(static_cast<float>(dst_rect.h) / zoom)),
+        1, CELL_H);
+    src_rect.x = (CELL_W - src_rect.w) / 2;
+    src_rect.y = (CELL_H - src_rect.h) / 2;
+    SDL_BlitSurfaceScaled(src, &src_rect, dst, &dst_rect,
+                          SDL_SCALEMODE_LINEAR);
 }
 
 int main(int argc, char* argv[])
@@ -655,6 +706,22 @@ int main(int argc, char* argv[])
         const std::vector<int> scenario_override =
             env_scenario_list("OPENGLAD_DEMO_SCENARIOS");
         const int forced_team_size = env_int("OPENGLAD_DEMO_TEAM_SIZE", 0, 0);
+
+        // OPENGLAD_DEMO_SHOW_FPS overrides the graphics/show_fps setting the
+        // main game exposes as --show-fps; unset (or empty) defers to it, so a
+        // fresh config dir means off. The log line is emitted here, not at the
+        // first draw, so even a one-frame run records the decision — and it is
+        // prefixed because gparser already logs a bare "FPS overlay on." for
+        // the command-line flag.
+        const char* fps_env = env_or_null("OPENGLAD_DEMO_SHOW_FPS");
+        const bool show_fps =
+            fps_env != nullptr
+                ? (std::string_view(fps_env) != "0" &&
+                   std::string_view(fps_env) != "off")
+                : cfg.is_on("graphics", "show_fps");
+        if (show_fps)
+            Log("openglad_demo: FPS overlay on\n");
+
         const CaptureSettings capture = capture_settings_from_env();
         std::unique_ptr<IndexedFrameWriter> capture_writer;
         if (capture.enabled()) {
@@ -687,30 +754,32 @@ int main(int argc, char* argv[])
             display_w = dm->w;
             display_h = dm->h;
         }
-        int grid_cols = display_w / CELL_W;
-        int grid_rows = display_h / CELL_H;
-        // The render loop is sequential on the main thread, so cell count
-        // drives steady-state frame cost linearly. Cap to the documented
-        // demo intent (4x3 = 12 cells, see CMakeLists.txt:1086) so a 4K+
-        // desktop doesn't drop FPS into the single digits. Power users can
-        // opt back in via OPENGLAD_DEMO_GRID=COLSxROWS.
+        // The compositor cover-scales each 320x200 session into its display
+        // cell, so the grid is a fixed choice rather than a function of
+        // display size. 6x4 = 24 cells is the documented demo intent (see
+        // CMakeLists.txt, openglad_demo); the render loop is sequential on
+        // the main thread, so cell count drives steady-state frame cost
+        // linearly — tune with OPENGLAD_DEMO_GRID=COLSxROWS.
+        int grid_cols = 6;
+        int grid_rows = 4;
         if (const char* grid_env = std::getenv("OPENGLAD_DEMO_GRID")) {
             int gc = 0, gr = 0;
             if (std::sscanf(grid_env, "%dx%d", &gc, &gr) == 2 && gc >= 1 && gr >= 1) {
                 grid_cols = gc;
                 grid_rows = gr;
             }
-        } else {
-            grid_cols = std::min(grid_cols, 4);
-            grid_rows = std::min(grid_rows, 3);
         }
         const int num_sessions = grid_cols * grid_rows;
+        const float cell_zoom =
+            env_float("OPENGLAD_DEMO_ZOOM", DEFAULT_CELL_ZOOM, 1.0f);
 
-        Log("Display: {}x{}, grid: {}x{} = {} sessions\n",
-            display_w, display_h, grid_cols, grid_rows, num_sessions);
+        Log("Display: {}x{}, grid: {}x{} = {} sessions, cell zoom {:.2f}\n",
+            display_w, display_h, grid_cols, grid_rows, num_sessions,
+            cell_zoom);
 
-        if (num_sessions <= 0) {
-            LogError("Display too small for even one {}x{} cell\n", CELL_W, CELL_H);
+        if (display_w < grid_cols || display_h < grid_rows) {
+            LogError("Display too small for a {}x{} grid\n",
+                     grid_cols, grid_rows);
             return 1;
         }
 
@@ -752,12 +821,47 @@ int main(int argc, char* argv[])
                               SDL_TEXTUREACCESS_STREAMING, display_w, display_h),
             SDL_DestroyTexture);
         if (!composite_surface || !composite_tex) {
-            LogError("Failed to create composite surface/texture\n");
+            LogError("Failed to create composite {} ({}x{}, renderer={}): {}\n",
+                     !composite_surface ? "surface" : "texture",
+                     display_w, display_h,
+                     static_cast<void*>(E_Screen->renderer), SDL_GetError());
             return 1;
         }
         // SDL3 defaults alpha-format textures to BLEND; the composite pixels
         // are XRGB (alpha=0), so blending would present nothing.
         SDL_SetTextureBlendMode(composite_tex.get(), SDL_BLENDMODE_NONE);
+
+        // Whole-grid captures bypass the scaled on-screen composite: the
+        // indexed writer depends on palette-exact pixels, so capture frames
+        // are assembled from unscaled 1:1 cell blits at native resolution.
+        std::unique_ptr<SDL_Surface, decltype(&SDL_DestroySurface)>
+            capture_grid_surface(nullptr, SDL_DestroySurface);
+        if (capture.enabled() && capture.session_index < 0) {
+            capture_grid_surface.reset(SDL_CreateSurface(
+                grid_cols * CELL_W, grid_rows * CELL_H,
+                SDL_PIXELFORMAT_XRGB8888));
+            if (!capture_grid_surface) {
+                LogError("Failed to create capture grid surface: {}\n",
+                         SDL_GetError());
+                return 1;
+            }
+        }
+
+        // Private scratch for the FPS readout. The host canvas cannot be used:
+        // it is the surface every cell is copied out of in render_session_frame,
+        // so anything left there reaches the next frame's capture output.
+        std::unique_ptr<SDL_Surface, decltype(&SDL_DestroySurface)> fps_strip(
+            nullptr, SDL_DestroySurface);
+        FpsCounter fps_counter;
+        if (show_fps) {
+            fps_strip.reset(SDL_CreateSurface(FPS_STRIP_W, FPS_STRIP_H,
+                                              SDL_PIXELFORMAT_XRGB8888));
+            if (!fps_strip) {
+                LogError("Failed to create FPS overlay surface: {}\n",
+                         SDL_GetError());
+                return 1;
+            }
+        }
 
         // --- Create sub-sessions (main thread) ---
         std::vector<DemoSession> demos(static_cast<size_t>(num_sessions));
@@ -923,22 +1027,71 @@ int main(int argc, char* argv[])
                 SDL_Surface* src = demos[static_cast<size_t>(i)].session->session_surface_;
                 int col = i % grid_cols;
                 int row = i / grid_cols;
-                composite_session(composite_surface.get(), src, col, row);
+                composite_session(composite_surface.get(), src, col, row,
+                                  grid_cols, grid_rows, cell_zoom);
             }
 
-            // Whole-grid dump: every cell at once, cropped to the grid area
-            // (the composite surface itself is display-sized).
+            // Whole-grid dump: every cell at once, at native cell resolution
+            // (the on-screen composite is scaled, so it is unusable here).
             if (capture_this_frame && capture.session_index < 0) {
+                for (int i = 0; i < num_sessions; i++) {
+                    SDL_Surface* src =
+                        demos[static_cast<size_t>(i)].session->session_surface_;
+                    SDL_Rect cell{(i % grid_cols) * CELL_W,
+                                  (i / grid_cols) * CELL_H, CELL_W, CELL_H};
+                    SDL_BlitSurface(src, nullptr, capture_grid_surface.get(),
+                                    &cell);
+                }
                 const std::string path = capture_path();
-                if (!capture_writer->write(composite_surface.get(),
-                                           host_session.curpal_, path,
-                                           grid_cols * CELL_W,
-                                           grid_rows * CELL_H)) {
+                if (!capture_writer->write(capture_grid_surface.get(),
+                                           host_session.curpal_, path)) {
                     throw std::runtime_error(std::format(
                         "openglad_demo failed to write capture frame {}: {}",
                         path, SDL_GetError()));
                 }
                 captured_frames++;
+            }
+
+            // One readout for the whole grid, sampled once per presented
+            // frame, so it measures the compositor loop rather than any one
+            // session. It lands here — after both capture paths have consumed
+            // the session surfaces, before the present — so it reaches the
+            // screen and OPENGLAD_DEMO_COMPOSITE_DUMP but never a capture
+            // frame, which must stay palette-exact.
+            if (show_fps) {
+                const int fps = fps_counter.update(SDL_GetTicks());
+                const std::string fps_text = std::format("FPS: {}", fps);
+                // Text draws through og::runtime::current_session and
+                // E_Screen->render, not through the screen it is called on;
+                // both must name the host for the palette lookup to resolve.
+                auto host_scope = host_session.activate();
+                text& font = host_session.myscreen_->text_normal;
+                const int text_w = std::clamp(font.query_width(fps_text) + 4,
+                                              1, FPS_STRIP_W);
+                SDL_Surface* saved_render = E_Screen->render;
+                E_Screen->render = fps_strip.get();
+                SDL_FillSurfaceRect(fps_strip.get(), nullptr, 0x000000);
+                font.write_xy(2, 2, fps_text, YELLOW, static_cast<short>(1));
+                E_Screen->render = saved_render;
+
+                // Blit only the used span so the backing box hugs the text
+                // instead of trailing the strip's worst-case width.
+                const SDL_Rect strip_src{0, 0, text_w, FPS_STRIP_H};
+
+                // Integer magnification keeps the 5x6 font crisp on HiDPI
+                // displays; the clamps hold the strip on-surface when the
+                // display is smaller than the strip plus its margin.
+                const int fps_scale = std::max(1, display_w / 1024);
+                const int strip_w = text_w * fps_scale;
+                const int strip_h = FPS_STRIP_H * fps_scale;
+                const int margin = 8 * fps_scale;
+                SDL_Rect strip_dst{
+                    std::max(0, display_w - strip_w - margin),
+                    std::clamp(margin, 0, std::max(0, display_h - strip_h)),
+                    strip_w, strip_h};
+                SDL_BlitSurfaceScaled(fps_strip.get(), &strip_src,
+                                      composite_surface.get(), &strip_dst,
+                                      SDL_SCALEMODE_NEAREST);
             }
 
             SDL_UpdateTexture(composite_tex.get(), nullptr,
@@ -980,6 +1133,19 @@ int main(int argc, char* argv[])
             if (capture.limit > 0 && captured_frames >= capture.limit) {
                 running = false;
             }
+
+            // Opt-in debug dump of the final presented composite (the scaled
+            // grid exactly as shown on screen), for eyeballing the layout
+            // without a screen recorder.
+            if (!running) {
+                if (const char* dump =
+                        env_or_null("OPENGLAD_DEMO_COMPOSITE_DUMP")) {
+                    if (!SDL_SaveBMP(composite_surface.get(), dump)) {
+                        LogError("composite dump to '{}' failed: {}\n",
+                                 dump, SDL_GetError());
+                    }
+                }
+            }
         }
 
         if (capture_writer) {
@@ -1001,6 +1167,8 @@ int main(int argc, char* argv[])
         // Cleanup (the unique_ptr deleters also free on any early-return/throw path)
         composite_tex.reset();
         composite_surface.reset();
+        capture_grid_surface.reset();
+        fps_strip.reset();
         for (auto& d : demos) {
             d.session.reset();
         }

--- a/src/platform/sdl/sai2x.cpp
+++ b/src/platform/sdl/sai2x.cpp
@@ -801,10 +801,10 @@ Screen::Screen( RenderEngine engine, int width, int height, int fullscreen)
     // game away to black. Request the SDL2-default opaque context everywhere.
     SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
 
-    #ifdef TESTING
     renderer = SDL_CreateRenderer(window, nullptr);
-    #else
-    renderer = SDL_CreateRenderer(window, nullptr);
+    if (renderer == nullptr)
+        LogError("SDL_CreateRenderer failed: {}\n", SDL_GetError());
+    #ifndef TESTING
     SDL_SetRenderVSync(renderer, 1);
     #endif
 

--- a/tests/unit/test_session_raii.cpp
+++ b/tests/unit/test_session_raii.cpp
@@ -468,48 +468,59 @@ TEST(SessionRaii, session_state_modification_isolation)
 
 TEST(SessionRaii, demo_grid_layout_non_overlapping)
 {
-    // Verify the 4x3 grid layout produces 12 non-overlapping sub-regions.
-    constexpr int COLS = 4;
-    constexpr int ROWS = 3;
-    constexpr int W = 320;
-    constexpr int H = 200;
+    // Verify the demo compositor's 6x4 display-cell layout (per-index
+    // rounding, matching composite_session in demo.cpp) produces 24
+    // non-overlapping sub-regions that tile the whole display, including
+    // displays that don't divide evenly.
+    constexpr int COLS = 6;
+    constexpr int ROWS = 4;
     constexpr int TOTAL = COLS * ROWS;
 
     struct Rect { int x, y, w, h; };
-    std::vector<Rect> rects;
 
-    for (int i = 0; i < TOTAL; i++) {
-        int col = i % COLS;
-        int row = i / COLS;
-        rects.push_back({col * W, row * H, W, H});
-    }
-
-    ASSERT_TRUE(rects.size() == 12);
-
-    // Verify no two rects overlap
-    for (size_t i = 0; i < rects.size(); i++) {
-        for (size_t j = i + 1; j < rects.size(); j++) {
-            const auto& a = rects[i];
-            const auto& b = rects[j];
-            bool overlaps = (a.x < b.x + b.w) && (a.x + a.w > b.x) &&
-                            (a.y < b.y + b.h) && (a.y + a.h > b.y);
-            ASSERT_TRUE(!overlaps);
+    for (const auto& [DISPLAY_W, DISPLAY_H] :
+         {std::pair{1536, 960}, std::pair{1024, 768}, std::pair{1366, 767}}) {
+        std::vector<Rect> rects;
+        for (int i = 0; i < TOTAL; i++) {
+            int col = i % COLS;
+            int row = i / COLS;
+            int x = col * DISPLAY_W / COLS;
+            int y = row * DISPLAY_H / ROWS;
+            rects.push_back({x, y,
+                             (col + 1) * DISPLAY_W / COLS - x,
+                             (row + 1) * DISPLAY_H / ROWS - y});
         }
-    }
 
-    // Verify they tile the full display
-    int total_area = 0;
-    for (const auto& r : rects) {
-        total_area += r.w * r.h;
-    }
-    ASSERT_TRUE(total_area == COLS * W * ROWS * H);
+        ASSERT_TRUE(rects.size() == 24);
 
-    // Verify bounds
-    for (const auto& r : rects) {
-        ASSERT_TRUE(r.x >= 0);
-        ASSERT_TRUE(r.y >= 0);
-        ASSERT_TRUE(r.x + r.w <= COLS * W);
-        ASSERT_TRUE(r.y + r.h <= ROWS * H);
+        // Verify no two rects overlap
+        for (size_t i = 0; i < rects.size(); i++) {
+            for (size_t j = i + 1; j < rects.size(); j++) {
+                const auto& a = rects[i];
+                const auto& b = rects[j];
+                bool overlaps = (a.x < b.x + b.w) && (a.x + a.w > b.x) &&
+                                (a.y < b.y + b.h) && (a.y + a.h > b.y);
+                ASSERT_TRUE(!overlaps);
+            }
+        }
+
+        // Verify they tile the full display: total area matches and every
+        // rect stays in bounds, which together with non-overlap means full
+        // coverage (no seams).
+        int total_area = 0;
+        for (const auto& r : rects) {
+            total_area += r.w * r.h;
+        }
+        ASSERT_TRUE(total_area == DISPLAY_W * DISPLAY_H);
+
+        for (const auto& r : rects) {
+            ASSERT_TRUE(r.w > 0);
+            ASSERT_TRUE(r.h > 0);
+            ASSERT_TRUE(r.x >= 0);
+            ASSERT_TRUE(r.y >= 0);
+            ASSERT_TRUE(r.x + r.w <= DISPLAY_W);
+            ASSERT_TRUE(r.y + r.h <= DISPLAY_H);
+        }
     }
 }
 


### PR DESCRIPTION
## What

`openglad_demo` now tiles **24 sessions in a 6x4 grid that fills the entire display**, with a slight zoom, plus an opt-in **whole-grid FPS overlay**.

- Each 320x200 session surface is cover-scaled into its display cell: uniform magnification + center crop, so cells fill edge-to-edge with no letterboxing and no aspect distortion. `OPENGLAD_DEMO_ZOOM` tunes the extra magnification (default 1.1x on top of the cover scale); `OPENGLAD_DEMO_GRID` still overrides the grid.
- Whole-grid captures (`OPENGLAD_DEMO_CAPTURE_SESSION=-1`) now composite unscaled cells into a dedicated native-resolution surface — `IndexedFrameWriter` showcase frames stay palette-exact and keep their pinned 640x200 (2x1) dimensions.
- `OPENGLAD_DEMO_COMPOSITE_DUMP=<path>.bmp` dumps the final presented composite, enabling headless visual verification of the scaled layout.
- `OPENGLAD_DEMO_SHOW_FPS` (falling back to the game's `graphics/show_fps` config key) draws a single whole-grid FPS readout — compositor loop rate, not 24 per-cell numbers — in the top-right, using the game's own text renderer via a private scratch surface. It writes only to the presented composite; capture frames are byte-identical with it on or off. `FpsCounter` moves from `fps_overlay.cpp` into the header for reuse; `draw_fps_overlay` behavior is unchanged.
- `SDL_CreateRenderer` failure is now logged at the failure site (previously the first symptom was a misleading composite-texture error, and `SDL_SetRenderVSync` clobbered the real error string).

## Testing

- `scripts/test_demo_smoke.sh` — new FPS-overlay section: exact log-line assertions for on/off/`=0`, a same-seed determinism control, dump-existence guards, and an on-vs-off pixel inequality assert. Full script passes locally.
- `tests/unit/test_session_raii.cpp` — grid-layout test now pins the 6x4 per-index rounding math (non-overlap + exact full-display coverage) across even and uneven display sizes.
- Visually verified via headless composite dumps: 24 cells tile the full display with no seams; `FPS: 12` renders top-right (matches the demo's paced frame period); capture frames contain no overlay pixels.
- `docs/ARCHITECTURE.md` gains a table documenting all `OPENGLAD_DEMO_*` knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)