### PR TITLE
Uncap render rate: wall-clock sim scheduling, GPU demo compositing, profile-guided optimization

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -386,6 +386,23 @@ SDL_RenderPresent (once)
 - Each sub-session gets a unique random seed and random scenario assignment
 - All sessions run in spectator mode (0-player, fully AI-controlled)
 
+#### Pacing modes
+
+The main loop runs in one of two modes, decided once at startup:
+
+- **Uncapped** (the default): the sim stays at exactly one tick per 81.6 ms of wall clock (a `FixedStepAccumulator` runs 0–8 catch-up ticks per loop pass; a stall past 8 periods drops the backlog with a log line instead of slowing the game), while the loop renders and presents on every pass with no sleep and vsync off. Compositing is GPU per-cell: each session surface streams into its own texture and the renderer scales it into its display cell.
+- **Lockstep**: one sim tick per rendered frame, software compositing, sleep to the 81.6 ms frame period. This is the pixel-pinned path — `scripts/test_demo_smoke.sh` byte-compares its composite dumps.
+
+Lockstep is selected automatically whenever the run dumps pixels — frame capture (`OPENGLAD_DEMO_CAPTURE_DIR`) or a composite dump (`OPENGLAD_DEMO_COMPOSITE_DUMP`) — and can be forced with `OPENGLAD_DEMO_LOCKSTEP=1`. The chosen mode is logged as `openglad_demo: pacing lockstep|uncapped`.
+
+In both modes `OPENGLAD_DEMO_MAX_FRAMES` counts **sim ticks**, so a run's game-time duration is deterministic regardless of render speed. Every run ends with an exit summary:
+
+```
+openglad_demo: 61 sim ticks, 3459 rendered frames in 4.901 s (705.7 fps, 12.25 ticks/s)
+```
+
+`ticks/s` holding ≈12.25 under load is the proof that render cost no longer slows the game; `fps` is the render benchmark.
+
 #### Environment knobs
 
 Every knob is opt-in: unset, the demo takes its production path.
@@ -395,7 +412,9 @@ Every knob is opt-in: unset, the demo takes its production path.
 | `OPENGLAD_DEMO_GRID` | `COLSxROWS` grid topology (default `6x4`) |
 | `OPENGLAD_DEMO_ZOOM` | Extra magnification on top of the cover scale, clamped to ≥ 1.0 (default 1.1) |
 | `OPENGLAD_DEMO_SEED` | Unsigned seed for scenario shuffle and per-session RNG |
-| `OPENGLAD_DEMO_MAX_FRAMES` | Stop after N main-loop frames (0 = run forever) |
+| `OPENGLAD_DEMO_MAX_FRAMES` | Stop after N sim ticks (0 = run forever) |
+| `OPENGLAD_DEMO_LOCKSTEP` | `1` or `on` forces lockstep pacing without a capture or dump |
+| `OPENGLAD_DEMO_VSYNC` | Set to anything but `0` to keep vsync on in uncapped mode (default: off) |
 | `OPENGLAD_DEMO_CAMPAIGN` | Campaign the scenarios are loaded from (default `gladiator`) |
 | `OPENGLAD_DEMO_SCENARIOS` | Comma-separated scenario ids assigned to cells in order, replacing the shuffled pool |
 | `OPENGLAD_DEMO_TEAM_SIZE` | Force the generated player team size |
@@ -502,6 +521,8 @@ game_frame(screen& s, GameLoopFrameState& st)
       ├── Radar minimap
       └── Present to display
 ```
+
+Sim and render are paced independently: the sim tick interval comes solely from `world.timer_wait`, while render frequency follows the `graphics` / `target_fps` setting in `openglad.yaml` (clamped to 10–240). `target_fps: 0` is the uncapped sentinel — the render pacer is bypassed entirely, every loop pass renders, and vsync is switched off at bootstrap. It is a config-file-only knob with no Options menu entry; game speed is unaffected either way.
 
 ### Emscripten (Web) Build Flow
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,7 +391,7 @@ SDL_RenderPresent (once)
 The main loop runs in one of two modes, decided once at startup:
 
 - **Uncapped** (the default): the sim stays at exactly one tick per 81.6 ms of wall clock (a `FixedStepAccumulator` runs 0–8 catch-up ticks per loop pass; a stall past 8 periods drops the backlog with a log line instead of slowing the game), while the loop renders and presents on every pass with no sleep and vsync off. Compositing is GPU per-cell: each session surface streams into its own texture and the renderer scales it into its display cell.
-- **Lockstep**: one sim tick per rendered frame, software compositing, sleep to the 81.6 ms frame period. This is the pixel-pinned path — `scripts/test_demo_smoke.sh` byte-compares its composite dumps.
+- **Lockstep**: one sim tick per rendered frame, software compositing, sleep to the 81.6 ms frame period — except frame-capture runs, which never sleep (no viewer; the capture takes frames as fast as the sim produces them). This is the pixel-pinned path — `scripts/test_demo_smoke.sh` byte-compares its composite dumps.
 
 Lockstep is selected automatically whenever the run dumps pixels — frame capture (`OPENGLAD_DEMO_CAPTURE_DIR`) or a composite dump (`OPENGLAD_DEMO_COMPOSITE_DUMP`) — and can be forced with `OPENGLAD_DEMO_LOCKSTEP=1`. The chosen mode is logged as `openglad_demo: pacing lockstep|uncapped`.
 

--- a/include/openglad/core/frame_pacing.h
+++ b/include/openglad/core/frame_pacing.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 
 namespace og::core {
@@ -51,6 +52,31 @@ private:
     std::uint32_t interval_ms_ = 0;
     std::uint32_t next_deadline_ms_ = 0;
     bool initialized_ = false;
+};
+
+// Wall-clock fixed-step scheduler for caller-managed loops (openglad_demo).
+// Seeded one full period so the first advance() fires a tick immediately.
+// On a stall longer than max_catchup periods the backlog is dropped and
+// reported, mirroring FrameDeadlinePacer's slip-resync policy.
+class FixedStepAccumulator
+{
+public:
+    FixedStepAccumulator(std::chrono::microseconds period, int max_catchup);
+
+    struct Result
+    {
+        int ticks = 0;
+        int dropped_ticks = 0;
+    };
+
+    [[nodiscard]] Result advance(std::chrono::microseconds elapsed);
+    // Back to the seeded state: the next advance() ticks at once.
+    void reset();
+
+private:
+    std::chrono::microseconds period_;
+    int max_catchup_ = 0;
+    std::chrono::microseconds accumulated_;
 };
 
 } // namespace og::core

--- a/include/openglad/core/frame_rate_config.h
+++ b/include/openglad/core/frame_rate_config.h
@@ -16,6 +16,11 @@ inline constexpr int kDefaultTargetFps = 60;
 inline constexpr int kMinTargetFps = 10;
 inline constexpr int kMaxTargetFps = 240;
 
+// Sentinel for "no render frame cap": the loop renders on every pass with no
+// pacer and vsync off. Any configured value <= 0 means this. Sim cadence is
+// unaffected — it still comes solely from world.timer_wait.
+inline constexpr int kUncappedTargetFps = 0;
+
 // Templated on the cfg type so this header does not need to include
 // <openglad/resources/gparser.h>, which is outside og_core's component
 // include sandbox. Callers (glad.cpp, tests) instantiate with cfg_store,
@@ -27,12 +32,22 @@ template <typename Cfg>
     const auto parsed = parse_int_strict(raw);
     if (!parsed)
         return kDefaultTargetFps;
+    if (*parsed <= 0)
+        return kUncappedTargetFps;
     return std::clamp(*parsed, kMinTargetFps, kMaxTargetFps);
 }
 
 template <typename Cfg>
 void apply_target_fps_to_cfg(Cfg& cfg, int fps)
 {
+    // The sentinel must survive the boot-time read/write round trip: clamping
+    // it here would rewrite a user's uncapped setting as kMinTargetFps.
+    if (fps <= 0)
+    {
+        cfg.apply_setting("graphics", "target_fps",
+                          std::to_string(kUncappedTargetFps));
+        return;
+    }
     const int clamped = std::clamp(fps, kMinTargetFps, kMaxTargetFps);
     cfg.apply_setting("graphics", "target_fps", std::to_string(clamped));
 }

--- a/include/openglad/gameplay/obmap.h
+++ b/include/openglad/gameplay/obmap.h
@@ -19,6 +19,7 @@
 // Definition of OBMAP class
 
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <unordered_map>
 #include <list>
@@ -30,6 +31,10 @@ class obmap
 	public:
 		obmap();
 		~obmap();
+		// cell_index_ holds pointers into pos_to_walker nodes; a copied obmap
+		// would alias the source's piles.
+		obmap(const obmap&) = delete;
+		obmap& operator=(const obmap&) = delete;
 		short query_list(walker  *ob, short x, short y);
 		short remove(walker  *ob);  // This goes in walker's destructor
 		short add(walker  *ob, short x, short y);  // This goes in walker's constructor
@@ -43,4 +48,16 @@ class obmap
 
 		static short hash(short y);
 		static short unhash(short y);
+
+	private:
+		// O(1) shadow index over pos_to_walker, keyed by packed (numx, numy).
+		// std::map nodes are pointer-stable, so an entry stays valid until its
+		// node is erased; every erase inside obmap.cpp forgets its key, and a
+		// wholesale external pos_to_walker.clear() (level teardown) is caught
+		// by sync_cell_index() before any cached pointer is dereferenced.
+		// External code may insert piles into pos_to_walker directly (tests
+		// do; the index tolerates unknown keys) but must never erase
+		// individual piles behind obmap's back.
+		std::unordered_map<std::uint32_t, std::list<walker*>*> cell_index_;
+		void sync_cell_index();
 };

--- a/include/openglad/interface/fps_overlay.h
+++ b/include/openglad/interface/fps_overlay.h
@@ -11,7 +11,10 @@ class screen;
 // compositor needs the same measurement for its whole-grid readout; keeping one
 // definition keeps the two overlays reporting the same quantity.
 struct FpsCounter {
-    static constexpr std::size_t kCap = 256;
+    // Ring capacity. Samples leave the window by age, but a full ring
+    // overwrites its oldest entry, so the readout is only honest up to
+    // kCap / (kWindowMs / 1000) frames per second and saturates above it.
+    static constexpr std::size_t kCap = 2048;
     static constexpr std::uint64_t kWindowMs = 500;
     std::array<std::uint64_t, kCap> ts{};
     std::size_t head = 0;

--- a/include/openglad/interface/render/effects.h
+++ b/include/openglad/interface/render/effects.h
@@ -25,9 +25,22 @@ class walker;
 
 // Advance all render-only effect state — the frame tick driving weather
 // drift, ripple/trail/dust phases and the fire-glow flicker, plus pruning of
-// the per-entity position store. Called exactly once per rendered frame
+// the per-entity position store. Called once per rendered frame
 // (screen::redraw); never read by the sim.
 void effects_advance_frame();
+
+// Uncapped render paths present at machine rate, so a per-redraw frame-tick
+// advance would animate every frame_tick-keyed cosmetic at hardware speed.
+// With this on, effects_advance_frame gates the advance to the wall clock at
+// the classic 72 fps render cadence instead. Off (the default) keeps the
+// exact one-advance-per-call behavior every capped path and test relies on.
+void effects_set_wall_clock_cadence(bool on);
+
+#ifdef TESTING
+// Drives the same wall-clock gate with an injected clock, so the cadence is
+// testable without real time.
+void effects_advance_frame_at(std::uint32_t now_ms);
+#endif
 
 // The current render-only effects frame tick, for callers that thread it
 // into stateless per-pixel effects (the depth-fog drift in DepthFxParams).

--- a/include/openglad/platform/sai2x.h
+++ b/include/openglad/platform/sai2x.h
@@ -199,6 +199,13 @@ class Screen
 
 		void clear_window();
 
+		// Vsync for the presenting renderer. The choice is remembered and
+		// replayed at every renderer creation (construction and
+		// recreate_render_backend), so a lost device cannot restore the
+		// display-rate cap that an uncapped frame rate turned off.
+		void set_vsync(bool on);
+		[[nodiscard]] bool vsync_enabled() const { return vsync_enabled_; }
+
 	private:
 		// Ensures an atomic surface/texture pair exists at 2x source size.
 		// Rejects overflow, the renderer's maximum texture dimension and the
@@ -252,6 +259,7 @@ class Screen
 		bool last_world_present_used_render2_ = false;
 		bool fail_next_gameplay_ui_allocation_ = false;
 		bool fail_next_world_canvas_allocation_ = false;
+		bool vsync_enabled_ = true;
 };
 
 extern std::unique_ptr<Screen> E_Screen;

--- a/scripts/test_demo_smoke.sh
+++ b/scripts/test_demo_smoke.sh
@@ -53,6 +53,8 @@ grep -Fq \
     'openglad_demo: 2 sessions initialized, spawning 2 worker threads' \
     <<<"$output"
 grep -Fq 'openglad_demo: campaign gladiator' <<<"$output"
+# No capture or dump knob set, so this run takes the uncapped pacing path.
+grep -Fq 'openglad_demo: pacing uncapped' <<<"$output"
 
 # The capture knobs are opt-in: a production run writes no frames at all.
 if [[ -n "$(find "$test_root" -name '*.bmp' -print -quit)" ]]; then
@@ -146,6 +148,8 @@ capture_output=$(
 printf '%s\n' "$capture_output"
 grep -Fq 'openglad_demo: campaign concept' <<<"$capture_output"
 grep -Fq '  session 0: scenario 605' <<<"$capture_output"
+# Capture depends on frame N being sim tick N, so enabling it forces lockstep.
+grep -Fq 'openglad_demo: pacing lockstep' <<<"$capture_output"
 grep -Fq 'openglad_demo: captured 3 frames' <<<"$capture_output"
 expect_capture_frames "$test_root/capture" 3 320 200
 
@@ -236,6 +240,9 @@ fps_on_output=$(
 )
 printf '%s\n' "$fps_on_output"
 grep -Fq 'openglad_demo: FPS overlay on' <<<"$fps_on_output"
+# A composite dump also forces lockstep: the dumped pixels are the byte-pinned
+# software-compositor output the reproducibility checks below rely on.
+grep -Fq 'openglad_demo: pacing lockstep' <<<"$fps_on_output"
 
 # Unset knob with a fresh config dir: graphics/show_fps is off, so is the
 # overlay.
@@ -308,3 +315,38 @@ if cmp -s "$test_root/fps-on.bmp" "$test_root/fps-off.bmp"; then
     printf 'FPS overlay left the presented composite unchanged\n' >&2
     exit 1
 fi
+
+# --- Pacing modes -----------------------------------------------------------
+# OPENGLAD_DEMO_MAX_FRAMES counts sim ticks in both modes, so an uncapped run
+# reports exactly its budget in the exit summary. The rendered-frame count is
+# hardware-dependent and deliberately unasserted.
+uncapped_ticks_output=$(
+    env \
+        SDL_VIDEODRIVER=dummy \
+        SDL_AUDIODRIVER=dummy \
+        SDL_RENDER_DRIVER=software \
+        OPENGLAD_DEMO_GRID=1x1 \
+        OPENGLAD_DEMO_MAX_FRAMES=3 \
+        OPENGLAD_DEMO_SEED=6 \
+        OPENGLAD_CONFIG_DIR="$test_root/uncapped-ticks-config" \
+        "$demo_bin" 2>&1
+)
+printf '%s\n' "$uncapped_ticks_output"
+grep -Fq 'openglad_demo: pacing uncapped' <<<"$uncapped_ticks_output"
+grep -Fq 'openglad_demo: 3 sim ticks,' <<<"$uncapped_ticks_output"
+
+# OPENGLAD_DEMO_LOCKSTEP forces the lockstep path without a capture or dump.
+lockstep_forced_output=$(
+    env \
+        SDL_VIDEODRIVER=dummy \
+        SDL_AUDIODRIVER=dummy \
+        SDL_RENDER_DRIVER=software \
+        OPENGLAD_DEMO_GRID=1x1 \
+        OPENGLAD_DEMO_MAX_FRAMES=1 \
+        OPENGLAD_DEMO_SEED=6 \
+        OPENGLAD_DEMO_LOCKSTEP=1 \
+        OPENGLAD_CONFIG_DIR="$test_root/lockstep-forced-config" \
+        "$demo_bin" 2>&1
+)
+printf '%s\n' "$lockstep_forced_output"
+grep -Fq 'openglad_demo: pacing lockstep' <<<"$lockstep_forced_output"

--- a/scripts/test_emscripten_build.sh
+++ b/scripts/test_emscripten_build.sh
@@ -69,7 +69,9 @@ if [[ -n "${EMSDK:-}" ]] && [[ -d "$EMSDK/upstream/bin" ]]; then
 LLVM_ROOT = '$EMSDK/upstream/bin'
 BINARYEN_ROOT = '$EMSDK/upstream'
 EOF
-    emsdk_node="$(ls -d "$EMSDK"/node/*/bin/node 2>/dev/null | head -1)"
+    # `|| true`: an emsdk without a bundled node (system-node layouts) must
+    # fall through, not abort the script via set -e/pipefail.
+    emsdk_node="$(ls -d "$EMSDK"/node/*/bin/node 2>/dev/null | head -1 || true)"
     if [[ -n "$emsdk_node" ]]; then
         sed -i '/^NODE_JS = /d' "$EM_CONFIG_FILE"
         printf "NODE_JS = '%s'\n" "$emsdk_node" >>"$EM_CONFIG_FILE"

--- a/scripts/test_emscripten_build.sh
+++ b/scripts/test_emscripten_build.sh
@@ -58,6 +58,23 @@ rm -f "$EM_CONFIG_FILE"
 EM_CONFIG="$EM_CONFIG_FILE" "$EMCC_BIN" --generate-config >/dev/null
 
 sed -i '/^CACHE = /d;/^PORTS = /d' "$EM_CONFIG_FILE"
+
+# --generate-config guesses system tool locations (LLVM_ROOT=/usr/bin). Under
+# an emsdk install the toolchain lives in $EMSDK/upstream and node ships inside
+# the SDK, so the isolated config must be pointed there explicitly or every
+# compile fails with "cannot find /usr/bin/llvm-ar".
+if [[ -n "${EMSDK:-}" ]] && [[ -d "$EMSDK/upstream/bin" ]]; then
+    sed -i '/^LLVM_ROOT = /d;/^BINARYEN_ROOT = /d' "$EM_CONFIG_FILE"
+    cat >>"$EM_CONFIG_FILE" <<EOF
+LLVM_ROOT = '$EMSDK/upstream/bin'
+BINARYEN_ROOT = '$EMSDK/upstream'
+EOF
+    emsdk_node="$(ls -d "$EMSDK"/node/*/bin/node 2>/dev/null | head -1)"
+    if [[ -n "$emsdk_node" ]]; then
+        sed -i '/^NODE_JS = /d' "$EM_CONFIG_FILE"
+        printf "NODE_JS = '%s'\n" "$emsdk_node" >>"$EM_CONFIG_FILE"
+    fi
+fi
 printf '\n' >>"$EM_CONFIG_FILE"
 cat >>"$EM_CONFIG_FILE" <<EOF
 CACHE = '$EM_CACHE_DIR' # directory

--- a/src/core/frame_pacing.cpp
+++ b/src/core/frame_pacing.cpp
@@ -88,4 +88,35 @@ FrameDeadlineDecision FrameDeadlinePacer::tick(std::uint32_t now_ms)
     return FrameDeadlineDecision{true, true, 0u, next_deadline_ms_};
 }
 
+FixedStepAccumulator::FixedStepAccumulator(std::chrono::microseconds period,
+                                           int max_catchup)
+    : period_(std::max(std::chrono::microseconds{1}, period)),
+      max_catchup_(max_catchup),
+      accumulated_(period_)
+{
+}
+
+FixedStepAccumulator::Result FixedStepAccumulator::advance(
+    std::chrono::microseconds elapsed)
+{
+    accumulated_ += elapsed;
+
+    // Duration division is exact integer math; the remainder stays in
+    // accumulated_ so fractional periods carry across calls without drift.
+    const auto due = accumulated_ / period_;
+    if (due > max_catchup_)
+    {
+        accumulated_ = std::chrono::microseconds::zero();
+        return Result{max_catchup_, static_cast<int>(due) - max_catchup_};
+    }
+
+    accumulated_ -= due * period_;
+    return Result{static_cast<int>(due), 0};
+}
+
+void FixedStepAccumulator::reset()
+{
+    accumulated_ = period_;
+}
+
 } // namespace og::core

--- a/src/gameplay/astar.cpp
+++ b/src/gameplay/astar.cpp
@@ -279,8 +279,10 @@ SolveResult AStar::solve(State start,
                 {
                     child->parent = node;
                     child->cost_from_start = new_cost;
-                    child->est_to_goal =
-                        impl_->graph.least_cost_estimate(child->state, end);
+                    // est_to_goal was already computed when the node was first
+                    // reached; the Graph contract (astar.h) makes the heuristic
+                    // a pure function of (state, end) within one solve, so the
+                    // stored value is bit-identical to a recomputation.
                     child->total_cost = calc_total_cost(*child);
                     if (child->in_open)
                         open.update(child);

--- a/src/gameplay/obmap.cpp
+++ b/src/gameplay/obmap.cpp
@@ -49,6 +49,25 @@ static short floor_numx_offset(const walker* ob)
 	return static_cast<short>(f * OB_FLOOR_STRIDE);
 }
 
+// Injective for every (short, short) pair: 16 bits per coordinate. Hash-derived
+// coordinates are always non-negative, but crafted keys (tests) round-trip
+// safely through the uint16 casts too.
+static inline std::uint32_t pack_cell(short numx, short numy)
+{
+	return (static_cast<std::uint32_t>(static_cast<std::uint16_t>(numx)) << 16) |
+	       static_cast<std::uint32_t>(static_cast<std::uint16_t>(numy));
+}
+
+// The only external mutation of pos_to_walker in the codebase is a wholesale
+// clear() at level teardown (game_world / level_runtime_data), after which the
+// map stays empty until the next obmap call. So "map empty, index non-empty"
+// is exactly (and only) the stale-after-external-clear state.
+void obmap::sync_cell_index()
+{
+	if (!cell_index_.empty() && pos_to_walker.empty())
+		cell_index_.clear();
+}
+
 // These are passed in as PIXEL coordinates now...
 obmap::obmap()
 {
@@ -81,21 +100,35 @@ short obmap::query_list(walker  *ob, short x, short y)
 	startnumy = hash(y);
 	endnumy   = hash( static_cast<short>(y+ob->sizey()) );
 
+	sync_cell_index();
+
 	// For each y grid row we are in...
 	for (numx = startnumx; numx <= endnumx; numx++)
 	{
 		for (numy = startnumy; numy <= endnumy; numy++)
 		{
-			// Avoid default-constructing empty piles during queries.
-			auto it = pos_to_walker.find(std::make_pair(numx, numy));
-			if (it == pos_to_walker.end())
-				continue;
+			const std::list<walker*>* pile;
+			const std::uint32_t key = pack_cell(numx, numy);
+			auto cached = cell_index_.find(key);
+			if (cached != cell_index_.end())
+			{
+				pile = cached->second;
+			}
+			else
+			{
+				// Avoid default-constructing empty piles during queries.
+				auto it = pos_to_walker.find(std::make_pair(numx, numy));
+				if (it == pos_to_walker.end())
+					continue;
+				pile = &it->second;
+				cell_index_.emplace(key, &it->second);
+			}
 			// Snapshot the pile: collision handlers inside ob_pass_check
 			// (e.g. walker::death → obmap::remove) can erase this
 			// pos_to_walker entry, which would leave a dangling reference
 			// and corrupt iterator traversal — the root cause of the
 			// walker_to_pos.find() infinite-loop hang.
-			auto pile_snapshot = it->second;
+			auto pile_snapshot = *pile;
 			if (!ob_pass_check(x, y, ob, pile_snapshot, this))
 				return 0;
 		}
@@ -110,6 +143,8 @@ short obmap::remove(walker  *ob)  // This goes in walker's destructor
     // Some of this is redundant, but its worth avoiding segfaults, IMO :-)
     if (!ob)
         return 0;
+
+    sync_cell_index();
 
     // Fast path only: removal is driven by walker_to_pos bookkeeping.
     // Do not scan the entire pos_to_walker map in production; that can turn
@@ -145,7 +180,10 @@ short obmap::remove(walker  *ob)  // This goes in walker's destructor
                 if (g->second.size() != before)
                     removed_any = true;
                 if (g->second.empty())
+                {
+                    cell_index_.erase(pack_cell(numx, numy));
                     pos_to_walker.erase(g);
+                }
             }
         }
         return removed_any ? 1 : 0;
@@ -160,7 +198,10 @@ short obmap::remove(walker  *ob)  // This goes in walker's destructor
             continue;
         g->second.remove(ob);
         if (g->second.empty())
+        {
+            cell_index_.erase(pack_cell(pos.first, pos.second));
             pos_to_walker.erase(g);
+        }
     }
 
     // Erase the walker from the walker map too
@@ -178,6 +219,8 @@ short obmap::add(walker  *ob, short x, short y)  // This goes in walker's constr
 
 	if (x < 0 || y < 0)
 		return 0;
+
+	sync_cell_index();
 
 	// Tighten invariants: a walker may only be present once. If callers try to
 	// add it again, remove via O(1) bookkeeping first.
@@ -198,11 +241,22 @@ short obmap::add(walker  *ob, short x, short y)  // This goes in walker's constr
 		{
 		    // Store this position
 		    pos.push_back(std::make_pair(numx, numy));
-		    
+
 			// Put the walker here too (no duplicates).
-			auto& pile = pos_to_walker[std::make_pair(numx, numy)];
-			if (std::find(pile.begin(), pile.end(), ob) == pile.end())
-				pile.push_back(ob);
+			const std::uint32_t key = pack_cell(numx, numy);
+			std::list<walker*>* pile;
+			auto cached = cell_index_.find(key);
+			if (cached != cell_index_.end())
+			{
+				pile = cached->second;
+			}
+			else
+			{
+				pile = &pos_to_walker[std::make_pair(numx, numy)];
+				cell_index_.emplace(key, pile);
+			}
+			if (std::find(pile->begin(), pile->end(), ob) == pile->end())
+				pile->push_back(ob);
 				}
 			}
 		
@@ -248,7 +302,19 @@ std::list<walker*>& obmap::obmap_get_list(short x, short y, int floor)
 	if (floor < 0) floor = 0;
 	if (floor > 120) floor = 120;
 	const short fo = static_cast<short>(floor * OB_FLOOR_STRIDE);
-	return pos_to_walker[std::make_pair(static_cast<short>(hash(x) + fo), hash(y))];
+	const short numx = static_cast<short>(hash(x) + fo);
+	const short numy = hash(y);
+	sync_cell_index();
+	const std::uint32_t key = pack_cell(numx, numy);
+	auto cached = cell_index_.find(key);
+	if (cached != cell_index_.end())
+		return *cached->second;
+	// A miss still default-constructs the empty pile node (the historical
+	// operator[] semantics): diagnostics iterate pos_to_walker and observe
+	// these nodes, so queries must keep creating them.
+	std::list<walker*>& pile = pos_to_walker[std::make_pair(numx, numy)];
+	cell_index_.emplace(key, &pile);
+	return pile;
 }
 
 /***********************************************

--- a/src/gameplay/world_snapshot.cpp
+++ b/src/gameplay/world_snapshot.cpp
@@ -14,7 +14,9 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstring>
 #include <limits>
 #include <stdexcept>
@@ -272,12 +274,6 @@ void append_i32(std::vector<std::uint8_t>& buffer, std::int32_t value)
     append_u32(buffer, static_cast<std::uint32_t>(value));
 }
 
-void append_u64(std::vector<std::uint8_t>& buffer, std::uint64_t value)
-{
-    for (int i = 0; i < 8; ++i)
-        buffer.push_back(static_cast<std::uint8_t>((value >> (i * 8)) & 0xffu));
-}
-
 void append_f32(std::vector<std::uint8_t>& buffer, float value)
 {
     std::uint32_t bits = 0;
@@ -306,51 +302,223 @@ void append_string(std::vector<std::uint8_t>& buffer, const std::string& value)
                  value.size());
 }
 
-bool mask_has_bit(const std::uint64_t* mask, std::uint8_t bit_index) noexcept
+// Mask bits at or above og::dirty::FIELD_COUNT name no field. Keyframe
+// captures set every bit of both words, so the walk below drops them exactly
+// like the ascending 0..FIELD_COUNT loop it replaced.
+constexpr std::array<std::uint64_t, og::sim::kEntitySnapshotDirtyMaskWords>
+build_dirty_mask_valid_bits()
 {
-    return (mask[bit_index / 64] & (1ULL << (bit_index % 64))) != 0;
+    std::array<std::uint64_t, og::sim::kEntitySnapshotDirtyMaskWords> words{};
+    for (std::size_t word = 0; word < words.size(); ++word)
+    {
+        const std::size_t low_bit = word * 64;
+        if (low_bit >= og::dirty::FIELD_COUNT)
+            continue;
+
+        const std::size_t count = og::dirty::FIELD_COUNT - low_bit;
+        words[word] = (count >= 64) ? ~0ULL : ((1ULL << count) - 1ULL);
+    }
+    return words;
 }
 
+constexpr auto kDirtyMaskValidBits = build_dirty_mask_valid_bits();
+
+// Visits the set field bits in ascending index order -- the order every
+// serialized entity record is pinned to.
+template <typename Visitor>
+void for_each_dirty_field_bit(const std::uint64_t* mask, Visitor&& visit)
+{
+    for (std::size_t word = 0; word < og::sim::kEntitySnapshotDirtyMaskWords; ++word)
+    {
+        std::uint64_t bits = mask[word] & kDirtyMaskValidBits[word];
+        while (bits != 0)
+        {
+            const std::size_t bit_offset =
+                static_cast<std::size_t>(std::countr_zero(bits));
+            bits &= bits - 1;
+            visit(static_cast<std::uint8_t>(word * 64 + bit_offset));
+        }
+    }
+}
+
+constexpr std::array<const og::sim::EntitySnapshotFieldDesc*, og::dirty::FIELD_COUNT>
+build_field_desc_by_bit()
+{
+    std::array<const og::sim::EntitySnapshotFieldDesc*, og::dirty::FIELD_COUNT> table{};
+    for (const og::sim::EntitySnapshotFieldDesc& desc : og::sim::kEntitySnapshotFields)
+        table[desc.bit_index] = &desc;
+    return table;
+}
+
+constexpr auto kFieldDescByBit = build_field_desc_by_bit();
+
+// Manual bits (and out-of-range indices) stay null, the same miss the table
+// scan this replaced reported.
 const og::sim::EntitySnapshotFieldDesc* find_field_desc(std::uint8_t bit_index)
 {
-    const auto it = std::find_if(
-        std::begin(og::sim::kEntitySnapshotFields),
-        std::end(og::sim::kEntitySnapshotFields),
-        [bit_index](const og::sim::EntitySnapshotFieldDesc& desc) {
-            return desc.bit_index == bit_index;
-        });
-    return it == std::end(og::sim::kEntitySnapshotFields) ? nullptr : &*it;
+    return (bit_index < og::dirty::FIELD_COUNT) ? kFieldDescByBit[bit_index] : nullptr;
 }
 
-void append_raw_trivial_field(std::vector<std::uint8_t>& buffer,
-                              const void* src,
-                              std::size_t size)
+// One wire write: `size` bytes read out of the EntitySnapshot at `offset` and
+// emitted little-endian.
+struct EntityFieldWriteStep
+{
+    std::uint16_t offset = 0;
+    std::uint8_t size = 0;
+};
+
+constexpr std::size_t kEntityFieldStepCapacity =
+    og::sim::kEntitySnapshotTrackedFieldCount + NUM_SPECIALS;
+
+struct EntityFieldWirePlan
+{
+    std::array<EntityFieldWriteStep, kEntityFieldStepCapacity> steps{};
+    // Slice of `steps` a dirty bit contributes, and the bytes it emits.
+    std::array<std::uint16_t, og::dirty::FIELD_COUNT> step_start{};
+    std::array<std::uint8_t, og::dirty::FIELD_COUNT> step_count{};
+    std::array<std::uint8_t, og::dirty::FIELD_COUNT> wire_bytes{};
+    std::size_t all_fields_bytes = 0;
+};
+
+// Flattens the per-bit rules into offset/size writes: the entity-id bit rides
+// the record header and emits no field bytes, the two manual bits live outside
+// kEntitySnapshotFields, and the special-cost array expands to one write per
+// element so every step is a single scalar.
+constexpr EntityFieldWirePlan build_entity_field_wire_plan()
+{
+    EntityFieldWirePlan plan{};
+    std::uint16_t next_step = 0;
+    for (std::uint8_t bit = 0; bit < og::dirty::FIELD_COUNT; ++bit)
+    {
+        plan.step_start[bit] = next_step;
+        if (bit == og::dirty::BIT_ENTITY_ID)
+            continue;
+
+        if (bit == og::dirty::BIT_SPECIAL_COST)
+        {
+            for (std::size_t i = 0; i < NUM_SPECIALS; ++i)
+            {
+                plan.steps[next_step++] = {
+                    static_cast<std::uint16_t>(
+                        offsetof(og::sim::EntitySnapshot, special_cost) +
+                        i * sizeof(std::uint16_t)),
+                    static_cast<std::uint8_t>(sizeof(std::uint16_t))};
+            }
+            plan.step_count[bit] = static_cast<std::uint8_t>(NUM_SPECIALS);
+        }
+        else if (bit == og::dirty::BIT_REGEN_DELAY)
+        {
+            plan.steps[next_step++] = {
+                static_cast<std::uint16_t>(
+                    offsetof(og::sim::EntitySnapshot, regen_delay)),
+                static_cast<std::uint8_t>(sizeof(std::int32_t))};
+            plan.step_count[bit] = 1;
+        }
+        else if (bit == og::dirty::BIT_DO_BOUNCE)
+        {
+            plan.steps[next_step++] = {
+                static_cast<std::uint16_t>(
+                    offsetof(og::sim::EntitySnapshot, do_bounce)),
+                static_cast<std::uint8_t>(sizeof(std::int32_t))};
+            plan.step_count[bit] = 1;
+        }
+        else
+        {
+            const og::sim::EntitySnapshotFieldDesc* const desc = kFieldDescByBit[bit];
+            plan.steps[next_step++] = {desc->snap_offset, desc->size};
+            plan.step_count[bit] = 1;
+        }
+
+        for (std::uint16_t i = 0; i < plan.step_count[bit]; ++i)
+        {
+            plan.wire_bytes[bit] = static_cast<std::uint8_t>(
+                plan.wire_bytes[bit] +
+                plan.steps[plan.step_start[bit] + i].size);
+        }
+        plan.all_fields_bytes += plan.wire_bytes[bit];
+    }
+    return plan;
+}
+
+constexpr EntityFieldWirePlan kEntityFieldWirePlan = build_entity_field_wire_plan();
+
+constexpr bool entity_field_wire_plan_is_valid()
+{
+    std::size_t total_steps = 0;
+    for (std::uint8_t bit = 0; bit < og::dirty::FIELD_COUNT; ++bit)
+    {
+        total_steps += kEntityFieldWirePlan.step_count[bit];
+
+        std::size_t bytes = 0;
+        for (std::uint16_t i = 0; i < kEntityFieldWirePlan.step_count[bit]; ++i)
+        {
+            const EntityFieldWriteStep& step =
+                kEntityFieldWirePlan.steps[kEntityFieldWirePlan.step_start[bit] + i];
+            if (step.size != 1 && step.size != 2 && step.size != 4 && step.size != 8)
+                return false;
+            if (static_cast<std::size_t>(step.offset) + step.size >
+                sizeof(og::sim::EntitySnapshot))
+                return false;
+            bytes += step.size;
+        }
+
+        if (bytes != kEntityFieldWirePlan.wire_bytes[bit])
+            return false;
+    }
+
+    return total_steps <= kEntityFieldStepCapacity;
+}
+
+static_assert(entity_field_wire_plan_is_valid(),
+              "entity field wire plan drift -- every step must be an in-bounds "
+              "1/2/4/8-byte EntitySnapshot read");
+
+std::uint8_t* write_u32_le(std::uint8_t* out, std::uint32_t value)
+{
+    out[0] = static_cast<std::uint8_t>(value & 0xffu);
+    out[1] = static_cast<std::uint8_t>((value >> 8) & 0xffu);
+    out[2] = static_cast<std::uint8_t>((value >> 16) & 0xffu);
+    out[3] = static_cast<std::uint8_t>((value >> 24) & 0xffu);
+    return out + 4;
+}
+
+std::uint8_t* write_u64_le(std::uint8_t* out, std::uint64_t value)
+{
+    for (int i = 0; i < 8; ++i)
+        out[i] = static_cast<std::uint8_t>((value >> (i * 8)) & 0xffu);
+    return out + 8;
+}
+
+// Host byte order never reaches the wire: every scalar is composed
+// little-endian byte by byte, exactly as the append_* writers do.
+std::uint8_t* write_field_le(std::uint8_t* out,
+                             const std::uint8_t* src,
+                             std::uint8_t size)
 {
     switch (size)
     {
     case 1:
-        append_u8(buffer, *static_cast<const std::uint8_t*>(src));
-        return;
+        out[0] = *src;
+        return out + 1;
     case 2:
     {
         std::uint16_t value = 0;
         std::memcpy(&value, src, sizeof(value));
-        append_u16(buffer, value);
-        return;
+        out[0] = static_cast<std::uint8_t>(value & 0xffu);
+        out[1] = static_cast<std::uint8_t>((value >> 8) & 0xffu);
+        return out + 2;
     }
     case 4:
     {
         std::uint32_t value = 0;
         std::memcpy(&value, src, sizeof(value));
-        append_u32(buffer, value);
-        return;
+        return write_u32_le(out, value);
     }
     case 8:
     {
         std::uint64_t value = 0;
         std::memcpy(&value, src, sizeof(value));
-        append_u64(buffer, value);
-        return;
+        return write_u64_le(out, value);
     }
     default:
         throw std::runtime_error("snapshot serialization: unsupported field size");
@@ -393,39 +561,6 @@ void read_raw_trivial_field(ByteReader& reader,
     }
 }
 
-void serialize_entity_field(std::vector<std::uint8_t>& buffer,
-                            const og::sim::EntitySnapshot& snapshot,
-                            std::uint8_t bit_index)
-{
-    switch (bit_index)
-    {
-    case og::dirty::BIT_ENTITY_ID:
-        return;
-    case og::dirty::BIT_REGEN_DELAY:
-        append_i32(buffer, snapshot.regen_delay);
-        return;
-    case og::dirty::BIT_SPECIAL_COST:
-        for (int i = 0; i < NUM_SPECIALS; ++i)
-            append_u16(buffer, snapshot.special_cost[i]);
-        return;
-    case og::dirty::BIT_DO_BOUNCE:
-        append_i32(buffer, snapshot.do_bounce);
-        return;
-    default:
-        break;
-    }
-
-    const og::sim::EntitySnapshotFieldDesc* const field = find_field_desc(bit_index);
-    if (field == nullptr)
-    {
-        throw std::runtime_error("snapshot serialization: unknown entity field bit");
-    }
-
-    const std::uint8_t* const src =
-        reinterpret_cast<const std::uint8_t*>(&snapshot) + field->snap_offset;
-    append_raw_trivial_field(buffer, src, field->size);
-}
-
 void deserialize_entity_field(ByteReader& reader,
                               og::sim::EntitySnapshot& snapshot,
                               std::uint8_t bit_index)
@@ -459,28 +594,42 @@ void deserialize_entity_field(ByteReader& reader,
     read_raw_trivial_field(reader, dst, field->size, "entity.field");
 }
 
-void serialize_entity_fields(std::vector<std::uint8_t>& buffer,
-                             const og::sim::EntitySnapshot& snapshot,
-                             const std::uint64_t* dirty_mask)
+std::size_t entity_fields_wire_size(const std::uint64_t* dirty_mask)
 {
-    for (std::uint8_t bit = 0; bit < og::dirty::FIELD_COUNT; ++bit)
-    {
-        if (!mask_has_bit(dirty_mask, bit))
-            continue;
-        serialize_entity_field(buffer, snapshot, bit);
-    }
+    std::size_t total = 0;
+    for_each_dirty_field_bit(dirty_mask, [&total](std::uint8_t bit) {
+        total += kEntityFieldWirePlan.wire_bytes[bit];
+    });
+    return total;
+}
+
+// Writes exactly entity_fields_wire_size(dirty_mask) bytes at `out`.
+std::uint8_t* write_entity_fields(std::uint8_t* out,
+                                  const og::sim::EntitySnapshot& snapshot,
+                                  const std::uint64_t* dirty_mask)
+{
+    const std::uint8_t* const base =
+        reinterpret_cast<const std::uint8_t*>(&snapshot);
+    for_each_dirty_field_bit(dirty_mask, [&out, base](std::uint8_t bit) {
+        const std::uint16_t start = kEntityFieldWirePlan.step_start[bit];
+        const std::uint8_t count = kEntityFieldWirePlan.step_count[bit];
+        for (std::uint8_t i = 0; i < count; ++i)
+        {
+            const EntityFieldWriteStep& step =
+                kEntityFieldWirePlan.steps[start + i];
+            out = write_field_le(out, base + step.offset, step.size);
+        }
+    });
+    return out;
 }
 
 void deserialize_entity_fields(ByteReader& reader,
                                og::sim::EntitySnapshot& snapshot,
                                const std::uint64_t* dirty_mask)
 {
-    for (std::uint8_t bit = 0; bit < og::dirty::FIELD_COUNT; ++bit)
-    {
-        if (!mask_has_bit(dirty_mask, bit))
-            continue;
+    for_each_dirty_field_bit(dirty_mask, [&reader, &snapshot](std::uint8_t bit) {
         deserialize_entity_field(reader, snapshot, bit);
-    }
+    });
 }
 
 void copy_entity_field(og::sim::EntitySnapshot& dst,
@@ -516,12 +665,9 @@ void copy_entity_field(og::sim::EntitySnapshot& dst,
 void apply_entity_delta_fields(og::sim::EntitySnapshot& baseline,
                                const og::sim::EntitySnapshot& delta)
 {
-    for (std::uint8_t bit = 0; bit < og::dirty::FIELD_COUNT; ++bit)
-    {
-        if (!mask_has_bit(delta.dirty_mask, bit))
-            continue;
+    for_each_dirty_field_bit(delta.dirty_mask, [&baseline, &delta](std::uint8_t bit) {
         copy_entity_field(baseline, delta, bit);
-    }
+    });
 }
 
 void serialize_guy_snapshot(std::vector<std::uint8_t>& buffer,
@@ -791,8 +937,11 @@ void deserialize_match_knobs(ByteReader& reader,
         reader.read_i16("world.ctf_requested_strip_scenario_troops");
 }
 
+// `snapshot_hash` is passed in rather than read off the snapshot: the hash
+// payload serializes the same world block with the field zeroed.
 void serialize_world_state(std::vector<std::uint8_t>& buffer,
-                           const og::sim::WorldSnapshot& snapshot)
+                           const og::sim::WorldSnapshot& snapshot,
+                           std::uint32_t snapshot_hash)
 {
     append_u32(buffer, snapshot.tick_count);
     append_u32(buffer, snapshot.rng_state);
@@ -820,7 +969,7 @@ void serialize_world_state(std::vector<std::uint8_t>& buffer,
     append_bool(buffer, snapshot.paused);
     append_u8(buffer, snapshot.pause_player_index);
     append_u8(buffer, snapshot.weather);
-    append_u32(buffer, snapshot.snapshot_hash);
+    append_u32(buffer, snapshot_hash);
     // Snapshot v10 block order: respawn engine, scripted-mode state, match
     // knobs. The raw payload-offset pins in test_mode_snapshot.cpp key off
     // this order.
@@ -1031,12 +1180,26 @@ void deserialize_guy_snapshots(ByteReader& reader,
         snapshots.push_back(deserialize_guy_snapshot(reader));
 }
 
+// guy_id + entity_id + flags + both dirty words: the widest record header.
+constexpr std::size_t kEntityRecordHeaderMaxBytes =
+    2 * sizeof(std::uint32_t) + 1 + 2 * sizeof(std::uint64_t);
+constexpr std::size_t kEntityRecordScratchBytes =
+    kEntityRecordHeaderMaxBytes + kEntityFieldWirePlan.all_fields_bytes;
+constexpr std::size_t kKeyframeEntityRecordBytes =
+    2 * sizeof(std::uint32_t) + kEntityFieldWirePlan.all_fields_bytes;
+
+// Records are composed in a stack scratch buffer and appended with one copy:
+// the per-tick snapshot hash serializes every field of every entity, where
+// byte-at-a-time appends dominated. Only the bytes written are appended.
 void serialize_keyframe_entity(std::vector<std::uint8_t>& buffer,
                                const og::sim::EntitySnapshot& snapshot)
 {
-    append_i32(buffer, snapshot.guy_id);
-    append_u32(buffer, snapshot.entity_id);
-    serialize_entity_fields(buffer, snapshot, kAllEntityFieldsDirty.data());
+    std::array<std::uint8_t, kEntityRecordScratchBytes> scratch;
+    std::uint8_t* out = scratch.data();
+    out = write_u32_le(out, static_cast<std::uint32_t>(snapshot.guy_id));
+    out = write_u32_le(out, snapshot.entity_id);
+    out = write_entity_fields(out, snapshot, kAllEntityFieldsDirty.data());
+    buffer.insert(buffer.end(), scratch.data(), out);
 }
 
 og::sim::EntitySnapshot deserialize_keyframe_entity(ByteReader& reader)
@@ -1050,21 +1213,32 @@ og::sim::EntitySnapshot deserialize_keyframe_entity(ByteReader& reader)
     return snapshot;
 }
 
+std::size_t delta_entity_wire_size(const og::sim::EntitySnapshot& snapshot)
+{
+    std::size_t total = 2 * sizeof(std::uint32_t) + 1 + sizeof(std::uint64_t);
+    if (snapshot.dirty_mask[1] != 0)
+        total += sizeof(std::uint64_t);
+    return total + entity_fields_wire_size(snapshot.dirty_mask);
+}
+
 void serialize_delta_entity(std::vector<std::uint8_t>& buffer,
                             const og::sim::EntitySnapshot& snapshot)
 {
-    append_i32(buffer, snapshot.guy_id);
-    append_u32(buffer, snapshot.entity_id);
+    std::array<std::uint8_t, kEntityRecordScratchBytes> scratch;
+    std::uint8_t* out = scratch.data();
+    out = write_u32_le(out, static_cast<std::uint32_t>(snapshot.guy_id));
+    out = write_u32_le(out, snapshot.entity_id);
 
     std::uint8_t flags = 0;
     if (snapshot.dirty_mask[1] != 0)
         flags |= kDeltaEntityHasDirtyWord1Flag;
-    append_u8(buffer, flags);
-    append_u64(buffer, snapshot.dirty_mask[0]);
+    *out++ = flags;
+    out = write_u64_le(out, snapshot.dirty_mask[0]);
     if ((flags & kDeltaEntityHasDirtyWord1Flag) != 0)
-        append_u64(buffer, snapshot.dirty_mask[1]);
+        out = write_u64_le(out, snapshot.dirty_mask[1]);
 
-    serialize_entity_fields(buffer, snapshot, snapshot.dirty_mask);
+    out = write_entity_fields(out, snapshot, snapshot.dirty_mask);
+    buffer.insert(buffer.end(), scratch.data(), out);
 }
 
 og::sim::EntitySnapshot deserialize_delta_entity(ByteReader& reader)
@@ -1095,6 +1269,9 @@ void serialize_keyframe_entity_list(std::vector<std::uint8_t>& buffer,
         throw std::runtime_error("snapshot serialization: too many entities");
     }
 
+    // Keyframe records are fixed size, so this is the exact final length.
+    buffer.reserve(buffer.size() + sizeof(std::uint32_t) +
+                   entities.size() * kKeyframeEntityRecordBytes);
     append_u32(buffer, static_cast<std::uint32_t>(entities.size()));
     for (const auto& entity : entities)
         serialize_keyframe_entity(buffer, entity);
@@ -1119,6 +1296,11 @@ void serialize_delta_entity_list(std::vector<std::uint8_t>& buffer,
     {
         throw std::runtime_error("delta serialization: too many entities");
     }
+
+    std::size_t list_bytes = sizeof(std::uint32_t);
+    for (const auto& entity : entities)
+        list_bytes += delta_entity_wire_size(entity);
+    buffer.reserve(buffer.size() + list_bytes);
 
     append_u32(buffer, static_cast<std::uint32_t>(entities.size()));
     for (const auto& entity : entities)
@@ -1211,11 +1393,32 @@ std::vector<std::uint8_t> decompress_zlib_payload(const std::uint8_t* data,
     return output;
 }
 
+// Growth hints only -- the payload's exact length comes from the blocks
+// themselves. The scalar allowance covers the fixed world/respawn/mode/grid
+// header blocks; the guy allowance covers a fixed record plus a short name.
+constexpr std::size_t kSnapshotScalarBlockReserve = 1024;
+constexpr std::size_t kGuySnapshotReserveBytes = 96;
+constexpr std::size_t kGridDirtyTileWireBytes = 5;
+
+std::size_t snapshot_payload_reserve_hint(const og::sim::WorldSnapshot& snapshot,
+                                          std::size_t grid_bytes)
+{
+    return kSnapshotScalarBlockReserve + grid_bytes +
+           snapshot.grid_dirty_tiles.size() * kGridDirtyTileWireBytes +
+           snapshot.guy_snapshots.size() * kGuySnapshotReserveBytes +
+           (snapshot.oblist.size() + snapshot.fxlist.size() +
+            snapshot.weaplist.size()) *
+               kKeyframeEntityRecordBytes +
+           snapshot.removed_entity_ids.size() * sizeof(std::uint32_t);
+}
+
 std::vector<std::uint8_t> serialize_snapshot_payload(const og::sim::WorldSnapshot& snapshot)
 {
     std::vector<std::uint8_t> payload;
+    payload.reserve(snapshot_payload_reserve_hint(
+        snapshot, snapshot.full_grid_data.size()));
     append_u8(payload, og::sim::kSnapshotFormatVersion);
-    serialize_world_state(payload, snapshot);
+    serialize_world_state(payload, snapshot, snapshot.snapshot_hash);
     serialize_grid_state(payload, snapshot);
     serialize_guy_snapshots(payload, snapshot.guy_snapshots);
     serialize_keyframe_entity_list(payload, snapshot.oblist);
@@ -1233,24 +1436,60 @@ std::vector<std::uint8_t> serialize_snapshot_payload(const og::sim::WorldSnapsho
     return payload;
 }
 
+// The normalized grid is either fully materialized (dirty + full resend, no
+// dirty tiles) or absent entirely, so it always satisfies the checks
+// serialize_grid_state runs and the block is written straight out.
+void serialize_hash_grid_block(std::vector<std::uint8_t>& buffer,
+                               std::uint8_t width,
+                               std::uint8_t height,
+                               const std::uint8_t* data,
+                               std::size_t size)
+{
+    const bool materialized =
+        width != 0 && height != 0 && size == grid_cell_count(width, height);
+
+    append_u8(buffer, width);
+    append_u8(buffer, height);
+    append_bool(buffer, materialized);
+    append_bool(buffer, materialized);
+    append_u32(buffer, materialized ? static_cast<std::uint32_t>(size) : 0U);
+    if (materialized)
+        append_bytes(buffer, data, size);
+    append_u32(buffer, 0U);
+}
+
+// The hash payload is the keyframe payload with the volatile parts
+// normalized away: hash field zeroed, removed ids dropped, grid materialized
+// from the world when the snapshot carries only an incremental update.
+// Emitted directly rather than through a normalized COPY of the snapshot --
+// the copy duplicated every entity vector on the per-tick capture path.
 std::vector<std::uint8_t> serialize_snapshot_payload_for_hash(
     const og::sim::WorldSnapshot& snapshot,
     const GameWorld* world = nullptr)
 {
-    og::sim::WorldSnapshot normalized = snapshot;
-    normalized.snapshot_hash = 0;
-    normalized.removed_entity_ids.clear();
-    if (!has_materialized_grid(normalized) && world != nullptr && world->grid.valid())
+    std::uint8_t grid_width = snapshot.grid_width;
+    std::uint8_t grid_height = snapshot.grid_height;
+    const std::uint8_t* grid_data = snapshot.full_grid_data.data();
+    std::size_t grid_size = snapshot.full_grid_data.size();
+    if (!has_materialized_grid(snapshot) && world != nullptr && world->grid.valid())
     {
-        normalized.grid_width = world->grid.w;
-        normalized.grid_height = world->grid.h;
-        const std::size_t grid_size =
-            static_cast<std::size_t>(world->grid.w) * world->grid.h;
-        normalized.full_grid_data.assign(world->grid.data.get(),
-                                         world->grid.data.get() + grid_size);
+        grid_width = world->grid.w;
+        grid_height = world->grid.h;
+        grid_data = world->grid.data.get();
+        grid_size = static_cast<std::size_t>(world->grid.w) * world->grid.h;
     }
-    normalize_materialized_grid(normalized);
-    return serialize_snapshot_payload(normalized);
+
+    std::vector<std::uint8_t> payload;
+    payload.reserve(snapshot_payload_reserve_hint(snapshot, grid_size));
+    append_u8(payload, og::sim::kSnapshotFormatVersion);
+    serialize_world_state(payload, snapshot, 0U);
+    serialize_hash_grid_block(payload, grid_width, grid_height, grid_data, grid_size);
+    serialize_guy_snapshots(payload, snapshot.guy_snapshots);
+    serialize_keyframe_entity_list(payload, snapshot.oblist);
+    serialize_keyframe_entity_list(payload, snapshot.fxlist);
+    serialize_keyframe_entity_list(payload, snapshot.weaplist);
+    append_u32(payload, 0U);
+    return payload;
 }
 
 std::uint32_t compute_snapshot_hash_impl(const og::sim::WorldSnapshot& snapshot,
@@ -1305,8 +1544,12 @@ og::sim::WorldSnapshot deserialize_snapshot_payload(const std::vector<std::uint8
 std::vector<std::uint8_t> serialize_delta_payload(const og::sim::WorldSnapshot& delta)
 {
     std::vector<std::uint8_t> payload;
+    // Growth hint for the scalar blocks; the entity lists reserve exactly.
+    payload.reserve(kSnapshotScalarBlockReserve + delta.full_grid_data.size() +
+                    delta.grid_dirty_tiles.size() * kGridDirtyTileWireBytes +
+                    delta.guy_snapshots.size() * kGuySnapshotReserveBytes);
     append_u8(payload, og::sim::kSnapshotFormatVersion);
-    serialize_world_state(payload, delta);
+    serialize_world_state(payload, delta, delta.snapshot_hash);
     serialize_grid_state(payload, delta);
     serialize_guy_snapshots(payload, delta.guy_snapshots);
     serialize_delta_entity_list(payload, delta.oblist);
@@ -1376,6 +1619,10 @@ void apply_delta_entity_list(std::vector<og::sim::EntitySnapshot>& target,
                              const std::vector<og::sim::EntitySnapshot>& delta_entities,
                              std::vector<std::uint32_t>& removed_entity_ids)
 {
+    // Upper bound on the entities this pass can append to `target`, so the
+    // push_backs below never reallocate mid-loop.
+    target.reserve(target.size() + delta_entities.size());
+
     for (const auto& delta_entity : delta_entities)
     {
         if (entity_delta_is_removal(delta_entity))

--- a/src/interface/render/effects.cpp
+++ b/src/interface/render/effects.cpp
@@ -231,19 +231,50 @@ void generate_depth_noise()
 // half spatial frequency and drifts faster, so the banks evolve instead of
 // sliding past as one rigid sheet. Negative world coords wrap fine under
 // two's-complement & kNoiseMask.
-int cloud_sample(int wx, int wy, std::uint32_t tick)
+//
+// Walked one world row at a time: for a fixed world y both layers sit on a
+// fixed lattice row, and one world pixel to the right advances layer 1 by
+// one lattice column and layer 2 — sampling at half frequency — by one
+// every other pixel. sample() must return exactly what the two-layer
+// formula gives for (wx, wy): the weather pins compare rendered pixels byte
+// for byte.
+class CloudRow
 {
-	const int t = static_cast<int>(tick & 0x0FFFFFFFu);
-	const int x1 = (wx + t / 2) & kNoiseMask;
-	const int y1 = (wy + t / 4) & kNoiseMask;
-	const int x2 = ((wx >> 1) + t) & kNoiseMask;
-	const int y2 = ((wy >> 1) - t / 8) & kNoiseMask;
-	const int s1 = cloud_noise[static_cast<std::size_t>(x1 + kNoiseSize * y1)];
-	const int s2 = cloud_noise[static_cast<std::size_t>(x2 + kNoiseSize * y2)];
-	return (s1 + s2) / 2;
-}
+public:
+	CloudRow(int wx, int wy, std::uint32_t tick)
+	{
+		const int t = static_cast<int>(tick & 0x0FFFFFFFu);
+		row1_ = cloud_noise.data() +
+		    static_cast<std::size_t>(kNoiseSize * ((wy + t / 4) & kNoiseMask));
+		row2_ = cloud_noise.data() +
+		    static_cast<std::size_t>(kNoiseSize *
+		                             (((wy >> 1) - t / 8) & kNoiseMask));
+		x1_ = (wx + t / 2) & kNoiseMask;
+		x2_ = ((wx >> 1) + t) & kNoiseMask;
+		// (wx >> 1) gains one on the step INTO an even column, i.e. on the
+		// step out of an odd one.
+		half_ = wx & 1;
+	}
 
-// Depth-fog drift: like cloud_sample, two layers of the depth field evolve
+	int sample() const { return (row1_[x1_] + row2_[x2_]) / 2; }
+
+	void step()
+	{
+		x1_ = (x1_ + 1) & kNoiseMask;
+		if (half_)
+			x2_ = (x2_ + 1) & kNoiseMask;
+		half_ ^= 1;
+	}
+
+private:
+	const unsigned char* row1_;
+	const unsigned char* row2_;
+	int x1_;
+	int x2_;
+	int half_;
+};
+
+// Depth-fog drift: like the cloud field, two layers of the depth field evolve
 // against each other, but slower and along different headings (E+N vs the
 // clouds' W+S), so fog banks crawl rather than race and never track the sky.
 int depth_fog_sample(int x, int y, std::uint32_t tick)
@@ -1433,55 +1464,71 @@ void draw_cloud_overlay(viewscreen* vs, GameWorld& world)
 	screen* dest = og::runtime::current_session->myscreen_;
 	bool rained = false;
 	// World-anchored sampling: a world pixel keeps its cloud regardless of
-	// camera scroll; only the tick moves the banks and drops the rain.
-	for (Sint32 y = vs->yloc; y < vs->endy; y++)
+	// camera scroll; only the tick moves the banks and drops the rain. The
+	// three kinds are mutually exclusive, so each drives its own pixel loop.
+	if (clouds_on)
 	{
-		const int wy = static_cast<int>(y - vs->yloc + vs->topy);
-		for (Sint32 x = vs->xloc; x < vs->endx; x++)
+		for (Sint32 y = vs->yloc; y < vs->endy; y++)
 		{
-			const int wx = static_cast<int>(x - vs->xloc + vs->topx);
-			if (clouds_on)
+			const int wy = static_cast<int>(y - vs->yloc + vs->topy);
+			const int wx0 = static_cast<int>(vs->topx);
+			CloudRow shadow(wx0 + kCloudShadowOffsetX, wy + kCloudShadowOffsetY,
+			                frame_tick);
+			CloudRow bank(wx0, wy, frame_tick);
+			for (Sint32 x = vs->xloc; x < vs->endx; x++)
 			{
 				// Ground shadow first, so a bank blends over its own shadow
 				// where the two overlap: the shadow of the bank overhead
 				// lands displaced by the fixed sun offset.
-				const int cast_a = cloud_alpha(cloud_sample(
-				    wx + kCloudShadowOffsetX, wy + kCloudShadowOffsetY,
-				    frame_tick));
+				const int cast_a = cloud_alpha(shadow.sample());
 				if (cast_a > 0)
 					dest->pointb(x, y, PURE_BLACK,
 					             static_cast<unsigned char>(
 					                 cast_a * kCloudShadowScale / 100));
-				const int a = cloud_alpha(cloud_sample(wx, wy, frame_tick));
+				const int a = cloud_alpha(bank.sample());
 				if (a > 0)
 					dest->pointb(x, y, PURE_WHITE,
 					             static_cast<unsigned char>(a));
+				shadow.step();
+				bank.step();
 			}
-			if (rain_on || snow_on)
+		}
+	}
+	else if (rain_on || snow_on)
+	{
+		// Full-screen fall: density comes from the cell-occupancy hash
+		// alone. Rain streaks lean ~14 degrees (1px right per 4 down, wind
+		// from the left): q = 4*wx - wy is constant along that slant, so
+		// hashing q's cell keys whole slanted rails, and the falling phase
+		// below makes each segment slide DOWN-ALONG its rail — angled fall
+		// for free. The per-rail hash de-phases neighbors and the per-cell
+		// hash leaves most cells dry. Snow rails are twice as steep (1px
+		// per 8 down) and alternate lean direction per 32px world-column
+		// band.
+		for (Sint32 y = vs->yloc; y < vs->endy; y++)
+		{
+			const int wy = static_cast<int>(y - vs->yloc + vs->topy);
+			const std::uint32_t vbase =
+			    static_cast<std::uint32_t>(wy) - frame_tick * fall;
+			const int wx0 = static_cast<int>(vs->topx);
+			// q is a multiple of the rail divisor in wx (4 and >>2 for rain,
+			// 8 and >>3 for snow), so the hashed rail key is wx plus a row
+			// constant — one step per pixel along the row. Snow re-bases at
+			// each 32px band edge, where the lean flips.
+			int rail = rain_on ? wx0 + ((-wy) >> 2) : 0;
+			int wx = wx0;
+			for (Sint32 x = vs->xloc; x < vs->endx; x++, wx++)
 			{
-				// Full-screen fall: density comes from the cell-occupancy
-				// hash alone. Rain streaks lean ~14 degrees (1px right per 4
-				// down, wind from the left): q = 4*wx - wy is constant along
-				// that slant, so hashing q's cell keys whole slanted rails,
-				// and the falling phase below makes each segment slide
-				// DOWN-ALONG its rail — angled fall for free. The per-rail
-				// hash de-phases neighbors and the per-cell hash leaves most
-				// cells dry. Snow rails are twice as steep (1px per 8 down)
-				// and alternate lean direction per 32px world-column band.
-				int q;
-				if (rain_on)
-					q = 4 * wx - wy;
-				else
+				if (snow_on && (wx == wx0 || (wx & 31) == 0))
 				{
 					const int s =
 					    (hash_u32(static_cast<std::uint32_t>(wx >> 5)) & 1u)
 					        ? 1 : -1;
-					q = 8 * wx - s * wy;
+					rail = wx + ((-s * wy) >> 3);
 				}
-				const std::uint32_t col = hash_u32(
-				    static_cast<std::uint32_t>(rain_on ? (q >> 2) : (q >> 3)));
-				const std::uint32_t v = static_cast<std::uint32_t>(wy) -
-				    frame_tick * fall + col;
+				const std::uint32_t col =
+				    hash_u32(static_cast<std::uint32_t>(rail));
+				const std::uint32_t v = vbase + col;
 				const std::uint32_t pos = v & kRainPeriodMask;
 				if (pos < streak_len &&
 				    (hash_u32(col + (v >> 6) * kRainCellStride) & 7u) <
@@ -1494,6 +1541,7 @@ void draw_cloud_overlay(viewscreen* vs, GameWorld& world)
 					                 static_cast<int>(pos) * alpha_step));
 					rained = true;
 				}
+				rail++;
 			}
 		}
 	}

--- a/src/interface/render/effects.cpp
+++ b/src/interface/render/effects.cpp
@@ -19,6 +19,7 @@
 
 #include <openglad/core/colors.h>
 #include <openglad/core/constants.h>
+#include <openglad/core/frame_pacing.h>
 #include <openglad/core/pixdefs.h>
 #include <openglad/core/test_trace.h>
 #include <openglad/core/terrain_types.h>
@@ -36,6 +37,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -966,7 +968,63 @@ int depth_fog_alpha_at(int x, int y, std::uint32_t tick, int stories)
 	return a;
 }
 
+namespace
+{
+
+// Wall-clock cadence for uncapped rendering: 14 ms per effects tick, i.e. the
+// classic 72 fps render rate ((1000 + 36) / 72), so cosmetics animate exactly
+// as a 72 fps capped game shows regardless of the present rate. Off by
+// default; every capped path and test keeps one advance per call.
+inline constexpr std::uint32_t kWallClockCadenceIntervalMs = 14;
+bool wall_clock_cadence = false;
+og::core::FrameDeadlinePacer cadence_pacer;
+
+void advance_frame_state();
+
+void advance_frame_if_due(std::uint32_t now_ms)
+{
+	if (cadence_pacer.interval_ms() != kWallClockCadenceIntervalMs)
+		cadence_pacer.configure(kWallClockCadenceIntervalMs, now_ms);
+	if (cadence_pacer.tick(now_ms).run_tick)
+		advance_frame_state();
+}
+
+} // namespace
+
+void effects_set_wall_clock_cadence(bool on)
+{
+	wall_clock_cadence = on;
+}
+
 void effects_advance_frame()
+{
+	if (!wall_clock_cadence)
+	{
+		advance_frame_state();
+		return;
+	}
+	advance_frame_if_due(static_cast<std::uint32_t>(
+	    std::chrono::duration_cast<std::chrono::milliseconds>(
+	        std::chrono::steady_clock::now().time_since_epoch())
+	        .count()));
+}
+
+#ifdef TESTING
+void effects_advance_frame_at(std::uint32_t now_ms)
+{
+	if (!wall_clock_cadence)
+	{
+		advance_frame_state();
+		return;
+	}
+	advance_frame_if_due(now_ms);
+}
+#endif
+
+namespace
+{
+
+void advance_frame_state()
 {
 	++frame_tick;
 	// Drop history for entities no viewport has drawn in kStoreMaxAge ticks
@@ -1005,6 +1063,8 @@ void effects_advance_frame()
 			++it;
 	}
 }
+
+} // namespace
 
 bool draw_walker_trail(walker& w, viewscreen* vs)
 {
@@ -1582,6 +1642,8 @@ UpperFloorShadowMaskStats upper_floor_shadow_mask_stats_for_testing()
 void effects_reset_for_testing()
 {
 	frame_tick = 0;
+	wall_clock_cadence = false;
+	cadence_pacer = og::core::FrameDeadlinePacer{};
 	cloud_noise_ready = false;
 	depth_noise_ready = false;
 	glow_kernel_ready = false;

--- a/src/interface/render/view.cpp
+++ b/src/interface/render/view.cpp
@@ -1652,21 +1652,23 @@ void viewscreen::draw_floor_effects(LevelRuntimeData* data, int floor)
 	if (camera_pass && editor_floor_override_ < 0 &&
 	    draw_stair_overlays(this, data->world().grid_for_floor(floor)))
 		TRACE("render", "stair_overlay floor=%d", floor);
-	const bool reflections_on = cfg.is_on("effects", "reflections") &&
-	    camera_pass;
-	const bool ripples_on = cfg.is_on("effects", "ripples") && camera_pass;
-	const bool trails_on = cfg.is_on("effects", "trails") && camera_pass;
+	// Cheap pass tests lead: cfg.is_on walks two string maps, and a
+	// non-camera floor pass reads none of these keys.
+	const bool reflections_on = camera_pass &&
+	    cfg.is_on("effects", "reflections");
+	const bool ripples_on = camera_pass && cfg.is_on("effects", "ripples");
+	const bool trails_on = camera_pass && cfg.is_on("effects", "trails");
+	const bool dust_key_on = camera_pass && multifloor &&
+	    cfg.is_on("effects", "dust");
 	// Dust falls only when some floor exists above the camera.
-	const bool dust_on = cfg.is_on("effects", "dust") && camera_pass &&
-	    multifloor &&
+	const bool dust_on = dust_key_on &&
 	    current_floor_ < static_cast<Sint32>(data->world().floor_count() - 1);
 	// The falling cue rides the dust key (it IS falling debris): a landing
 	// floor always has the from-floor above it, so the extra top-floor
 	// condition on dust_on would be redundant here. Spectator/capture
 	// cameras keep it; only the editor's authoring view stays clean (same
 	// gate as the overhang shadows — nothing falls in the editor anyway).
-	const bool fall_cue_on = cfg.is_on("effects", "dust") && camera_pass &&
-	    multifloor && !editor_authoring_view_;
+	const bool fall_cue_on = dust_key_on && !editor_authoring_view_;
 	if (fall_cue_on)
 	{
 		effects_track_air_falls(data->world());

--- a/src/interface/render/walker_draw.cpp
+++ b/src/interface/render/walker_draw.cpp
@@ -338,12 +338,12 @@ static void draw_damage_number(walker::DamageNumber& dn, viewscreen* view_buf)
 
 void draw_small_health_bar(walker* w, viewscreen* view_buf)
 {
-    if(!cfg.is_on("effects", "mini_hp_bar"))
+    if(w->query_order() != Order::Living && w->query_order() != Order::Generator)
     {
         return;
     }
 
-    if(w->query_order() != Order::Living && w->query_order() != Order::Generator)
+    if(!cfg.is_on("effects", "mini_hp_bar"))
     {
         return;
     }
@@ -485,13 +485,10 @@ static bool mark_player_controls_outline()
 bool draw_walker(walker& w, viewscreen* view_buf, unsigned char alpha,
                  bool layer_active)
 {
-    const bool show_attack_lunge = cfg.is_on("effects", "attack_lunge");
-    const bool show_hit_recoil = cfg.is_on("effects", "hit_recoil");
-    const bool show_hit_flash = cfg.is_on("effects", "hit_flash");
-    const bool show_hit_anim = cfg.is_on("effects", "hit_anim");
-    const bool show_damage_numbers = cfg.is_on("effects", "damage_numbers");
-    const bool show_heal_numbers = cfg.is_on("effects", "heal_numbers");
-
+    // Every "effects" gate below is read at the point of use, behind the
+    // cheap entity test that decides whether the effect can apply at all:
+    // cfg.is_on walks two string maps, and draw_walker runs once per drawn
+    // entity per viewport per frame.
     const WalkerRenderPosition draw_pos =
         resolve_walker_render_position(w, view_buf->interpolation_alpha);
     const short draw_x = static_cast<short>(draw_pos.worldx);
@@ -514,8 +511,8 @@ bool draw_walker(walker& w, viewscreen* view_buf, unsigned char alpha,
 	// NOT here — render must not write sim-read entity state (it freezes in the
 	// headless server). Enforced by scripts/check_render_no_sim_writes.sh.
 
-    if (!show_hit_anim && w.query_order() == Order::FX &&
-        w.family() == FAMILY_HIT)
+    if (w.query_order() == Order::FX && w.family() == FAMILY_HIT &&
+        !cfg.is_on("effects", "hit_anim"))
     {
         return true;
     }
@@ -530,7 +527,7 @@ bool draw_walker(walker& w, viewscreen* view_buf, unsigned char alpha,
 	// thrown rock arcing, a fireball drifting). worldz==0 leaves output unchanged.
 	yscreen -= static_cast<Sint32>(w.worldz());
 
-		if(show_attack_lunge && w.attack_lunge() > 0.0f)
+		if(w.attack_lunge() > 0.0f && cfg.is_on("effects", "attack_lunge"))
 	    {
 	        const float dx = w.attack_lunge() * ATTACK_LUNGE_SIZE * cosf(w.attack_lunge_angle());
 	        const float dy = w.attack_lunge() * ATTACK_LUNGE_SIZE * sinf(w.attack_lunge_angle());
@@ -538,7 +535,7 @@ bool draw_walker(walker& w, viewscreen* view_buf, unsigned char alpha,
 	        yscreen += static_cast<Sint32>(dy);
 	    }
 
-		if(show_hit_recoil && w.hit_recoil() > 0.0f)
+		if(w.hit_recoil() > 0.0f && cfg.is_on("effects", "hit_recoil"))
 	    {
 	        const float dx = w.hit_recoil() * HIT_RECOIL_SIZE * cosf(w.hit_recoil_angle());
 	        const float dy = w.hit_recoil() * HIT_RECOIL_SIZE * sinf(w.hit_recoil_angle());
@@ -620,7 +617,7 @@ bool draw_walker(walker& w, viewscreen* view_buf, unsigned char alpha,
 	}
 
 	// Draw me
-		if(show_hit_flash && w.hurt_flash())
+		if(w.hurt_flash() && cfg.is_on("effects", "hit_flash"))
 	    {
         auto bmp_span = std::span<const unsigned char>{w.bmp_data(), static_cast<size_t>(w.sizex() * w.sizey())};
         og::runtime::current_session->myscreen_->walkputbuffer_flash(xscreen, yscreen, w.sizex(), w.sizey(),
@@ -665,6 +662,15 @@ bool draw_walker(walker& w, viewscreen* view_buf, unsigned char alpha,
         render_context->trim_owner(owner_entity_id, w.damage_numbers.size());
     }
 
+    // The gates are only worth reading when the block below can do
+    // something: with no numbers to advance its entire effect is the
+    // null-screen early return.
+    const bool damage_numbers_matter =
+        !w.damage_numbers.empty() || game_screen == nullptr;
+    const bool show_damage_numbers =
+        damage_numbers_matter && cfg.is_on("effects", "damage_numbers");
+    const bool show_heal_numbers =
+        damage_numbers_matter && cfg.is_on("effects", "heal_numbers");
     if (show_damage_numbers || show_heal_numbers)
     {
         if (game_screen == nullptr)
@@ -778,7 +784,7 @@ void ground_plane_anchor(walker& w, viewscreen* view_buf,
         draw_pos.worldy - static_cast<float>(view_buf->topy) +
         static_cast<float>(view_buf->yloc));
 
-    if(cfg.is_on("effects", "attack_lunge") && w.attack_lunge() > 0.0f)
+    if(w.attack_lunge() > 0.0f && cfg.is_on("effects", "attack_lunge"))
     {
         const float dx = w.attack_lunge() * ATTACK_LUNGE_SIZE * cosf(w.attack_lunge_angle());
         const float dy = w.attack_lunge() * ATTACK_LUNGE_SIZE * sinf(w.attack_lunge_angle());
@@ -786,7 +792,7 @@ void ground_plane_anchor(walker& w, viewscreen* view_buf,
         yscreen += static_cast<Sint32>(dy);
     }
 
-    if(cfg.is_on("effects", "hit_recoil") && w.hit_recoil() > 0.0f)
+    if(w.hit_recoil() > 0.0f && cfg.is_on("effects", "hit_recoil"))
     {
         const float dx = w.hit_recoil() * HIT_RECOIL_SIZE * cosf(w.hit_recoil_angle());
         const float dy = w.hit_recoil() * HIT_RECOIL_SIZE * sinf(w.hit_recoil_angle());
@@ -897,8 +903,8 @@ bool draw_walker_reflection(walker& w, viewscreen* view_buf,
 
 bool draw_walker_tile(walker& w, viewscreen* view_buf)
 {
-    if (!cfg.is_on("effects", "hit_anim") &&
-        w.query_order() == Order::FX && w.family() == FAMILY_HIT)
+    if (w.query_order() == Order::FX && w.family() == FAMILY_HIT &&
+        !cfg.is_on("effects", "hit_anim"))
     {
         return true;
     }

--- a/src/interface/score_panel.cpp
+++ b/src/interface/score_panel.cpp
@@ -39,6 +39,13 @@
 #include <string_view>
 #include <vector>
 
+// HUD-only randomness (the score count-up easing below), drawn once per
+// rendered frame: this is the session-scope RNG — a per-session SeededRandom in
+// demo sessions, the production RNG in the main game. It must never be the
+// authoritative world.rng_ gameplay stream, which gameplay draws reach through
+// walker_rng() (that prefers world->rng_ whenever gameplay is active). The two
+// streams staying distinct is what lets the panel redraw at any frame rate
+// without moving a single gameplay outcome.
 static inline Uint32 rng(Uint32 max_exclusive)
 {
     return ctx().rng->next(max_exclusive);

--- a/src/platform/sdl/demo.cpp
+++ b/src/platform/sdl/demo.cpp
@@ -39,6 +39,7 @@
 #include <openglad/legacy/base.h>
 #include <openglad/resources/io.h>
 #include <openglad/platform/sai2x.h>
+#include <openglad/interface/render/effects.h>
 #include <openglad/interface/render/view.h>
 #include <openglad/interface/game_context.h>
 #include <openglad/platform/game_loop.h>
@@ -779,6 +780,12 @@ int main(int argc, char* argv[])
              (std::string_view(lockstep_env) == "1" ||
               std::string_view(lockstep_env) == "on"));
         Log("openglad_demo: pacing {}\n", lockstep ? "lockstep" : "uncapped");
+        // Machine-rate presenting would otherwise animate every render-only
+        // cosmetic (weather, ripples, trails) at hardware speed; the wall
+        // clock holds them at the classic 72 fps cadence. Lockstep keeps the
+        // per-redraw advance its byte-pinned dumps rely on.
+        if (!lockstep)
+            effects_set_wall_clock_cadence(true);
 
         // OPENGLAD_DEMO_MAX_FRAMES bounds only the main loop. Grid sizing and
         // scenario selection remain the real demo paths; automation can pick a
@@ -945,6 +952,13 @@ int main(int argc, char* argv[])
             for (int i = 0; i < num_sessions; i++) {
                 SDL_Surface* src =
                     demos[static_cast<size_t>(i)].session->session_surface_;
+                // GameSession treats a failed session-surface allocation as
+                // non-fatal; degrade to a blank cell like the software
+                // compositor does instead of dereferencing null.
+                if (src == nullptr) {
+                    cell_tex.emplace_back(nullptr, SDL_DestroyTexture);
+                    continue;
+                }
                 SdlTexturePtr tex(
                     SDL_CreateTexture(E_Screen->renderer, src->format,
                                       SDL_TEXTUREACCESS_STREAMING,
@@ -1036,8 +1050,10 @@ int main(int argc, char* argv[])
         auto last_time = std::chrono::steady_clock::now();
         const auto run_start = last_time;
         bool running = true;
-        int frames_run = 0;       // sim ticks, in both pacing modes
-        int rendered_frames = 0;  // loop passes that presented
+        // 64-bit: an unattended uncapped run presents at machine rate, and a
+        // 32-bit rendered-frame counter would overflow within days.
+        long long frames_run = 0;       // sim ticks, in both pacing modes
+        long long rendered_frames = 0;  // loop passes that presented
         int captured_frames = 0;
 
         // Phases 2+3: one barriered sim generation across all sessions.
@@ -1097,8 +1113,8 @@ int main(int argc, char* argv[])
                 }
                 ticks_this_iter = due.ticks;
                 if (max_frames > 0) {
-                    ticks_this_iter = std::min(ticks_this_iter,
-                                               max_frames - frames_run);
+                    ticks_this_iter = static_cast<int>(std::min<long long>(
+                        ticks_this_iter, max_frames - frames_run));
                 }
             }
             for (int t = 0; t < ticks_this_iter; ++t)
@@ -1245,6 +1261,10 @@ int main(int argc, char* argv[])
                 for (int i = 0; i < num_sessions; i++) {
                     SDL_Surface* src =
                         demos[static_cast<size_t>(i)].session->session_surface_;
+                    if (src == nullptr ||
+                        !cell_tex[static_cast<size_t>(i)]) {
+                        continue;  // surface allocation failed: blank cell
+                    }
                     SDL_UpdateTexture(cell_tex[static_cast<size_t>(i)].get(),
                                       nullptr, src->pixels, src->pitch);
                     const CellRects r = cell_rects(
@@ -1356,8 +1376,8 @@ int main(int argc, char* argv[])
             "openglad_demo: {} sim ticks, {} rendered frames in {:.3f} s "
             "({:.1f} fps, {:.2f} ticks/s)\n",
             frames_run, rendered_frames, run_secs,
-            rendered_frames / std::max(run_secs, 1e-6),
-            frames_run / std::max(run_secs, 1e-6)));
+            static_cast<double>(rendered_frames) / std::max(run_secs, 1e-6),
+            static_cast<double>(frames_run) / std::max(run_secs, 1e-6)));
 
         if (capture_writer) {
             Log("openglad_demo: captured {} frames to {}\n",

--- a/src/platform/sdl/demo.cpp
+++ b/src/platform/sdl/demo.cpp
@@ -26,6 +26,7 @@
  */
 
 #include <openglad/core/constants.h>
+#include <openglad/core/frame_pacing.h>
 #include <openglad/core/util.h>
 #include <openglad/core/version.h>
 #include <openglad/resources/company.h>
@@ -636,37 +637,59 @@ static void render_session_frame(screen& s, SDL_Surface* session_surface)
     }
 }
 
-// Blit a 320x200 session surface into its cell of the composite surface.
-// Cells split the composite evenly (per-index rounding, so the grid always
-// covers the full display with no seams). The source is cover-scaled: magnify
-// uniformly until the frame fills the cell in both dimensions, times the zoom
-// boost, then center-crop the excess.
+// Cell geometry for compositing a 320x200 session frame into its display
+// cell. Cells split the destination evenly (per-index rounding, so the grid
+// always covers the full display with no seams). The source is cover-scaled:
+// magnify uniformly until the frame fills the cell in both dimensions, times
+// the zoom boost, then center-crop the excess.
+//
+// Shared by the software (lockstep) and GPU (uncapped) compositors so the two
+// paths cannot disagree about layout. The lockstep pixel output is pinned by
+// scripts/test_demo_smoke.sh; keep the arithmetic bit-exact.
+struct CellRects {
+    SDL_Rect src;
+    SDL_Rect dst;
+};
+
+static CellRects cell_rects(int dst_w, int dst_h, int grid_col, int grid_row,
+                            int grid_cols, int grid_rows, float zoom_boost)
+{
+    CellRects r;
+    r.dst.x = grid_col * dst_w / grid_cols;
+    r.dst.y = grid_row * dst_h / grid_rows;
+    r.dst.w = (grid_col + 1) * dst_w / grid_cols - r.dst.x;
+    r.dst.h = (grid_row + 1) * dst_h / grid_rows - r.dst.y;
+
+    const float cover = std::max(
+        static_cast<float>(r.dst.w) / static_cast<float>(CELL_W),
+        static_cast<float>(r.dst.h) / static_cast<float>(CELL_H));
+    const float zoom = cover * std::max(1.0f, zoom_boost);
+    r.src.w = std::clamp(
+        static_cast<int>(std::lround(static_cast<float>(r.dst.w) / zoom)),
+        1, CELL_W);
+    r.src.h = std::clamp(
+        static_cast<int>(std::lround(static_cast<float>(r.dst.h) / zoom)),
+        1, CELL_H);
+    r.src.x = (CELL_W - r.src.w) / 2;
+    r.src.y = (CELL_H - r.src.h) / 2;
+    return r;
+}
+
+static SDL_FRect to_frect(const SDL_Rect& r)
+{
+    return SDL_FRect{static_cast<float>(r.x), static_cast<float>(r.y),
+                     static_cast<float>(r.w), static_cast<float>(r.h)};
+}
+
+// Software compositor cell blit (lockstep mode).
 static void composite_session(SDL_Surface* dst, SDL_Surface* src,
                               int grid_col, int grid_row,
                               int grid_cols, int grid_rows, float zoom_boost)
 {
     if (!src || !dst) return;
-    SDL_Rect dst_rect;
-    dst_rect.x = grid_col * dst->w / grid_cols;
-    dst_rect.y = grid_row * dst->h / grid_rows;
-    dst_rect.w = (grid_col + 1) * dst->w / grid_cols - dst_rect.x;
-    dst_rect.h = (grid_row + 1) * dst->h / grid_rows - dst_rect.y;
-
-    const float cover = std::max(
-        static_cast<float>(dst_rect.w) / static_cast<float>(CELL_W),
-        static_cast<float>(dst_rect.h) / static_cast<float>(CELL_H));
-    const float zoom = cover * std::max(1.0f, zoom_boost);
-    SDL_Rect src_rect;
-    src_rect.w = std::clamp(
-        static_cast<int>(std::lround(static_cast<float>(dst_rect.w) / zoom)),
-        1, CELL_W);
-    src_rect.h = std::clamp(
-        static_cast<int>(std::lround(static_cast<float>(dst_rect.h) / zoom)),
-        1, CELL_H);
-    src_rect.x = (CELL_W - src_rect.w) / 2;
-    src_rect.y = (CELL_H - src_rect.h) / 2;
-    SDL_BlitSurfaceScaled(src, &src_rect, dst, &dst_rect,
-                          SDL_SCALEMODE_LINEAR);
+    CellRects r = cell_rects(dst->w, dst->h, grid_col, grid_row,
+                             grid_cols, grid_rows, zoom_boost);
+    SDL_BlitSurfaceScaled(src, &r.src, dst, &r.dst, SDL_SCALEMODE_LINEAR);
 }
 
 int main(int argc, char* argv[])
@@ -739,6 +762,24 @@ int main(int argc, char* argv[])
                 capture.start, capture.limit);
         }
 
+        // Pacing mode, decided once at startup. Lockstep is the pixel-pinned
+        // path — one sim tick per rendered frame, software compositing, sleep
+        // to FRAME_PERIOD — and every run that dumps pixels (capture or
+        // composite dump) must take it, or the byte-identity pins in
+        // scripts/test_demo_smoke.sh and scripts/media/capture_showcase.sh
+        // would depend on machine speed. Uncapped holds the sim at
+        // FRAME_PERIOD on the wall clock and renders as fast as the machine
+        // allows. OPENGLAD_DEMO_LOCKSTEP=1 forces lockstep for reproducible
+        // debugging without a dump.
+        const char* composite_dump = env_or_null("OPENGLAD_DEMO_COMPOSITE_DUMP");
+        const char* lockstep_env = env_or_null("OPENGLAD_DEMO_LOCKSTEP");
+        const bool lockstep =
+            capture.enabled() || composite_dump != nullptr ||
+            (lockstep_env != nullptr &&
+             (std::string_view(lockstep_env) == "1" ||
+              std::string_view(lockstep_env) == "on"));
+        Log("openglad_demo: pacing {}\n", lockstep ? "lockstep" : "uncapped");
+
         // OPENGLAD_DEMO_MAX_FRAMES bounds only the main loop. Grid sizing and
         // scenario selection remain the real demo paths; automation can pick a
         // cheap topology explicitly with OPENGLAD_DEMO_GRID=1x1.
@@ -808,6 +849,15 @@ int main(int argc, char* argv[])
         // also survives resize/fullscreen events for the demo's lifetime.
         E_Screen->set_world_canvas_pinned_classic(true);
         host_session.myscreen_->relayout_views();
+
+        // Uncapped mode measures how fast the machine can render; vsync would
+        // pin that to the display refresh. OPENGLAD_DEMO_VSYNC=1 keeps the
+        // driver default for tear-free viewing.
+        if (!lockstep) {
+            const char* vsync_env = env_or_null("OPENGLAD_DEMO_VSYNC");
+            if (vsync_env == nullptr || std::string_view(vsync_env) == "0")
+                E_Screen->set_vsync(false);
+        }
 
         init_input();
         load_player_control_settings_from_cfg(cfg);
@@ -880,6 +930,53 @@ int main(int argc, char* argv[])
                 std::make_unique<og::runtime::GameSession>(sub_cfg);
         }
 
+        // Uncapped-mode GPU compositor: one streaming texture per cell, so
+        // the renderer scales cells itself and the per-frame CPU cost is N
+        // small uploads instead of a full-display software blit plus one
+        // display-sized upload. Lockstep keeps the software compositor: its
+        // pixel output is pinned by scripts/test_demo_smoke.sh. The textures
+        // share the session surface format so SDL_UpdateTexture is a straight
+        // row copy.
+        using SdlTexturePtr =
+            std::unique_ptr<SDL_Texture, decltype(&SDL_DestroyTexture)>;
+        std::vector<SdlTexturePtr> cell_tex;
+        SdlTexturePtr fps_tex(nullptr, SDL_DestroyTexture);
+        if (!lockstep) {
+            for (int i = 0; i < num_sessions; i++) {
+                SDL_Surface* src =
+                    demos[static_cast<size_t>(i)].session->session_surface_;
+                SdlTexturePtr tex(
+                    SDL_CreateTexture(E_Screen->renderer, src->format,
+                                      SDL_TEXTUREACCESS_STREAMING,
+                                      CELL_W, CELL_H),
+                    SDL_DestroyTexture);
+                if (!tex) {
+                    LogError("Failed to create cell texture {}: {}\n", i,
+                             SDL_GetError());
+                    return 1;
+                }
+                // XRGB pixels carry alpha 0; blending would present nothing.
+                SDL_SetTextureBlendMode(tex.get(), SDL_BLENDMODE_NONE);
+                // Matches the software compositor's SDL_SCALEMODE_LINEAR.
+                SDL_SetTextureScaleMode(tex.get(), SDL_SCALEMODE_LINEAR);
+                cell_tex.push_back(std::move(tex));
+            }
+            if (show_fps) {
+                fps_tex.reset(SDL_CreateTexture(
+                    E_Screen->renderer, fps_strip->format,
+                    SDL_TEXTUREACCESS_STREAMING, FPS_STRIP_W, FPS_STRIP_H));
+                if (!fps_tex) {
+                    LogError("Failed to create FPS overlay texture: {}\n",
+                             SDL_GetError());
+                    return 1;
+                }
+                SDL_SetTextureBlendMode(fps_tex.get(), SDL_BLENDMODE_NONE);
+                // Integer-magnified 5x6 font: NEAREST keeps it crisp, as in
+                // the software path's scaled blit.
+                SDL_SetTextureScaleMode(fps_tex.get(), SDL_SCALEMODE_NEAREST);
+            }
+        }
+
         // Build a shuffled list of scenario IDs.
         std::mt19937 demo_rng(demo_seed);
         auto pick_scenarios = [&]() {
@@ -930,10 +1027,37 @@ int main(int argc, char* argv[])
         // --- Main loop ---
         constexpr int TIMER_WAIT_TICKS = 6;
         constexpr std::chrono::microseconds FRAME_PERIOD{TIMER_WAIT_TICKS * 13600};
+        // Uncapped-mode sim scheduler: 0..8 wall-clock-due ticks per loop
+        // pass, so game speed holds at exactly one tick per FRAME_PERIOD
+        // until a single render pass exceeds 8 periods (~653 ms); past that
+        // the backlog is dropped with a log line instead of slowing the game.
+        og::core::FixedStepAccumulator sim_clock{FRAME_PERIOD, /*max_catchup=*/8};
 
+        auto last_time = std::chrono::steady_clock::now();
+        const auto run_start = last_time;
         bool running = true;
-        int frames_run = 0;
+        int frames_run = 0;       // sim ticks, in both pacing modes
+        int rendered_frames = 0;  // loop passes that presented
         int captured_frames = 0;
+
+        // Phases 2+3: one barriered sim generation across all sessions.
+        auto run_generation = [&] {
+            // --- Phase 2: Signal workers to simulate one frame ---
+            {
+                std::lock_guard lock(sync.mtx);
+                sync.workers_done = 0;
+                sync.generation++;
+            }
+            sync.start_cv.notify_all();
+
+            // --- Phase 3: Wait for all workers to finish simulation ---
+            {
+                std::unique_lock lock(sync.mtx);
+                sync.done_cv.wait(lock, [&] {
+                    return sync.workers_done >= num_sessions;
+                });
+            }
+        };
 
         while (running) {
             auto frame_start = std::chrono::steady_clock::now();
@@ -957,21 +1081,28 @@ int main(int argc, char* argv[])
 
             if (!running) break;
 
-            // --- Phase 2: Signal workers to simulate one frame ---
-            {
-                std::lock_guard lock(sync.mtx);
-                sync.workers_done = 0;
-                sync.generation++;
+            // Lockstep: exactly one sim tick per rendered frame. Uncapped:
+            // whatever the wall clock owes, clamped so the run never exceeds
+            // its OPENGLAD_DEMO_MAX_FRAMES tick budget.
+            int ticks_this_iter = 1;
+            if (!lockstep) {
+                const auto now = std::chrono::steady_clock::now();
+                const auto due = sim_clock.advance(
+                    std::chrono::duration_cast<std::chrono::microseconds>(
+                        now - last_time));
+                last_time = now;
+                if (due.dropped_ticks > 0) {
+                    Log("openglad_demo: dropped {} sim ticks after a stall\n",
+                        due.dropped_ticks);
+                }
+                ticks_this_iter = due.ticks;
+                if (max_frames > 0) {
+                    ticks_this_iter = std::min(ticks_this_iter,
+                                               max_frames - frames_run);
+                }
             }
-            sync.start_cv.notify_all();
-
-            // --- Phase 3: Wait for all workers to finish simulation ---
-            {
-                std::unique_lock lock(sync.mtx);
-                sync.done_cv.wait(lock, [&] {
-                    return sync.workers_done >= num_sessions;
-                });
-            }
+            for (int t = 0; t < ticks_this_iter; ++t)
+                run_generation();
 
             // Frame gating for the opt-in capture, decided once so the
             // single-cell and whole-grid paths cannot disagree.
@@ -1022,85 +1153,149 @@ int main(int argc, char* argv[])
             E_Screen->suppress_present = false;
 
             // --- Phase 5: Composite and present (main thread only) ---
-            SDL_FillSurfaceRect(composite_surface.get(), nullptr, 0x000000);
-            for (int i = 0; i < num_sessions; i++) {
-                SDL_Surface* src = demos[static_cast<size_t>(i)].session->session_surface_;
-                int col = i % grid_cols;
-                int row = i / grid_cols;
-                composite_session(composite_surface.get(), src, col, row,
-                                  grid_cols, grid_rows, cell_zoom);
-            }
+            if (lockstep) {
+                // Software compositor: this branch's pixel output (and the
+                // composite dump written from it) is byte-pinned by
+                // scripts/test_demo_smoke.sh.
+                SDL_FillSurfaceRect(composite_surface.get(), nullptr, 0x000000);
+                for (int i = 0; i < num_sessions; i++) {
+                    SDL_Surface* src = demos[static_cast<size_t>(i)].session->session_surface_;
+                    int col = i % grid_cols;
+                    int row = i / grid_cols;
+                    composite_session(composite_surface.get(), src, col, row,
+                                      grid_cols, grid_rows, cell_zoom);
+                }
 
-            // Whole-grid dump: every cell at once, at native cell resolution
-            // (the on-screen composite is scaled, so it is unusable here).
-            if (capture_this_frame && capture.session_index < 0) {
+                // Whole-grid dump: every cell at once, at native cell resolution
+                // (the on-screen composite is scaled, so it is unusable here).
+                if (capture_this_frame && capture.session_index < 0) {
+                    for (int i = 0; i < num_sessions; i++) {
+                        SDL_Surface* src =
+                            demos[static_cast<size_t>(i)].session->session_surface_;
+                        SDL_Rect cell{(i % grid_cols) * CELL_W,
+                                      (i / grid_cols) * CELL_H, CELL_W, CELL_H};
+                        SDL_BlitSurface(src, nullptr, capture_grid_surface.get(),
+                                        &cell);
+                    }
+                    const std::string path = capture_path();
+                    if (!capture_writer->write(capture_grid_surface.get(),
+                                               host_session.curpal_, path)) {
+                        throw std::runtime_error(std::format(
+                            "openglad_demo failed to write capture frame {}: {}",
+                            path, SDL_GetError()));
+                    }
+                    captured_frames++;
+                }
+
+                // One readout for the whole grid, sampled once per presented
+                // frame, so it measures the compositor loop rather than any one
+                // session. It lands here — after both capture paths have consumed
+                // the session surfaces, before the present — so it reaches the
+                // screen and OPENGLAD_DEMO_COMPOSITE_DUMP but never a capture
+                // frame, which must stay palette-exact.
+                if (show_fps) {
+                    const int fps = fps_counter.update(SDL_GetTicks());
+                    const std::string fps_text = std::format("FPS: {}", fps);
+                    // Text draws through og::runtime::current_session and
+                    // E_Screen->render, not through the screen it is called on;
+                    // both must name the host for the palette lookup to resolve.
+                    auto host_scope = host_session.activate();
+                    text& font = host_session.myscreen_->text_normal;
+                    const int text_w = std::clamp(font.query_width(fps_text) + 4,
+                                                  1, FPS_STRIP_W);
+                    SDL_Surface* saved_render = E_Screen->render;
+                    E_Screen->render = fps_strip.get();
+                    SDL_FillSurfaceRect(fps_strip.get(), nullptr, 0x000000);
+                    font.write_xy(2, 2, fps_text, YELLOW, static_cast<short>(1));
+                    E_Screen->render = saved_render;
+
+                    // Blit only the used span so the backing box hugs the text
+                    // instead of trailing the strip's worst-case width.
+                    const SDL_Rect strip_src{0, 0, text_w, FPS_STRIP_H};
+
+                    // Integer magnification keeps the 5x6 font crisp on HiDPI
+                    // displays; the clamps hold the strip on-surface when the
+                    // display is smaller than the strip plus its margin.
+                    const int fps_scale = std::max(1, display_w / 1024);
+                    const int strip_w = text_w * fps_scale;
+                    const int strip_h = FPS_STRIP_H * fps_scale;
+                    const int margin = 8 * fps_scale;
+                    SDL_Rect strip_dst{
+                        std::max(0, display_w - strip_w - margin),
+                        std::clamp(margin, 0, std::max(0, display_h - strip_h)),
+                        strip_w, strip_h};
+                    SDL_BlitSurfaceScaled(fps_strip.get(), &strip_src,
+                                          composite_surface.get(), &strip_dst,
+                                          SDL_SCALEMODE_NEAREST);
+                }
+
+                SDL_UpdateTexture(composite_tex.get(), nullptr,
+                                  composite_surface->pixels,
+                                  composite_surface->pitch);
+                SDL_RenderClear(E_Screen->renderer);
+                SDL_RenderTexture(E_Screen->renderer, composite_tex.get(),
+                               nullptr, nullptr);
+                SDL_RenderPresent(E_Screen->renderer);
+            } else {
+                // GPU compositor: the renderer scales each cell straight from
+                // its streaming texture. No capture path runs here — capture
+                // and composite dumps force lockstep at startup.
+                SDL_SetRenderDrawColor(E_Screen->renderer, 0, 0, 0, 255);
+                SDL_RenderClear(E_Screen->renderer);
                 for (int i = 0; i < num_sessions; i++) {
                     SDL_Surface* src =
                         demos[static_cast<size_t>(i)].session->session_surface_;
-                    SDL_Rect cell{(i % grid_cols) * CELL_W,
-                                  (i / grid_cols) * CELL_H, CELL_W, CELL_H};
-                    SDL_BlitSurface(src, nullptr, capture_grid_surface.get(),
-                                    &cell);
+                    SDL_UpdateTexture(cell_tex[static_cast<size_t>(i)].get(),
+                                      nullptr, src->pixels, src->pitch);
+                    const CellRects r = cell_rects(
+                        display_w, display_h, i % grid_cols, i / grid_cols,
+                        grid_cols, grid_rows, cell_zoom);
+                    const SDL_FRect src_f = to_frect(r.src);
+                    const SDL_FRect dst_f = to_frect(r.dst);
+                    SDL_RenderTexture(E_Screen->renderer,
+                                      cell_tex[static_cast<size_t>(i)].get(),
+                                      &src_f, &dst_f);
                 }
-                const std::string path = capture_path();
-                if (!capture_writer->write(capture_grid_surface.get(),
-                                           host_session.curpal_, path)) {
-                    throw std::runtime_error(std::format(
-                        "openglad_demo failed to write capture frame {}: {}",
-                        path, SDL_GetError()));
+
+                if (show_fps) {
+                    const int fps = fps_counter.update(SDL_GetTicks());
+                    const std::string fps_text = std::format("FPS: {}", fps);
+                    // Text draws through og::runtime::current_session and
+                    // E_Screen->render, not through the screen it is called on;
+                    // both must name the host for the palette lookup to resolve.
+                    auto host_scope = host_session.activate();
+                    text& font = host_session.myscreen_->text_normal;
+                    const int text_w = std::clamp(font.query_width(fps_text) + 4,
+                                                  1, FPS_STRIP_W);
+                    SDL_Surface* saved_render = E_Screen->render;
+                    E_Screen->render = fps_strip.get();
+                    SDL_FillSurfaceRect(fps_strip.get(), nullptr, 0x000000);
+                    font.write_xy(2, 2, fps_text, YELLOW, static_cast<short>(1));
+                    E_Screen->render = saved_render;
+
+                    SDL_UpdateTexture(fps_tex.get(), nullptr,
+                                      fps_strip->pixels, fps_strip->pitch);
+
+                    // Same strip geometry as the software path, rendered from
+                    // only the used span so the backing box hugs the text.
+                    const SDL_Rect strip_src{0, 0, text_w, FPS_STRIP_H};
+                    const int fps_scale = std::max(1, display_w / 1024);
+                    const int strip_w = text_w * fps_scale;
+                    const int strip_h = FPS_STRIP_H * fps_scale;
+                    const int margin = 8 * fps_scale;
+                    const SDL_Rect strip_dst{
+                        std::max(0, display_w - strip_w - margin),
+                        std::clamp(margin, 0, std::max(0, display_h - strip_h)),
+                        strip_w, strip_h};
+                    const SDL_FRect strip_src_f = to_frect(strip_src);
+                    const SDL_FRect strip_dst_f = to_frect(strip_dst);
+                    SDL_RenderTexture(E_Screen->renderer, fps_tex.get(),
+                                      &strip_src_f, &strip_dst_f);
                 }
-                captured_frames++;
+
+                SDL_RenderPresent(E_Screen->renderer);
             }
-
-            // One readout for the whole grid, sampled once per presented
-            // frame, so it measures the compositor loop rather than any one
-            // session. It lands here — after both capture paths have consumed
-            // the session surfaces, before the present — so it reaches the
-            // screen and OPENGLAD_DEMO_COMPOSITE_DUMP but never a capture
-            // frame, which must stay palette-exact.
-            if (show_fps) {
-                const int fps = fps_counter.update(SDL_GetTicks());
-                const std::string fps_text = std::format("FPS: {}", fps);
-                // Text draws through og::runtime::current_session and
-                // E_Screen->render, not through the screen it is called on;
-                // both must name the host for the palette lookup to resolve.
-                auto host_scope = host_session.activate();
-                text& font = host_session.myscreen_->text_normal;
-                const int text_w = std::clamp(font.query_width(fps_text) + 4,
-                                              1, FPS_STRIP_W);
-                SDL_Surface* saved_render = E_Screen->render;
-                E_Screen->render = fps_strip.get();
-                SDL_FillSurfaceRect(fps_strip.get(), nullptr, 0x000000);
-                font.write_xy(2, 2, fps_text, YELLOW, static_cast<short>(1));
-                E_Screen->render = saved_render;
-
-                // Blit only the used span so the backing box hugs the text
-                // instead of trailing the strip's worst-case width.
-                const SDL_Rect strip_src{0, 0, text_w, FPS_STRIP_H};
-
-                // Integer magnification keeps the 5x6 font crisp on HiDPI
-                // displays; the clamps hold the strip on-surface when the
-                // display is smaller than the strip plus its margin.
-                const int fps_scale = std::max(1, display_w / 1024);
-                const int strip_w = text_w * fps_scale;
-                const int strip_h = FPS_STRIP_H * fps_scale;
-                const int margin = 8 * fps_scale;
-                SDL_Rect strip_dst{
-                    std::max(0, display_w - strip_w - margin),
-                    std::clamp(margin, 0, std::max(0, display_h - strip_h)),
-                    strip_w, strip_h};
-                SDL_BlitSurfaceScaled(fps_strip.get(), &strip_src,
-                                      composite_surface.get(), &strip_dst,
-                                      SDL_SCALEMODE_NEAREST);
-            }
-
-            SDL_UpdateTexture(composite_tex.get(), nullptr,
-                              composite_surface->pixels,
-                              composite_surface->pitch);
-            SDL_RenderClear(E_Screen->renderer);
-            SDL_RenderTexture(E_Screen->renderer, composite_tex.get(),
-                           nullptr, nullptr);
-            SDL_RenderPresent(E_Screen->renderer);
+            rendered_frames++;
 
             // If all sessions are done, restart them with new scenarios.
             if (active_count == 0) {
@@ -1113,12 +1308,19 @@ int main(int argc, char* argv[])
                                       demo_campaign, forced_team_size);
                 }
                 E_Screen->suppress_present = false;
+                if (!lockstep) {
+                    // Re-init takes seconds of wall time; a stale elapsed
+                    // base would burst catch-up ticks into fresh scenarios.
+                    sim_clock.reset();
+                    last_time = std::chrono::steady_clock::now();
+                }
             }
 
             // Frame pacing: sleep remainder of the target frame period.
             // A capture run has no viewer, so it takes the frames as fast as
-            // the simulation produces them.
-            if (!capture.enabled()) {
+            // the simulation produces them. Uncapped never sleeps: the
+            // present rate is the point.
+            if (lockstep && !capture.enabled()) {
                 auto elapsed = std::chrono::steady_clock::now() - frame_start;
                 auto remaining = FRAME_PERIOD - elapsed;
                 if (remaining > std::chrono::microseconds(1000)) {
@@ -1126,7 +1328,7 @@ int main(int argc, char* argv[])
                 }
             }
 
-            frames_run++;
+            frames_run += ticks_this_iter;
             if (max_frames > 0 && frames_run >= max_frames) {
                 running = false;
             }
@@ -1136,17 +1338,26 @@ int main(int argc, char* argv[])
 
             // Opt-in debug dump of the final presented composite (the scaled
             // grid exactly as shown on screen), for eyeballing the layout
-            // without a screen recorder.
-            if (!running) {
-                if (const char* dump =
-                        env_or_null("OPENGLAD_DEMO_COMPOSITE_DUMP")) {
-                    if (!SDL_SaveBMP(composite_surface.get(), dump)) {
-                        LogError("composite dump to '{}' failed: {}\n",
-                                 dump, SDL_GetError());
-                    }
+            // without a screen recorder. Setting it implies lockstep, so the
+            // composite surface always holds the presented frame here.
+            if (!running && composite_dump != nullptr) {
+                if (!SDL_SaveBMP(composite_surface.get(), composite_dump)) {
+                    LogError("composite dump to '{}' failed: {}\n",
+                             composite_dump, SDL_GetError());
                 }
             }
         }
+
+        // Pre-formatted with std::format: Log's own {} substitution ignores
+        // precision specifiers.
+        const double run_secs = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - run_start).count();
+        Log(std::format(
+            "openglad_demo: {} sim ticks, {} rendered frames in {:.3f} s "
+            "({:.1f} fps, {:.2f} ticks/s)\n",
+            frames_run, rendered_frames, run_secs,
+            rendered_frames / std::max(run_secs, 1e-6),
+            frames_run / std::max(run_secs, 1e-6)));
 
         if (capture_writer) {
             Log("openglad_demo: captured {} frames to {}\n",
@@ -1165,6 +1376,8 @@ int main(int argc, char* argv[])
         }
 
         // Cleanup (the unique_ptr deleters also free on any early-return/throw path)
+        cell_tex.clear();
+        fps_tex.reset();
         composite_tex.reset();
         composite_surface.reset();
         capture_grid_surface.reset();

--- a/src/platform/sdl/game_loop.cpp
+++ b/src/platform/sdl/game_loop.cpp
@@ -162,6 +162,16 @@ std::uint32_t render_interval_ms_for_session()
         1u, og::core::target_frame_interval_ms(target_fps));
 }
 
+// Uncapped sentinel (target_fps <= 0): render on every loop pass and leave
+// render_pacer unconfigured (interval_ms() stays 0). Sessionless callers keep
+// the capped default.
+bool render_uncapped_for_session()
+{
+    return og::runtime::current_session != nullptr &&
+           og::runtime::current_session->target_fps_ <=
+               og::core::kUncappedTargetFps;
+}
+
 og::runtime::GameSession* require_local_transport_session()
 {
     og::runtime::GameSession* const gameplay_session =
@@ -291,21 +301,29 @@ GameFrameResult game_frame_with_result(screen& s, GameLoopFrameState& st, const 
     {
         const TickSchedule schedule = compute_tick_schedule(s, deps);
         const std::uint32_t sim_interval = schedule.interval_ms;
-        const std::uint32_t render_interval = render_interval_ms_for_session();
         const std::uint32_t now = now_ms_fn();
         if (st.sim_pacer.interval_ms() != sim_interval)
             st.sim_pacer.configure(sim_interval, now);
-        if (deps.enable_render &&
-            st.render_pacer.interval_ms() != render_interval)
-            st.render_pacer.configure(render_interval, now);
+
+        const bool uncapped_render =
+            deps.enable_render && render_uncapped_for_session();
+        if (deps.enable_render && !uncapped_render)
+        {
+            const std::uint32_t render_interval =
+                render_interval_ms_for_session();
+            if (st.render_pacer.interval_ms() != render_interval)
+                st.render_pacer.configure(render_interval, now);
+        }
 
         const og::core::FrameDeadlineDecision sim_decision =
             st.sim_pacer.tick(now);
         const og::core::FrameDeadlineDecision render_decision =
-            deps.enable_render
-                ? st.render_pacer.tick(now)
-                : og::core::FrameDeadlineDecision{
-                      false, false, UINT32_MAX, 0u};
+            !deps.enable_render
+                ? og::core::FrameDeadlineDecision{
+                      false, false, UINT32_MAX, 0u}
+                : uncapped_render
+                      ? og::core::FrameDeadlineDecision{false, true, 0u, 0u}
+                      : st.render_pacer.tick(now);
 
         if (!sim_decision.run_tick && !render_decision.run_render)
         {

--- a/src/platform/sdl/glad.cpp
+++ b/src/platform/sdl/glad.cpp
@@ -24,6 +24,7 @@
 #include <openglad/gameplay/input_state.h>
 #include <openglad/gameplay/statistics.h>
 #include <openglad/gameplay/walker.h>
+#include <openglad/interface/render/effects.h>
 #include <openglad/interface/render/view.h>
 #include <openglad/interface/screen.h>
 #include <openglad/platform/emscripten/web_runtime_diagnostics.h>
@@ -228,9 +229,15 @@ void bootstrap_runtime(int argc, char* argv[])
     og::core::apply_target_fps_to_cfg(cfg, fps);
     og::runtime::current_session->target_fps_ = fps;
     // Uncapped means "as fast as the hardware allows": the display-rate cap
-    // vsync imposes would defeat the setting outright.
-    if (fps == og::core::kUncappedTargetFps && E_Screen)
-        E_Screen->set_vsync(false);
+    // vsync imposes would defeat the setting outright. Render-only cosmetics
+    // switch to the wall clock so they animate at the classic 72 fps cadence
+    // rather than at whatever rate the hardware presents.
+    if (fps == og::core::kUncappedTargetFps)
+    {
+        if (E_Screen)
+            E_Screen->set_vsync(false);
+        effects_set_wall_clock_cadence(true);
+    }
     og::runtime::current_session->show_fps_ = cfg.is_on("graphics", "show_fps");
     cfg.save_settings();
 #if defined(__EMSCRIPTEN__) && !defined(TESTING)

--- a/src/platform/sdl/glad.cpp
+++ b/src/platform/sdl/glad.cpp
@@ -30,6 +30,7 @@
 #include <openglad/platform/game_loop.h>
 #include <openglad/platform/game_session.h>
 #include <openglad/platform/local_transport_shadow.h>
+#include <openglad/platform/sai2x.h>
 #include <openglad/platform/screen_lifecycle.h>
 #include <openglad/platform/video_sdl.h>
 #ifdef __EMSCRIPTEN__
@@ -226,6 +227,10 @@ void bootstrap_runtime(int argc, char* argv[])
     const int fps = og::core::target_fps_from_cfg(cfg);
     og::core::apply_target_fps_to_cfg(cfg, fps);
     og::runtime::current_session->target_fps_ = fps;
+    // Uncapped means "as fast as the hardware allows": the display-rate cap
+    // vsync imposes would defeat the setting outright.
+    if (fps == og::core::kUncappedTargetFps && E_Screen)
+        E_Screen->set_vsync(false);
     og::runtime::current_session->show_fps_ = cfg.is_on("graphics", "show_fps");
     cfg.save_settings();
 #if defined(__EMSCRIPTEN__) && !defined(TESTING)

--- a/src/platform/sdl/sai2x.cpp
+++ b/src/platform/sdl/sai2x.cpp
@@ -805,7 +805,7 @@ Screen::Screen( RenderEngine engine, int width, int height, int fullscreen)
     if (renderer == nullptr)
         LogError("SDL_CreateRenderer failed: {}\n", SDL_GetError());
     #ifndef TESTING
-    SDL_SetRenderVSync(renderer, 1);
+    SDL_SetRenderVSync(renderer, vsync_enabled_ ? 1 : 0);
     #endif
 
 	SDL_GetWindowSize(window, &w, &h);
@@ -838,6 +838,17 @@ Screen::Screen( RenderEngine engine, int width, int height, int fullscreen)
     // set_world_zoom() replaces this with the requested world-only filter.
     // The initial nearest engine keeps boot/UI presentation byte-identical.
     world_engine_ = engine;
+}
+
+void Screen::set_vsync(bool on)
+{
+	// Stored even under TESTING (which never touches SDL vsync at all):
+	// both renderer-creation sites replay this member.
+	vsync_enabled_ = on;
+	#ifndef TESTING
+	if (renderer != nullptr)
+		SDL_SetRenderVSync(renderer, on ? 1 : 0);
+	#endif
 }
 
 Screen::~Screen()
@@ -1358,7 +1369,7 @@ bool Screen::recreate_render_backend()
 		return false;
 	}
 	#ifndef TESTING
-	SDL_SetRenderVSync(renderer, 1);
+	SDL_SetRenderVSync(renderer, vsync_enabled_ ? 1 : 0);
 	#endif
 
 	// Constructor parity for the fixed 320x200 UI texture: opaque present,

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -1232,7 +1232,6 @@ void sdl_video::putdatatext(Sint32 startx, Sint32 starty, Sint32 xsize, Sint32 y
 			rect.y = cury;
 			rect.w = 1;
 			rect.h = 1;
-			Log("test\n");
 			SDL_FillSurfaceRect(E_Screen->render,&rect,static_cast<Uint32>(color));
 		}
     	}

--- a/tests/integration/test_game_loop.cpp
+++ b/tests/integration/test_game_loop.cpp
@@ -3567,9 +3567,11 @@ TEST(MasterSpeedRegression, uncapped_render_renders_every_call_at_master_cadence
             << "scenario must keep running across all 600 uncapped frames";
     }
 
-    // Render must fire on every call — no pacer gating. A 240 fps cap over a
-    // 600 ms drive window would allow at most ~150 renders, so exact equality
-    // is the uncapped-specific pin.
+    // Render must fire on every call — no pacer gating. If the capped branch
+    // consumed the sentinel instead, target_frame_interval_ms(0) == 1 ms
+    // would gate exactly the first of the 600 one-millisecond steps (599
+    // renders), so exact equality still discriminates — by one frame, with
+    // the pacer-unconfigured and no-sleep pins below carrying the rest.
     EXPECT_EQ(kFrames, render_count)
         << "uncapped render must fire on every game_frame_with_result call";
 

--- a/tests/integration/test_game_loop.cpp
+++ b/tests/integration/test_game_loop.cpp
@@ -3507,6 +3507,109 @@ TEST(MasterSpeedRegression, sim_runs_at_timer_wait_cadence)
     game_screen->world().delete_objects();
 }
 
+TEST(MasterSpeedRegression, uncapped_render_renders_every_call_at_master_cadence)
+{
+    screen* const game_screen = og::runtime::current_session->myscreen_;
+    ASSERT_TRUE(game_screen != nullptr);
+    GameSpeedGuard speed(1.0f);
+    ASSERT_TRUE(load_minimal_game_loop_scenario("test_uncapped_render"))
+        << "load_saved_game should succeed for uncapped-render regression test";
+
+    // Set the uncapped sentinel for this test, restoring target_fps on exit.
+    const int saved_target_fps = og::runtime::current_session->target_fps_;
+    og::runtime::current_session->target_fps_ = og::core::kUncappedTargetFps;
+    struct TargetFpsRestore {
+        int saved;
+        ~TargetFpsRestore() {
+            og::runtime::current_session->target_fps_ = saved;
+        }
+    } target_fps_restore{saved_target_fps};
+
+    // Force the master cadence: world.timer_wait = DEFAULT_TIMER_WAIT (=6),
+    // so sim_interval = 6 * 13.6 ≈ 82 ms. Confirmed in assertions below.
+    game_screen->world().timer_wait = og::sim::DEFAULT_TIMER_WAIT;
+
+    constexpr int kFrames = 600;
+    const std::uint32_t sim_interval =
+        static_cast<std::uint32_t>(std::lround(
+            og::sim::DEFAULT_TIMER_WAIT * og::sim::TIMER_WAIT_TO_MS));
+    ASSERT_EQ(82u, sim_interval);
+
+    og::runtime::set_runtime_trace_enabled(true);
+    og::runtime::clear_runtime_trace();
+
+    GameLoopFrameState st;
+    std::uint32_t fake_now = 200000u;
+    int tick_count = 0;
+    int render_count = 0;
+    std::vector<std::uint32_t> sleeps;
+    // Pre-configure only the sim pacer; the uncapped path must never touch
+    // render_pacer, so it stays uninitialized (interval_ms() == 0).
+    st.sim_pacer.configure(sim_interval, fake_now);
+
+    GameLoopDeps deps;
+    deps.enable_render = true;
+    deps.enable_event_poll = false;
+    // Master-cadence default branch: deps.fixed_tick_ms == 0 forces
+    // compute_tick_schedule() to read from world.timer_wait.
+    deps.fixed_tick_ms = 0u;
+    deps.now_ms = [&fake_now]() { return fake_now; };
+    deps.sleep_ms = [&sleeps](std::uint32_t ms) { sleeps.push_back(ms); };
+    deps.after_act = [&tick_count](screen&) { ++tick_count; };
+    deps.on_render = [&render_count](screen&) { ++render_count; };
+
+    for (int i = 0; i < kFrames; ++i)
+    {
+        fake_now += 1u;
+        const GameFrameResult result =
+            game_frame_with_result(*game_screen, st, deps);
+        ASSERT_EQ(GameFrameResult::Continue, result)
+            << "scenario must keep running across all 600 uncapped frames";
+    }
+
+    // Render must fire on every call — no pacer gating. A 240 fps cap over a
+    // 600 ms drive window would allow at most ~150 renders, so exact equality
+    // is the uncapped-specific pin.
+    EXPECT_EQ(kFrames, render_count)
+        << "uncapped render must fire on every game_frame_with_result call";
+
+    // 600 calls × 1 ms / 82 ms ≈ 7 sim ticks. Allow ±1 to absorb the initial
+    // deadline phase. Sim cadence must be identical to the capped sibling.
+    const int expected_sim_ticks =
+        static_cast<int>(static_cast<std::uint32_t>(kFrames) / sim_interval);
+    EXPECT_EQ(7, expected_sim_ticks)
+        << "expected_sim_ticks formula must match the documented constant";
+    EXPECT_NEAR(expected_sim_ticks, tick_count, 1)
+        << "sim must stay at master cadence (~82 ms / tick) under uncapped "
+           "render";
+
+    // Uncapped render fires every call, so the idle sleep branch (which on
+    // master fires on every same-deadline call) must never be reached.
+    EXPECT_TRUE(sleeps.empty())
+        << "no sleeps expected when render fires on every call";
+    const auto traces = og::runtime::copy_runtime_trace();
+    const int sleep_traces = static_cast<int>(std::count_if(
+        traces.begin(), traces.end(),
+        [](const og::runtime::RuntimeTraceRecord& r) {
+            return r.category == "game_loop" &&
+                r.event == "desktop_loop_sleep_ms";
+        }));
+    EXPECT_EQ(0, sleep_traces)
+        << "desktop_loop_sleep_ms must not fire when render fires every call";
+
+    // The uncapped path bypasses render_pacer entirely: it must never have
+    // been configured across 600 rendered frames.
+    EXPECT_EQ(0u, st.render_pacer.interval_ms())
+        << "render_pacer must stay unconfigured when target_fps is uncapped";
+
+    // Sanity: world.timer_wait must remain at DEFAULT_TIMER_WAIT throughout —
+    // any drift would mean the test is implicitly retuning master cadence.
+    EXPECT_EQ(og::sim::DEFAULT_TIMER_WAIT, game_screen->world().timer_wait)
+        << "world.timer_wait must not drift during the regression run";
+
+    game_screen->world().delete_objects();
+}
+
 // ---------------------------------------------------------------------------
 // Regression test: options_menu via game_frame_with_result call chain.
 //

--- a/tests/integration/test_render_effects.cpp
+++ b/tests/integration/test_render_effects.cpp
@@ -5989,3 +5989,41 @@ TEST_F(RenderEffects, zz_bench_large_canvas_redraw)
     scr()->relayout_views();
     restore_world(vs);
 }
+
+// Uncapped render paths advance the effects frame tick on the wall clock (one
+// advance per 14 ms, the classic 72 fps cadence) instead of once per call, so
+// machine-rate presenting cannot speed up weather/ripple/trail animation. The
+// gate is exercised through the injected-clock entry point; the default
+// per-call behavior every other test relies on is pinned at the end.
+TEST(EffectsCadence, wall_clock_gates_frame_advancement)
+{
+	effects_reset_for_testing();
+	ASSERT_EQ(0u, effects_frame_tick());
+
+	effects_set_wall_clock_cadence(true);
+	// First call configures the pacer: deadline lands one interval out, so
+	// no advance yet.
+	effects_advance_frame_at(100000);
+	ASSERT_EQ(0u, effects_frame_tick())
+	    << "first gated call must only arm the 14 ms deadline";
+	effects_advance_frame_at(100014);
+	ASSERT_EQ(1u, effects_frame_tick()) << "deadline reached: one advance";
+	effects_advance_frame_at(100020);
+	ASSERT_EQ(1u, effects_frame_tick())
+	    << "mid-interval call must not advance";
+	effects_advance_frame_at(100028);
+	ASSERT_EQ(2u, effects_frame_tick()) << "next deadline: one advance";
+	// A machine-rate burst inside one interval still yields zero advances.
+	for (std::uint32_t now = 100029; now < 100042; ++now)
+		effects_advance_frame_at(now);
+	ASSERT_EQ(2u, effects_frame_tick())
+	    << "13 calls inside one interval must not advance the tick";
+
+	effects_set_wall_clock_cadence(false);
+	effects_advance_frame();
+	ASSERT_EQ(3u, effects_frame_tick())
+	    << "with the cadence off every call advances, as all capped paths "
+	       "and tests rely on";
+
+	effects_reset_for_testing();
+}

--- a/tests/unit/test_frame_deadline_pacer.cpp
+++ b/tests/unit/test_frame_deadline_pacer.cpp
@@ -4,6 +4,7 @@
 #include <openglad/core/runtime_trace.h>
 #include <openglad/core/util.h>
 
+#include <chrono>
 #include <cstdint>
 #include <vector>
 
@@ -252,6 +253,97 @@ TEST(FrameDeadlinePacer, ResetReanchorsDeadline)
     EXPECT_FALSE(d.run_tick);
     EXPECT_EQ(d.sleep_ms, 14u);
     EXPECT_EQ(d.next_deadline_ms, 114u);
+}
+
+// The demo sim period: 6 timer_wait ticks of 13600 us.
+constexpr std::chrono::microseconds kSimPeriod{81600};
+constexpr int kMaxCatchup = 8;
+
+TEST(FixedStepAccumulator, SeededConstructionTicksOnFirstAdvance)
+{
+    og::core::FixedStepAccumulator acc{kSimPeriod, kMaxCatchup};
+
+    const auto first = acc.advance(std::chrono::microseconds{0});
+    EXPECT_EQ(first.ticks, 1);
+    EXPECT_EQ(first.dropped_ticks, 0);
+
+    // The seed is spent: no time has passed, so nothing more is due.
+    const auto second = acc.advance(std::chrono::microseconds{0});
+    EXPECT_EQ(second.ticks, 0);
+    EXPECT_EQ(second.dropped_ticks, 0);
+}
+
+TEST(FixedStepAccumulator, FullPeriodTicksOnceAndLeavesNoRemainder)
+{
+    og::core::FixedStepAccumulator acc{kSimPeriod, kMaxCatchup};
+    ASSERT_EQ(acc.advance(std::chrono::microseconds{0}).ticks, 1);
+
+    const auto due = acc.advance(kSimPeriod);
+    EXPECT_EQ(due.ticks, 1);
+    EXPECT_EQ(due.dropped_ticks, 0);
+
+    // One microsecond short of the next period must not tick; the final
+    // microsecond must — proving the previous call consumed exactly one period.
+    EXPECT_EQ(acc.advance(kSimPeriod - std::chrono::microseconds{1}).ticks, 0);
+    EXPECT_EQ(acc.advance(std::chrono::microseconds{1}).ticks, 1);
+}
+
+TEST(FixedStepAccumulator, FractionalElapsedCarriesAcrossCalls)
+{
+    og::core::FixedStepAccumulator acc{kSimPeriod, kMaxCatchup};
+    ASSERT_EQ(acc.advance(std::chrono::microseconds{0}).ticks, 1);
+
+    const auto half = kSimPeriod / 2;
+    const auto first = acc.advance(half);
+    EXPECT_EQ(first.ticks, 0);
+    EXPECT_EQ(first.dropped_ticks, 0);
+
+    const auto second = acc.advance(half);
+    EXPECT_EQ(second.ticks, 1);
+    EXPECT_EQ(second.dropped_ticks, 0);
+}
+
+TEST(FixedStepAccumulator, StallBeyondCatchupDropsAndClearsBacklog)
+{
+    og::core::FixedStepAccumulator acc{kSimPeriod, kMaxCatchup};
+
+    // Seeded period + 10 elapsed periods = 11 due, 3 beyond the catch-up bound.
+    const auto stalled = acc.advance(10 * kSimPeriod);
+    EXPECT_EQ(stalled.ticks, kMaxCatchup);
+    EXPECT_EQ(stalled.dropped_ticks, 3);
+
+    // The dropped backlog is gone: the next period starts from zero.
+    EXPECT_EQ(acc.advance(std::chrono::microseconds{1000}).ticks, 0);
+    EXPECT_EQ(acc.advance(kSimPeriod - std::chrono::microseconds{1000}).ticks, 1);
+}
+
+TEST(FixedStepAccumulator, ResetRestoresSeededState)
+{
+    og::core::FixedStepAccumulator acc{kSimPeriod, kMaxCatchup};
+    ASSERT_EQ(acc.advance(std::chrono::microseconds{0}).ticks, 1);
+    ASSERT_EQ(acc.advance(kSimPeriod / 2).ticks, 0);
+
+    acc.reset();
+
+    const auto first = acc.advance(std::chrono::microseconds{0});
+    EXPECT_EQ(first.ticks, 1);
+    EXPECT_EQ(first.dropped_ticks, 0);
+
+    // The half period banked before reset() was discarded, not carried over.
+    EXPECT_EQ(acc.advance(kSimPeriod / 2).ticks, 0);
+}
+
+TEST(FixedStepAccumulator, NonPositivePeriodClampsToOneMicrosecond)
+{
+    og::core::FixedStepAccumulator acc{std::chrono::microseconds{0}, kMaxCatchup};
+
+    // A zero period would divide by zero; clamped to 1 us, 100 us of elapsed
+    // time owes 100 ticks and so saturates the catch-up bound.
+    EXPECT_EQ(acc.advance(std::chrono::microseconds{0}).ticks, 1);
+
+    const auto stalled = acc.advance(std::chrono::microseconds{100});
+    EXPECT_EQ(stalled.ticks, kMaxCatchup);
+    EXPECT_EQ(stalled.dropped_ticks, 92);
 }
 
 } // namespace

--- a/tests/unit/test_frame_rate_config.cpp
+++ b/tests/unit/test_frame_rate_config.cpp
@@ -92,6 +92,30 @@ TEST_F(FrameRateConfigTest, RoundTrip)
     EXPECT_EQ(og::core::target_fps_from_cfg(cfg), og::core::kDefaultTargetFps);
 }
 
+TEST_F(FrameRateConfigTest, UncappedSentinelParses)
+{
+    cfg.apply_setting("graphics", "target_fps", "0");
+    EXPECT_EQ(og::core::target_fps_from_cfg(cfg), og::core::kUncappedTargetFps);
+
+    cfg.apply_setting("graphics", "target_fps", "-3");
+    EXPECT_EQ(og::core::target_fps_from_cfg(cfg), og::core::kUncappedTargetFps);
+
+    // Adjacent positive values still clamp up to the minimum cap.
+    cfg.apply_setting("graphics", "target_fps", "1");
+    EXPECT_EQ(og::core::target_fps_from_cfg(cfg), og::core::kMinTargetFps);
+}
+
+TEST_F(FrameRateConfigTest, ApplyPreservesUncappedSentinel)
+{
+    og::core::apply_target_fps_to_cfg(cfg, 0);
+    EXPECT_EQ(cfg.get_setting("graphics", "target_fps"), "0");
+    EXPECT_EQ(og::core::target_fps_from_cfg(cfg), og::core::kUncappedTargetFps);
+
+    og::core::apply_target_fps_to_cfg(cfg, -5);
+    EXPECT_EQ(cfg.get_setting("graphics", "target_fps"), "0");
+    EXPECT_EQ(og::core::target_fps_from_cfg(cfg), og::core::kUncappedTargetFps);
+}
+
 TEST(FrameRateConfigInterval, RoundsHalfUp)
 {
     EXPECT_EQ(og::core::target_frame_interval_ms(72), 14u);


### PR DESCRIPTION
## What

Separates render rate from the fixed sim cadence everywhere, so rendering scales to whatever the hardware allows while gameplay stays bit-identical at 12.25 ticks/s (`world.timer_wait` master semantics, untouched).

**openglad_demo** — the old loop ran one sim tick + one render + sleep per 81.6 ms (12 fps cap; overload meant slow motion). Now:
- Interactive runs schedule sim generations off the wall clock (`FixedStepAccumulator`, exactly one tick per 81.6 ms, bounded catch-up of 8, dropped-backlog logging) and render/present on every pass with vsync off.
- Compositing is GPU per-cell (streaming texture per session, renderer scales into the cell) instead of software bilinear into a display-sized surface + full-display upload.
- Runs that dump pixels (capture, composite dump) automatically keep the byte-pinned lockstep path; `OPENGLAD_DEMO_LOCKSTEP=1` forces it. `OPENGLAD_DEMO_MAX_FRAMES` counts sim ticks in both modes, and every run exits with a `N sim ticks, M rendered frames … (fps, ticks/s)` summary.

**Main game** — `graphics/target_fps: 0` now means uncapped: render pacer bypassed, vsync off at bootstrap, sentinel survives the cfg round trip (previously any `0` would have been clamped to 10 and persisted). Defaults unchanged (60/72); sim cadence never consults the render rate (`SimCadenceInputs` static_assert still pins that).

**Render-only cosmetics** — `effects_advance_frame` used to advance once per redraw, which at machine-rate presenting would run weather/ripples/trails at hardware speed. Uncapped paths now gate the advance to the wall clock at the classic 72 fps cadence; every capped path and test keeps the exact per-call behavior (new `EffectsCadence` test drives the gate with an injected clock).

**Profile-guided optimization** (gprofng on a 10 s uncapped 6x4 run; every change proven output-identical):
- `obmap`: O(1) shadow index over `pos_to_walker`'s node-stable piles (the RB-tree walk in `obmap_get_list` was 10.7% of total CPU). Same node set, ordering, and iteration; A* reuses its stored per-solve heuristic.
- `world_snapshot`: constexpr field-desc lookup (linear scan was 6.6%), `countr_zero` dirty-bit walk, stack-scratch record composition instead of per-byte `push_back`, and the per-tick snapshot-hash path no longer deep-copies the whole snapshot (~4.8x). Wire bytes unchanged (differential probe vs the pristine encoder: 502 KB identical, mutation-sensitive).
- Weather overlays: row-walker samplers with per-pixel output replayed identical to the old loops (2.35 M `pointb` calls compared); `cfg.is_on` gate reads moved behind the cheap entity tests that already gated each effect.

Also fixes `scripts/test_emscripten_build.sh` for emsdk installs: the generated isolated config guessed `LLVM_ROOT=/usr/bin`, so the test could never build with the toolchain CI pins (emsdk 6.0.3).

## Numbers (dummy driver, software renderer, 1024x768, 123-tick runs)

| Grid | Before | After decoupling | After optimization |
|---|---|---|---|
| 1x1 | 12.25 fps cap | 1028.6 fps | **1036.7 fps** |
| 2x2 | 12.25 fps cap | 628.4 fps | **705.4 fps** |
| 6x4 (24 sessions) | ~4 fps, sim in slow motion | 124.7 fps | **165.5 fps** |

Game speed holds at 12.3–12.4 ticks/s in every configuration — render load can no longer slow the sim (up to a sustained 653 ms render pass, past which ticks drop with a log line instead of silent slow motion).

## Verification

- Full ctest: 58/58 passed (including the emscripten build with emsdk 6.0.3).
- Parity: 221/221 `parity_runner_smoke` dumps byte-identical before/after the branch (218/221 match committed goldens exactly; the 3 exceptions are pre-existing drift, verified byte-identical between master-built and branch-built runners in the same workspace).
- Demo smoke passes end to end; lockstep composite dumps byte-identical across 5 run pairs, and identical to pre-branch lockstep output.
- `MasterSpeedRegression` pins both capped and uncapped: render fires every call, sim ticks unchanged, `timer_wait` no-drift.
- Adversarial review pass (3 dimensions, findings independently verified) — all 6 confirmed findings fixed in the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)