### PR TITLE
Menu quintet: single quit fade, aligned Base Camp, list campaign browser, full-screen help, seat-chip team cycling

### DIFF
--- a/cmake/OpenGladTests.cmake
+++ b/cmake/OpenGladTests.cmake
@@ -194,6 +194,7 @@ set(ALL_INTEGRATION_TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/integration/test_company_list.cpp
     ${CMAKE_SOURCE_DIR}/tests/integration/test_cloud_ui.cpp
     ${CMAKE_SOURCE_DIR}/tests/integration/test_uxshots_probe.cpp
+    ${CMAKE_SOURCE_DIR}/tests/integration/test_seat_chip.cpp
 )
 
 function(og_add_test_group NAME)
@@ -527,6 +528,7 @@ og_add_test_group(og_test_menu_engine FILES
 og_add_test_group(og_test_basecamp FILES
     test_company_list.cpp
     test_uxshots_probe.cpp
+    test_seat_chip.cpp
 )
 
 og_add_test_group(og_test_input FILES

--- a/cmake/OpenGladTests.cmake
+++ b/cmake/OpenGladTests.cmake
@@ -1127,6 +1127,13 @@ set_tests_properties(og_test_picker_network PROPERTIES
     RUN_SERIAL TRUE
     TIMEOUT 420
 )
+# og_test_view runs ~49s alone but is sleep-dominated (<1s CPU: injector
+# waits and menu-frame settles), so a contended parallel schedule
+# stretches its wall clock several-fold; it crossed the 180s default on
+# 2026-08-13 when the seat-chip suite landed in the same schedule.
+# Same reasoning as og_unit_data above: one generous budget in every
+# lane, and a genuine hang still trips well before the job cap.
+set_tests_properties(og_test_view PROPERTIES TIMEOUT 420)
 
 # og_test_menu_ui is the slowest integration binary: its injector flows
 # gate on fadeblack animations (~0.75-1s wall clock each), so it runs

--- a/include/openglad/interface/base.h
+++ b/include/openglad/interface/base.h
@@ -112,6 +112,7 @@ inline constexpr int HELP_WIDTH = 100;   // maximum length of display line
 namespace og::io { class OgFile; }
 short   fill_help_array(char somearray[HELP_WIDTH][MAX_LINES], og::io::OgFile& infile);
 short   read_campaign_intro(screen *scr);
+short   show_campaign_description(screen *scr, const std::string& campaign_id);
 short   read_scenario(screen  *scr);
 std::string read_one_line(og::io::OgFile& infile, short length);
 

--- a/include/openglad/interface/ui/menu_screen_spec.h
+++ b/include/openglad/interface/ui/menu_screen_spec.h
@@ -228,6 +228,14 @@ std::vector<const MenuButtonSpec*> materialized_spec_rows_for(
 // spec.exit_value (or propagates a remote-start MENU_EXIT).
 Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state = nullptr);
 
+// Post-game teardown hand-off (#200): the code that ends a mission already
+// fades the presented canvas to black, so the next screen's
+// EnterTransition::FadeAroundEntry must skip its own fade-out instead of
+// fading the stale menu image out a second time. One-shot; the fade-in still
+// runs. consume_* is the runner's own read-and-clear.
+void suppress_next_menu_entry_fade_out();
+bool consume_suppressed_menu_entry_fade_out();
+
 // Registry of picker-screen ownership. Runtime screens carry their spec;
 // legacy screens carry their blocking entry point. NETWORKING is owned by
 // the SdlPickerClient state machine and therefore has a null entry point

--- a/include/openglad/interface/ui/menu_screen_spec.h
+++ b/include/openglad/interface/ui/menu_screen_spec.h
@@ -260,6 +260,7 @@ enum class MenuScreenId : std::uint8_t {
     Scenario,
     Teams,
     Networking,
+    Help,
     Count,
 };
 
@@ -280,6 +281,11 @@ const MenuScreenSpec& hire_menu_screen_spec();
 const MenuScreenSpec& train_menu_screen_spec();
 const MenuScreenSpec& progress_menu_screen_spec();
 const MenuScreenSpec& view_scenario_menu_screen_spec();
+
+// #168 full-screen HELP: three content tabs over a paged text frame. The
+// tab/pager state lives in help.cpp behind a file-static pointer (the VIEW
+// LEVEL idiom); show_general_help() is the blocking wrapper.
+const MenuScreenSpec& help_menu_screen_spec();
 
 // The MP and no-MP main-menu specs share the same geometry.
 // DISABLE_MULTIPLAYER selects the compiled variant (including the

--- a/include/openglad/interface/ui/picker_common.h
+++ b/include/openglad/interface/ui/picker_common.h
@@ -79,30 +79,77 @@ bool picker_rects_overlap(const PickerRect& a, const PickerRect& b);
 
 struct CampaignPickerLayout
 {
-    PickerRect prev;
-    PickerRect next;
+    PickerRect prev;          // list page up
+    PickerRect next;          // list page down
     PickerRect choose;   // OK
     PickerRect cancel;
     PickerRect delete_button;
     PickerRect reset_button;  // occupies the DELETE cell; the two never co-exist
     PickerRect id_button;     // ENTER ID, stacked under DELETE/RESET
-    PickerRect icon;          // campaign icon (title is drawn above it)
+    PickerRect icon;          // campaign icon (inside the detail pane)
     int title_y = 0;          // top pixel row of the centered title
     int title_center_x = 0;
     int title_max_chars = 0;  // widest title that clears every control
+
+    // Left list pane (issue #186): one row per campaign, scrolled in pages
+    // of list_rows by PREV/NEXT.
+    PickerRect list;             // the block of list rows
+    int list_rows = 0;           // visible rows per page
+    int list_row_h = 0;
+    int list_row_pitch = 0;
+    int list_label_max_chars = 0;  // row title budget after the marker column
+    int header_y = 0;              // "CAMPAIGNS" pane header row
+
+    // Right detail pane for the highlighted entry.
+    PickerRect detail;
+    PickerRect desc_box;
+    PickerRect more_button;   // opens the full description; shown on overflow
+    int desc_rows = 0;        // description rows the box can show
+    int desc_max_chars = 0;   // character budget of one description row
 };
 
 // The single source of the browser's control geometry. Pure, so the overlap
 // contract is unit-testable without SDL.
 CampaignPickerLayout campaign_picker_layout();
 
+// Pixel rect of one visible list row (0-based, < list_rows).
+PickerRect campaign_picker_row_rect(int row);
+
 // Pixel rect a centered title of `chars` glyphs occupies (6px advance, 8px
 // glyph height), given the layout above.
 PickerRect campaign_title_rect(int chars);
 
-// Title as drawn: unchanged when it fits `title_max_chars`, otherwise cut to
-// the budget with a trailing "..." so it can never reach a control.
+// Text cut to a glyph budget: unchanged when it fits, otherwise clipped with
+// a trailing "..." (budgets of <= 3 just clip).
+std::string fit_text_to_chars(std::string_view text, int budget);
+
+// Title as drawn in the detail pane: fit_text_to_chars at title_max_chars.
 std::string fit_campaign_title(std::string_view title);
+
+// A campaign's list-row label: the cached display title fitted to the row
+// budget (falls back to the raw id inside campaign_display_title).
+std::string fit_campaign_row_label(std::string_view title);
+
+// --- List paging (pure; the SDL loop stores offset + cursor) ---
+
+// First visible row, clamped so a full page shows whenever one exists.
+int campaign_list_clamp_offset(int offset, int total, int rows);
+
+// Minimal scroll of `offset` that brings `cursor` on screen.
+int campaign_list_offset_for_cursor(int cursor, int offset, int total, int rows);
+
+// Offset after one PREV (direction < 0) or NEXT (direction > 0) page step.
+int campaign_list_page_step(int offset, int total, int rows, int direction);
+
+// Cursor pulled into the visible window [offset, offset + rows).
+int campaign_list_clamp_cursor(int cursor, int offset, int total, int rows);
+
+// "3 of 8" position readout ("0 of 0" for an empty shelf).
+std::string format_campaign_position_label(int cursor, int total);
+
+// True when the wrapped description does not fit desc_rows rows of the
+// detail pane's box — exactly when the MORE control shows.
+bool campaign_description_overflows(const std::string& description);
 
 // Positional indices into the browser's button table. Growth is append-only
 // for the same reason every other picker screen's is.
@@ -113,17 +160,24 @@ inline constexpr int kCampaignPickerCancelIndex = 3;
 inline constexpr int kCampaignPickerDeleteIndex = 4;
 inline constexpr int kCampaignPickerIdIndex = 5;
 inline constexpr int kCampaignPickerResetIndex = 6;
-inline constexpr int kCampaignPickerButtonCount = 7;
+inline constexpr int kCampaignPickerRowBaseIndex = 7;
+inline constexpr int kCampaignPickerRowCount = 6;
+inline constexpr int kCampaignPickerMoreIndex = 13;
+inline constexpr int kCampaignPickerButtonCount = 14;
 
 // Which of the browser's conditional buttons are hidden this frame. CANCEL
 // and ENTER ID are always visible; DELETE and RESET share a cell, so RESET
-// shows exactly when DELETE hides.
+// shows exactly when DELETE hides. visible_rows counts the list rows that
+// have a campaign behind them this page; MORE shows only when the
+// highlighted entry's description overflows the detail box.
 struct CampaignPickerVisibility
 {
-    bool prev_hidden = false;    // on the first campaign
-    bool next_hidden = false;    // on the last campaign
+    bool prev_hidden = false;    // on the first page
+    bool next_hidden = false;    // on the last page
     bool choose_hidden = false;  // no selectable entry
     bool delete_hidden = false;  // browser opened without delete enabled
+    int visible_rows = kCampaignPickerRowCount;
+    bool more_hidden = true;
 };
 
 struct CampaignPickerNavLinks
@@ -141,6 +195,55 @@ struct CampaignPickerNavLinks
 // reachable from the default highlight (CANCEL).
 std::array<CampaignPickerNavLinks, kCampaignPickerButtonCount>
 campaign_picker_nav(const CampaignPickerVisibility& visibility);
+
+// Commit a campaign chosen in a browser to the save: load (mount) it and, on
+// success, write current_campaign and the resolved level cursor. On a failed
+// load the save is left untouched and the previous campaign is remounted, so
+// a bad ENTER ID can never write a negative scen_num into the save (issue
+// #186). Callers surface the failure (popup) themselves.
+bool apply_campaign_selection(SaveData& save, const std::string& campaign_id,
+                              int first_level);
+
+// --- Level browser (SET LEVEL) geometry ---
+//
+// Three radar-preview rows on the left, the selected level's description on
+// the right. The legacy inline literals put row 2's preview frame against
+// the screen bottom and drew the description box OVER rows 0-1's stats
+// column; every rect below is derived from this one grid instead.
+struct LevelPickerLayout
+{
+    PickerRect prev;
+    PickerRect next;
+    PickerRect choose;        // OK
+    PickerRect cancel;
+    PickerRect delete_button;
+    PickerRect id_button;     // ENTER ID
+    PickerRect desc_box;
+
+    int row_x = 0;            // shared left edge of the preview rows
+    int row0_y = 0;           // title row of preview row 0
+    int row_pitch = 0;
+    int row_count = 0;
+    int radar_dy = 0;         // radar top offset below a row's title line
+    int radar_max_w = 0;      // radar viewport clamps (RADAR_X/RADAR_Y)
+    int radar_max_h = 0;
+    int stats_x = 0;          // shared left edge of every stats column
+    int stats_max_chars = 0;  // budget of one stats line before desc_box
+    int status_x = 0;         // CLEARED/CURRENT column on the title line
+    int title_max_chars = 0;  // row title budget before the status column
+    int army_x = 0;           // "Army power" readout
+    int army_y = 0;
+    int desc_max_chars = 0;
+};
+
+LevelPickerLayout level_picker_layout();
+
+// Title row y of preview row `row`.
+int level_picker_row_y(int row);
+
+// The status column text, derived exactly as the PROGRESS report derives its
+// Status field: CLEARED wins over CURRENT; otherwise empty.
+const char* level_row_status_label(bool cleared, bool current);
 
 // --- Family display helpers ---
 

--- a/include/openglad/interface/ui/picker_ui_state.h
+++ b/include/openglad/interface/ui/picker_ui_state.h
@@ -115,6 +115,8 @@ struct PickerState {
     std::vector<button> company_backups_buttons;
     // #155 CLOUD SAVE subscreen — engine screen.
     std::vector<button> cloud_save_buttons;
+    // #168 full-screen HELP — engine screen.
+    std::vector<button> help_buttons;
 
     // MATCHUP subscreen: roster slot selected by the legacy local guy row.
     int teams_menu_guy_slot = 0;

--- a/include/openglad/interface/ui/picker_ui_state.h
+++ b/include/openglad/interface/ui/picker_ui_state.h
@@ -139,4 +139,14 @@ struct PickerState {
     // dispatch (-1 = none). Set in vbutton::do_call; run_menu_screen MUST
     // consume it every frame (TESTING-enforced retvalue-zero discipline).
     int menu_spec_clicked_row = -1;
+
+    // UI-canvas pointer position at the last button activation, stamped by
+    // EVERY do_call dispatch site: the mouse branch of vbutton::leftclick
+    // writes the live pointer, while the hotkey branch and the keyboard-FIRE
+    // dispatch in handle_menu_nav write -1/-1. A spec-row handler can
+    // therefore route on WHERE its rect was clicked without ever misreading
+    // a stale pointer on a coordinate-free activation (#202: the seat-card
+    // team chip).
+    int menu_click_x = -1;
+    int menu_click_y = -1;
 };

--- a/src/interface/ui/button.cpp
+++ b/src/interface/ui/button.cpp
@@ -332,6 +332,10 @@ Sint32 vbutton::leftclick(Sint32 whichbutton)
             vdisplay();
             if (myfunc)
             {
+                // Coordinate-free activation: never leave a stale pointer
+                // for sub-rect affordances (#202).
+                pks().menu_click_x = -1;
+                pks().menu_click_y = -1;
                 retvalue = do_call(myfunc, arg);
             }
             while (og::runtime::current_session->keystates_[hotkey])
@@ -351,6 +355,13 @@ Sint32 vbutton::leftclick(Sint32 whichbutton)
             vdisplay();
             if (myfunc)
             {
+                // Pointer activation: stamp the UI-canvas position that hit
+                // this rect so a spec row can route on the sub-rect (#202
+                // seat-card team chip). _no_poll: mouse_on() just sampled
+                // this state; polling again could move it mid-dispatch.
+                MouseState& mymouse = query_mouse_no_poll();
+                pks().menu_click_x = static_cast<int>(mymouse.x);
+                pks().menu_click_y = static_cast<int>(mymouse.y);
                 retvalue = do_call(myfunc, arg);
             }
             return retvalue;

--- a/src/interface/ui/campaign_picker.cpp
+++ b/src/interface/ui/campaign_picker.cpp
@@ -223,12 +223,13 @@ void CampaignEntry::draw(int team_power)
     // Title, fitted to the pane's budget so it can never reach a control.
     write_centered(layout.title_y, og::ui::fit_campaign_title(title), WHITE);
 
-    // Rating stars + version share the next row.
+    // Rating stars
     std::string rating_text = "";
     for(int i = 0; i < int(rating); i++)
     {
         rating_text += '*';
     }
+    // Print version
     std::string buf = std::format("v{}", version);
     if(rating_text.size() > 0)
     {
@@ -240,16 +241,18 @@ void CampaignEntry::draw(int team_power)
     else
         write_centered(layout.title_y + 10, buf, WHITE);
 
-    // Icon in its frame.
+    // Draw icon button
     og::runtime::current_session->myscreen_->draw_button(
         layout.icon.x - 2, layout.icon.y - 2, layout.icon.x + layout.icon.w + 2,
         layout.icon.y + layout.icon.h + 2, 1, 1);
+    // Draw icon
     if (icon)
         icon->drawMix(layout.icon.x, layout.icon.y,
                       og::runtime::current_session->myscreen_->viewob[0].get());
     int y = layout.icon.y + layout.icon.h + 4;
 
-    // Power compare: the pane is 176px wide, so the readout is two rows.
+    // Print suggested power
+    // (the pane is 176px wide, so the power compare reads out as two rows)
     if(team_power >= 0)
     {
         write_centered(y, std::format("Your Power: {}", team_power),
@@ -269,7 +272,7 @@ void CampaignEntry::draw(int team_power)
         y += 8;
     }
 
-    // Completion progress
+    // Print completion progress
     if(num_levels_completed < 0)
         buf = std::format("{} level{}", num_levels, (num_levels == 1? "" : "s"));
     else
@@ -277,7 +280,7 @@ void CampaignEntry::draw(int team_power)
     write_centered(y, buf, WHITE);
     y += 8;
 
-    // Authors
+    // Print authors
     if(authors.size() > 0)
     {
         write_centered(y, og::ui::fit_text_to_chars(
@@ -286,10 +289,11 @@ void CampaignEntry::draw(int team_power)
                        WHITE);
     }
 
-    // Description box, flowed to its character budget (issue #152).
-    // Paragraphs mode reflows the authored hand-wrap. Overflow is handled by
-    // the browser's MORE control (a real button over the full-text
-    // scroller), not a dead "(more...)" string.
+    // Draw description box
+    // Text is flowed to the box's character budget (issue #152): Paragraphs
+    // mode reflows the authored hand-wrap. Overflow is handled by the
+    // browser's MORE control (a real button over the full-text scroller),
+    // not a dead "(more...)" string.
     const og::ui::PickerRect& descbox = layout.desc_box;
     og::runtime::current_session->myscreen_->draw_box(descbox.x, descbox.y, descbox.x + descbox.w, descbox.y + descbox.h, GREY, 1, 1);
     const std::vector<std::string> desc_lines = og::core::wrap_text(
@@ -302,7 +306,7 @@ void CampaignEntry::draw(int team_power)
                           BLACK, 1);
     }
 
-    // Contributors, on the MORE row left of the button.
+    // Print contributors, on the MORE row left of the button.
     if(contributors.size() > 0)
     {
         const int contrib_budget =
@@ -332,6 +336,7 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
 
     (void)unmount_campaign_package_with_error(old_campaign_id);
 
+    // Here are the browser variables
     // The shelf (ids in select order) and its LAZY entry cache: list rows
     // need only the cached display title, so opening the browser mounts
     // nothing. The CampaignEntry (mount + yaml parse + icon decode) is built
@@ -458,6 +463,7 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
 
 		CampaignEntry* current = ensure_entry(cursor);
 
+		// Update hidden buttons
 		buttons[prev_index].hidden = (offset == 0);
 		buttons[next_index].hidden = (offset + layout.list_rows >= total);
 		buttons[choose_index].hidden = (total == 0);
@@ -753,7 +759,8 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
             loadtext.write_xy(more_button.x + 8, more_button.y + 2, "More", DARK_BLUE, 1);
         }
 
-        // Detail pane for the highlighted entry (loaded by sync_visibility).
+        // Draw entry
+        // (the detail pane for the highlighted row, loaded by sync_visibility)
         if(cursor >= 0 && cursor < static_cast<int>(entries.size()) && entries[static_cast<std::size_t>(cursor)] != nullptr)
             entries[static_cast<std::size_t>(cursor)]->draw(army_power);
 

--- a/src/interface/ui/campaign_picker.cpp
+++ b/src/interface/ui/campaign_picker.cpp
@@ -18,6 +18,7 @@
 #include <openglad/interface/ui/campaign_picker.h>
 #include <openglad/interface/ui/picker_common.h>
 #include <openglad/interface/ui/picker_lobby_client.h>
+#include <openglad/resources/campaign_metadata.h>
 #include <openglad/resources/campaign_yaml.h>
 #include <openglad/resources/game_mode.h>
 #include <openglad/resources/io_common.h>
@@ -43,6 +44,10 @@ bool yes_or_no_prompt(const char* title, const char* message, bool default_value
 bool no_or_yes_prompt(const char* title, const char* message, bool default_value);
 
 bool prompt_for_string(const std::string& message, std::string& result);
+
+// help.cpp: the intro-style scroller over an arbitrary campaign's full
+// description (the browser's MORE control).
+short show_campaign_description(screen* scr, const std::string& campaign_id);
 
 inline constexpr int OG_OK = 4;
 void draw_highlight_interior(const button& b);
@@ -147,8 +152,8 @@ public:
 
     CampaignEntry(const std::string& campaign_id, int levels_completed);
     ~CampaignEntry();
-    
-    void draw(const UiRect& area, int team_power);
+
+    void draw(int team_power);
 };
 
 CampaignEntry::CampaignEntry(const std::string& campaign_id, int levels_completed)
@@ -202,116 +207,110 @@ CampaignEntry::~CampaignEntry()
     icondata.free();
 }
 
-void CampaignEntry::draw(const UiRect& area, int team_power)
+// Draw the highlighted entry's detail pane (right column of the browser).
+void CampaignEntry::draw(int team_power)
 {
-    int x = area.x;
-    int y = area.y;
-    int w = area.w;
-    int h = area.h;
-    
+    const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
+    const int cx = layout.title_center_x;
+
     text& loadtext = og::runtime::current_session->myscreen_->text_normal;
+    const auto write_centered = [&](int y, const std::string& line,
+                                    unsigned char color) {
+        loadtext.write_xy(cx - static_cast<Sint32>(line.size()) * 3, y,
+                          line.c_str(), color, 1);
+    };
 
-    // Print title. Fitted to the width that clears the RESET/DELETE face on
-    // the same pixel row (issue: long campaign names clipped into ENTER ID,
-    // which now lives a row lower).
-    const std::string shown_title = og::ui::fit_campaign_title(title);
-    loadtext.write_xy(x + w/2 - static_cast<Sint32>(shown_title.size())*3, y - 22, shown_title.c_str(), WHITE, 1);
+    // Title, fitted to the pane's budget so it can never reach a control.
+    write_centered(layout.title_y, og::ui::fit_campaign_title(title), WHITE);
 
-    // Rating stars
+    // Rating stars + version share the next row.
     std::string rating_text = "";
     for(int i = 0; i < int(rating); i++)
     {
         rating_text += '*';
     }
-    loadtext.write_xy(x + w/2 - static_cast<Sint32>(rating_text.size())*3, y - 14, rating_text.c_str(), WHITE, 1);
-
-    // Print version
     std::string buf = std::format("v{}", version);
     if(rating_text.size() > 0)
-        loadtext.write_xy(x + w/2 + static_cast<Sint32>(rating_text.size())*3 + 6, y - 14, buf.c_str(), WHITE, 1);
-    else
-        loadtext.write_xy(x + w/2 - static_cast<Sint32>(buf.size())*3, y - 14, buf.c_str(), WHITE, 1);
-
-    // Draw icon button
-    og::runtime::current_session->myscreen_->draw_button(x - 2, y - 2, x + w + 2, y + h + 2, 1, 1);
-    // Draw icon
-	if (icon)
-	    icon->drawMix(x, y, og::runtime::current_session->myscreen_->viewob[0].get());
-	y += h + 4;
-
-	// Print suggested power
-	if(team_power >= 0)
     {
-        buf = std::format("Your Power: {}", team_power);
-        std::string buf2;
-        if(suggested_power > 0)
-            buf2 = std::format(", Suggested Power: {}", suggested_power);
-
-        int len = static_cast<int>(buf.size());
-        int len2 = static_cast<int>(buf2.size());
-        loadtext.write_xy(x + w/2 - (len + len2)*3, y, buf.c_str(), LIGHT_GREEN, 1);
-        loadtext.write_xy(x + w/2 - (len + len2)*3 + len*6, y, buf2.c_str(), (team_power >= suggested_power? LIGHT_GREEN : RED), 1);
+        loadtext.write_xy(cx - static_cast<Sint32>(rating_text.size())*3,
+                          layout.title_y + 10, rating_text.c_str(), WHITE, 1);
+        loadtext.write_xy(cx + static_cast<Sint32>(rating_text.size())*3 + 6,
+                          layout.title_y + 10, buf.c_str(), WHITE, 1);
     }
     else
+        write_centered(layout.title_y + 10, buf, WHITE);
+
+    // Icon in its frame.
+    og::runtime::current_session->myscreen_->draw_button(
+        layout.icon.x - 2, layout.icon.y - 2, layout.icon.x + layout.icon.w + 2,
+        layout.icon.y + layout.icon.h + 2, 1, 1);
+    if (icon)
+        icon->drawMix(layout.icon.x, layout.icon.y,
+                      og::runtime::current_session->myscreen_->viewob[0].get());
+    int y = layout.icon.y + layout.icon.h + 4;
+
+    // Power compare: the pane is 176px wide, so the readout is two rows.
+    if(team_power >= 0)
     {
+        write_centered(y, std::format("Your Power: {}", team_power),
+                       LIGHT_GREEN);
+        y += 8;
         if(suggested_power > 0)
-            buf = std::format("Suggested Power: {}", suggested_power);
-        else
-            buf.clear();
-
-        int len = static_cast<int>(buf.size());
-        loadtext.write_xy(x + w/2 - (len)*3, y, buf.c_str(), LIGHT_GREEN, 1);
+        {
+            write_centered(y, std::format("Suggested Power: {}", suggested_power),
+                           team_power >= suggested_power ? LIGHT_GREEN : RED);
+            y += 8;
+        }
     }
-    y += 8;
+    else if(suggested_power > 0)
+    {
+        write_centered(y, std::format("Suggested Power: {}", suggested_power),
+                       LIGHT_GREEN);
+        y += 8;
+    }
 
-    // Print completion progress
+    // Completion progress
     if(num_levels_completed < 0)
         buf = std::format("{} level{}", num_levels, (num_levels == 1? "" : "s"));
     else
         buf = std::format("{} out of {} completed", num_levels_completed, num_levels);
-    loadtext.write_xy(x + w/2 - static_cast<int>(buf.size())*3, y, buf.c_str(), WHITE, 1);
+    write_centered(y, buf, WHITE);
     y += 8;
 
-    // Print authors
+    // Authors
     if(authors.size() > 0)
     {
-        buf = std::format("By {}", authors);
-        loadtext.write_xy(x + w/2 - static_cast<int>(buf.size())*3, y, buf.c_str(), WHITE, 1);
+        write_centered(y, og::ui::fit_text_to_chars(
+                              std::format("By {}", authors),
+                              layout.title_max_chars),
+                       WHITE);
     }
-    
-    // Draw description box
-    UiRect descbox = {160 - 225/2, area.y + area.h + 35, 225, 60};
+
+    // Description box, flowed to its character budget (issue #152).
+    // Paragraphs mode reflows the authored hand-wrap. Overflow is handled by
+    // the browser's MORE control (a real button over the full-text
+    // scroller), not a dead "(more...)" string.
+    const og::ui::PickerRect& descbox = layout.desc_box;
     og::runtime::current_session->myscreen_->draw_box(descbox.x, descbox.y, descbox.x + descbox.w, descbox.y + descbox.h, GREY, 1, 1);
-    
-    // Print description, flowed to the box's character budget (issue #152):
-    // text starts at descbox.x+5 and glyphs advance 6px. Campaign blurbs are
-    // prose, so Paragraphs mode reflows the authored hand-wrap. When the
-    // text is taller than the box, the last visible row becomes a
-    // "(more...)" pointer at the full-text campaign intro scroller.
     const std::vector<std::string> desc_lines = og::core::wrap_text(
-        description, (descbox.w - 10) / 6, og::core::WrapMode::Paragraphs);
-    int j = 10;
-    for(size_t li = 0; li < desc_lines.size(); li++)
+        description, layout.desc_max_chars, og::core::WrapMode::Paragraphs);
+    for(int row = 0; row < layout.desc_rows &&
+        row < static_cast<int>(desc_lines.size()); row++)
     {
-        if(j + 10 > descbox.h)
-            break;
-        const bool last_visible_row = (j + 20 > descbox.h);
-        if(last_visible_row && li + 1 < desc_lines.size())
-        {
-            loadtext.write_xy(descbox.x + 5, descbox.y + j, "(more...)", BLACK, 1);
-            break;
-        }
-        loadtext.write_xy(descbox.x + 5, descbox.y + j, desc_lines[li].c_str(), BLACK, 1);
-        j += 10;
+        loadtext.write_xy(descbox.x + 5, descbox.y + 3 + 10 * row,
+                          desc_lines[static_cast<std::size_t>(row)].c_str(),
+                          BLACK, 1);
     }
-    y = descbox.y + descbox.h + 2;
-    
-    // Print contributors
+
+    // Contributors, on the MORE row left of the button.
     if(contributors.size() > 0)
     {
-        buf = std::format("Thanks to {}", contributors);
-        loadtext.write_xy(x + w/2 - static_cast<int>(buf.size())*3, y, buf.c_str(), WHITE, 1);
-        y += 10;
+        const int contrib_budget =
+            (layout.more_button.x - descbox.x - 6) / 6;
+        buf = og::ui::fit_text_to_chars(
+            std::format("Thanks to {}", contributors), contrib_budget);
+        loadtext.write_xy(descbox.x, layout.more_button.y + 2, buf.c_str(),
+                          WHITE, 1);
     }
 }
 
@@ -328,33 +327,50 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
     std::string old_campaign_id = get_mounted_campaign();
     CampaignEntry* result = nullptr;
     CampaignResult ret_value;
-    
+
     text& loadtext = og::runtime::current_session->myscreen_->text_normal;
-    
+
     (void)unmount_campaign_package_with_error(old_campaign_id);
 
-    // Here are the browser variables
+    // The shelf (ids in select order) and its LAZY entry cache: list rows
+    // need only the cached display title, so opening the browser mounts
+    // nothing. The CampaignEntry (mount + yaml parse + icon decode) is built
+    // on first highlight and cached.
+    std::vector<std::string> ids;
     std::vector<std::unique_ptr<CampaignEntry>> entries;
-    
-    unsigned int current_campaign_index = 0;
-    
-    // Load campaigns (default campaign first; remainder stays alphabetical).
-    std::list<std::string> campaign_ids = list_campaigns();
-    og::ui::order_campaigns_for_select(campaign_ids);
-    og::ui::filter_campaigns_for_networked_lobby(campaign_ids,
-                                                 networked_campaign_select());
-    int i = 0;
-    for(auto& cid : campaign_ids)
+    const auto rescan = [&]() {
+        std::list<std::string> campaign_ids = list_campaigns();
+        og::ui::order_campaigns_for_select(campaign_ids);
+        og::ui::filter_campaigns_for_networked_lobby(
+            campaign_ids, networked_campaign_select());
+        ids.assign(campaign_ids.begin(), campaign_ids.end());
+        entries.clear();
+        entries.resize(ids.size());
+    };
+    rescan();
+
+    const auto ensure_entry = [&](int index) -> CampaignEntry* {
+        if (index < 0 || index >= static_cast<int>(ids.size()))
+            return nullptr;
+        auto& slot = entries[static_cast<std::size_t>(index)];
+        if (!slot)
+        {
+            int num_completed = -1;
+            if (save_data != nullptr)
+                num_completed = save_data->get_num_levels_completed(
+                    ids[static_cast<std::size_t>(index)]);
+            slot = std::make_unique<CampaignEntry>(
+                ids[static_cast<std::size_t>(index)], num_completed);
+        }
+        return slot.get();
+    };
+
+    // The list cursor starts on the campaign that was mounted.
+    int cursor = 0;
+    for (int index = 0; index < static_cast<int>(ids.size()); ++index)
     {
-        int num_completed = -1;
-        if(save_data != nullptr)
-            num_completed = save_data->get_num_levels_completed(cid);
-        entries.push_back(std::make_unique<CampaignEntry>(cid, num_completed));
-
-        if(cid == old_campaign_id)
-            current_campaign_index = static_cast<unsigned int>(i);
-
-        i++;
+        if (ids[static_cast<std::size_t>(index)] == old_campaign_id)
+            cursor = index;
     }
 
     // Figure out how good the player's army is
@@ -370,10 +386,9 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
             }
         }
     }
-    
-    // Campaign icon positioning + buttons (single source: picker_common).
+
+    // Control geometry + nav (single source: picker_common).
     const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
-    const UiRect area = layout.icon;
 
     const UiRect prev = layout.prev;
     const UiRect next = layout.next;
@@ -383,12 +398,15 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
     // ENTER ID stacks UNDER DELETE/RESET so the title row is clear.
     const UiRect id_button = layout.id_button;
     const UiRect reset_button = layout.reset_button;
+    const UiRect more_button = layout.more_button;
 
-    
+    int offset = og::ui::campaign_list_offset_for_cursor(
+        cursor, 0, static_cast<int>(ids.size()), layout.list_rows);
+
     // Controller input
     int retvalue = 0;
 	int highlighted_button = 3;
-	
+
 	const int prev_index = og::ui::kCampaignPickerPrevIndex;
 	const int next_index = og::ui::kCampaignPickerNextIndex;
 	const int choose_index = og::ui::kCampaignPickerChooseIndex;
@@ -396,44 +414,94 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
 	const int delete_index = og::ui::kCampaignPickerDeleteIndex;
 	const int id_index = og::ui::kCampaignPickerIdIndex;
 	const int reset_index = og::ui::kCampaignPickerResetIndex;
+	const int row_base_index = og::ui::kCampaignPickerRowBaseIndex;
+	const int more_index = og::ui::kCampaignPickerMoreIndex;
 
-	// Whole-graph rewire from the current visibility, applied at setup and
-	// again whenever a click changes what is showing (picker_common owns the
-	// graph so the BFS pin can walk every variant headlessly).
-	const auto apply_nav = [&](button* rows) {
+	const UiRect row0 = og::ui::campaign_picker_row_rect(0);
+	const UiRect row1 = og::ui::campaign_picker_row_rect(1);
+	const UiRect row2 = og::ui::campaign_picker_row_rect(2);
+	const UiRect row3 = og::ui::campaign_picker_row_rect(3);
+	const UiRect row4 = og::ui::campaign_picker_row_rect(4);
+	const UiRect row5 = og::ui::campaign_picker_row_rect(5);
+
+	button buttons[og::ui::kCampaignPickerButtonCount] = {
+        button("prev", "PREV", KEYSTATE_UNKNOWN, prev.x, prev.y, prev.w, prev.h, 0, -1 , MenuNav{}),
+        button("next", "NEXT", KEYSTATE_UNKNOWN, next.x, next.y, next.w, next.h, 0, -1 , MenuNav{}),
+        button("ok", "OK", KEYSTATE_UNKNOWN, choose.x, choose.y, choose.w, choose.h, 0, -1 , MenuNav{}),
+        button("cancel", "CANCEL", KEYSTATE_ESCAPE, cancel.x, cancel.y, cancel.w, cancel.h, 0, -1 , MenuNav{}),
+        button("delete", "DELETE", KEYSTATE_UNKNOWN, delete_button.x, delete_button.y, delete_button.w, delete_button.h, 0, -1 , MenuNav{}),
+        button("enter_id", "ENTER ID", KEYSTATE_UNKNOWN, id_button.x, id_button.y, id_button.w, id_button.h, 0, -1 , MenuNav{}),
+        button("reset", "RESET", KEYSTATE_UNKNOWN, reset_button.x, reset_button.y, reset_button.w, reset_button.h, 0, -1 , MenuNav{}),
+        button("entry_1", "1", KEYSTATE_UNKNOWN, row0.x, row0.y, row0.w, row0.h, 0, -1 , MenuNav{}),
+        button("entry_2", "2", KEYSTATE_UNKNOWN, row1.x, row1.y, row1.w, row1.h, 0, -1 , MenuNav{}),
+        button("entry_3", "3", KEYSTATE_UNKNOWN, row2.x, row2.y, row2.w, row2.h, 0, -1 , MenuNav{}),
+        button("entry_4", "4", KEYSTATE_UNKNOWN, row3.x, row3.y, row3.w, row3.h, 0, -1 , MenuNav{}),
+        button("entry_5", "5", KEYSTATE_UNKNOWN, row4.x, row4.y, row4.w, row4.h, 0, -1 , MenuNav{}),
+        button("entry_6", "6", KEYSTATE_UNKNOWN, row5.x, row5.y, row5.w, row5.h, 0, -1 , MenuNav{}),
+        button("more", "MORE", KEYSTATE_UNKNOWN, more_button.x, more_button.y, more_button.w, more_button.h, 0, -1 , MenuNav{}),
+	};
+
+	// Rows visible on this page (recomputed by sync_visibility below).
+	int visible_rows = 0;
+
+	// Whole-graph rewire + hidden flags from the current list window
+	// (picker_common owns the graph so the BFS pin can walk every variant
+	// headlessly). Also loads the highlighted entry — the ONLY entry a frame
+	// ever mounts.
+	const auto sync_visibility = [&]() {
+		const int total = static_cast<int>(ids.size());
+		offset = og::ui::campaign_list_clamp_offset(offset, total,
+		                                            layout.list_rows);
+		cursor = og::ui::campaign_list_clamp_cursor(cursor, offset, total,
+		                                            layout.list_rows);
+		visible_rows = std::max(0, std::min(layout.list_rows, total - offset));
+
+		CampaignEntry* current = ensure_entry(cursor);
+
+		buttons[prev_index].hidden = (offset == 0);
+		buttons[next_index].hidden = (offset + layout.list_rows >= total);
+		buttons[choose_index].hidden = (total == 0);
+		buttons[delete_index].hidden = !enable_delete;
+		buttons[reset_index].hidden = enable_delete;
+		for (int row = 0; row < og::ui::kCampaignPickerRowCount; ++row)
+			buttons[row_base_index + row].hidden = (row >= visible_rows);
+		buttons[more_index].hidden =
+			current == nullptr ||
+			!og::ui::campaign_description_overflows(current->description);
+
 		const og::ui::CampaignPickerVisibility visibility{
-			.prev_hidden = rows[prev_index].hidden,
-			.next_hidden = rows[next_index].hidden,
-			.choose_hidden = rows[choose_index].hidden,
-			.delete_hidden = rows[delete_index].hidden,
+			.prev_hidden = buttons[prev_index].hidden,
+			.next_hidden = buttons[next_index].hidden,
+			.choose_hidden = buttons[choose_index].hidden,
+			.delete_hidden = buttons[delete_index].hidden,
+			.visible_rows = visible_rows,
+			.more_hidden = buttons[more_index].hidden,
 		};
 		const auto nav = og::ui::campaign_picker_nav(visibility);
 		for (int btn = 0; btn < og::ui::kCampaignPickerButtonCount; ++btn)
 		{
-			rows[btn].nav = MenuNav{.up = nav[static_cast<std::size_t>(btn)].up, .down = nav[static_cast<std::size_t>(btn)].down,
-			                        .left = nav[static_cast<std::size_t>(btn)].left, .right = nav[static_cast<std::size_t>(btn)].right};
+			buttons[btn].nav = MenuNav{.up = nav[static_cast<std::size_t>(btn)].up, .down = nav[static_cast<std::size_t>(btn)].down,
+			                           .left = nav[static_cast<std::size_t>(btn)].left, .right = nav[static_cast<std::size_t>(btn)].right};
+		}
+
+		if (buttons[highlighted_button].hidden)
+		{
+			if (highlighted_button >= row_base_index &&
+			    highlighted_button < row_base_index + og::ui::kCampaignPickerRowCount &&
+			    visible_rows > 0)
+				highlighted_button = row_base_index + visible_rows - 1;
+			else if (highlighted_button == prev_index && !buttons[next_index].hidden)
+				highlighted_button = next_index;
+			else if (highlighted_button == next_index && !buttons[prev_index].hidden)
+				highlighted_button = prev_index;
+			else
+				highlighted_button = cancel_index;
 		}
 	};
-	
-	button buttons[] = {
-        button("prev", "PREV", KEYSTATE_UNKNOWN, prev.x, prev.y, prev.w, prev.h, 0, -1 , MenuNav{.up=id_index, .down=cancel_index, .right=next_index}),
-        button("next", "NEXT", KEYSTATE_UNKNOWN, next.x, next.y, next.w, next.h, 0, -1 , MenuNav{.up=id_index, .down=choose_index, .left=prev_index}),
-        button("ok", "OK", KEYSTATE_UNKNOWN, choose.x, choose.y, choose.w, choose.h, 0, -1 , MenuNav{.up=next_index, .left=cancel_index}),
-        button("cancel", "CANCEL", KEYSTATE_ESCAPE, cancel.x, cancel.y, cancel.w, cancel.h, 0, -1 , MenuNav{.up=prev_index, .right=choose_index}),
-        button("delete", "DELETE", KEYSTATE_UNKNOWN, delete_button.x, delete_button.y, delete_button.w, delete_button.h, 0, -1 , MenuNav{.down=id_index}),
-        button("enter_id", "ENTER ID", KEYSTATE_UNKNOWN, id_button.x, id_button.y, id_button.w, id_button.h, 0, -1 , MenuNav{.up=delete_index, .down=next_index}),
-        button("reset", "RESET", KEYSTATE_UNKNOWN, reset_button.x, reset_button.y, reset_button.w, reset_button.h, 0, -1 , MenuNav{.down=id_index}),
-	};
-	
-	buttons[prev_index].hidden = (current_campaign_index == 0);
-	buttons[next_index].hidden = (current_campaign_index + 1 >= entries.size());
-	buttons[choose_index].hidden = !(current_campaign_index < entries.size() && entries[current_campaign_index] != nullptr);
-	buttons[delete_index].hidden = !enable_delete;
-	buttons[reset_index].hidden = enable_delete;
-	
-	apply_nav(buttons);
+	sync_visibility();
 
     bool done = false;
+    int last_highlighted = highlighted_button;
 #ifdef TESTING
     campaign_picker_testing_mark_entered();
 #endif
@@ -451,8 +519,18 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
 
         // Get keys and stuff
         get_input_events(POLL);
-		
+
         handle_menu_nav(buttons, highlighted_button, retvalue, false);
+
+        // Moving the keyboard highlight onto a list row moves the list
+        // cursor with it, so the detail pane follows the arrow keys.
+        if (highlighted_button != last_highlighted)
+        {
+            const int row = highlighted_button - row_base_index;
+            if (row >= 0 && row < visible_rows)
+                cursor = offset + row;
+            last_highlighted = highlighted_button;
+        }
 
         // Quit if 'q' is pressed
         if(og::runtime::current_session->keystates_[KEYSTATE_q])
@@ -462,7 +540,7 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
 		MouseState& mymouse = query_mouse();
         int mx = static_cast<int>(mymouse.x);
         int my = static_cast<int>(mymouse.y);
-        
+
         bool do_click = mymouse.left;
 		bool do_prev = !buttons[prev_index].hidden && ((do_click && prev.x <= mx && mx <= prev.x + prev.w
                && prev.y <= my && my <= prev.y + prev.h) || (retvalue == OG_OK && highlighted_button == prev_index));
@@ -478,9 +556,27 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
                && reset_button.y <= my && my <= reset_button.y + reset_button.h) || (retvalue == OG_OK && highlighted_button == reset_index));
         bool do_id = (do_click && id_button.x <= mx && mx <= id_button.x + id_button.w
                && id_button.y <= my && my <= id_button.y + id_button.h) || (retvalue == OG_OK && highlighted_button == id_index);
+        bool do_more = !buttons[more_index].hidden && ((do_click && more_button.x <= mx && mx <= more_button.x + more_button.w
+               && more_button.y <= my && my <= more_button.y + more_button.h) || (retvalue == OG_OK && highlighted_button == more_index));
+        // A click on a visible list row, or Enter while one is highlighted.
+        int selected_row = -1;
+        for (int row = 0; row < visible_rows; ++row)
+        {
+            const UiRect rect = og::ui::campaign_picker_row_rect(row);
+            if ((do_click && rect.x <= mx && mx <= rect.x + rect.w
+                 && rect.y <= my && my <= rect.y + rect.h) ||
+                (retvalue == OG_OK && highlighted_button == row_base_index + row))
+            {
+                selected_row = row;
+                break;
+            }
+        }
+        const bool do_select = selected_row >= 0 && !do_prev && !do_next &&
+            !do_choose && !do_cancel && !do_delete && !do_reset && !do_id &&
+            !do_more;
 #ifdef TESTING
         if (do_prev || do_next || do_choose || do_cancel || do_delete ||
-            do_reset || do_id)
+            do_reset || do_id || do_more || do_select)
         {
             campaign_picker_testing_mark_action();
         }
@@ -491,28 +587,28 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
 			    wait_for_mouse_release();
 			}
 
-        // Prev
+        // Prev page
         if(do_prev)
         {
-            if(current_campaign_index > 0)
-            {
-                current_campaign_index--;
-            }
+            offset = og::ui::campaign_list_page_step(
+                offset, static_cast<int>(ids.size()), layout.list_rows, -1);
+            cursor = og::ui::campaign_list_clamp_cursor(
+                cursor, offset, static_cast<int>(ids.size()), layout.list_rows);
         }
-        // Next
+        // Next page
         else if(do_next)
         {
-            if(current_campaign_index + 1 < entries.size())
-            {
-                current_campaign_index++;
-            }
+            offset = og::ui::campaign_list_page_step(
+                offset, static_cast<int>(ids.size()), layout.list_rows, 1);
+            cursor = og::ui::campaign_list_clamp_cursor(
+                cursor, offset, static_cast<int>(ids.size()), layout.list_rows);
         }
         // Choose
         else if(do_choose)
         {
-            if(current_campaign_index < entries.size() && entries[current_campaign_index] != nullptr)
+            result = ensure_entry(cursor);
+            if(result != nullptr)
             {
-                result = entries[current_campaign_index].get();
                 done = true;
                 break;
             }
@@ -527,31 +623,21 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
         // Delete
         else if(do_delete)
        {
-           if(yes_or_no_prompt("Delete campaign", "Delete this campaign permanently?", false)
+           // Bounds check: DELETE stays clickable even when the shelf
+           // scanned empty, so never index an empty list.
+           if(cursor >= 0 && cursor < static_cast<int>(ids.size())
+              && yes_or_no_prompt("Delete campaign", "Delete this campaign permanently?", false)
               && no_or_yes_prompt("Delete campaign", "Are you really sure?", false))
            {
-               delete_campaign(entries[current_campaign_index]->id);
-               
+               delete_campaign(ids[static_cast<std::size_t>(cursor)]);
+
                restore_default_campaigns();
                (void)remount_campaign_package_with_error();  // Just in case we deleted the current campaign
-               
-               // Reload the picker
-	               entries.clear();
-               
-               campaign_ids = list_campaigns();
-               og::ui::order_campaigns_for_select(campaign_ids);
-               og::ui::filter_campaigns_for_networked_lobby(
-                   campaign_ids, networked_campaign_select());
 
-                for(auto& cid : campaign_ids)
-                {
-                    int num_completed = -1;
-                    if(save_data != nullptr)
-                        num_completed = save_data->get_num_levels_completed(cid);
-	                    entries.push_back(std::make_unique<CampaignEntry>(cid, num_completed));
-	                }
-                
-                current_campaign_index = 0;
+               // Reload the picker
+               rescan();
+               cursor = 0;
+               offset = 0;
            }
        }
         // Enter ID
@@ -569,53 +655,78 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
        // Reset progress
        else if(do_reset)
        {
-           if(yes_or_no_prompt("Reset campaign", "Reset your progress\nin this campaign?", false)
+           if(cursor >= 0 && cursor < static_cast<int>(ids.size())
+              && yes_or_no_prompt("Reset campaign", "Reset your progress\nin this campaign?", false)
               && no_or_yes_prompt("Reset campaign", "Are you really sure?", false))
            {
-               og::runtime::current_session->myscreen_->save_data.reset_campaign(entries[current_campaign_index]->id);
+               og::runtime::current_session->myscreen_->save_data.reset_campaign(ids[static_cast<std::size_t>(cursor)]);
+               // Drop the cached entry so its completion line reloads.
+               entries[static_cast<std::size_t>(cursor)].reset();
            }
        }
-       
+       // Full description in the intro-style scroller
+       else if(do_more)
+       {
+           CampaignEntry* current = ensure_entry(cursor);
+           if(current != nullptr)
+               (void)show_campaign_description(
+                   og::runtime::current_session->myscreen_, current->id);
+       }
+       // Select a list row
+       else if(do_select)
+       {
+           cursor = offset + selected_row;
+           highlighted_button = row_base_index + selected_row;
+           last_highlighted = highlighted_button;
+       }
+
         retvalue = 0;
 
-        // Update hidden buttons
-        if(do_prev || do_next || do_choose || do_cancel || do_delete || do_id)
-        {
-            buttons[prev_index].hidden = (current_campaign_index == 0);
-            buttons[next_index].hidden = (current_campaign_index + 1 >= entries.size());
-            buttons[choose_index].hidden = !(current_campaign_index < entries.size() && entries[current_campaign_index] != nullptr);
-            buttons[delete_index].hidden = !enable_delete;
-            buttons[reset_index].hidden = enable_delete;
-
-            apply_nav(buttons);
-            
-            if(buttons[highlighted_button].hidden)
-            {
-                if(highlighted_button == prev_index && !buttons[next_index].hidden)
-                    highlighted_button = next_index;
-                else if(highlighted_button == next_index && !buttons[prev_index].hidden)
-                    highlighted_button = prev_index;
-                else
-                    highlighted_button = cancel_index;
-            }
-        }
+        sync_visibility();
 
         // Draw
         og::runtime::current_session->myscreen_->clearbuffer();
 
-        if(current_campaign_index > 0)
+        // List pane: header, one row per campaign on this page, pagers with
+        // the position readout between them.
+        loadtext.write_xy(layout.list.x, layout.header_y, "CAMPAIGNS", WHITE, 1);
+        for (int row = 0; row < visible_rows; ++row)
+        {
+            const UiRect rect = og::ui::campaign_picker_row_rect(row);
+            const int index = offset + row;
+            const std::string& row_id = ids[static_cast<std::size_t>(index)];
+            og::runtime::current_session->myscreen_->draw_button(rect.x, rect.y, rect.x + rect.w, rect.y + rect.h, 1, 1);
+            // Marker column: '*' flags the campaign that was active when the
+            // browser opened.
+            if (row_id == old_campaign_id)
+                loadtext.write_xy(rect.x + 3, rect.y + 2, "*", RED, 1);
+            const std::string label = og::ui::fit_campaign_row_label(
+                og::data::campaign_display_title(row_id));
+            loadtext.write_xy(rect.x + 10, rect.y + 2, label.c_str(),
+                              index == cursor ? DARK_GREEN : DARK_BLUE, 1);
+            if (index == cursor)
+                og::runtime::current_session->myscreen_->draw_box(rect.x - 2, rect.y - 2, rect.x + rect.w + 2, rect.y + rect.h + 2, DARK_BLUE, 0, 1);
+        }
+
+        if(!buttons[prev_index].hidden)
         {
             og::runtime::current_session->myscreen_->draw_button(prev.x, prev.y, prev.x + prev.w, prev.y + prev.h, 1, 1);
             loadtext.write_xy(prev.x + 2, prev.y + 2, "Prev", DARK_BLUE, 1);
         }
-        
-        if(current_campaign_index + 1 < entries.size())
+
+        if(!buttons[next_index].hidden)
         {
             og::runtime::current_session->myscreen_->draw_button(next.x, next.y, next.x + next.w, next.y + next.h, 1, 1);
             loadtext.write_xy(next.x + 2, next.y + 2, "Next", DARK_BLUE, 1);
         }
-        
-        if(current_campaign_index < entries.size() && entries[current_campaign_index] != nullptr)
+
+        const std::string position_label = og::ui::format_campaign_position_label(
+            cursor, static_cast<int>(ids.size()));
+        loadtext.write_xy(layout.list.x + layout.list.w / 2
+                              - static_cast<int>(position_label.size()) * 3,
+                          prev.y + 2, position_label.c_str(), WHITE, 1);
+
+        if(!buttons[choose_index].hidden)
         {
             og::runtime::current_session->myscreen_->draw_button(choose.x, choose.y, choose.x + choose.w, choose.y + choose.h, 1, 1);
             loadtext.write_xy(choose.x + 9, choose.y + 2, "OK", DARK_GREEN, 1);
@@ -632,13 +743,19 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
             og::runtime::current_session->myscreen_->draw_button(reset_button.x, reset_button.y, reset_button.x + reset_button.w, reset_button.y + reset_button.h, 1, 1);
             loadtext.write_xy(reset_button.x + 2, reset_button.y + 2, "Reset", RED, 1);
         }
-        
+
         og::runtime::current_session->myscreen_->draw_button(id_button.x, id_button.y, id_button.x + id_button.w, id_button.y + id_button.h, 1, 1);
         loadtext.write_xy(id_button.x + 2, id_button.y + 2, "Enter ID", DARK_BLUE, 1);
-        
-        // Draw entry
-        if(current_campaign_index < entries.size() && entries[current_campaign_index] != nullptr)
-            entries[current_campaign_index]->draw(area, army_power);
+
+        if(!buttons[more_index].hidden)
+        {
+            og::runtime::current_session->myscreen_->draw_button(more_button.x, more_button.y, more_button.x + more_button.w, more_button.y + more_button.h, 1, 1);
+            loadtext.write_xy(more_button.x + 8, more_button.y + 2, "More", DARK_BLUE, 1);
+        }
+
+        // Detail pane for the highlighted entry (loaded by sync_visibility).
+        if(cursor >= 0 && cursor < static_cast<int>(entries.size()) && entries[static_cast<std::size_t>(cursor)] != nullptr)
+            entries[static_cast<std::size_t>(cursor)]->draw(army_power);
 
         draw_highlight(buttons[highlighted_button]);
         og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
@@ -646,7 +763,7 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
     }
 
     wait_for_key_release(KEYSTATE_q, "quit");
-    
+
     // Restore old campaign
     (void)mount_campaign_package_with_error(old_campaign_id);
     
@@ -670,11 +787,12 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
                CampaignLoadError::None)
         {
             const short kept_cursor = save_data->scen_num;
-            std::map<std::string, int>::const_iterator cursor =
+            std::map<std::string, int>::const_iterator level_cursor =
                 save_data->current_levels.find(ret_value.id);
             save_data->scen_num = static_cast<short>(
-                cursor != save_data->current_levels.end() ? cursor->second
-                                                          : ret_value.first_level);
+                level_cursor != save_data->current_levels.end()
+                    ? level_cursor->second
+                    : ret_value.first_level);
             og::mode::current_progression().ensure_level_available(*save_data);
             save_data->scen_num = kept_cursor;
         }

--- a/src/interface/ui/help.cpp
+++ b/src/interface/ui/help.cpp
@@ -36,6 +36,8 @@
 #include <openglad/resources/og_file.h>
 #include <openglad/interface/screen.h>
 #include <openglad/interface/game_context.h>
+#include <openglad/interface/ui/menu_screen_spec.h>
+#include "picker_sdl_defs.h"
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #define YIELD_SLEEP(ms) emscripten_sleep(ms)
@@ -610,8 +612,6 @@ enum class HelpTab {
 	NumTabs = 3
 };
 
-static const char* tab_names[] = { "Controls", "Classes", "Editor" };
-
 // Helper struct to hold tab content reference
 struct TabContent {
 	const char** static_lines;           // For controls (static array)
@@ -666,255 +666,229 @@ static const char* get_content_line(const TabContent& content, int index)
 	return "";
 }
 
-// Tab button dimensions
-inline constexpr Sint32 TAB_Y = 20;
-inline constexpr Sint32 TAB_HEIGHT = 12;
-inline constexpr Sint32 TAB_WIDTH = 58;
-inline constexpr Sint32 TAB_SPACING = 2;
-inline constexpr Sint32 TAB_START_X = HELPTEXT_LEFT + 10;
-inline constexpr Sint32 CONTENT_TOP = TAB_Y + TAB_HEIGHT + 4;  // Content starts below tabs
+// ---------------------------------------------------------------------------
+// Full-screen HELP (#168): engine-hosted. The spec (tab strip, BACK, and the
+// PREV/NEXT pagers on the shared layout constants in picker_sdl_defs.h)
+// lives in menu_screen_specs.cpp; the hooks below own the content — the
+// active tab's flowed lines and its PageModel — through a file-static
+// pointer (the VIEW LEVEL idiom: the rewire and state-override signatures
+// carry no screen_state). Null state = no open screen (the bare engine
+// sweeps) and presents the single-page shape: pagers hidden, BACK's
+// right-link closed.
+
+// Flow budget of the content frame: glyphs start at kHelpTextX and the
+// frame's right edge sits at kHelpFrameRight, so the box width feeding
+// help_char_budget is their distance (304px -> 50 chars; 10 + 50*6 = 310
+// keeps the widest line inside the frame bevel).
+inline constexpr int kHelpTextBoxWidth = kHelpFrameRight - kHelpTextX;
+
+// Footer ink between BACK and the pagers: the key-hint row, the version
+// row, and the right-aligned "p/N" page indicator.
+inline constexpr int kHelpFooterBarLeft = kHelpBackX + kHelpBackWidth + 2;
+inline constexpr int kHelpFooterBarRight = kHelpPrevX - 3;
+inline constexpr int kHelpFooterTextX = kHelpFooterBarLeft + 2;
+inline constexpr int kHelpFooterHintY = kHelpFooterY + 2;
+inline constexpr int kHelpFooterVersionY = kHelpFooterY + 11;
+
+namespace
+{
+struct HelpScreenState
+{
+	og::ui::PageModel pager;
+	std::vector<std::string> lines;  // active tab, flowed to the frame budget
+	HelpTab tab = HelpTab::Controls;
+};
+
+HelpScreenState* g_help_screen_state = nullptr;
+
+#ifdef TESTING
+std::atomic<int> s_help_active_tab{0};
+std::atomic<int> s_help_page{0};
+
+void help_publish_probes(const HelpScreenState& state)
+{
+	s_help_active_tab.store(static_cast<int>(state.tab),
+	                        std::memory_order_release);
+	s_help_page.store(state.pager.page, std::memory_order_release);
+}
+#endif
+
+std::vector<std::string> help_flow_tab_lines(HelpTab tab)
+{
+	const TabContent content = get_tab_content(tab);
+	std::list<std::string> source;
+	for (int i = 0; i < content.num_lines; i++)
+		source.push_back(get_content_line(content, i));
+	// HardBreaks keeps authored line breaks and the ASCII heading rules
+	// intact; only over-budget lines re-wrap (issue #152's fix, retargeted
+	// from the 39-char dialog to the full-width frame).
+	return og::core::wrap_lines(source, help_char_budget(kHelpTextBoxWidth));
+}
+
+// Reflow and reset the pager. Re-selecting the active tab keeps the page
+// (the legacy switch-only-when-different behavior); `force` seeds entry.
+void help_switch_tab(HelpScreenState& state, HelpTab tab, bool force = false)
+{
+	if (!force && state.tab == tab)
+		return;
+	state.tab = tab;
+	state.lines = help_flow_tab_lines(tab);
+	state.pager = og::ui::PageModel::make(static_cast<int>(state.lines.size()),
+	                                      kHelpLinesPerPage);
+#ifdef TESTING
+	help_publish_probes(state);
+#endif
+}
+} // namespace
+
+// PREV/NEXT visibility: hidden while the active tab fits one page (and for
+// the bare-sweep null state).
+og::ui::RowState help_engine_pager_row_state(
+    const og::ui::MenuLabelContext& /*context*/)
+{
+	const HelpScreenState* const state = g_help_screen_state;
+	return (state != nullptr && state->pager.multi_page())
+	    ? og::ui::RowState::Visible
+	    : og::ui::RowState::Hidden;
+}
+
+// Nav closure over the hidden pagers, re-asserted per frame over the static
+// base link (the VIEW LEVEL shape).
+void help_engine_rewire(button* buttons, int num_buttons,
+                        int& /*highlighted_button*/)
+{
+	if (num_buttons <= kHelpMenuBackIndex)
+		return;
+	const HelpScreenState* const state = g_help_screen_state;
+	const bool multi_page = state != nullptr && state->pager.multi_page();
+	buttons[kHelpMenuBackIndex].nav.right =
+	    multi_page ? kHelpMenuPrevIndex : -1;
+}
+
+// G3 generic row dispatch: the tab rows and pagers all carry
+// ButtonAction::MenuSpecRow (arg == spec ordinal), so mouse clicks, keyboard
+// FIRE, and the 1/2/3 + PageUp/PageDown hotkeys land here.
+Sint32 help_engine_on_spec_row(int row, void* /*screen_state*/)
+{
+	HelpScreenState* const state = g_help_screen_state;
+	if (state == nullptr)
+		return 0;
+	switch (row)
+	{
+	case kHelpMenuControlsTabIndex:
+		help_switch_tab(*state, HelpTab::Controls);
+		break;
+	case kHelpMenuClassesTabIndex:
+		help_switch_tab(*state, HelpTab::Classes);
+		break;
+	case kHelpMenuEditorTabIndex:
+		help_switch_tab(*state, HelpTab::Editor);
+		break;
+	case kHelpMenuPrevIndex:
+		(void)state->pager.step(-1);
+		break;
+	case kHelpMenuNextIndex:
+		(void)state->pager.step(1);
+		break;
+	default:
+		break;
+	}
+#ifdef TESTING
+	help_publish_probes(*state);
+#endif
+	return 0;
+}
+
+// Mouse wheel pages the active tab: the engine loop polls every ~10ms, so
+// one notch's accumulated delta maps to one page step.
+bool help_engine_frame_tick(void* /*screen_state*/, int /*frame*/)
+{
+	HelpScreenState* const state = g_help_screen_state;
+	if (state == nullptr)
+		return true;
+	const short scroll_delta = get_and_reset_scroll_amount();
+	if (scroll_delta < 0)
+		(void)state->pager.step(1);
+	else if (scroll_delta > 0)
+		(void)state->pager.step(-1);
+#ifdef TESTING
+	help_publish_probes(*state);
+#endif
+	return true;
+}
+
+// Content pass (after draw_buttons; every rect here stays outside the
+// button bands): active-tab underline, the framed page of text, and the
+// footer bar with the key hint, the version string — the ONLY build-version
+// surface on web — and the page indicator.
+void help_engine_draw_content(void* /*screen_state*/)
+{
+	const HelpScreenState* const state = g_help_screen_state;
+	if (state == nullptr)
+		return;
+	screen* const scr = og::runtime::current_session->myscreen_;
+	text& mytext = scr->text_normal;
+
+	// Active-tab underline in the 2px gap between the strip and the frame.
+	const int tab_x = kHelpTabX(static_cast<int>(state->tab));
+	scr->draw_text_bar(tab_x + 1, kHelpTabY + kHelpTabHeight + 1,
+	                   tab_x + kHelpTabWidth - 1, kHelpFrameTop - 1);
+
+	// Content frame and the current page of flowed text.
+	scr->draw_button(kHelpFrameLeft, kHelpFrameTop, kHelpFrameRight,
+	                 kHelpFrameBottom, 3, 1);
+	const int first_line = state->pager.first_index();
+	for (int line_index = first_line; line_index < state->pager.end_index();
+	     ++line_index)
+	{
+		mytext.write_xy(kHelpTextX,
+		                static_cast<short>(kHelpTextTop +
+		                    (line_index - first_line) * kHelpLinePitch),
+		                state->lines[static_cast<std::size_t>(line_index)].c_str(),
+		                static_cast<unsigned char>(DARK_BLUE), 1);
+	}
+
+	// Footer bar between BACK and the pagers.
+	scr->draw_text_bar(kHelpFooterBarLeft, kHelpFooterY, kHelpFooterBarRight,
+	                   kHelpFooterY + kHelpFooterHeight - 1);
+	mytext.write_xy(kHelpFooterTextX, kHelpFooterHintY,
+	                og::input::kWebBackKeyMode ? "1/2/3:Tab  BKSP:Exit"
+	                                           : "1/2/3:Tab  ESC:Exit",
+	                static_cast<unsigned char>(RED), 1);
+	const std::string version =
+	    std::format("GLADIATOR v{}", OPENGLAD_VERSION_STRING);
+	mytext.write_xy(kHelpFooterTextX, kHelpFooterVersionY, version.c_str(),
+	                static_cast<unsigned char>(RED), 1);
+	if (state->pager.multi_page())
+	{
+		const std::string indicator = state->pager.indicator();
+		mytext.write_xy(
+		    kHelpFooterBarRight - 1 - static_cast<int>(indicator.size()) * 6,
+		    kHelpFooterVersionY, indicator.c_str(),
+		    static_cast<unsigned char>(RED), 1);
+	}
+}
 
 Sint32 show_general_help()
 {
 	// Load help files from disk (only loads once)
 	load_help_files();
 
-	HelpTab current_tab = HelpTab::Controls;
-	TabContent current_content = get_tab_content(current_tab);
+	HelpScreenState state;
+	help_switch_tab(state, HelpTab::Controls, true);
 
-	// Flow each tab's lines to the 39-char frame budget (issue #152); the
-	// user-editable help files and the three over-budget Controls lines wrap
-	// instead of painting past the dialog bevel. HardBreaks preserves the
-	// tab's ASCII tables.
-	const auto flow_tab_lines = [](const TabContent& content) {
-		std::list<std::string> source;
-		for (int i = 0; i < content.num_lines; i++)
-			source.push_back(get_content_line(content, i));
-		return og::core::wrap_lines(source, help_char_budget(240));
-	};
-	std::vector<std::string> flowed_lines = flow_tab_lines(current_content);
+	og::runtime::current_session->myscreen_->clearbuffer();
+	// A wheel notch queued before entry must not page the first frame.
+	(void)get_and_reset_scroll_amount();
 
-	Sint32 screenlines = static_cast<Sint32>(flowed_lines.size()) * 8;
-	Sint32 j;
-	Sint32 linesdown;
-	Sint32 changed;
-	Sint32 templines;
-	KeyRepeat gh_page_down_key, gh_page_up_key;
+	g_help_screen_state = &state;
+	(void)og::ui::run_menu_screen(og::ui::help_menu_screen_spec(), &state);
+	g_help_screen_state = nullptr;
 
-	text& mytext = og::runtime::current_session->myscreen_->text_normal;
-	Sint32 bottomrow = (screenlines - ((DISPLAY_LINES-1)*8));
-	if (bottomrow < 0) bottomrow = 0;
+	og::runtime::current_session->myscreen_->clearbuffer();
 
-	// Lambda to update content when tab changes
-	auto switch_tab = [&](HelpTab new_tab) {
-		current_tab = new_tab;
-		current_content = get_tab_content(current_tab);
-		flowed_lines = flow_tab_lines(current_content);
-		screenlines = static_cast<Sint32>(flowed_lines.size()) * 8;
-		bottomrow = (screenlines - ((DISPLAY_LINES-1)*8));
-		if (bottomrow < 0) bottomrow = 0;
-		linesdown = 0;
-		changed = 1;
-	};
-
-	clear_keyboard();
-	linesdown = 0;
-	changed = 1;
-
-	// Track previous mouse state for click detection
-	bool prev_mouse_left = false;
-
-	// Key-state polling preserves held-key behavior. The key-event latch also
-	// catches a short Escape press (including the web Back-key remap) that begins
-	// and ends between two frames. Do not use input_continue here: ordinary
-	// mouse-down events set that shared modal latch too, including tab clicks.
-	while (!og::runtime::current_session->keystates_[KEYSTATE_ESCAPE] &&
-	       !(query_key_press_event() && query_key() == KEYCODE_ESCAPE))
-	{
-		YIELD_SLEEP(10);
-		get_input_events(POLL);
-
-		// Handle mouse clicks on tabs
-		MouseState& mymouse = query_mouse_no_poll();
-		bool mouse_clicked = mymouse.left && !prev_mouse_left;
-		prev_mouse_left = mymouse.left;
-
-			if (mouse_clicked)
-			{
-				const int mx = static_cast<int>(mymouse.x);
-				const int my = static_cast<int>(mymouse.y);
-
-			// Check if click is in tab area
-			if (my >= TAB_Y && my <= TAB_Y + TAB_HEIGHT)
-			{
-				for (int t = 0; t < static_cast<int>(HelpTab::NumTabs); t++)
-				{
-					int tab_x = TAB_START_X + t * (TAB_WIDTH + TAB_SPACING);
-					if (mx >= tab_x && mx <= tab_x + TAB_WIDTH)
-					{
-						if (static_cast<HelpTab>(t) != current_tab)
-						{
-							switch_tab(static_cast<HelpTab>(t));
-						}
-						break;
-					}
-				}
-			}
-		}
-
-		// Handle keyboard tab switching (1, 2, 3 keys)
-		static bool key1_was_pressed = false;
-		static bool key2_was_pressed = false;
-		static bool key3_was_pressed = false;
-
-		if (og::runtime::current_session->keystates_[KEYSTATE_1] && !key1_was_pressed && current_tab != HelpTab::Controls)
-		{
-			switch_tab(HelpTab::Controls);
-		}
-		key1_was_pressed = og::runtime::current_session->keystates_[KEYSTATE_1];
-
-		if (og::runtime::current_session->keystates_[KEYSTATE_2] && !key2_was_pressed && current_tab != HelpTab::Classes)
-		{
-			switch_tab(HelpTab::Classes);
-		}
-		key2_was_pressed = og::runtime::current_session->keystates_[KEYSTATE_2];
-
-		if (og::runtime::current_session->keystates_[KEYSTATE_3] && !key3_was_pressed && current_tab != HelpTab::Editor)
-		{
-			switch_tab(HelpTab::Editor);
-		}
-		key3_was_pressed = og::runtime::current_session->keystates_[KEYSTATE_3];
-
-		short scroll_delta = get_and_reset_scroll_amount();
-		if (scroll_delta < 0 && linesdown < bottomrow)
-		{
-			while(linesdown < bottomrow && scroll_delta != 0)
-			{
-				linesdown++;
-				scroll_delta++;
-			}
-			changed = 1;
-		}
-
-		bool gh_page_down_held =
-			og::runtime::current_session->keystates_[KEYSTATE_PAGEDOWN];
-		bool gh_page_up_held =
-			og::runtime::current_session->keystates_[KEYSTATE_PAGEUP];
-#ifdef TESTING
-		gh_page_down_held = gh_page_down_held ||
-			s_help_test_page_down.load(std::memory_order_acquire);
-		gh_page_up_held = gh_page_up_held ||
-			s_help_test_page_up.load(std::memory_order_acquire);
-#endif
-		// Edge-triggered with hold-repeat (issue #156): the old phase-modulo
-		// gate swallowed short PageUp/PageDown taps here too.
-		if (key_repeat_fired(gh_page_down_key, gh_page_down_held,
-		                     query_timer(), kKeyFirstDelayTicks,
-		                     kPageRepeatTicks) &&
-		    linesdown < bottomrow)
-		{
-			templines = linesdown + (DISPLAY_LINES * 7);
-			if (templines > bottomrow)
-				templines = bottomrow;
-			if (linesdown != templines)
-			{
-				linesdown = templines;
-				changed = 1;
-			}
-		}
-
-		if (scroll_delta > 0 && linesdown)
-		{
-			while(linesdown && scroll_delta != 0)
-			{
-				linesdown--;
-				scroll_delta--;
-			}
-			changed = 1;
-		}
-
-		if (key_repeat_fired(gh_page_up_key, gh_page_up_held, query_timer(),
-		                     kKeyFirstDelayTicks, kPageRepeatTicks) &&
-		    linesdown)
-		{
-			linesdown -= (DISPLAY_LINES * 7);
-			if (linesdown < 0)
-				linesdown = 0;
-			changed = 1;
-		}
-
-		if (changed)
-		{
-			templines = linesdown/8;
-
-			// Calculate content area dimensions
-			int content_text_top = CONTENT_TOP + 8;  // Where text starts (after title bar)
-			int content_bottom = content_text_top + (DISPLAY_LINES * 7) + 10;
-
-			// Draw the main dialog background (covers everything)
-			og::runtime::current_session->myscreen_->draw_button(HELPTEXT_LEFT-4, TAB_Y-4,
-			                      HELPTEXT_LEFT+240, content_bottom + 8, 3, 1);
-
-			// Draw tabs
-			for (int t = 0; t < static_cast<int>(HelpTab::NumTabs); t++)
-			{
-				int tab_x = TAB_START_X + t * (TAB_WIDTH + TAB_SPACING);
-
-				// Draw tab button
-				og::runtime::current_session->myscreen_->draw_button(tab_x, TAB_Y, tab_x + TAB_WIDTH, TAB_Y + TAB_HEIGHT, 1, 1);
-
-				// Highlight selected tab by drawing over bottom edge
-				if (static_cast<HelpTab>(t) == current_tab)
-				{
-					og::runtime::current_session->myscreen_->draw_text_bar(tab_x + 1, TAB_Y + TAB_HEIGHT - 1,
-					                        tab_x + TAB_WIDTH - 1, TAB_Y + TAB_HEIGHT);
-				}
-
-				// Draw tab label
-				int label_len = static_cast<int>(strlen(tab_names[t]));
-				int label_x = tab_x + (TAB_WIDTH - label_len * 6) / 2;
-				mytext.write_xy(label_x, TAB_Y + 3, tab_names[t],
-				                (static_cast<HelpTab>(t) == current_tab) ? static_cast<unsigned char>(DARK_BLUE) : static_cast<unsigned char>(BLACK), 1);
-			}
-
-			// Draw content area (below tabs)
-			og::runtime::current_session->myscreen_->draw_button(HELPTEXT_LEFT-4, CONTENT_TOP,
-			                      HELPTEXT_LEFT+240, content_bottom + 8, 3, 1);
-
-			// Draw content text
-			for (j=0; j < DISPLAY_LINES; j++)
-			{
-				int line_idx = j + templines;
-				if (line_idx >= 0 &&
-				    line_idx < static_cast<int>(flowed_lines.size()))
-				{
-					int text_y = content_text_top + (j * 7) - (linesdown % 8);
-					mytext.write_xy(HELPTEXT_LEFT+2, static_cast<short>(text_y),
-					                flowed_lines[static_cast<std::size_t>(line_idx)].c_str(),
-					                static_cast<unsigned char>(DARK_BLUE), 1);
-				}
-			}
-
-			// Draw title bar (top of content area)
-			og::runtime::current_session->myscreen_->draw_text_bar(HELPTEXT_LEFT, CONTENT_TOP,
-			                        HELPTEXT_LEFT+240-4, CONTENT_TOP + 6);
-			std::string title = std::format("GLADIATOR v{}", OPENGLAD_VERSION_STRING);
-			mytext.write_xy(HELPTEXT_LEFT+60, CONTENT_TOP + 1, title.c_str(), static_cast<unsigned char>(RED), 1);
-
-			// Draw footer bar (bottom of content area)
-			og::runtime::current_session->myscreen_->draw_text_bar(HELPTEXT_LEFT, content_bottom,
-			                        HELPTEXT_LEFT+240-4, content_bottom + 6);
-			mytext.write_xy(HELPTEXT_LEFT+30, content_bottom + 1,
-			                og::input::kWebBackKeyMode
-			                    ? "1/2/3:Tab  BKSP:Exit"
-			                    : "1/2/3:Tab  ESC:Exit",
-			                static_cast<unsigned char>(RED), 1);
-
-			og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
-			changed = 0;
-		}
-	}
-
+	// Drain a still-held Escape: the re-entered main menu's QUIT row carries
+	// KEYSTATE_ESCAPE and would consume the same press.
 	while (og::runtime::current_session->keystates_[KEYSTATE_ESCAPE])
 	{
 		YIELD_SLEEP(1);

--- a/src/interface/ui/help.cpp
+++ b/src/interface/ui/help.cpp
@@ -437,9 +437,13 @@ short read_scenario(screen *s)
 		[&](int idx) { return s->get_level_description_line(idx); });
 }
 
-short read_campaign_intro(screen *s)
+// The intro-style scroller over one campaign's full description. Shared by
+// read_campaign_intro and the campaign browser's MORE control (which passes
+// the highlighted — not necessarily current — campaign id).
+static short scroll_campaign_description(screen *s,
+	const std::string& campaign_id)
 {
-	CampaignData data(s->save_data.current_campaign);
+	CampaignData data(campaign_id);
 	if (!data.load())
 		return 1;
 
@@ -448,6 +452,22 @@ short read_campaign_intro(screen *s)
 		static_cast<int>(data.description.size()), 240,
 		data.title.c_str(), HELPTEXT_LEFT-4, HELPTEXT_TOP-4-8, 244, 119,
 		[&](int idx) { return data.getDescriptionLine(idx); });
+}
+
+short show_campaign_description(screen *scr, const std::string& campaign_id)
+{
+#ifdef TESTING
+	// Same guard as read_scenario: the viewer blocks on input, so test flows
+	// that click MORE must not hang unless a test opts into the real view.
+	if (!help_testing_force_scroll_text())
+		return 1;
+#endif
+	return scroll_campaign_description(scr, campaign_id);
+}
+
+short read_campaign_intro(screen *s)
+{
+	return scroll_campaign_description(s, s->save_data.current_campaign);
 }
 
 

--- a/src/interface/ui/help.cpp
+++ b/src/interface/ui/help.cpp
@@ -32,6 +32,7 @@
 #include <openglad/interface/web_back_key.h>
 #include <openglad/interface/web_control_defaults.h>
 #include <openglad/interface/base.h>
+#include <openglad/interface/button.h>
 #include <openglad/interface/ui/scroll_view_layout.h>
 #include <openglad/resources/og_file.h>
 #include <openglad/interface/screen.h>
@@ -837,10 +838,10 @@ bool help_engine_frame_tick(void* /*screen_state*/, int /*frame*/)
 	return true;
 }
 
-// Content pass (after draw_buttons; every rect here stays outside the
-// button bands): active-tab underline, the framed page of text, and the
-// footer bar with the key hint, the version string — the ONLY build-version
-// surface on web — and the page indicator.
+// Content pass (after draw_buttons): the framed page of text with the active
+// tab merged into its top edge, and the footer bar with the key hint, the
+// version string — the ONLY build-version surface on web — and the page
+// indicator.
 void help_engine_draw_content(void* /*screen_state*/)
 {
 	const HelpScreenState* const state = g_help_screen_state;
@@ -849,14 +850,25 @@ void help_engine_draw_content(void* /*screen_state*/)
 	screen* const scr = og::runtime::current_session->myscreen_;
 	text& mytext = scr->text_normal;
 
-	// Active-tab underline in the 2px gap between the strip and the frame.
-	const int tab_x = kHelpTabX(static_cast<int>(state->tab));
-	scr->draw_text_bar(tab_x + 1, kHelpTabY + kHelpTabHeight + 1,
-	                   tab_x + kHelpTabWidth - 1, kHelpFrameTop - 1);
-
 	// Content frame and the current page of flowed text.
 	scr->draw_button(kHelpFrameLeft, kHelpFrameTop, kHelpFrameRight,
-	                 kHelpFrameBottom, 3, 1);
+	                 kHelpFrameBottom, kHelpFrameBorder, 1);
+
+	// Folder-tab merge: repaint the connector band in the button colors so the
+	// active tab and the frame read as one surface. The face fill erases the
+	// tab's bottom bevel and the frame's top bevel over the tab's interior,
+	// and the two edge columns carry the tab's own side bevels down to where
+	// the frame's face begins. Buttons are drawn before the content pass, so
+	// covering both edges here is legitimate. Inactive tabs keep the plain gap.
+	const int tab_x = kHelpTabX(static_cast<int>(state->tab));
+	const int connector_h = kHelpConnectorBottom - kHelpConnectorTop + 1;
+	scr->fastbox(tab_x + 1, kHelpConnectorTop, kHelpTabWidth - 2, connector_h,
+	             static_cast<unsigned char>(BUTTON_FACING));
+	scr->fastbox(tab_x, kHelpConnectorTop, 1, connector_h,
+	             static_cast<unsigned char>(BUTTON_LEFT));
+	scr->fastbox(tab_x + kHelpTabWidth - 1, kHelpConnectorTop, 1, connector_h,
+	             static_cast<unsigned char>(BUTTON_RIGHT));
+
 	const int first_line = state->pager.first_index();
 	for (int line_index = first_line; line_index < state->pager.end_index();
 	     ++line_index)

--- a/src/interface/ui/level_picker.cpp
+++ b/src/interface/ui/level_picker.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <openglad/interface/ui/level_picker.h>
+#include <openglad/interface/ui/picker_common.h>
 #include <openglad/interface/level_runtime_data.h>
 #include <openglad/resources/level_data_hooks.h>
 #include <openglad/interface/render/radar.h>
@@ -271,7 +272,7 @@ bool sort_scen(const std::string& first, const std::string& second)
 class BrowserEntry
 {
     public:
-    
+
     LevelRuntimeData level_data;
     UiRect mapAreas;
     radar myradar;
@@ -280,13 +281,15 @@ class BrowserEntry
     float average_enemy_level;
     int num_enemies;
     float difficulty;
+    bool is_cleared;               // PROGRESS-report derivation (issue #186)
+    bool is_current;
     std::list<int> exits;
     std::array<std::string, 80> scentext;           // Array to hold scenario information
     int scentextlines = 0;                 // How many lines of text in scenario info
-    
+
     BrowserEntry(screen* screenp, int index, int scen_num);
     ~BrowserEntry();
-    
+
     void updateIndex(int index);
     void draw(screen* screenp);
 };
@@ -296,31 +299,33 @@ BrowserEntry::BrowserEntry(screen* screenp, int index, int scen_num)
 {
 	(void)screenp;
 	    level_data.load();
-    
-    myradar.start(&level_data);
-    
 
+    myradar.start(&level_data);
+
+	    const og::ui::LevelPickerLayout layout = og::ui::level_picker_layout();
 	    const int w = myradar.xview;
 	    const int h = myradar.yview;
-    
+
     mapAreas.w = w;
     mapAreas.h = h;
-    mapAreas.x = 10;
-    mapAreas.y = 5 + (53 + 12)*index;
-    
-	    myradar.xloc = static_cast<short>(mapAreas.x + mapAreas.w/2 - w/2);
-	    myradar.yloc = static_cast<short>(mapAreas.y + 10);
-    
-    
+    mapAreas.x = layout.row_x;
+    mapAreas.y = og::ui::level_picker_row_y(index);
+
+	    myradar.xloc = static_cast<short>(mapAreas.x);
+	    myradar.yloc = static_cast<short>(mapAreas.y + layout.radar_dy);
+
+
     getLevelStats(level_data, &max_enemy_level, &average_enemy_level, &num_enemies, &difficulty, exits);
-    
+
+    // Status markers, derived exactly as the PROGRESS report derives them.
+    const SaveData& save = og::runtime::current_session->myscreen_->save_data;
+    is_cleared = save.is_level_completed(scen_num);
+    is_current = (scen_num == save.scen_num);
+
     // Store this level's info
-    level_name = level_data.world().title;
-    if(level_name.size() > 20)
-    {
-        level_name = level_name.substr(0, 20) + "...";
-    }
-    
+    level_name = og::ui::fit_text_to_chars(level_data.world().title,
+                                           layout.title_max_chars + 3);
+
 	    scentextlines = static_cast<int>(std::min<size_t>(level_data.description.size(), 80u));
     int i = 0;
     for(auto& line : level_data.description)
@@ -337,16 +342,16 @@ BrowserEntry::~BrowserEntry() = default;
 
 void BrowserEntry::updateIndex(int index)
 {
-	    const int w = myradar.xview;
-	    mapAreas.y = 5 + (53 + 12)*index;
-	    
-	    myradar.xloc = static_cast<short>(mapAreas.x + mapAreas.w/2 - w/2);
-	    myradar.yloc = static_cast<short>(mapAreas.y + 10);
+	    mapAreas.y = og::ui::level_picker_row_y(index);
+
+	    myradar.xloc = static_cast<short>(mapAreas.x);
+	    myradar.yloc = static_cast<short>(mapAreas.y + og::ui::level_picker_layout().radar_dy);
 }
 
 void BrowserEntry::draw(screen* screenp)
 {
 	(void)screenp;
+	    const og::ui::LevelPickerLayout layout = og::ui::level_picker_layout();
 	    int x = myradar.xloc;
 	    int y = myradar.yloc;
     int w = myradar.xview;
@@ -354,20 +359,29 @@ void BrowserEntry::draw(screen* screenp)
     og::runtime::current_session->myscreen_->draw_button(x - 2, y - 2, x + w + 2, y + h + 2, 1, 1);
     // Draw radar
     myradar.draw(&level_data);
-    
+
     text& loadtext = og::runtime::current_session->myscreen_->text_normal;
     loadtext.write_xy(mapAreas.x, mapAreas.y, level_name.c_str(), DARK_BLUE, 1);
-    
+
+    // CLEARED/CURRENT column on the title line (PROGRESS's colors).
+    const char* status = og::ui::level_row_status_label(is_cleared, is_current);
+    if(status[0] != '\0')
+        loadtext.write_xy(layout.status_x, mapAreas.y, status,
+                          is_cleared ? DARK_GREEN : YELLOW, 1);
+
+    // Stats share one column (layout.stats_x) regardless of this row's
+    // radar width, so the three rows read as a grid.
+    const int stats_x = layout.stats_x;
     std::string buf = std::format("ID: {}", level_data.world().id);
-    loadtext.write_xy(x + w + 5, y, buf.c_str(), WHITE, 1);
+    loadtext.write_xy(stats_x, y, buf.c_str(), WHITE, 1);
     buf = std::format("Enemies: {}", num_enemies);
-    loadtext.write_xy(x + w + 5, y + 8, buf.c_str(), WHITE, 1);
+    loadtext.write_xy(stats_x, y + 8, buf.c_str(), WHITE, 1);
     buf = std::format("Max level: {}", max_enemy_level);
-    loadtext.write_xy(x + w + 5, y + 16, buf.c_str(), WHITE, 1);
+    loadtext.write_xy(stats_x, y + 16, buf.c_str(), WHITE, 1);
     buf = std::format("Avg level: {:.1f}", average_enemy_level);
-    loadtext.write_xy(x + w + 5, y + 24, buf.c_str(), WHITE, 1);
+    loadtext.write_xy(stats_x, y + 24, buf.c_str(), WHITE, 1);
     buf = std::format("Difficulty: {:.0f}", difficulty);
-    loadtext.write_xy(x + w + 5, y + 32, buf.c_str(), RED, 1);
+    loadtext.write_xy(stats_x, y + 32, buf.c_str(), RED, 1);
 
     if(exits.size() > 0)
     {
@@ -379,9 +393,8 @@ void BrowserEntry::draw(screen* screenp)
             exits_str += std::to_string(exit_level);
             first = false;
         }
-        if(exits_str.size() > 20)
-            exits_str = exits_str.substr(0, 17) + "...";
-        loadtext.write_xy(x + w + 5, y + 40, exits_str.c_str(), WHITE, 1);
+        exits_str = og::ui::fit_text_to_chars(exits_str, layout.stats_max_chars);
+        loadtext.write_xy(stats_x, y + 40, exits_str.c_str(), WHITE, 1);
     }
 }
 
@@ -442,22 +455,22 @@ int pick_level(screen *screenp, int default_level, bool enable_delete)
 		}
 	}
     
-    // Buttons
-    int screenW = 320;
-    int screenH = 200;
-    UiRect prev = {screenW - 150, 20, 30, 10};
-    UiRect next = {screenW - 150, screenH - 50, 30, 10};
-    UiRect descbox = {prev.x - 40, prev.y + 15, 185, next.y - 10 - (prev.y + prev.h)};
-    
-    UiRect choose = {screenW - 50, screenH - 30, 30, 10};
-    UiRect cancel = {screenW - 100, screenH - 30, 38, 10};
-    UiRect delete_button = {screenW - 50, 10, 38, 10};
-    UiRect id_button = {delete_button.x - 52 - 10, 10, 52, 10};
-    
+    // Buttons (geometry single-sourced in picker_common so the pure layout
+    // pins keep the previews on screen and the desc box off the stats).
+    const og::ui::LevelPickerLayout layout = og::ui::level_picker_layout();
+    const UiRect prev = {layout.prev.x, layout.prev.y, layout.prev.w, layout.prev.h};
+    const UiRect next = {layout.next.x, layout.next.y, layout.next.w, layout.next.h};
+    const UiRect descbox = {layout.desc_box.x, layout.desc_box.y, layout.desc_box.w, layout.desc_box.h};
+
+    const UiRect choose = {layout.choose.x, layout.choose.y, layout.choose.w, layout.choose.h};
+    const UiRect cancel = {layout.cancel.x, layout.cancel.y, layout.cancel.w, layout.cancel.h};
+    const UiRect delete_button = {layout.delete_button.x, layout.delete_button.y, layout.delete_button.w, layout.delete_button.h};
+    const UiRect id_button = {layout.id_button.x, layout.id_button.y, layout.id_button.w, layout.id_button.h};
+
     // Controller input
     int retvalue = 0;
 	int highlighted_button = 3;
-	
+
 	int prev_index = 0;
 	int next_index = 1;
 	int choose_index = 2;
@@ -467,7 +480,7 @@ int pick_level(screen *screenp, int default_level, bool enable_delete)
 	int entry1_index = 6;
 	int entry2_index = 7;
 	int entry3_index = 8;
-	
+
 	button buttons[] = {
         button("prev", "PREV", KEYSTATE_UNKNOWN, prev.x, prev.y, prev.w, prev.h, 0, -1 , MenuNav{.down=next_index, .left=entry1_index, .right=id_index}),
         button("next", "NEXT", KEYSTATE_UNKNOWN, next.x, next.y, next.w, next.h, 0, -1 , MenuNav{.up=prev_index, .left=entry3_index, .right=cancel_index}),
@@ -475,9 +488,9 @@ int pick_level(screen *screenp, int default_level, bool enable_delete)
         button("cancel", "CANCEL", KEYSTATE_ESCAPE, cancel.x, cancel.y, cancel.w, cancel.h, 0, -1 , MenuNav{.up=id_index, .left=next_index, .right=choose_index}),
         button("delete", "DELETE", KEYSTATE_UNKNOWN, delete_button.x, delete_button.y, delete_button.w, delete_button.h, 0, -1 , MenuNav{.down=choose_index, .left=id_index}, true),
         button("enter_id", "ENTER ID", KEYSTATE_UNKNOWN, id_button.x, id_button.y, id_button.w, id_button.h, 0, -1 , MenuNav{.down=cancel_index, .left=prev_index, .right=delete_index}),
-        button("entry_1", "1", KEYSTATE_UNKNOWN, 10, 15, 40, (53 - 12), 0, -1 , MenuNav{.down=entry2_index, .right=prev_index}),
-        button("entry_2", "2", KEYSTATE_UNKNOWN, 10, 15 + (53 + 12), 40, (53 - 12), 0, -1 , MenuNav{.up=entry1_index, .down=entry3_index, .right=next_index}),
-        button("entry_3", "3", KEYSTATE_UNKNOWN, 10, 15 + (53 + 12)*2, 40, (53 - 12), 0, -1 , MenuNav{.up=entry2_index, .right=next_index}),
+        button("entry_1", "1", KEYSTATE_UNKNOWN, layout.row_x, og::ui::level_picker_row_y(0) + layout.radar_dy, 40, layout.radar_max_h, 0, -1 , MenuNav{.down=entry2_index, .right=prev_index}),
+        button("entry_2", "2", KEYSTATE_UNKNOWN, layout.row_x, og::ui::level_picker_row_y(1) + layout.radar_dy, 40, layout.radar_max_h, 0, -1 , MenuNav{.up=entry1_index, .down=entry3_index, .right=next_index}),
+        button("entry_3", "3", KEYSTATE_UNKNOWN, layout.row_x, og::ui::level_picker_row_y(2) + layout.radar_dy, 40, layout.radar_max_h, 0, -1 , MenuNav{.up=entry2_index, .right=next_index}),
 
 	};
     
@@ -705,10 +718,10 @@ int pick_level(screen *screenp, int default_level, bool enable_delete)
         
         // Draw
         og::runtime::current_session->myscreen_->clearbuffer();
-        
+
         std::string buf = std::format("Army power: {}", army_power);
-        loadtext.write_xy(prev.x + 50, prev.y + 2, buf.c_str(), RED, 1);
-        
+        loadtext.write_xy(layout.army_x, layout.army_y, buf.c_str(), RED, 1);
+
         og::runtime::current_session->myscreen_->draw_button(prev.x, prev.y, prev.x + prev.w, prev.y + prev.h, 1, 1);
         loadtext.write_xy(prev.x + 2, prev.y + 2, "Prev", DARK_BLUE, 1);
         og::runtime::current_session->myscreen_->draw_button(next.x, next.y, next.x + next.w, next.y + next.h, 1, 1);
@@ -717,7 +730,6 @@ int pick_level(screen *screenp, int default_level, bool enable_delete)
         {
             og::runtime::current_session->myscreen_->draw_button(choose.x, choose.y, choose.x + choose.w, choose.y + choose.h, 1, 1);
             loadtext.write_xy(choose.x + 9, choose.y + 2, "OK", DARK_GREEN, 1);
-            loadtext.write_xy(next.x, choose.y + 20, entries[static_cast<std::size_t>(selected_entry)]->level_name.c_str(), DARK_GREEN, 1);
         }
         og::runtime::current_session->myscreen_->draw_button(cancel.x, cancel.y, cancel.x + cancel.w, cancel.y + cancel.h, 1, 1);
         loadtext.write_xy(cancel.x + 2, cancel.y + 2, "Cancel", RED, 1);
@@ -726,10 +738,35 @@ int pick_level(screen *screenp, int default_level, bool enable_delete)
             og::runtime::current_session->myscreen_->draw_button(delete_button.x, delete_button.y, delete_button.x + delete_button.w, delete_button.y + delete_button.h, 1, 1);
             loadtext.write_xy(delete_button.x + 2, delete_button.y + 2, "Delete", RED, 1);
         }
-        
+
         og::runtime::current_session->myscreen_->draw_button(id_button.x, id_button.y, id_button.x + id_button.w, id_button.y + id_button.h, 1, 1);
         loadtext.write_xy(id_button.x + 2, id_button.y + 2, "Enter ID", DARK_BLUE, 1);
-        
+
+        // Description first, then the preview rows: the box's rect no longer
+        // reaches the stats column, and painting it before the entries keeps
+        // it from overprinting them even if one drifts.
+        if(selected_entry != -1 && selected_entry < level_list_length && entries[static_cast<std::size_t>(selected_entry)] != nullptr)
+        {
+            // Flowed to the box's character budget (issue #152): scenario
+            // briefings are authored for the 33-char SCENARIO INFORMATION
+            // dialog and overflow this box without wrapping.
+            og::runtime::current_session->myscreen_->draw_box(descbox.x, descbox.y, descbox.x + descbox.w, descbox.y + descbox.h, GREY, 1, 1);
+            std::list<std::string> raw_desc;
+            for(int i = 0; i < entries[static_cast<std::size_t>(selected_entry)]->scentextlines; i++)
+                raw_desc.push_back(entries[static_cast<std::size_t>(selected_entry)]->scentext[static_cast<std::size_t>(i)]);
+            const std::vector<std::string> desc_lines =
+                og::core::wrap_lines(raw_desc, layout.desc_max_chars);
+            for(std::size_t i = 0; i < desc_lines.size(); i++)
+            {
+                // Clip against the box the text is drawn into (the old test
+                // compared against prev.y + 20, 5px below the box top).
+                const int line_y = 10*static_cast<int>(i) + 1;
+                if(line_y + 6 > descbox.h)
+                    break;
+                loadtext.write_xy(descbox.x + 2, descbox.y + line_y, desc_lines[i].c_str(), BLACK, 1);
+            }
+        }
+
         if(selected_entry != -1)
         {
             int i = selected_entry;
@@ -747,30 +784,7 @@ int pick_level(screen *screenp, int default_level, bool enable_delete)
             if(i < level_list_length && entries[static_cast<std::size_t>(i)] != nullptr)
                 entries[static_cast<std::size_t>(i)]->draw(og::runtime::current_session->myscreen_);
         }
-        
-        // Description, flowed to the box's character budget (issue #152):
-        // scenario briefings are authored for the 33-char SCENARIO
-        // INFORMATION dialog and overflow this 30-char box without wrapping.
-        if(selected_entry != -1 && selected_entry < level_list_length && entries[static_cast<std::size_t>(selected_entry)] != nullptr)
-        {
-            og::runtime::current_session->myscreen_->draw_box(descbox.x, descbox.y, descbox.x + descbox.w, descbox.y + descbox.h, GREY, 1, 1);
-            std::list<std::string> raw_desc;
-            for(int i = 0; i < entries[static_cast<std::size_t>(selected_entry)]->scentextlines; i++)
-                raw_desc.push_back(entries[static_cast<std::size_t>(selected_entry)]->scentext[static_cast<std::size_t>(i)]);
-            const std::vector<std::string> desc_lines =
-                og::core::wrap_lines(raw_desc, descbox.w / 6);
-            for(std::size_t i = 0; i < desc_lines.size(); i++)
-            {
-                // Clip against the box the text is drawn into (the old test
-                // compared against prev.y + 20, 5px below the box top).
-                const int line_y = 10*static_cast<int>(i) + 1;
-                if(line_y + 6 > descbox.h)
-                    break;
-                loadtext.write_xy(descbox.x, descbox.y + line_y, desc_lines[i].c_str(), BLACK, 1);
-            }
-        }
-        
-        
+
         draw_highlight(buttons[highlighted_button]);
 		og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
 		og::input_native::sleep_ms(10);

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -268,6 +268,9 @@ constexpr MenuBuildVariant kCompiledBuildVariant =
     MenuBuildVariant::Native;
 #endif
 
+// One-shot: set by the post-game teardown, consumed by the next screen.
+bool g_suppress_entry_fade_out = false;
+
 bool spec_row_survives_build(const MenuButtonSpec& row, MenuBuildVariant variant)
 {
     switch (row.build) {
@@ -282,6 +285,18 @@ bool spec_row_survives_build(const MenuButtonSpec& row, MenuBuildVariant variant
 }
 
 } // namespace
+
+void suppress_next_menu_entry_fade_out()
+{
+    g_suppress_entry_fade_out = true;
+}
+
+bool consume_suppressed_menu_entry_fade_out()
+{
+    const bool suppressed = g_suppress_entry_fade_out;
+    g_suppress_entry_fade_out = false;
+    return suppressed;
+}
 
 #ifdef TESTING
 void picker_testing_draw_menu_highlight(const MenuScreenSpec& spec,
@@ -336,6 +351,10 @@ void materialize_menu_buttons(const MenuScreenSpec& spec,
 
 Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
 {
+    // Consumed unconditionally: the flag is a hand-off from the screen that
+    // ran last, so whichever screen opens next must clear it even when it
+    // does not fade around its entry.
+    const bool skip_entry_fade_out = consume_suppressed_menu_entry_fade_out();
     // Sequence the D3 accessors: buttons() fills the vector count() reads.
     button* buttons = spec.buttons_accessor();
     const int num_buttons = spec.count_accessor();
@@ -381,7 +400,11 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
         // deploy X is a button, and splitting them across the fade makes the
         // control pop in as the first full frame replaces the partial one.
         screen* scr = og::runtime::current_session->myscreen_;
-        scr->fadeblack(0);
+        // ...unless the post-game teardown already faded to black (#200): the
+        // fade-out would run over the stale menu image the UI canvas still
+        // holds and play the same transition a second time.
+        if (!skip_entry_fade_out)
+            scr->fadeblack(0);
         if (spec.backdrop)
             draw_backdrop();
         if (spec.draw_background != nullptr)

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -1826,6 +1826,13 @@ constexpr int kBaseCampFamilySwatchHeight = 8;
 // One seat-card table: the button specs and the chip overlay both index it.
 constexpr int kBaseCampSeatCardWidth = 57;
 constexpr int kBaseCampSeatCardPitch = 58;  // card face + 1px focus gutter
+// The 8x8 numbered team chip drawn on each card's right end, and the #202
+// pointer zone that cycles it in place: the chip plus 2px of grace on its
+// left, running to the card's right edge. Pointer clicks inside the zone
+// cycle the seat's team; the rest of the card (and every coordinate-free
+// activation) opens the seat editor.
+constexpr int kBaseCampSeatChipOffsetX = 48;
+constexpr int kBaseCampSeatChipZoneOffsetX = kBaseCampSeatChipOffsetX - 2;
 constexpr int kBaseCampSeatCardX0 = 54;
 constexpr std::array<int, kBaseCampSeatCardsPerPage> kBaseCampSeatCardX{
     kBaseCampSeatCardX0, kBaseCampSeatCardX0 + kBaseCampSeatCardPitch,
@@ -2664,6 +2671,39 @@ void persist_player_controls()
     cfg.save_settings();
 }
 
+// The ONE seat-team mutation path (#202): the seat editor's TEAM row and
+// the base-camp card's chip zone cycle through the same selectable-team
+// sequence, issue the same lobby request (which carries the sync /
+// ready-withdraw side effects), pop the same denial, and write the same
+// trace.
+Sint32 base_camp_cycle_seat_team(const og::sim::LobbyPlayer& player)
+{
+    const SaveData& save =
+        og::runtime::current_session->myscreen_->save_data;
+    const std::vector<short> teams =
+        base_camp_selectable_seat_teams(save);
+    if (teams.empty())
+        return MENU_OK;
+    const auto current =
+        std::find(teams.begin(), teams.end(), player.team);
+    const short next_team = current == teams.end()
+        ? teams.front()
+        : teams[(static_cast<std::size_t>(
+                      std::distance(teams.begin(), current)) +
+                  1) %
+                teams.size()];
+    if (!picker_lobby_request_seat_team_change(
+            player.player_index, player.seat_id, next_team))
+    {
+        popup_dialog("TEAM", "CHANGE DENIED");
+        return MENU_OK;
+    }
+    TRACE("basecamp", "seat_team player=%d team=%d",
+          static_cast<int>(player.player_index) + 1,
+          static_cast<int>(next_team) + 1);
+    return MENU_OK;
+}
+
 Sint32 seat_settings_on_spec_row(int row, void* screen_state)
 {
     auto* const state =
@@ -2675,32 +2715,8 @@ Sint32 seat_settings_on_spec_row(int row, void* screen_state)
     if (!resolve_seat_settings_player(*state, player))
         return MENU_REDRAW;
 
-    if (row == kSeatSettingsTeamIndex) {
-        const SaveData& save =
-            og::runtime::current_session->myscreen_->save_data;
-        const std::vector<short> teams =
-            base_camp_selectable_seat_teams(save);
-        if (teams.empty())
-            return MENU_OK;
-        const auto current =
-            std::find(teams.begin(), teams.end(), player.team);
-        const short next_team = current == teams.end()
-            ? teams.front()
-            : teams[(static_cast<std::size_t>(
-                          std::distance(teams.begin(), current)) +
-                      1) %
-                    teams.size()];
-        if (!picker_lobby_request_seat_team_change(
-                player.player_index, player.seat_id, next_team))
-        {
-            popup_dialog("TEAM", "CHANGE DENIED");
-            return MENU_OK;
-        }
-        TRACE("basecamp", "seat_team player=%d team=%d",
-              static_cast<int>(player.player_index) + 1,
-              static_cast<int>(next_team) + 1);
-        return MENU_OK;
-    }
+    if (row == kSeatSettingsTeamIndex)
+        return base_camp_cycle_seat_team(player);
 
     if (row == kSeatSettingsModeIndex) {
         (void)toggle_player_control_mode(state->local_slot);
@@ -3346,7 +3362,8 @@ void base_camp_draw_content(void* screen_state)
                 static_cast<int>(seat.team), 0,
                 static_cast<int>(SCORE_TEAM_COUNT) - 1);
             const int chip_x =
-                kBaseCampSeatCardX[static_cast<std::size_t>(card)] + 48;
+                kBaseCampSeatCardX[static_cast<std::size_t>(card)] +
+                kBaseCampSeatChipOffsetX;
             game->fastbox(chip_x, kBaseCampSeatRailY + 1, 8, 8, PURE_BLACK);
             game->fastbox(
                 chip_x + 1, kBaseCampSeatRailY + 2, 6, 6,
@@ -3621,6 +3638,27 @@ Sint32 base_camp_on_spec_row(int row, void* screen_state)
         if (picker_lobby_local_seat_count() == 0) {
             popup_dialog("SPECTATOR", "PRESS + TO ADD A PLAYER");
             return MENU_OK;
+        }
+
+        // #202: a pointer click on the card's team-square region cycles the
+        // seat's team in place through the seat editor's exact mutation
+        // path. Keyboard FIRE / hotkey dispatches stamp menu_click_x = -1
+        // and fall through to the editor, as do clicks on the P#/name
+        // region. Non-editable seats never reach here (the ownership and
+        // spectator gates above popped already).
+        {
+            const int card_x =
+                kBaseCampSeatCardX[static_cast<std::size_t>(card)];
+            const int click_x = pks().menu_click_x;
+            if (click_x >= card_x + kBaseCampSeatChipZoneOffsetX &&
+                click_x < card_x + kBaseCampSeatCardWidth)
+            {
+                const Sint32 chip_ret = base_camp_cycle_seat_team(seat);
+                // Same-frame chip digit: the card overlay draws from
+                // st->seats, so re-collect before this frame's content pass.
+                base_camp_refresh_rows(*st);
+                return chip_ret;
+            }
         }
 
         const Sint32 ret = run_seat_settings_menu(seat, local_slot);

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -132,6 +132,14 @@ void picker_view_scenario_engine_rewire(button* buttons, int num_buttons,
 Sint32 picker_view_scenario_engine_consume_click(Sint32 retvalue,
                                                  void* screen_state);
 void picker_view_scenario_engine_draw_content(void* screen_state);
+// HELP engine hooks (#168; defined beside the tab content in help.cpp).
+og::ui::RowState help_engine_pager_row_state(
+    const og::ui::MenuLabelContext& context);
+void help_engine_rewire(button* buttons, int num_buttons,
+                        int& highlighted_button);
+Sint32 help_engine_on_spec_row(int row, void* screen_state);
+bool help_engine_frame_tick(void* screen_state, int frame);
+void help_engine_draw_content(void* screen_state);
 
 static inline PickerState& pks()
 {
@@ -1675,6 +1683,56 @@ constexpr MenuButtonSpec kViewScenarioRows[] = {
      .state_override = &picker_view_scenario_engine_pager_row_state,
      .hidden = true},
 };
+
+// ---------------------------------------------------------------------------
+// HELP (#168): the full-screen general help — three content tabs (CONTROLS |
+// CLASSES | EDITOR) on the top strip, the paged text frame below, BACK and
+// the PageModel PREV/NEXT pagers in the command band (the VIEW LEVEL footer
+// geometry). Every row dispatches through MenuSpecRow except BACK, so
+// keyboard FIRE, mouse clicks, and the 1/2/3 + PageUp/PageDown hotkeys all
+// route through help_engine_on_spec_row in help.cpp; the pager visibility
+// override and the rewire read the open screen's state through a file-static
+// pointer there (null = the single-page bare-sweep shape: pagers hidden,
+// BACK's right-link closed).
+
+constexpr MenuButtonSpec kHelpMenuRows[] = {
+    {.id = "help_tab_controls", .label = "CONTROLS", .hotkey = KEYSTATE_1,
+     .x = kHelpTabX(0), .y = kHelpTabY, .w = kHelpTabWidth, .h = kHelpTabHeight,
+     .action = ButtonAction::MenuSpecRow, .arg = kHelpMenuControlsTabIndex,
+     .nav = {.down = kHelpMenuBackIndex, .right = kHelpMenuClassesTabIndex}},
+    {.id = "help_tab_classes", .label = "CLASSES", .hotkey = KEYSTATE_2,
+     .x = kHelpTabX(1), .y = kHelpTabY, .w = kHelpTabWidth, .h = kHelpTabHeight,
+     .action = ButtonAction::MenuSpecRow, .arg = kHelpMenuClassesTabIndex,
+     .nav = {.down = kHelpMenuBackIndex, .left = kHelpMenuControlsTabIndex,
+             .right = kHelpMenuEditorTabIndex}},
+    {.id = "help_tab_editor", .label = "EDITOR", .hotkey = KEYSTATE_3,
+     .x = kHelpTabX(2), .y = kHelpTabY, .w = kHelpTabWidth, .h = kHelpTabHeight,
+     .action = ButtonAction::MenuSpecRow, .arg = kHelpMenuEditorTabIndex,
+     .nav = {.down = kHelpMenuBackIndex, .left = kHelpMenuClassesTabIndex}},
+    {.id = "help_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+     .x = kHelpBackX, .y = kHelpFooterY,
+     .w = kHelpBackWidth, .h = kHelpFooterHeight,
+     .action = ButtonAction::ReturnMenu, .arg = MENU_REDRAW,
+     .nav = {.up = kHelpMenuControlsTabIndex, .right = kHelpMenuPrevIndex}},
+    {.id = "help_page_prev", .label = "PREV", .hotkey = KEYSTATE_PAGEUP,
+     .x = kHelpPrevX, .y = kHelpFooterY,
+     .w = kHelpPagerWidth, .h = kHelpFooterHeight,
+     .action = ButtonAction::MenuSpecRow, .arg = kHelpMenuPrevIndex,
+     .nav = {.up = kHelpMenuEditorTabIndex, .left = kHelpMenuBackIndex,
+             .right = kHelpMenuNextIndex},
+     .state_override = &help_engine_pager_row_state,
+     .hidden = true},
+    {.id = "help_page_next", .label = "NEXT", .hotkey = KEYSTATE_PAGEDOWN,
+     .x = kHelpNextX, .y = kHelpFooterY,
+     .w = kHelpPagerWidth, .h = kHelpFooterHeight,
+     .action = ButtonAction::MenuSpecRow, .arg = kHelpMenuNextIndex,
+     .nav = {.up = kHelpMenuEditorTabIndex, .left = kHelpMenuPrevIndex},
+     .state_override = &help_engine_pager_row_state,
+     .hidden = true},
+};
+
+static_assert(std::size(kHelpMenuRows) == kHelpMenuNextIndex + 1,
+              "help table anchor: MenuSpecRow args are spec ordinals");
 
 // ---------------------------------------------------------------------------
 // TEAM BUILD -> BASE CAMP (§2.5, regridded per §9.5 then §9.10, row-click
@@ -4965,6 +5023,37 @@ const MenuScreenSpec& view_scenario_menu_screen_spec()
     return spec;
 }
 
+const MenuScreenSpec& help_menu_screen_spec()
+{
+    static const MenuScreenSpec spec{
+        .name = "help",
+        .rows = kHelpMenuRows,
+        .row_count = static_cast<int>(std::size(kHelpMenuRows)),
+        .buttons_accessor = &picker_help_buttons,
+        .count_accessor = &picker_help_button_count,
+        // Nav closure over the hidden pagers (BACK's right-link), reading
+        // the open screen's PageModel.
+        .nav = {.kind = NavProgramKind::Rewire, .rewire = &help_engine_rewire},
+        // The legacy help loop entered with no fade and ran no remote-start
+        // check (a joiner parked here launches when the main menu re-enters
+        // — the FX-subscreen precedent). Keep both: DELIBERATELY not
+        // FadeAroundEntry (issue #200 is reworking that path).
+        .enter = EnterTransition::None,
+        .default_highlight = kHelpMenuBackIndex,
+        // BACK carries MENU_REDRAW and ends the screen there.
+        .exit_on_redraw = true,
+        .polls_lobby = true,
+        .draw_background = &picker_backdrop_draw_background,
+        .draw_content = &help_engine_draw_content,
+        // Mouse wheel -> page steps.
+        .frame_tick = &help_engine_frame_tick,
+        // Tab switches and page flips (G3 generic row dispatch).
+        .on_spec_row = &help_engine_on_spec_row,
+        .exit_value = MENU_REDRAW,
+    };
+    return spec;
+}
+
 const MenuScreenSpec& name_entry_menu_screen_spec()
 {
     static const MenuScreenSpec spec{
@@ -5275,6 +5364,10 @@ const MenuScreenHost& menu_screen_host(MenuScreenId id)
             // record"; pinned by
             // MenuEngine.networking_stays_legacy_v2_decision).
             set(MenuScreenId::Networking, {.kind = Kind::Legacy});
+            // #168: HELP is engine-hosted (the legacy overlay dialog loop in
+            // help.cpp is gone; show_general_help is the blocking wrapper).
+            set(MenuScreenId::Help,
+                {.kind = Kind::Engine, .spec = &help_menu_screen_spec()});
             return table;
         }();
     return hosts[static_cast<std::size_t>(id)];
@@ -5484,6 +5577,18 @@ button* picker_cloud_save_buttons()
 int picker_cloud_save_button_count()
 {
     return static_cast<int>(pks().cloud_save_buttons.size());
+}
+
+button* picker_help_buttons()
+{
+    og::ui::materialize_menu_buttons(og::ui::help_menu_screen_spec(),
+                                     pks().help_buttons);
+    return pks().help_buttons.data();
+}
+
+int picker_help_button_count()
+{
+    return static_cast<int>(pks().help_buttons.size());
 }
 
 #ifdef TESTING

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -1715,24 +1715,64 @@ constexpr int kBaseCampRowPitch = 14;
 // Round-6 horizontal grid: the panel's inner face is x=8..311, with explicit
 // DEPLOY and TEAM columns before the trainable NAME body. Maximum-width solo
 // and network row strings end their last digit's ink at x=297/295 (EXP/LV
-// columns at 264/280); the per-row move-up face sits at 300..308 — a
-// two-pixel gutter after the digits and three clear panel pixels before the
-// x=311 inner-face edge.
+// columns at 264/280); the per-row move-up face sits at 303..311 — five clear
+// pixels after the digits, ending flush with the inner face.
+// The right rail is ONE column: the roster pager '>', every per-row '^', the
+// seat rail's '+', and GO/READY all end on kBaseCampPanelRightX.
+constexpr int kBaseCampGlyphAdvance = 6;  // small font pen advance
+// EXCLUSIVE right edge == the inner grey face's last column (311) + 1 == the
+// GO/READY right edge (244 + 68).
+constexpr int kBaseCampPanelRightX = 312;
+constexpr int kBaseCampDeployColumnX = 23;
+constexpr int kBaseCampDeployColumnWidth = 14;
+// button.cpp centers a one-glyph label at (xloc+xend)/2 - (1*6 - 1)/2. The
+// foreign-row X/- glyph is hand-drawn in the content pass, so it derives the
+// same column instead of guessing it.
+constexpr int kBaseCampDeployGlyphX =
+    (kBaseCampDeployColumnX * 2 + kBaseCampDeployColumnWidth) / 2 -
+    (kBaseCampGlyphAdvance - 1) / 2;
 constexpr int kBaseCampDeployHeaderX = 12;
 constexpr int kBaseCampTeamHeaderX = 54;
 constexpr int kBaseCampNameColumnX = 88;
 constexpr int kBaseCampSoloClassColumnX = 164;
 constexpr int kBaseCampSoloLevelColumnX = 236;
 constexpr int kBaseCampSoloExpColumnX = 264;
+// picker_common writes EXP as a six-character right-aligned field, so its
+// digits ink out at x=297; the three-character header takes that field's last
+// three cells instead of sitting over its left pad.
+constexpr int kBaseCampSoloExpFieldChars = 6;
+constexpr int kBaseCampSoloExpHeaderX =
+    kBaseCampSoloExpColumnX +
+    (kBaseCampSoloExpFieldChars - 3) * kBaseCampGlyphAdvance;
 constexpr int kBaseCampNetCompanyColumnX = 160;
 constexpr int kBaseCampNetLevelColumnX = 280;
+// Roster pager cluster beside header line B: '<' | "p/N" strip | '>', with
+// uniform gutters and the '>' closing the right rail.
+constexpr int kBaseCampPagerWidth = 14;
+constexpr int kBaseCampPagerGap = 2;
+// The strip reserves three glyphs plus strip_text's 2px pad on each side.
+constexpr int kBaseCampPageIndicatorWidth = 3 * kBaseCampGlyphAdvance + 4;
+constexpr int kBaseCampPageNextX = kBaseCampPanelRightX - kBaseCampPagerWidth;
+constexpr int kBaseCampPageIndicatorX =
+    kBaseCampPageNextX - kBaseCampPagerGap - kBaseCampPageIndicatorWidth;
+constexpr int kBaseCampPagePrevX =
+    kBaseCampPageIndicatorX - kBaseCampPagerGap - kBaseCampPagerWidth;
+constexpr int kBaseCampMoveUpWidth = 9;
+constexpr int kBaseCampMoveUpX = kBaseCampPanelRightX - kBaseCampMoveUpWidth;
+constexpr int kBaseCampAddSeatWidth = 14;
+constexpr int kBaseCampAddSeatX = kBaseCampPanelRightX - kBaseCampAddSeatWidth;
 constexpr int kBaseCampFamilySwatchGap = 1;
 constexpr int kBaseCampFamilySwatchRampWidth = 8;
 constexpr int kBaseCampFamilySwatchWidth = kBaseCampFamilySwatchRampWidth + 2;
 constexpr int kBaseCampFamilySwatchHeight = 8;
-constexpr std::array<int, kBaseCampSeatCardsPerPage> kBaseCampSeatCardX{
-    54, 112, 170, 228};
+// One seat-card table: the button specs and the chip overlay both index it.
 constexpr int kBaseCampSeatCardWidth = 57;
+constexpr int kBaseCampSeatCardPitch = 58;  // card face + 1px focus gutter
+constexpr int kBaseCampSeatCardX0 = 54;
+constexpr std::array<int, kBaseCampSeatCardsPerPage> kBaseCampSeatCardX{
+    kBaseCampSeatCardX0, kBaseCampSeatCardX0 + kBaseCampSeatCardPitch,
+    kBaseCampSeatCardX0 + 2 * kBaseCampSeatCardPitch,
+    kBaseCampSeatCardX0 + 3 * kBaseCampSeatCardPitch};
 constexpr int kBaseCampSeatRailY = 164;
 // §9.5.4 + graft (a): non-identity fields on benched rows dim to palette
 // shade 21 — GREY(23)'s glyph ramp overlaps WHITE(24) by all but one step,
@@ -1830,7 +1870,9 @@ RowState base_camp_add_seat_row_state(
 // highlight reads — the §2.5 foreign-hit-zone precedent.
 #define OG_BASE_CAMP_DEP(i)                                                  \
     {.id = "roster_dep_" #i, .label = "",                                    \
-     .x = 23, .y = kBaseCampRowY0 + kBaseCampRowPitch * (i), .w = 14,         \
+     .x = kBaseCampDeployColumnX,                                            \
+     .y = kBaseCampRowY0 + kBaseCampRowPitch * (i),                          \
+     .w = kBaseCampDeployColumnWidth,                                        \
      .h = 10, .action = ButtonAction::MenuSpecRow, .arg = (i),               \
      .nav = {.up = (i) > 0 ? (i) - 1 : -1,                                    \
              .down = (i) < 7 ? (i) + 1 : kCreateMenuBackIndex,                \
@@ -1857,7 +1899,9 @@ RowState base_camp_add_seat_row_state(
      .no_draw = true}
 #define OG_BASE_CAMP_MOVE_UP(i)                                              \
     {.id = "roster_up_" #i, .label = "^",                                    \
-     .x = 300, .y = kBaseCampRowY0 + kBaseCampRowPitch * (i), .w = 9,         \
+     .x = kBaseCampMoveUpX,                                                  \
+     .y = kBaseCampRowY0 + kBaseCampRowPitch * (i),                          \
+     .w = kBaseCampMoveUpWidth,                                              \
      .h = 10, .action = ButtonAction::MenuSpecRow,                           \
      .arg = kBaseCampMoveUpBase + (i),                                       \
      .nav = {.left = kBaseCampRowBodyBase + (i)},                            \
@@ -1877,12 +1921,12 @@ constexpr MenuButtonSpec kBaseCampRows[] = {
     // relocated line B); real MenuSpecRow pager actions (keyboard-live),
     // hidden until the roster spans pages.
     {.id = "roster_page_prev", .label = "<",
-     .x = 263, .y = 15, .w = 14, .h = 10,
+     .x = kBaseCampPagePrevX, .y = 15, .w = kBaseCampPagerWidth, .h = 10,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampPagePrevIndex,
      .nav = {.down = kBaseCampRowBodyBase, .right = kBaseCampPageNextIndex},
      .hidden = true},
     {.id = "roster_page_next", .label = ">",
-     .x = 302, .y = 15, .w = 14, .h = 10,
+     .x = kBaseCampPageNextX, .y = 15, .w = kBaseCampPagerWidth, .h = 10,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampPageNextIndex,
      .nav = {.down = kBaseCampRowBodyBase, .left = kBaseCampPagePrevIndex},
      .hidden = true},
@@ -1952,22 +1996,26 @@ constexpr MenuButtonSpec kBaseCampRows[] = {
              .right = kBaseCampSeatCardBase},
      .hidden = true},
     {.id = "seat_card_0", .label = "",
-     .x = 54, .y = kBaseCampSeatRailY, .w = kBaseCampSeatCardWidth, .h = 10,
+     .x = kBaseCampSeatCardX[0], .y = kBaseCampSeatRailY,
+     .w = kBaseCampSeatCardWidth, .h = 10,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatCardBase,
      .nav = {.left = kBaseCampSeatPagePrevIndex,
              .right = kBaseCampSeatCardBase + 1}},
     {.id = "seat_card_1", .label = "",
-     .x = 112, .y = kBaseCampSeatRailY, .w = kBaseCampSeatCardWidth, .h = 10,
+     .x = kBaseCampSeatCardX[1], .y = kBaseCampSeatRailY,
+     .w = kBaseCampSeatCardWidth, .h = 10,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatCardBase + 1,
      .nav = {.left = kBaseCampSeatCardBase,
              .right = kBaseCampSeatCardBase + 2}},
     {.id = "seat_card_2", .label = "",
-     .x = 170, .y = kBaseCampSeatRailY, .w = kBaseCampSeatCardWidth, .h = 10,
+     .x = kBaseCampSeatCardX[2], .y = kBaseCampSeatRailY,
+     .w = kBaseCampSeatCardWidth, .h = 10,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatCardBase + 2,
      .nav = {.left = kBaseCampSeatCardBase + 1,
              .right = kBaseCampSeatCardBase + 3}},
     {.id = "seat_card_3", .label = "",
-     .x = 228, .y = kBaseCampSeatRailY, .w = kBaseCampSeatCardWidth, .h = 10,
+     .x = kBaseCampSeatCardX[3], .y = kBaseCampSeatRailY,
+     .w = kBaseCampSeatCardWidth, .h = 10,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatCardBase + 3,
      .nav = {.left = kBaseCampSeatCardBase + 2,
              .right = kBaseCampSeatPageNextIndex}},
@@ -1978,7 +2026,8 @@ constexpr MenuButtonSpec kBaseCampRows[] = {
              .left = kBaseCampSeatCardBase + 3},
      .hidden = true},
     {.id = "add_seat", .label = "+",
-     .x = 297, .y = kBaseCampSeatRailY, .w = 14, .h = 10,
+     .x = kBaseCampAddSeatX, .y = kBaseCampSeatRailY,
+     .w = kBaseCampAddSeatWidth, .h = 10,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampAddSeatIndex,
      .nav = {.down = kCreateMenuGoIndex,
              .left = kBaseCampSeatPageNextIndex},
@@ -2904,8 +2953,10 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
         // vbutton), so a toggle shows this frame.
         dep.label = (member != nullptr && member->deployed) ? "X" : "";
         dep.no_draw = !own;
-        dep.x = own ? 23 : 12;
-        dep.sizex = own ? 14 : 300;
+        // The foreign hit zone spans the panel: DEPLOY column to right rail.
+        dep.x = own ? kBaseCampDeployColumnX : kBaseCampDeployHeaderX;
+        dep.sizex = own ? kBaseCampDeployColumnWidth
+                        : kBaseCampPanelRightX - kBaseCampDeployHeaderX;
         vbutton* live = og::runtime::current_session->allbuttons_[static_cast<std::size_t>(r)];
         if (live != nullptr) {
             live->label = dep.label;
@@ -3195,8 +3246,11 @@ void base_camp_draw_content(void* screen_state)
     // (round 1 had 10px) — with the pager cluster beside it at y=15.
     strip_text(8, 17, line_b, line_b_color);
 
+    // The "p/N" strip sits in the pager cluster's reserved middle slot;
+    // strip_text backs its text with a 2px pad, so the text starts there.
     if (st != nullptr && st->page.multi_page())
-        strip_text(283, 17, st->page.indicator(), WHITE);
+        strip_text(kBaseCampPageIndicatorX + 2, 17, st->page.indicator(),
+                   WHITE);
 
     // Column headers at y=33: solo keeps CLASS/EXP; networked swaps in the
     // 16-char COMPANY column (§2.5 U7 — CLASS is carried by the family
@@ -3218,7 +3272,7 @@ void base_camp_draw_content(void* screen_state)
         mytext.write_xy(kBaseCampNameColumnX, 33, "NAME", BLACK, 1);
         mytext.write_xy(kBaseCampSoloClassColumnX, 33, "CLASS", BLACK, 1);
         mytext.write_xy(kBaseCampSoloLevelColumnX, 33, "LV", BLACK, 1);
-        mytext.write_xy(kBaseCampSoloExpColumnX, 33, "EXP", BLACK, 1);
+        mytext.write_xy(kBaseCampSoloExpHeaderX, 33, "EXP", BLACK, 1);
     }
 
     // Seat chips overlay the right edge of each compact card after buttons
@@ -3315,10 +3369,11 @@ void base_camp_draw_content(void* screen_state)
         // Row glyphs sit at y+2 — centers the 6px font in the 10px band.
         if (networked) {
             // Foreign rows have no deploy BUTTON (no_draw hit zone): their
-            // deploy state draws as the §2.5 X/- glyph at x=27.
+            // deploy state draws as the §2.5 X/- glyph, on the same column
+            // the button centerer gives the owned rows' X.
             if (!display.owned)
-                mytext.write_xy(27, y + 2, deployed ? "X" : "-",
-                                status_color, 1);
+                mytext.write_xy(kBaseCampDeployGlyphX, y + 2,
+                                deployed ? "X" : "-", status_color, 1);
             const BaseCampNetRowText row = format_base_camp_net_row(
                 member->name, display.company, member->level);
             mytext.write_xy_flat(kBaseCampNameColumnX, y + 2,

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -1770,17 +1770,24 @@ BaseCampScreenState* g_base_camp_state = nullptr;
 // six below the final row. Player-seat assignments now own y=164..173.
 constexpr int kBaseCampRowY0 = 45;
 constexpr int kBaseCampRowPitch = 14;
-// Round-6 horizontal grid: the panel's inner face is x=8..311, with explicit
-// DEPLOY and TEAM columns before the trainable NAME body. Maximum-width solo
-// and network row strings end their last digit's ink at x=297/295 (EXP/LV
-// columns at 264/280); the per-row move-up face sits at 303..311 — five clear
-// pixels after the digits, ending flush with the inner face.
-// The right rail is ONE column: the roster pager '>', every per-row '^', the
-// seat rail's '+', and GO/READY all end on kBaseCampPanelRightX.
+// Round-6 horizontal grid: the roster panel is outside-to-outside with the
+// button columns (outer bevel x=8..311, inner grey face x=10..309), with
+// explicit DEPLOY and TEAM columns before the trainable NAME body.
+// Maximum-width solo and network row strings end their last digit's ink at
+// x=297/295 (EXP/LV columns at 264/280); the per-row move-up face sits at
+// 301..309 — three clear pixels after the digits, ending flush with the
+// panel's inner face.
+// The right rail is ONE column: the roster pager '>', the seat rail's '+',
+// and GO/READY all end on kBaseCampPanelRightX (the panel's OUTER edge);
+// the per-row '^' lives INSIDE the panel and ends on the inner face
+// (kBaseCampPanelInnerRightX).
 constexpr int kBaseCampGlyphAdvance = 6;  // small font pen advance
-// EXCLUSIVE right edge == the inner grey face's last column (311) + 1 == the
-// GO/READY right edge (244 + 68).
+// Panel OUTER right edge (EXCLUSIVE): the bevel's last column (311) + 1 ==
+// the GO/READY right edge (244 + 68) — outside-to-outside alignment.
 constexpr int kBaseCampPanelRightX = 312;
+// Panel inner-face right edge (EXCLUSIVE): the outer edge minus the 2px
+// bevel. In-panel controls (the per-row '^') end here.
+constexpr int kBaseCampPanelInnerRightX = kBaseCampPanelRightX - 2;
 constexpr int kBaseCampDeployColumnX = 23;
 constexpr int kBaseCampDeployColumnWidth = 14;
 // button.cpp centers a one-glyph label at (xloc+xend)/2 - (1*6 - 1)/2. The
@@ -1816,7 +1823,8 @@ constexpr int kBaseCampPageIndicatorX =
 constexpr int kBaseCampPagePrevX =
     kBaseCampPageIndicatorX - kBaseCampPagerGap - kBaseCampPagerWidth;
 constexpr int kBaseCampMoveUpWidth = 9;
-constexpr int kBaseCampMoveUpX = kBaseCampPanelRightX - kBaseCampMoveUpWidth;
+constexpr int kBaseCampMoveUpX =
+    kBaseCampPanelInnerRightX - kBaseCampMoveUpWidth;
 constexpr int kBaseCampAddSeatWidth = 14;
 constexpr int kBaseCampAddSeatX = kBaseCampPanelRightX - kBaseCampAddSeatWidth;
 constexpr int kBaseCampFamilySwatchGap = 1;
@@ -2000,7 +2008,7 @@ constexpr MenuButtonSpec kBaseCampRows[] = {
     // same Scenario menu as the bottom command. Network status replaces
     // this line in multiplayer, so the per-frame rewire hides the zone.
     {.id = "scenario_line", .label = "",
-     .x = 6, .y = 14, .w = 208, .h = 12,
+     .x = 8, .y = 14, .w = 206, .h = 12,
      .action = ButtonAction::CreateScenarioMenu, .arg = -1,
      .nav = {.down = kCreateMenuScenarioIndex},
      .no_draw = true},
@@ -3250,9 +3258,11 @@ void base_camp_draw_background(void* /*screen_state*/)
 {
     picker_backdrop_draw_background(nullptr);
     screen* const game = og::runtime::current_session->myscreen_;
-    // Outer bevel (6,28)..(313,160); inner grey face (8,30)..(311,158).
-    // Content keeps a real inset on every edge instead of touching bevels.
-    game->draw_button(6, 28, 313, 160, 2, 1);
+    // Outer bevel (8,28)..(311,160); inner grey face (10,30)..(309,158) —
+    // outside-to-outside with the command strip (BACK/SEATS left edge 8,
+    // GO/'+'/'>' right edge 311). Content keeps a real inset on every edge
+    // instead of touching bevels.
+    game->draw_button(8, 28, 311, 160, 2, 1);
 }
 
 // The §2.5 content pass (after draw_buttons): header lines A/B, the page
@@ -3278,18 +3288,20 @@ void base_camp_draw_content(void* screen_state)
     // Line A (§9.10.3, G3): grey "COMPANY:" label + WHITE name (the 40-byte
     // save_name) on ONE shared backing strip — two strip_text calls would
     // leave a raw-backdrop seam between label and name — plus the gold
-    // block. Budget: 8 label chars + space + 26-char name clip = ink ending
-    // x<=217, 27px clear of the GOLD strip at x=244.
+    // block. Both strips share the panel's outside-to-outside lines: left
+    // edge 8, GOLD strip right edge 311 at its 11-char clip. Budget: 8 label
+    // chars + space + 26-char name clip = ink ending x<=219, 23px clear of
+    // the GOLD strip at x=242.
     std::string company = save.save_name;
     if (company.size() > 26)
         company.resize(26);
     {
         const int width = (9 + static_cast<int>(company.size())) * 6;
-        game->draw_rect_filled(6, 2, static_cast<Uint32>(width + 4), 8, PURE_BLACK, 150);
-        mytext.write_xy(8, 3, "COMPANY:", GREY, 1);
-        mytext.write_xy(62, 3, company.c_str(), WHITE, 1);
+        game->draw_rect_filled(8, 2, static_cast<Uint32>(width + 4), 8, PURE_BLACK, 150);
+        mytext.write_xy(10, 3, "COMPANY:", GREY, 1);
+        mytext.write_xy(64, 3, company.c_str(), WHITE, 1);
     }
-    strip_text(246, 3, format_base_camp_gold_label(save), YELLOW);
+    strip_text(244, 3, format_base_camp_gold_label(save), YELLOW);
 
     // Line B: solo scenario/deploy header, or the §9.12 (G5) networked
     // session status — role + room code + machine/player census ("HOSTING
@@ -3317,8 +3329,12 @@ void base_camp_draw_content(void* screen_state)
         line_b = format_base_camp_scen_line(save, game->world().title);
     }
     // §9.10.2 (G2): line B sits at y=17 — 14px below line A's y=3 baseline
-    // (round 1 had 10px) — with the pager cluster beside it at y=15.
-    strip_text(8, 17, line_b, line_b_color);
+    // (round 1 had 10px) — with the pager cluster beside it at y=15. Its
+    // backing strip starts on the panel's left line (strip_text backs the
+    // x=10 text with a 2px pad, so the strip rect starts at 8); the 34-char
+    // solo budget inks 10..213, strip rect 8..215 — 42px clear of the pager
+    // cluster at x=258.
+    strip_text(10, 17, line_b, line_b_color);
 
     // The "p/N" strip sits in the pager cluster's reserved middle slot;
     // strip_text backs its text with a 2px pad, so the text starts there.

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -1066,20 +1066,39 @@ public:
 #ifdef TESTING
         // Keep legacy menu-injector tests stable: they script Begin New Game ->
         // Hire menu directly and do not interact with the campaign picker UI.
+        // (This also keeps the blocking intro below out of every test flow.)
         return og::runtime::current_session->myscreen_->save_data.current_campaign;
 #endif
-        CampaignResult result = pick_campaign(&og::runtime::current_session->myscreen_->save_data);
+        screen* game = og::runtime::current_session->myscreen_;
+        CampaignResult result = pick_campaign(&game->save_data);
         if (result.id.empty())
             return {};
 
-        og::runtime::current_session->myscreen_->save_data.current_campaign = result.id;
-        og::runtime::current_session->myscreen_->save_data.scen_num = static_cast<short>(
-            load_campaign(result.id, og::runtime::current_session->myscreen_->save_data.current_levels, result.first_level));
+        // A failed load (bad ENTER ID, corrupt package) must not write its
+        // negative return into scen_num: roll back to the previous campaign
+        // and stay on the main menu.
+        if (!og::ui::apply_campaign_selection(game->save_data, result.id,
+                                              result.first_level))
+        {
+            popup_dialog("SET CAMPAIGN", "Could not load campaign.");
+            return {};
+        }
         // #162: the campaign just mounted may ship its own entity art or pack
         // families. Between screens here — the next screen re-inits its
         // buttons before anything draws from the loader.
         sdl_entity_loader()->reload_graphics_if_stale();
         picker_lobby_sync_settings_from_save();
+
+        // The CHOSEN campaign's intro, now that the selection committed
+        // (issue #186 — it used to show the default campaign's intro before
+        // the picker ever ran).
+        release_mouse();
+        game->clearbuffer();
+        game->swap();
+        read_campaign_intro(game);
+        game->refresh();
+        grab_mouse();
+        game->clear();
         return result.id;
     }
 
@@ -2674,9 +2693,16 @@ Sint32 do_pick_campaign(Sint32 arg1)
    CampaignResult result = pick_campaign(&og::runtime::current_session->myscreen_->save_data);
    if(result.id.size() > 0)
    {
-        // Load new campaign
-        og::runtime::current_session->myscreen_->save_data.current_campaign = result.id;
-        og::runtime::current_session->myscreen_->save_data.scen_num = static_cast<short>(load_campaign(result.id, og::runtime::current_session->myscreen_->save_data.current_levels, result.first_level));
+        // Load new campaign. A failed load (bad ENTER ID, corrupt package)
+        // rolls the save and mount back instead of writing load_campaign's
+        // negative return into scen_num.
+        if (!og::ui::apply_campaign_selection(
+                og::runtime::current_session->myscreen_->save_data, result.id,
+                result.first_level))
+        {
+            popup_dialog("SET CAMPAIGN", "Could not load campaign.");
+            return MENU_REDRAW;
+        }
         // #162: same MENU_REDRAW position as do_pick_spritesheet — the frame
         // skeleton re-creates every button pixie (reset_buttons) and the
         // SCENARIO spec's guard frame_tick reloads the preview level before

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -3407,8 +3407,13 @@ void picker_reinit_after_game()
     screen* const current_screen = og::runtime::current_session->myscreen_;
     current_screen->set_active_canvas(current_screen->last_presented_canvas());
     current_screen->fadeblack(0);
+    // #200: this IS the fade back to the menu, and it only blackened whichever
+    // canvas was last presented. Clear the other one too, and tell the next
+    // menu entry not to fade the stale image out a second time.
+    og::ui::suppress_next_menu_entry_fade_out();
     current_screen->clearbuffer();
     current_screen->set_active_canvas(CanvasTarget::UI);
+    current_screen->clearbuffer();
 
     grab_mouse();
 

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -1568,6 +1568,7 @@ void picker_cleanup_resources()
     pks().company_list_buttons.clear();
     pks().company_backups_buttons.clear();
     pks().cloud_save_buttons.clear();
+    pks().help_buttons.clear();
 }
 
 void picker_quit()

--- a/src/interface/ui/picker_common.cpp
+++ b/src/interface/ui/picker_common.cpp
@@ -10,6 +10,7 @@
 #include <openglad/resources/save_data.h>
 #include <openglad/resources/io_common.h>
 #include <openglad/core/campaign_ids.h>
+#include <openglad/core/text_wrap.h>
 #include <openglad/core/util.h>
 #include <openglad/core/scale_mode.h>
 #include <optional>
@@ -74,12 +75,31 @@ CampaignPickerLayout campaign_picker_layout()
 {
     constexpr int kScreenW = 320;
     constexpr int kScreenH = 200;
+    // The screen's two-column grid: the list pane on the left, the detail
+    // pane on the right; every rect derives from these edges.
+    constexpr int kListX = 8;
+    constexpr int kListW = 120;
+    constexpr int kDetailX = 136;
+    constexpr int kDetailW = 176;
 
     CampaignPickerLayout layout;
-    layout.icon = PickerRect{kScreenW / 2 - 16, 15 + 20, 32, 32};
 
-    layout.prev = PickerRect{layout.icon.x - 30 - 20, layout.icon.y, 30, 10};
-    layout.next = PickerRect{layout.icon.x + layout.icon.w + 20, layout.icon.y, 30, 10};
+    layout.header_y = 4;
+    layout.list_rows = 6;
+    layout.list_row_h = 10;
+    layout.list_row_pitch = 12;
+    layout.list = PickerRect{kListX, 14, kListW,
+                             layout.list_row_pitch * (layout.list_rows - 1) +
+                                 layout.list_row_h};
+    // A marker column (6px) leads each row; the label uses the rest.
+    layout.list_label_max_chars = (kListW - 2 * kGlyphAdvance) / kGlyphAdvance;
+
+    // Page controls sit directly under the list with the "N of M" readout
+    // centered between them.
+    const int pager_y = layout.list.y + layout.list.h + 6;
+    layout.prev = PickerRect{kListX, pager_y, 30, 10};
+    layout.next = PickerRect{kListX + kListW - 30, pager_y, 30, 10};
+
     layout.choose = PickerRect{kScreenW / 2 + 20, kScreenH - 15, 30, 10};
     layout.cancel = PickerRect{kScreenW / 2 - 38 - 20, kScreenH - 15, 38, 10};
 
@@ -87,29 +107,48 @@ CampaignPickerLayout campaign_picker_layout()
     layout.delete_button = PickerRect{kScreenW - 50, 10, 38, 10};
     layout.reset_button = layout.delete_button;
 
-    // ENTER ID sits directly under DELETE/RESET, right edges flush, so the
-    // whole title row left of x = kScreenW - 50 is free.
+    // ENTER ID sits directly under DELETE/RESET, right edges flush.
     layout.id_button = PickerRect{
         layout.delete_button.x + layout.delete_button.w - 52,
         layout.delete_button.y + layout.delete_button.h + 2,
         52,
         10};
 
-    layout.title_center_x = layout.icon.x + layout.icon.w / 2;
-    layout.title_y = layout.icon.y - 22;
+    // Detail pane: title, version row, icon, power/completion/authors lines,
+    // then the description box with the MORE control under its right edge.
+    layout.detail = PickerRect{kDetailX, 36, kDetailW, 140};
+    layout.title_center_x = kDetailX + kDetailW / 2;
+    layout.title_y = layout.detail.y;
+    layout.icon = PickerRect{layout.title_center_x - 16, 56, 32, 32};
+    layout.desc_box = PickerRect{kDetailX + 4, 126, kDetailW - 8, 44};
+    layout.desc_rows = 4;
+    layout.desc_max_chars = (layout.desc_box.w - 10) / kGlyphAdvance;
+    layout.more_button = PickerRect{
+        kDetailX + kDetailW - 40, layout.desc_box.y + layout.desc_box.h + 2,
+        40, 10};
 
-    // The title is centered, so a title of L glyphs spans
-    // center +/- 3L. DELETE/RESET is the only control left on the title row;
-    // its left edge caps the half-width, and the screen edge caps the other
-    // side. Both bounds are computed rather than written down so the budget
-    // follows the rects if the row ever moves again.
-    const int right_room = layout.delete_button.x - layout.title_center_x;
-    const int left_room = layout.title_center_x;
+    // The title is centered in the detail pane, so a title of L glyphs spans
+    // center +/- 3L; the pane edges cap the half-width. Computed rather than
+    // written down so the budget follows the pane if it ever moves again.
+    const int right_room =
+        layout.detail.x + layout.detail.w - layout.title_center_x;
+    const int left_room = layout.title_center_x - layout.detail.x;
     const int half_room = right_room < left_room ? right_room : left_room;
     layout.title_max_chars = (2 * half_room) / kGlyphAdvance;
     if (layout.title_max_chars < 0)
         layout.title_max_chars = 0;
     return layout;
+}
+
+PickerRect campaign_picker_row_rect(int row)
+{
+    const CampaignPickerLayout layout = campaign_picker_layout();
+    if (row < 0)
+        row = 0;
+    if (row >= layout.list_rows)
+        row = layout.list_rows - 1;
+    return PickerRect{layout.list.x, layout.list.y + layout.list_row_pitch * row,
+                      layout.list.w, layout.list_row_h};
 }
 
 PickerRect campaign_title_rect(int chars)
@@ -122,16 +161,81 @@ PickerRect campaign_title_rect(int chars)
                       layout.title_y, width, kGlyphHeight};
 }
 
-std::string fit_campaign_title(std::string_view title)
+std::string fit_text_to_chars(std::string_view text, int budget)
 {
-    const int budget = campaign_picker_layout().title_max_chars;
     if (budget <= 0)
         return std::string();
-    if (title.size() <= static_cast<std::size_t>(budget))
-        return std::string(title);
+    if (text.size() <= static_cast<std::size_t>(budget))
+        return std::string(text);
     if (budget <= 3)
-        return std::string(title.substr(0, static_cast<std::size_t>(budget)));
-    return std::string(title.substr(0, static_cast<std::size_t>(budget) - 3)) + "...";
+        return std::string(text.substr(0, static_cast<std::size_t>(budget)));
+    return std::string(text.substr(0, static_cast<std::size_t>(budget) - 3)) + "...";
+}
+
+std::string fit_campaign_title(std::string_view title)
+{
+    return fit_text_to_chars(title, campaign_picker_layout().title_max_chars);
+}
+
+std::string fit_campaign_row_label(std::string_view title)
+{
+    return fit_text_to_chars(title,
+                             campaign_picker_layout().list_label_max_chars);
+}
+
+int campaign_list_clamp_offset(int offset, int total, int rows)
+{
+    if (rows <= 0 || total <= rows)
+        return 0;
+    if (offset < 0)
+        return 0;
+    if (offset > total - rows)
+        return total - rows;
+    return offset;
+}
+
+int campaign_list_offset_for_cursor(int cursor, int offset, int total, int rows)
+{
+    offset = campaign_list_clamp_offset(offset, total, rows);
+    if (rows <= 0 || total <= 0)
+        return 0;
+    if (cursor < offset)
+        offset = cursor;
+    else if (cursor >= offset + rows)
+        offset = cursor - rows + 1;
+    return campaign_list_clamp_offset(offset, total, rows);
+}
+
+int campaign_list_page_step(int offset, int total, int rows, int direction)
+{
+    const int step = direction < 0 ? -rows : rows;
+    return campaign_list_clamp_offset(offset + step, total, rows);
+}
+
+int campaign_list_clamp_cursor(int cursor, int offset, int total, int rows)
+{
+    if (total <= 0)
+        return 0;
+    offset = campaign_list_clamp_offset(offset, total, rows);
+    const int visible = std::min(rows, total - offset);
+    const int last = offset + (visible > 0 ? visible : 1) - 1;
+    return std::clamp(cursor, offset, last);
+}
+
+std::string format_campaign_position_label(int cursor, int total)
+{
+    if (total <= 0)
+        return "0 of 0";
+    return std::format("{} of {}", std::clamp(cursor, 0, total - 1) + 1, total);
+}
+
+bool campaign_description_overflows(const std::string& description)
+{
+    const CampaignPickerLayout layout = campaign_picker_layout();
+    return static_cast<int>(
+               og::core::wrap_text(description, layout.desc_max_chars,
+                                   og::core::WrapMode::Paragraphs)
+                   .size()) > layout.desc_rows;
 }
 
 std::array<CampaignPickerNavLinks, kCampaignPickerButtonCount>
@@ -139,35 +243,147 @@ campaign_picker_nav(const CampaignPickerVisibility& visibility)
 {
     std::array<CampaignPickerNavLinks, kCampaignPickerButtonCount> nav{};
 
-    nav[kCampaignPickerPrevIndex] = {.up = kCampaignPickerIdIndex,
-                                     .down = kCampaignPickerCancelIndex,
-                                     .right = kCampaignPickerNextIndex};
+    const int rows =
+        std::clamp(visibility.visible_rows, 0, kCampaignPickerRowCount);
+    const int top_right = visibility.delete_hidden ? kCampaignPickerResetIndex
+                                                   : kCampaignPickerDeleteIndex;
+    const int first_row = rows > 0 ? kCampaignPickerRowBaseIndex : -1;
+    const int last_row = rows > 0 ? kCampaignPickerRowBaseIndex + rows - 1 : -1;
+    // Leaving the list downward lands on the pagers when a pager shows,
+    // otherwise straight on CANCEL (always visible).
+    const int below_list = !visibility.prev_hidden ? kCampaignPickerPrevIndex
+        : (!visibility.next_hidden ? kCampaignPickerNextIndex
+                                   : kCampaignPickerCancelIndex);
+    // The bottom of the left stack, as seen from CANCEL going up.
+    const int left_stack_bottom = !visibility.prev_hidden
+        ? kCampaignPickerPrevIndex
+        : (!visibility.next_hidden
+               ? kCampaignPickerNextIndex
+               : (last_row >= 0 ? last_row : kCampaignPickerIdIndex));
+
+    nav[kCampaignPickerPrevIndex] = {
+        .up = last_row >= 0 ? last_row : kCampaignPickerIdIndex,
+        .down = kCampaignPickerCancelIndex,
+        .right = visibility.next_hidden ? -1 : kCampaignPickerNextIndex};
     nav[kCampaignPickerNextIndex] = {
+        .up = last_row >= 0 ? last_row : kCampaignPickerIdIndex,
+        .down = kCampaignPickerCancelIndex,
+        .left = visibility.prev_hidden ? -1 : kCampaignPickerPrevIndex};
+    nav[kCampaignPickerChooseIndex] = {
+        .up = visibility.more_hidden ? kCampaignPickerIdIndex
+                                     : kCampaignPickerMoreIndex,
+        .left = kCampaignPickerCancelIndex};
+    nav[kCampaignPickerCancelIndex] = {
+        .up = left_stack_bottom,
+        .right = visibility.choose_hidden ? -1 : kCampaignPickerChooseIndex};
+
+    // DELETE / RESET share the top-right cell and drop onto ENTER ID, which
+    // sits directly below them; leftward they enter the top of the list.
+    nav[kCampaignPickerDeleteIndex] = {.down = kCampaignPickerIdIndex,
+                                       .left = first_row};
+    nav[kCampaignPickerResetIndex] = {.down = kCampaignPickerIdIndex,
+                                      .left = first_row};
+    nav[kCampaignPickerIdIndex] = {
+        .up = top_right,
+        .down = !visibility.more_hidden ? kCampaignPickerMoreIndex
+            : (visibility.choose_hidden ? kCampaignPickerCancelIndex
+                                        : kCampaignPickerChooseIndex),
+        .left = first_row};
+    nav[kCampaignPickerMoreIndex] = {
         .up = kCampaignPickerIdIndex,
         .down = visibility.choose_hidden ? kCampaignPickerCancelIndex
                                          : kCampaignPickerChooseIndex,
-        .left = kCampaignPickerPrevIndex};
-    nav[kCampaignPickerChooseIndex] = {.up = kCampaignPickerNextIndex,
-                                       .left = kCampaignPickerCancelIndex};
-    nav[kCampaignPickerCancelIndex] = {
-        .up = visibility.prev_hidden
-            ? (visibility.next_hidden ? kCampaignPickerIdIndex
-                                      : kCampaignPickerNextIndex)
-            : kCampaignPickerPrevIndex,
-        .right = kCampaignPickerChooseIndex};
+        .left = last_row};
 
-    // DELETE / RESET share the top-right cell and drop onto ENTER ID, which
-    // sits directly below them.
-    nav[kCampaignPickerDeleteIndex] = {.down = kCampaignPickerIdIndex};
-    nav[kCampaignPickerResetIndex] = {.down = kCampaignPickerIdIndex};
-    nav[kCampaignPickerIdIndex] = {
-        .up = visibility.delete_hidden ? kCampaignPickerResetIndex
-                                       : kCampaignPickerDeleteIndex,
-        .down = visibility.next_hidden
-            ? (visibility.prev_hidden ? kCampaignPickerCancelIndex
-                                      : kCampaignPickerPrevIndex)
-            : kCampaignPickerNextIndex};
+    // List rows: up/down walk the visible rows; the top row exits to
+    // DELETE/RESET and the bottom visible row to the pager band; rightward
+    // every row reaches the detail-side stack via ENTER ID. Rows past
+    // visible_rows are hidden, so their links are never followed.
+    for (int i = 0; i < kCampaignPickerRowCount; ++i)
+    {
+        const int index = kCampaignPickerRowBaseIndex + i;
+        nav[static_cast<std::size_t>(index)] = {
+            .up = i == 0 ? top_right : index - 1,
+            .down = (i >= rows - 1) ? below_list : index + 1,
+            .right = kCampaignPickerIdIndex};
+    }
     return nav;
+}
+
+bool apply_campaign_selection(SaveData& save, const std::string& campaign_id,
+                              int first_level)
+{
+    const std::string previous_campaign = save.current_campaign;
+    const int level = load_campaign(campaign_id, save.current_levels, first_level);
+    if (level < 0)
+    {
+        // Mirrors do_set_scen_level's rollback: keep the save untouched and
+        // put the previous campaign's package back so level data stays
+        // loadable.
+        (void)load_campaign(previous_campaign, save.current_levels,
+                            static_cast<int>(save.scen_num));
+        return false;
+    }
+    save.current_campaign = campaign_id;
+    save.scen_num = static_cast<short>(level);
+    return true;
+}
+
+// --- Level browser geometry ---
+
+LevelPickerLayout level_picker_layout()
+{
+    constexpr int kScreenW = 320;
+    constexpr int kScreenH = 200;
+    // Left column: the three preview rows. Right column: everything else,
+    // sharing kRightX as its left edge.
+    constexpr int kRowX = 10;
+    constexpr int kRightX = 174;
+
+    LevelPickerLayout layout;
+    layout.row_x = kRowX;
+    layout.row0_y = 4;
+    layout.row_count = 3;
+    layout.radar_dy = 9;
+    layout.radar_max_w = 60;  // RADAR_X/RADAR_Y viewport clamps (radar.cpp)
+    layout.radar_max_h = 44;
+    // Title line (8) + radar (44) + frame and breathing room; three rows at
+    // this pitch end at row0_y + 2*pitch + radar_dy + radar_max_h + 2 = 183,
+    // fully on the 200px screen.
+    layout.row_pitch = 62;
+
+    layout.stats_x = kRowX + layout.radar_max_w + 6;
+    layout.stats_max_chars = (kRightX - layout.stats_x - 2) / kGlyphAdvance;
+    layout.title_max_chars = 16;
+    layout.status_x = kRowX + (layout.title_max_chars + 3 + 1) * kGlyphAdvance;
+
+    layout.delete_button = PickerRect{kScreenW - 50, 10, 38, 10};
+    layout.id_button = PickerRect{layout.delete_button.x - 52 - 10, 10, 52, 10};
+    layout.prev = PickerRect{kRightX, 22, 30, 10};
+    layout.army_x = layout.prev.x + layout.prev.w + 6;
+    layout.army_y = layout.prev.y + 2;
+    layout.desc_box = PickerRect{kRightX, 36, kScreenW - 8 - kRightX, 112};
+    layout.desc_max_chars = (layout.desc_box.w - 4) / kGlyphAdvance;
+    layout.next = PickerRect{
+        kRightX, layout.desc_box.y + layout.desc_box.h + 4, 30, 10};
+    layout.choose = PickerRect{kScreenW - 50, kScreenH - 30, 30, 10};
+    layout.cancel = PickerRect{kScreenW - 100, kScreenH - 30, 38, 10};
+    return layout;
+}
+
+int level_picker_row_y(int row)
+{
+    const LevelPickerLayout layout = level_picker_layout();
+    return layout.row0_y + layout.row_pitch * row;
+}
+
+const char* level_row_status_label(bool cleared, bool current)
+{
+    if (cleared)
+        return "CLEARED";
+    if (current)
+        return "CURRENT";
+    return "";
 }
 
 // --- Family display helpers ---

--- a/src/interface/ui/picker_input.cpp
+++ b/src/interface/ui/picker_input.cpp
@@ -225,6 +225,10 @@ bool handle_menu_nav(button* buttons, int& highlighted_button, Sint32& retvalue,
                 og::runtime::current_session->allbuttons_[static_cast<std::size_t>(highlighted_button)]->vdisplay();
                 if(og::runtime::current_session->allbuttons_[static_cast<std::size_t>(highlighted_button)]->myfunc)
                 {
+                    // Coordinate-free activation: never leave a stale pointer
+                    // for sub-rect affordances (#202).
+                    pks().menu_click_x = -1;
+                    pks().menu_click_y = -1;
                     retvalue = og::runtime::current_session->allbuttons_[static_cast<std::size_t>(highlighted_button)]->do_call(og::runtime::current_session->allbuttons_[static_cast<std::size_t>(highlighted_button)]->myfunc, og::runtime::current_session->allbuttons_[static_cast<std::size_t>(highlighted_button)]->arg);
                 }
             }

--- a/src/interface/ui/picker_main_menu.cpp
+++ b/src/interface/ui/picker_main_menu.cpp
@@ -60,9 +60,8 @@ bool picker_prepare_new_game_setup()
 
     game->clear();
 
-    // Reset the save data so we have a fresh, new team. This happens BEFORE
-    // the intro: a new game always starts on the default campaign, so both
-    // the intro about to be shown and the mounted package must not be
+    // Reset the save data so we have a fresh, new team: a new game always
+    // starts on the default campaign, so the mounted package must not be
     // whatever campaign the previous session or match left selected.
 	og::ui::reset_for_new_game(game->save_data);
 
@@ -94,11 +93,12 @@ bool picker_prepare_new_game_setup()
 	og::runtime::current_session->current_guy_ = nullptr;
     picker_lobby_initialize_from_save();
 
-	// Starting new game ..
+	// Starting new game .. The campaign intro is NOT shown here anymore:
+	// the campaign select comes next, and the intro belongs to the campaign
+	// the player actually picks (SdlPickerClient::show_campaign_select).
 	release_mouse();
 	game->clearbuffer();
 	game->swap();
-	read_campaign_intro(game);
 	game->refresh();
 	grab_mouse();
 	game->clear();

--- a/src/interface/ui/picker_sdl_defs.h
+++ b/src/interface/ui/picker_sdl_defs.h
@@ -162,7 +162,8 @@ int picker_cloud_save_button_count();
 // The command roster at the §9.10.1 grid (round 2: the roster block gains
 // clear top/bottom margins): 8 roster rows/page (deploy toggle at x=23, team
 // color/cycler at x=61, row-body train zone at x=84..297, and move-up at
-// x=300, y=45+14r), the page cluster top-right,
+// x=303, y=45+14r — flush with the panel's right inner edge, like the roster
+// pager '>', the seat rail's '+' and GO), the page cluster top-right,
 // and the bottom command strip BACK | HIRE | SCENARIO | NETWORK | GO at
 // y=178. Spec ordinals group by kind so the MenuSpecRow arg (== ordinal, G3)
 // decodes as row/kind directly. GO is the only host-gated button. Cap-24

--- a/src/interface/ui/picker_sdl_defs.h
+++ b/src/interface/ui/picker_sdl_defs.h
@@ -430,8 +430,11 @@ inline constexpr int kHelpMenuEditorTabIndex = 2;
 inline constexpr int kHelpMenuBackIndex = 3;
 inline constexpr int kHelpMenuPrevIndex = 4;
 inline constexpr int kHelpMenuNextIndex = 5;
-// Tab strip: y=2..17 faces, 70px wide on a 75px pitch from x=5 (the frame's
-// left edge), leaving a 2px underline row (y=18..19) for the active tab.
+// Tab strip: 70px-wide faces on a 75px pitch from x=5 (the frame's left edge),
+// occupying rows kHelpTabY .. kHelpTabY + kHelpTabHeight - 1. The rows between
+// the strip and the frame are the connector band (kHelpConnector* below): the
+// ACTIVE tab is merged into the frame across it, inactive tabs leave it as
+// backdrop.
 inline constexpr int kHelpTabY = 2;
 inline constexpr int kHelpTabWidth = 70;
 inline constexpr int kHelpTabHeight = 15;
@@ -445,6 +448,16 @@ constexpr int kHelpTabX(int tab) { return kHelpFrameLeft + tab * kHelpTabPitch; 
 inline constexpr int kHelpFrameTop = 20;
 inline constexpr int kHelpFrameRight = 314;
 inline constexpr int kHelpFrameBottom = 160;
+// draw_button() paints this many nested bevel rings, so the frame's top bevel
+// owns rows kHelpFrameTop .. kHelpFrameTop + kHelpFrameBorder - 1 and its face
+// starts on the row below.
+inline constexpr int kHelpFrameBorder = 3;
+// Folder-tab merge: the active tab and the frame read as one surface. The
+// connector repaints from the tab's own bottom bevel row down through the
+// frame's last top-bevel row, so both of those edges disappear under the
+// active tab (help_engine_draw_content, after the frame is drawn).
+inline constexpr int kHelpConnectorTop = kHelpTabY + kHelpTabHeight - 1;
+inline constexpr int kHelpConnectorBottom = kHelpFrameTop + kHelpFrameBorder - 1;
 inline constexpr int kHelpTextX = 10;
 inline constexpr int kHelpTextTop = 28;
 inline constexpr int kHelpLinePitch = 7;

--- a/src/interface/ui/picker_sdl_defs.h
+++ b/src/interface/ui/picker_sdl_defs.h
@@ -156,6 +156,9 @@ int picker_company_backups_button_count();
 // #155 CLOUD SAVE subscreen — engine screen.
 button* picker_cloud_save_buttons();
 int picker_cloud_save_button_count();
+// #168 full-screen HELP — engine screen.
+button* picker_help_buttons();
+int picker_help_button_count();
 
 // --- Base camp (team build) layout contract (design §2.5 as amended §9.5,
 // regridded §9.10) -----------------------------------------------------------
@@ -414,6 +417,46 @@ inline constexpr int kViewScenarioBackIndex = 0;
 inline constexpr int kViewScenarioPrevIndex = 1;
 inline constexpr int kViewScenarioNextIndex = 2;
 inline constexpr int kViewScenarioRowsPerPage = 23;
+
+// --- HELP (full-screen, #168) layout contract --------------------------------
+// The screen is three bands: the tab strip (three tab buttons on one
+// baseline), the content frame (paged help text), and the command band
+// (BACK bottom-left, PREV/NEXT bottom-right on the VIEW LEVEL footer
+// geometry, with the key-hint and version strings between them). Every rect
+// in the spec and every draw in help.cpp derives from these constants.
+inline constexpr int kHelpMenuControlsTabIndex = 0;
+inline constexpr int kHelpMenuClassesTabIndex = 1;
+inline constexpr int kHelpMenuEditorTabIndex = 2;
+inline constexpr int kHelpMenuBackIndex = 3;
+inline constexpr int kHelpMenuPrevIndex = 4;
+inline constexpr int kHelpMenuNextIndex = 5;
+// Tab strip: y=2..17 faces, 70px wide on a 75px pitch from x=5 (the frame's
+// left edge), leaving a 2px underline row (y=18..19) for the active tab.
+inline constexpr int kHelpTabY = 2;
+inline constexpr int kHelpTabWidth = 70;
+inline constexpr int kHelpTabHeight = 15;
+inline constexpr int kHelpTabPitch = 75;
+// Content frame and text grid: text rows at y = kHelpTextTop + i*7; the
+// frame's right edge closes the 50-char flow budget (help_char_budget).
+// The tab column derives from the frame's left edge so the strip and the
+// frame share that column.
+inline constexpr int kHelpFrameLeft = 5;
+constexpr int kHelpTabX(int tab) { return kHelpFrameLeft + tab * kHelpTabPitch; }
+inline constexpr int kHelpFrameTop = 20;
+inline constexpr int kHelpFrameRight = 314;
+inline constexpr int kHelpFrameBottom = 160;
+inline constexpr int kHelpTextX = 10;
+inline constexpr int kHelpTextTop = 28;
+inline constexpr int kHelpLinePitch = 7;
+inline constexpr int kHelpLinesPerPage = 18;
+// Command band (BACK/PREV/NEXT share the VIEW LEVEL footer geometry).
+inline constexpr int kHelpFooterY = 170;
+inline constexpr int kHelpBackX = 10;
+inline constexpr int kHelpBackWidth = 44;
+inline constexpr int kHelpPrevX = 220;
+inline constexpr int kHelpNextX = 270;
+inline constexpr int kHelpPagerWidth = 40;
+inline constexpr int kHelpFooterHeight = 20;
 
 // --- GRAPHICS FX subscreen layout contract ----------------------------------
 // Positional index of the depth-selector cycle row (id "depth_fx") in

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -2696,10 +2696,16 @@ Sint32 go_menu(Sint32 arg1)
         og::runtime::current_session->myscreen_->set_active_canvas(
             og::runtime::current_session->myscreen_->last_presented_canvas());
         og::runtime::current_session->myscreen_->fadeblack(0);
+        // #200: this IS the fade back to the menu. Base Camp's entry must not
+        // play a second one over the stale pause-menu image.
+        og::ui::suppress_next_menu_entry_fade_out();
 
         // Zardus: PORT: doesn't seem to be neccessary
         og::runtime::current_session->myscreen_->clearbuffer();
         og::runtime::current_session->myscreen_->set_active_canvas(CanvasTarget::UI);
+        // The fade above only blackened whichever canvas was last presented;
+        // clear the other one too so no path re-enters a menu over stale ink.
+        og::runtime::current_session->myscreen_->clearbuffer();
 
         // Zardus: PORT: they had this in just so that the pallettes got reset to
         // normal. It actually faded in a black screen, since fading in the menu

--- a/tests/coverage_internal/campaign_picker_internal.inc
+++ b/tests/coverage_internal/campaign_picker_internal.inc
@@ -112,8 +112,7 @@ int campaign_picker_testing_exercise_entry_draw_paths()
     entry.num_levels = 1;
     entry.num_levels_completed = -1;
 
-    const UiRect area{144, 35, 32, 32};
-    entry.draw(area, 8);
+    entry.draw(8);
 
     entry.rating = 0.0f;
     entry.suggested_power = 0;
@@ -122,11 +121,11 @@ int campaign_picker_testing_exercise_entry_draw_paths()
     entry.authors.clear();
     entry.contributors.clear();
     entry.description = "one\ntwo\nthree\nfour\nfive\nsix\nseven";
-    entry.draw(area, -1);
+    entry.draw(-1);
 
     entry.suggested_power = 4;
-    entry.draw(area, -1);
-    entry.draw(area, 8);
+    entry.draw(-1);
+    entry.draw(8);
 
     const auto* const rendered = static_cast<const unsigned char*>(
         surface_restore.surface->pixels);

--- a/tests/coverage_internal/help_internal.inc
+++ b/tests/coverage_internal/help_internal.inc
@@ -30,18 +30,18 @@ bool help_testing_query_scroll_chrome()
 	return s_help_scroll_chrome.load(std::memory_order_acquire);
 }
 
-// #152: the Controls tab shipped three 41-42 char lines against the 39-char
-// frame. Flow the static table exactly as show_general_help does and report
-// the widest flowed line — or -1 if nothing wrapped (the overflow lines were
-// not flowed at all).
+// #168: the full-screen help flows the Controls table to the frame's
+// full-width budget (help_char_budget(kHelpTextBoxWidth) = 50 chars). Every
+// authored line already fits that budget, so the flow must not wrap anything
+// (-1 if it did); report the widest flowed line for the budget pin.
 Sint32 help_testing_controls_flowed_max_width()
 {
 	std::list<std::string> source;
 	for (int i = 0; i < NUM_CONTROLS_LINES; i++)
 		source.push_back(controls_help_lines[i]);
 	const std::vector<std::string> flowed =
-		og::core::wrap_lines(source, help_char_budget(240));
-	if (flowed.size() <= static_cast<std::size_t>(NUM_CONTROLS_LINES))
+		og::core::wrap_lines(source, help_char_budget(kHelpTextBoxWidth));
+	if (flowed.size() != static_cast<std::size_t>(NUM_CONTROLS_LINES))
 		return -1;
 	std::size_t max_len = 0;
 	for (const std::string& line : flowed)
@@ -50,6 +50,95 @@ Sint32 help_testing_controls_flowed_max_width()
 			max_len = line.size();
 	}
 	return static_cast<Sint32>(max_len);
+}
+
+// #168: injector probes for the full-screen help screen — the active tab and
+// the active tab's current page, published by the engine hooks.
+Sint32 help_testing_query_active_tab()
+{
+	return s_help_active_tab.load(std::memory_order_acquire);
+}
+
+Sint32 help_testing_query_help_page()
+{
+	return s_help_page.load(std::memory_order_acquire);
+}
+
+// #168: engine-hook exerciser (exact-check-count pattern): drives the help
+// spec hooks through the installed-state seam without a blocking loop.
+// Returns 0, or the negated index of the first failed check.
+Sint32 help_testing_exercise_menu_hooks()
+{
+	int check_index = 0;
+	int failed_check = 0;
+	const auto check = [&check_index, &failed_check](bool condition) {
+		++check_index;
+		if (!condition && failed_check == 0)
+			failed_check = check_index;
+	};
+
+	load_help_files();
+	og::ui::MenuLabelContext context;
+	std::vector<button> rows;
+	og::ui::materialize_menu_buttons(og::ui::help_menu_screen_spec(), rows);
+	check(static_cast<int>(rows.size()) == kHelpMenuNextIndex + 1);
+	int highlighted = kHelpMenuBackIndex;
+
+	// Null state (bare engine-sweep shape): pagers hidden, BACK's right-link
+	// closed, dispatch and the wheel tick no-op.
+	g_help_screen_state = nullptr;
+	check(help_engine_pager_row_state(context) == og::ui::RowState::Hidden);
+	help_engine_rewire(rows.data(), static_cast<int>(rows.size()),
+	                   highlighted);
+	check(rows[kHelpMenuBackIndex].nav.right == -1);
+	check(help_engine_on_spec_row(kHelpMenuClassesTabIndex, nullptr) == 0);
+	check(help_engine_frame_tick(nullptr, 0));
+
+	// Installed state: Controls flows multi-page at the 50-char budget.
+	HelpScreenState state;
+	help_switch_tab(state, HelpTab::Controls, true);
+	g_help_screen_state = &state;
+	check(state.pager.multi_page());
+	check(help_engine_pager_row_state(context) == og::ui::RowState::Visible);
+	help_engine_rewire(rows.data(), static_cast<int>(rows.size()),
+	                   highlighted);
+	check(rows[kHelpMenuBackIndex].nav.right == kHelpMenuPrevIndex);
+
+	// NEXT/PREV dispatch steps the pager (clamped at the first page).
+	check(help_engine_on_spec_row(kHelpMenuNextIndex, nullptr) == 0);
+	check(state.pager.page == 1);
+	check(help_engine_on_spec_row(kHelpMenuPrevIndex, nullptr) == 0);
+	check(state.pager.page == 0);
+	check(help_engine_on_spec_row(kHelpMenuPrevIndex, nullptr) == 0);
+	check(state.pager.page == 0);
+
+	// Re-selecting the active tab keeps the page; switching tabs reflows
+	// and resets the pager; an unknown row no-ops.
+	check(help_engine_on_spec_row(kHelpMenuNextIndex, nullptr) == 0);
+	check(help_engine_on_spec_row(kHelpMenuControlsTabIndex, nullptr) == 0);
+	check(state.tab == HelpTab::Controls && state.pager.page == 1);
+	check(help_engine_on_spec_row(kHelpMenuClassesTabIndex, nullptr) == 0);
+	check(state.tab == HelpTab::Classes && state.pager.page == 0);
+	check(help_testing_query_active_tab() ==
+	      static_cast<int>(HelpTab::Classes));
+	check(help_engine_on_spec_row(kHelpMenuEditorTabIndex, nullptr) == 0);
+	check(state.tab == HelpTab::Editor && state.pager.page == 0);
+	check(help_engine_on_spec_row(999, nullptr) == 0);
+	check(state.tab == HelpTab::Editor && state.pager.page == 0);
+
+	// Wheel: a negative accumulated delta pages down, positive pages back.
+	input_scroll_amount_ref() = -3;
+	check(help_engine_frame_tick(nullptr, 1));
+	check(state.pager.page == 1);
+	check(help_testing_query_help_page() == 1);
+	input_scroll_amount_ref() = 2;
+	check(help_engine_frame_tick(nullptr, 2));
+	check(state.pager.page == 0);
+	check(help_engine_frame_tick(nullptr, 3));
+	check(state.pager.page == 0);
+
+	g_help_screen_state = nullptr;
+	return failed_check == 0 ? 0 : -failed_check;
 }
 
 Sint32 help_testing_exercise_internal_paths()

--- a/tests/integration/test_back_to_mainmenu.cpp
+++ b/tests/integration/test_back_to_mainmenu.cpp
@@ -51,8 +51,9 @@ static int back_test_injector(void* data)
     // === Iteration 1: Click CONTINUE then BACK ===
 
     // Wait for mainmenu to initialize and complete fadeblack.
-    // mainmenu() calls init_buttons() then fadeblack(1) which takes ~500ms
-    // and eats SDL events during the fade.
+    // The main menu's run_menu_screen entry (EnterTransition::FadeWithInitialDraw)
+    // publishes its buttons, then fades out, composes, and fades in — the fade
+    // takes ~500ms and eats SDL events.
     wait_for_interactable("continue_game", 5000);
     SDL_Delay(750);
     state->times_saw_mainmenu++;
@@ -60,7 +61,8 @@ static int back_test_injector(void* data)
     fprintf(stderr, "  [test] Iteration 1: clicking continue_game\n");
     interact("continue_game");
 
-    // Wait for create_team_menu to init (fadeblack + level load)
+    // Wait for create_team_menu to init (Base Camp's FadeAroundEntry fades,
+    // then the runner loop's reload guard loads the level)
     SDL_Delay(500);
     wait_for_interactable("go", 10000);
     SDL_Delay(750);

--- a/tests/integration/test_campaign_and_level_picker.cpp
+++ b/tests/integration/test_campaign_and_level_picker.cpp
@@ -7,6 +7,7 @@
 #include <openglad/interface/input.h>
 #include <openglad/legacy/base.h>
 #include <openglad/interface/screen.h>
+#include <openglad/core/test_trace.h>
 #include <openglad/resources/io.h>
 #include <gtest/gtest.h>
 #include <SDL3/SDL.h>
@@ -81,6 +82,19 @@ std::string unique_test_campaign_id(std::string_view stem)
 // pick_campaign returns, so the injector holds 'q' across every input-loop
 // poll instead of guessing a wall-clock window.
 std::atomic<bool> g_picker_q_release{false};
+
+// Injector coordinates come from the pure layouts (the :539 precedent), so
+// a geometry change moves the clicks with it instead of silently missing.
+int rect_center_x(const og::ui::PickerRect& rect) { return rect.x + rect.w / 2; }
+int rect_center_y(const og::ui::PickerRect& rect) { return rect.y + rect.h / 2; }
+
+// A point inside level-preview row `row`'s radar even for the narrowest map.
+void level_row_click_point(int row, int& x, int& y)
+{
+    const og::ui::LevelPickerLayout layout = og::ui::level_picker_layout();
+    x = layout.row_x + 14;
+    y = og::ui::level_picker_row_y(row) + layout.radar_dy + 10;
+}
 } // namespace
 
 // Defined below; declared here so the injector can handshake on them.
@@ -471,27 +485,45 @@ static int picker_choose_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
+    const og::ui::PickerRect ok_rect = og::ui::campaign_picker_layout().choose;
     const bool ready = wait_for_campaign_picker_ready();
-    return ready && click_campaign_picker_action(195, 190) ? 0 : 1; // OK
+    return ready && click_campaign_picker_action(rect_center_x(ok_rect),
+                                                 rect_center_y(ok_rect))
+        ? 0
+        : 1; // OK
 }
 
-static int picker_cancel_injector(void* data)
+static int picker_more_then_cancel_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
-    const bool ready = wait_for_campaign_picker_ready();
-    return ready && click_campaign_picker_action(121, 190) ? 0 : 1; // CANCEL
+    const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
+    bool ok = wait_for_campaign_picker_ready();
+    // MORE is deterministically visible while gladiator is highlighted: its
+    // shipped description overflows the detail box. Under TESTING the
+    // full-description scroller returns immediately (help.cpp force guard),
+    // so the click exercises the control without blocking.
+    if (ok)
+        ok = click_campaign_picker_action(rect_center_x(layout.more_button),
+                                          rect_center_y(layout.more_button));
+    if (ok)
+        ok = click_campaign_picker_action(rect_center_x(layout.cancel),
+                                          rect_center_y(layout.cancel));
+    return ok ? 0 : 1;
 }
 
 static int campaign_delete_then_cancel_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
+    const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
     bool ok = wait_for_campaign_picker_ready();
     if (ok)
-        ok = click_campaign_picker_action(280, 15); // DELETE
+        ok = click_campaign_picker_action(rect_center_x(layout.delete_button),
+                                          rect_center_y(layout.delete_button));
     if (ok)
-        ok = click_campaign_picker_action(121, 190); // CANCEL
+        ok = click_campaign_picker_action(rect_center_x(layout.cancel),
+                                          rect_center_y(layout.cancel));
     return ok ? 0 : 1;
 }
 
@@ -499,17 +531,21 @@ static int campaign_reset_then_cancel_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
+    const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
     bool ok = wait_for_campaign_picker_ready();
     if (ok)
-        ok = click_campaign_picker_action(280, 15); // RESET
+        ok = click_campaign_picker_action(rect_center_x(layout.reset_button),
+                                          rect_center_y(layout.reset_button));
     if (ok)
-        ok = click_campaign_picker_action(121, 190); // CANCEL
+        ok = click_campaign_picker_action(rect_center_x(layout.cancel),
+                                          rect_center_y(layout.cancel));
     return ok ? 0 : 1;
 }
 
 struct CampaignNavigationInjectorContext
 {
-    std::size_t steps = 0;
+    std::size_t page_steps = 0;  // PREV/NEXT page clicks to reach the far page
+    int row = 0;                 // visible row to click once there
     bool next = true;
 };
 
@@ -518,15 +554,25 @@ static int campaign_next_prev_choose_injector(void* data)
     og::runtime::ensure_thread_session();
     const auto* const context =
         static_cast<const CampaignNavigationInjectorContext*>(data);
+    const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
     bool ok = context != nullptr && wait_for_campaign_picker_ready();
-    for (std::size_t i = 0; ok && i < context->steps; ++i)
+    for (std::size_t i = 0; ok && i < context->page_steps; ++i)
     {
-        ok = context->next
-            ? click_campaign_picker_action(210, 40) // NEXT
-            : click_campaign_picker_action(105, 40); // PREV
+        const og::ui::PickerRect pager =
+            context->next ? layout.next : layout.prev;
+        ok = click_campaign_picker_action(rect_center_x(pager),
+                                          rect_center_y(pager));
     }
     if (ok)
-        ok = click_campaign_picker_action(195, 190); // OK
+    {
+        const og::ui::PickerRect row_rect =
+            og::ui::campaign_picker_row_rect(context->row);
+        ok = click_campaign_picker_action(rect_center_x(row_rect),
+                                          rect_center_y(row_rect));
+    }
+    if (ok)
+        ok = click_campaign_picker_action(rect_center_x(layout.choose),
+                                          rect_center_y(layout.choose)); // OK
     return ok ? 0 : 1;
 }
 
@@ -555,16 +601,20 @@ static int campaign_confirmed_delete_injector(void* opaque)
     og::runtime::ensure_thread_session();
     auto* const context =
         static_cast<CampaignDeleteInjectorContext*>(opaque);
+    const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
 
     // One destructive click only. The cancel press cannot be consumed until
     // deletion and row reload finish, so its event handshake also proves the
     // destructive action committed before this thread inspects the package.
     bool clicked_delete = wait_for_campaign_picker_ready();
     if (clicked_delete)
-        clicked_delete = click_campaign_picker_action(280, 15); // DELETE
+        clicked_delete =
+            click_campaign_picker_action(rect_center_x(layout.delete_button),
+                                         rect_center_y(layout.delete_button));
     bool canceled = false;
     if (clicked_delete)
-        canceled = click_campaign_picker_action(121, 190); // CANCEL
+        canceled = click_campaign_picker_action(rect_center_x(layout.cancel),
+                                                rect_center_y(layout.cancel));
     const bool removed = !std::filesystem::exists(context->package);
     return clicked_delete && removed && canceled ? 0 : 1;
 }
@@ -573,12 +623,15 @@ static int campaign_confirmed_reset_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
+    const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
     bool reset = wait_for_campaign_picker_ready();
     if (reset)
-        reset = click_campaign_picker_action(280, 15); // RESET
+        reset = click_campaign_picker_action(rect_center_x(layout.reset_button),
+                                             rect_center_y(layout.reset_button));
     bool canceled = false;
     if (reset)
-        canceled = click_campaign_picker_action(121, 190); // CANCEL
+        canceled = click_campaign_picker_action(rect_center_x(layout.cancel),
+                                                rect_center_y(layout.cancel));
     return reset && canceled ? 0 : 1;
 }
 
@@ -586,11 +639,16 @@ static int level_picker_choose_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
+    const og::ui::LevelPickerLayout layout = og::ui::level_picker_layout();
+    int row_x = 0;
+    int row_y = 0;
+    level_row_click_point(0, row_x, row_y);
     SDL_Delay(500);
     for (int i = 0; i < 8; ++i) {
-        inject_click(24, 23, 100);   // Select entry 1
+        inject_click(row_x, row_y, 100);   // Select entry 1
         SDL_Delay(150);
-        inject_click(280, 175, 100); // OK
+        inject_click(rect_center_x(layout.choose),
+                     rect_center_y(layout.choose), 100); // OK
         SDL_Delay(150);
     }
     return 0;
@@ -600,14 +658,20 @@ static int level_picker_delete_then_cancel_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
+    const og::ui::LevelPickerLayout layout = og::ui::level_picker_layout();
+    int row_x = 0;
+    int row_y = 0;
+    level_row_click_point(0, row_x, row_y);
     SDL_Delay(500);
     for (int i = 0; i < 4; ++i) {
-        inject_click(24, 23, 100);  // Select entry 1
+        inject_click(row_x, row_y, 100);  // Select entry 1
         SDL_Delay(150);
-        inject_click(280, 15, 100); // DELETE
+        inject_click(rect_center_x(layout.delete_button),
+                     rect_center_y(layout.delete_button), 100); // DELETE
         SDL_Delay(150);
     }
-    repeated_click(239, 175, 8); // CANCEL
+    repeated_click(rect_center_x(layout.cancel),
+                   rect_center_y(layout.cancel), 8); // CANCEL
     return 0;
 }
 
@@ -615,15 +679,21 @@ static int level_picker_scroll_then_choose_first_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
+    const og::ui::LevelPickerLayout layout = og::ui::level_picker_layout();
+    int row_x = 0;
+    int row_y = 0;
+    level_row_click_point(0, row_x, row_y);
     bool ok = wait_for_level_picker_ready();
     if (ok)
         ok = click_level_picker_action(
-            180, 155); // NEXT: shift previews up and re-index them
+            rect_center_x(layout.next),
+            rect_center_y(layout.next)); // NEXT: shift previews up
     if (ok)
         ok = click_level_picker_action(
-            24, 23); // Select the entry shifted into the first row
+            row_x, row_y); // Select the entry shifted into the first row
     if (ok)
-        ok = click_level_picker_action(280, 175); // OK
+        ok = click_level_picker_action(rect_center_x(layout.choose),
+                                       rect_center_y(layout.choose)); // OK
     return ok ? 0 : 1;
 }
 
@@ -631,16 +701,23 @@ static int level_picker_scroll_back_then_choose_first_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
+    const og::ui::LevelPickerLayout layout = og::ui::level_picker_layout();
+    int row_x = 0;
+    int row_y = 0;
+    level_row_click_point(0, row_x, row_y);
     bool ok = wait_for_level_picker_ready();
     if (ok)
-        ok = click_level_picker_action(180, 155); // NEXT
+        ok = click_level_picker_action(rect_center_x(layout.next),
+                                       rect_center_y(layout.next)); // NEXT
     if (ok)
-        ok = click_level_picker_action(180, 25); // PREV
+        ok = click_level_picker_action(rect_center_x(layout.prev),
+                                       rect_center_y(layout.prev)); // PREV
     if (ok)
         ok = click_level_picker_action(
-            24, 23); // First entry after scrolling back
+            row_x, row_y); // First entry after scrolling back
     if (ok)
-        ok = click_level_picker_action(280, 175); // OK
+        ok = click_level_picker_action(rect_center_x(layout.choose),
+                                       rect_center_y(layout.choose)); // OK
     return ok ? 0 : 1;
 }
 
@@ -648,9 +725,11 @@ static int level_picker_enter_id_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
+    const og::ui::PickerRect id_button = og::ui::level_picker_layout().id_button;
     bool ok = wait_for_level_picker_ready();
     if (ok)
-        ok = click_level_picker_action(225, 15); // ENTER ID
+        ok = click_level_picker_action(rect_center_x(id_button),
+                                       rect_center_y(id_button)); // ENTER ID
     return ok ? 0 : 1;
 }
 
@@ -658,13 +737,19 @@ static int level_picker_delete_once_then_cancel_injector(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
+    const og::ui::LevelPickerLayout layout = og::ui::level_picker_layout();
+    int row_x = 0;
+    int row_y = 0;
+    level_row_click_point(0, row_x, row_y);
     bool ok = wait_for_level_picker_ready();
     if (ok)
-        ok = click_level_picker_action(24, 23); // Select first entry
+        ok = click_level_picker_action(row_x, row_y); // Select first entry
     if (ok)
-        ok = click_level_picker_action(280, 15); // DELETE
+        ok = click_level_picker_action(rect_center_x(layout.delete_button),
+                                       rect_center_y(layout.delete_button));
     if (ok)
-        ok = click_level_picker_action(239, 175); // CANCEL
+        ok = click_level_picker_action(rect_center_x(layout.cancel),
+                                       rect_center_y(layout.cancel)); // CANCEL
     return ok ? 0 : 1;
 }
 
@@ -766,8 +851,12 @@ TEST(CampaignAndLevelPicker, campaign_picker_mouse_choose_and_cancel_paths)
     ASSERT_TRUE(mount_campaign_package_with_error(old_campaign) == CampaignPackageIoError::None) << "failed to restore mounted campaign after choose path";
 
     input_guard.reset();
-    ScopedSdlThread cancel_thread(
-        SDL_CreateThread(picker_cancel_injector, "picker_cancel", nullptr));
+    // Highlight gladiator deterministically so MORE is visible (see the
+    // injector), then open the full description and cancel out.
+    ASSERT_EQ(CampaignPackageIoError::None,
+              mount_campaign_package_with_error("gladiator"));
+    ScopedSdlThread cancel_thread(SDL_CreateThread(
+        picker_more_then_cancel_injector, "picker_more_cancel", nullptr));
     ASSERT_TRUE(cancel_thread.valid()) << "failed to create cancel injector";
     CampaignResult canceled = pick_campaign(&og::runtime::current_session->myscreen_->save_data, false);
     const int cancel_rc = cancel_thread.join();
@@ -830,8 +919,20 @@ TEST(CampaignAndLevelPicker, campaign_picker_next_and_prev_reach_ordered_boundar
     CampaignMountGuard mount_guard;
     ASSERT_EQ(CampaignPackageIoError::None,
               mount_campaign_package_with_error(first));
+
+    // Page math mirrors campaign_list_page_step: from the first page,
+    // page_hops NEXT clicks land on the last page (offset = total - rows);
+    // from the last page the same count of PREV clicks lands on offset 0.
+    // A hidden pager can't acknowledge a click, so the counts must be exact.
+    const int total = static_cast<int>(ordered.size());
+    const int rows = og::ui::campaign_picker_layout().list_rows;
+    ASSERT_GT(total, rows)
+        << "the shipped shelf must span 2+ pages for this boundary walk";
+    const int last_offset = total - rows;
+    const std::size_t page_hops =
+        static_cast<std::size_t>((last_offset + rows - 1) / rows);
     CampaignNavigationInjectorContext next_context{
-        ordered.size() - 1u, true};
+        page_hops, rows - 1, true};
 
     ViewportGuard viewport_guard;
     og::runtime::current_session->window_w_ = 320;
@@ -855,13 +956,13 @@ TEST(CampaignAndLevelPicker, campaign_picker_next_and_prev_reach_ordered_boundar
 
     ASSERT_EQ(0, next_thread_result);
     ASSERT_EQ(last, next_result.id)
-        << "each acknowledged NEXT must reach the last ordered row";
+        << "paging NEXT then choosing the last row must reach the last ordered id";
 
     input_guard.reset();
     ASSERT_EQ(CampaignPackageIoError::None,
               mount_campaign_package_with_error(last));
     CampaignNavigationInjectorContext prev_context{
-        ordered.size() - 1u, false};
+        page_hops, 0, false};
     ScopedSdlThread prev_thread(SDL_CreateThread(
         campaign_next_prev_choose_injector,
         "campaign_prev_choose", &prev_context));
@@ -872,7 +973,7 @@ TEST(CampaignAndLevelPicker, campaign_picker_next_and_prev_reach_ordered_boundar
 
     EXPECT_EQ(0, prev_thread_result);
     EXPECT_EQ(first, prev_result.id)
-        << "each acknowledged PREV must return to the first ordered row";
+        << "paging PREV then choosing row 0 must return to the first ordered id";
 }
 
 TEST(CampaignAndLevelPicker, campaign_picker_enter_id_returns_exact_prompt_text)
@@ -1360,25 +1461,16 @@ TEST(CampaignAndLevelPicker, sync_campaign_mount_follows_save_and_restores_on_fa
 
 namespace
 {
-SDL_AtomicInt s_new_game_setup_done;
-
-int new_game_intro_dismisser(void* data)
+int new_game_name_accepter(void* data)
 {
     og::runtime::ensure_thread_session();
     (void)data;
-    // §2.2: picker_prepare_new_game_setup() now opens the name-entry screen
-    // first. Accept the generated company name BEFORE tapping Escape — on the
-    // name screen Escape is the BACK (cancel) hotkey, so an early Escape would
-    // abort the new game instead of dismissing the intro.
+    // §2.2: picker_prepare_new_game_setup() opens the name-entry screen
+    // first; accept the generated company name. The campaign intro no
+    // longer runs here — it moved behind the campaign select (issue #186:
+    // the intro belongs to the campaign the player picks), so after the
+    // accept the flow under test runs to completion without input.
     accept_generated_company_name(10000);
-    // Then picker_prepare_new_game_setup() blocks inside read_campaign_intro()
-    // until input_continue (Escape keydown). scroll_text_view() clears the
-    // keyboard on entry, so a single early press can be eaten — keep tapping
-    // until the flow under test reports completion.
-    for (int i = 0; i < 100 && !SDL_GetAtomicInt(&s_new_game_setup_done); ++i) {
-        SDL_Delay(200);
-        inject_key_press(SDLK_ESCAPE);
-    }
     return 0;
 }
 } // namespace
@@ -1399,12 +1491,10 @@ TEST(CampaignAndLevelPicker, new_game_resets_campaign_and_mount_to_default)
         save.team_list[static_cast<std::size_t>(i)].reset();
     save.team_size = 0;
 
-    SDL_SetAtomicInt(&s_new_game_setup_done, 0);
     SDL_Thread* thread =
-        SDL_CreateThread(new_game_intro_dismisser, "intro_dismiss", nullptr);
-    ASSERT_TRUE(thread != nullptr) << "failed to create intro dismisser thread";
+        SDL_CreateThread(new_game_name_accepter, "name_accept", nullptr);
+    ASSERT_TRUE(thread != nullptr) << "failed to create name accepter thread";
     const bool ok = picker_prepare_new_game_setup();
-    SDL_SetAtomicInt(&s_new_game_setup_done, 1);
     SDL_WaitThread(thread, nullptr);
 
     ASSERT_TRUE(ok) << "new game setup should not abort";
@@ -1416,4 +1506,165 @@ TEST(CampaignAndLevelPicker, new_game_resets_campaign_and_mount_to_default)
 
     ASSERT_EQ(CampaignPackageIoError::None,
               mount_campaign_package_with_error(old_mounted));
+}
+
+// --- Issue #186: committing a selection must survive a failed load ---------
+
+// button.cpp handler under test (SET CAMPAIGN mid-game path).
+Sint32 do_pick_campaign(Sint32 arg1);
+// handle_menu_nav's TESTING hook (the options-menu capture precedent).
+extern int g_test_menu_nav_key;
+
+TEST(CampaignAndLevelPicker, apply_campaign_selection_commits_or_rolls_back)
+{
+    SaveData& save = og::runtime::current_session->myscreen_->save_data;
+    const std::string old_mounted = get_mounted_campaign();
+    const std::string old_campaign = save.current_campaign;
+    const short old_scen = save.scen_num;
+
+    save.current_campaign = "gladiator";
+    save.scen_num = 1;
+    ASSERT_EQ(CampaignPackageIoError::None,
+              mount_campaign_package_with_error("gladiator"));
+
+    // Success: the save follows the selection and the cursor comes from
+    // load_campaign (first_level when the campaign has no tracked cursor).
+    save.current_levels.erase("modes");
+    ASSERT_TRUE(og::ui::apply_campaign_selection(save, "modes", 300));
+    EXPECT_EQ(std::string("modes"), save.current_campaign);
+    EXPECT_EQ(300, save.scen_num);
+    EXPECT_EQ(std::string("modes"), get_mounted_campaign());
+
+    // Failure: the save keeps the previous selection AND the previous
+    // package is remounted — no negative scen_num can reach the save.
+    ASSERT_FALSE(og::ui::apply_campaign_selection(
+        save, "this_campaign_should_not_exist", 1));
+    EXPECT_EQ(std::string("modes"), save.current_campaign)
+        << "a failed load must not adopt the bad campaign id";
+    EXPECT_EQ(300, save.scen_num)
+        << "a failed load must not clobber the level cursor";
+    EXPECT_EQ(std::string("modes"), get_mounted_campaign())
+        << "a failed load must remount the previous package";
+
+    save.current_campaign = old_campaign;
+    save.scen_num = old_scen;
+    ASSERT_EQ(CampaignPackageIoError::None,
+              mount_campaign_package_with_error(old_mounted));
+}
+
+TEST(CampaignAndLevelPicker, set_campaign_bad_enter_id_pops_and_keeps_save)
+{
+    trace_clear();
+    CampaignPickerInputGuard input_guard;
+    CampaignMountGuard mount_guard;
+    ViewportGuard viewport_guard;
+    og::runtime::current_session->window_w_ = 320;
+    og::runtime::current_session->window_h_ = 200;
+    og::runtime::current_session->viewport_offset_x_ = 0;
+    og::runtime::current_session->viewport_offset_y_ = 0;
+    og::runtime::current_session->viewport_w_ = 320;
+    og::runtime::current_session->viewport_h_ = 200;
+
+    SaveData& save = og::runtime::current_session->myscreen_->save_data;
+    const std::string old_campaign = save.current_campaign;
+    const short old_scen = save.scen_num;
+    // Deterministic starting point: save and mount agree on gladiator.
+    save.current_campaign = "gladiator";
+    save.scen_num = 1;
+    ASSERT_EQ(CampaignPackageIoError::None,
+              mount_campaign_package_with_error("gladiator"));
+
+    PromptQueueGuard prompt_queue;
+    prompt_queue.push("this_campaign_should_not_exist");
+    char& end = og::runtime::current_session->myscreen_->world().end;
+    WorldEndGuard end_guard(end);
+    end = 0;
+
+    ScopedSdlThread thread(SDL_CreateThread(
+        campaign_enter_id_injector, "campaign_bad_enter_id", nullptr));
+    ASSERT_TRUE(thread.valid());
+    const Sint32 redraw = do_pick_campaign(0);
+    const int thread_result = thread.join();
+
+    EXPECT_EQ(0, thread_result);
+    EXPECT_EQ(2, static_cast<int>(redraw)) << "handler must return MENU_REDRAW";
+    EXPECT_TRUE(trace_contains("popup", "Could not load campaign"))
+        << "the failed load must surface a popup";
+    EXPECT_EQ(std::string("gladiator"), save.current_campaign)
+        << "the save must keep its previous campaign";
+    EXPECT_EQ(1, save.scen_num)
+        << "no negative load_campaign return may reach scen_num";
+    EXPECT_EQ(std::string("gladiator"), get_mounted_campaign())
+        << "the previous package must be remounted";
+
+    save.current_campaign = old_campaign;
+    save.scen_num = old_scen;
+}
+
+// Arrow keys drive the list: walking the highlight up from CANCEL lands on
+// the last visible row, and the detail cursor follows it, so OK chooses
+// that row's campaign.
+TEST(CampaignAndLevelPicker, campaign_picker_keyboard_row_highlight_moves_cursor)
+{
+    cleanup_leftover_test_campaigns();
+    std::list<std::string> ordered = list_campaigns();
+    og::ui::order_campaigns_for_select(ordered);
+    const int rows = og::ui::campaign_picker_layout().list_rows;
+    ASSERT_GT(static_cast<int>(ordered.size()), rows)
+        << "the shipped shelf must overflow one page so NEXT is the up-exit";
+    // Page 1 shows rows [0, rows); the expected pick is its last row.
+    const std::string expected =
+        *std::next(ordered.begin(), static_cast<std::ptrdiff_t>(rows - 1));
+
+    CampaignPickerInputGuard input_guard;
+    CampaignMountGuard mount_guard;
+    ASSERT_EQ(CampaignPackageIoError::None,
+              mount_campaign_package_with_error(ordered.front()));
+
+    ViewportGuard viewport_guard;
+    og::runtime::current_session->window_w_ = 320;
+    og::runtime::current_session->window_h_ = 200;
+    og::runtime::current_session->viewport_offset_x_ = 0;
+    og::runtime::current_session->viewport_offset_y_ = 0;
+    og::runtime::current_session->viewport_w_ = 320;
+    og::runtime::current_session->viewport_h_ = 200;
+
+    char& end = og::runtime::current_session->myscreen_->world().end;
+    WorldEndGuard end_guard(end);
+    end = 0;
+
+    struct KeyboardWalkInjector
+    {
+        static int run(void*)
+        {
+            og::runtime::ensure_thread_session();
+            if (!wait_for_campaign_picker_ready())
+                return 1;
+            // CANCEL.up -> NEXT (page 1 of 2+), NEXT.up -> last visible row.
+            // The nav hook is consumed once per ~10ms loop pass; the delays
+            // give each press its own pass (options-menu capture precedent).
+            SDL_Delay(300);
+            g_test_menu_nav_key = KEY_UP;
+            SDL_Delay(500);
+            g_test_menu_nav_key = KEY_UP;
+            SDL_Delay(500);
+            const og::ui::PickerRect ok_rect =
+                og::ui::campaign_picker_layout().choose;
+            return click_campaign_picker_action(rect_center_x(ok_rect),
+                                                rect_center_y(ok_rect))
+                ? 0
+                : 2;
+        }
+    };
+
+    ScopedSdlThread thread(SDL_CreateThread(
+        KeyboardWalkInjector::run, "campaign_keyboard_walk", nullptr));
+    ASSERT_TRUE(thread.valid());
+    const CampaignResult result = pick_campaign(
+        &og::runtime::current_session->myscreen_->save_data, false);
+    const int thread_result = thread.join();
+
+    EXPECT_EQ(0, thread_result);
+    EXPECT_EQ(expected, result.id)
+        << "the arrowed-to row must be the one OK chooses";
 }

--- a/tests/integration/test_fairy_death.cpp
+++ b/tests/integration/test_fairy_death.cpp
@@ -121,7 +121,7 @@ static void cleanup_picker_state()
 // fairy dies in-world, then unwind back to the picker.
 //
 // Flow:
-//   Main Menu -> Begin New Game -> (dismiss campaign intro) ->
+//   Main Menu -> Begin New Game -> (accept company name) ->
 //   Hire Menu -> NEXT x12 to reach FAERIE -> HIRE ME -> BACK ->
 //   Team Menu -> (set scen_num=4) -> GO -> game runs -> fairy dies ->
 //   natural defeat resolves -> BACK -> exits
@@ -231,10 +231,9 @@ static int fairy_injector(void* data)
     // §2.2: accept the generated company name at the name-entry screen.
     accept_generated_company_name();
 
-    // Dismiss campaign intro screen (blocks until Escape)
-    SDL_Delay(kMenuTransitionMs);
-    fprintf(stderr, "  [test] dismissing campaign intro\n");
-    inject_key_press(SDLK_ESCAPE);
+    // No campaign intro here anymore (issue #186: it moved behind the
+    // campaign select, skipped under TESTING) — an Escape here would BACK
+    // out of the team-build screen instead.
 
     // New games now land on team build first, then enter hire explicitly.
     SDL_Delay(kUiSettleMs);

--- a/tests/integration/test_help_smoke.cpp
+++ b/tests/integration/test_help_smoke.cpp
@@ -19,6 +19,7 @@
 // From help.cpp
 short read_scenario(screen* scr);
 short read_campaign_intro(screen* scr);
+short show_campaign_description(screen* scr, const std::string& campaign_id);
 Sint32 show_general_help();
 std::unique_ptr<og::ui::IPickerClient> picker_testing_create_sdl_client();
 Sint32 help_testing_exercise_internal_paths();
@@ -394,6 +395,27 @@ TEST(HelpSmoke, help_read_campaign_intro_smoke_exits_on_input)
     ASSERT_NE(nullptr, thread.get()) << "failed to create injector thread";
 
     ASSERT_EQ(192, read_campaign_intro(og::runtime::current_session->myscreen_));
+    ASSERT_EQ(0, thread.join());
+}
+
+// The campaign browser's MORE control routes here with an explicit id; the
+// forced view must render the same scroller read_campaign_intro shows for
+// that campaign (same 192-scanline gladiator description), independent of
+// the save's current campaign.
+TEST(HelpSmoke, help_show_campaign_description_forced_view_scrolls)
+{
+    std::string& campaign = og::runtime::current_session->myscreen_->save_data.current_campaign;
+    CurrentCampaignGuard campaign_guard(campaign);
+    campaign = "tower";  // NOT the id under view
+    ForceScrollTextGuard force_scroll;
+    HelpTestingInputGuard input_guard;
+
+    SdlThreadJoinGuard thread(
+        SDL_CreateThread(intro_injector_thread, "desc_injector", nullptr));
+    ASSERT_NE(nullptr, thread.get()) << "failed to create injector thread";
+
+    ASSERT_EQ(192, show_campaign_description(
+                       og::runtime::current_session->myscreen_, "gladiator"));
     ASSERT_EQ(0, thread.join());
 }
 

--- a/tests/integration/test_help_smoke.cpp
+++ b/tests/integration/test_help_smoke.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <SDL3/SDL.h>
 #include "test_input_helpers.h"
+#include "test_interact.h"
 
 #include <atomic>
 #include <list>
@@ -21,6 +22,7 @@ short read_campaign_intro(screen* scr);
 Sint32 show_general_help();
 std::unique_ptr<og::ui::IPickerClient> picker_testing_create_sdl_client();
 Sint32 help_testing_exercise_internal_paths();
+Sint32 help_testing_exercise_menu_hooks();
 void help_testing_set_force_scroll_text(bool enabled);
 void help_testing_set_page_state(bool page_up, bool page_down);
 Sint32 help_testing_controls_flowed_max_width();
@@ -28,6 +30,8 @@ void help_testing_set_line_key_state(bool line_up, bool line_down);
 void help_testing_set_jump_key_state(bool home_down, bool end_down);
 Sint32 help_testing_query_linesdown();
 bool help_testing_query_scroll_chrome();
+Sint32 help_testing_query_active_tab();
+Sint32 help_testing_query_help_page();
 
 struct ViewportGuard
 {
@@ -124,51 +128,125 @@ struct CurrentCampaignGuard
 
 struct HelpInjectorState
 {
-    std::atomic<bool> escape_queued{false};
+    // Probe values observed by the injector (-1 = the wait timed out and
+    // the tab/page never reached the expected value).
+    std::atomic<int> page_after_wheel_down{-1};
+    std::atomic<int> page_after_wheel_up{-1};
+    std::atomic<int> page_after_next{-1};
+    std::atomic<int> page_after_prev{-1};
+    std::atomic<int> tab_after_classes{-1};
+    std::atomic<int> tab_after_editor{-1};
+    std::atomic<int> tab_after_controls{-1};
+    std::atomic<bool> back_clicked{false};
 };
 
+// Poll the help screen's probes until they reach `expected` (the engine loop
+// iterates every ~10ms); report the final observed value either way.
+static int settle_help_page(int expected, int timeout_ms)
+{
+    for (int waited = 0; waited <= timeout_ms; waited += 10)
+    {
+        if (help_testing_query_help_page() == expected)
+            return expected;
+        SDL_Delay(10);
+    }
+    return help_testing_query_help_page();
+}
+
+static int settle_help_tab(int expected, int timeout_ms)
+{
+    for (int waited = 0; waited <= timeout_ms; waited += 10)
+    {
+        if (help_testing_query_active_tab() == expected)
+            return expected;
+        SDL_Delay(10);
+    }
+    return help_testing_query_active_tab();
+}
+
+// #168: the full-screen help is an engine screen — drive it by interactable
+// id (tabs, pagers, BACK), never by raw coordinates.
 static int help_injector_thread(void* data)
 {
     og::runtime::ensure_thread_session();
     auto* state = static_cast<HelpInjectorState*>(data);
-    SDL_Delay(100);
 
-    // Exercise both wheel directions while the long Controls tab is active.
-    SDL_Event wheel{};
-    wheel.type = SDL_EVENT_MOUSE_WHEEL;
-    wheel.wheel.y = -3;
-    wheel.wheel.integer_y = -3;
-    SDL_PushEvent(&wheel);
+    if (wait_for_interactable("help_tab_classes", 5000))
+    {
+        SDL_Delay(300);
 
-    SDL_Delay(50);
+        // Wheel pages the multi-page Controls tab down, then back up.
+        SDL_Event wheel{};
+        wheel.type = SDL_EVENT_MOUSE_WHEEL;
+        wheel.wheel.y = -3;
+        wheel.wheel.integer_y = -3;
+        SDL_PushEvent(&wheel);
+        state->page_after_wheel_down.store(settle_help_page(1, 2000),
+                                           std::memory_order_release);
 
-    wheel.wheel.y = 1;
-    wheel.wheel.integer_y = 1;
-    SDL_PushEvent(&wheel);
-    SDL_Delay(50);
+        wheel.wheel.y = 1;
+        wheel.wheel.integer_y = 1;
+        SDL_PushEvent(&wheel);
+        state->page_after_wheel_up.store(settle_help_page(0, 2000),
+                                         std::memory_order_release);
 
-    // Hold page keys long enough to cross the viewer's intentional 10-tick
-    // repeat debounce.  The atomic seam models held input without writing to
-    // SDL's thread-owned keyboard-state array.
-    help_testing_set_page_state(false, true);
-    SDL_Delay(220);
-    help_testing_set_page_state(false, false);
-    help_testing_set_page_state(true, false);
-    SDL_Delay(220);
-    help_testing_set_page_state(false, false);
+        // The PREV/NEXT pagers (visible: Controls flows to several pages).
+        if (wait_for_interactable("help_page_next", 2000))
+        {
+            SDL_Delay(300);
+            interact("help_page_next");
+            state->page_after_next.store(settle_help_page(1, 2000),
+                                         std::memory_order_release);
+            SDL_Delay(300);
+            interact("help_page_prev");
+            state->page_after_prev.store(settle_help_page(0, 2000),
+                                         std::memory_order_release);
+        }
 
-    // Click all three tabs, including the return to Controls.
-    inject_click(120, 22, 10);
-    inject_click(182, 22, 10);
-    inject_click(60, 22, 10);
+        // All three tabs, including the return to Controls.
+        SDL_Delay(300);
+        interact("help_tab_classes");
+        state->tab_after_classes.store(settle_help_tab(1, 2000),
+                                       std::memory_order_release);
+        SDL_Delay(300);
+        interact("help_tab_editor");
+        state->tab_after_editor.store(settle_help_tab(2, 2000),
+                                      std::memory_order_release);
+        SDL_Delay(300);
+        interact("help_tab_controls");
+        state->tab_after_controls.store(settle_help_tab(0, 2000),
+                                        std::memory_order_release);
+        SDL_Delay(300);
+    }
 
-    SDL_Delay(50);
-
-    // Dismiss through the production key-event path. show_general_help also
-    // retains held-key polling, while the key-event latch catches a short press.
-    state->escape_queued.store(true, std::memory_order_release);
-    inject_key_press(SDLK_ESCAPE, 10);
+    // Dismiss via BACK (its Escape hotkey is keystate-polled, which an
+    // injected SDL event cannot reach).
+    state->back_clicked.store(true, std::memory_order_release);
+    interact("help_back");
     return 0;
+}
+
+// Shared assertions for every flow that runs the injector against the open
+// help screen: tab switches, wheel paging, and pager clicks all happened at
+// their expected values, and the screen stayed open until BACK.
+static void expect_help_injector_flow(const HelpInjectorState& state)
+{
+    EXPECT_EQ(1, state.page_after_wheel_down.load(std::memory_order_acquire))
+        << "wheel down must page the Controls tab to page 1";
+    EXPECT_EQ(0, state.page_after_wheel_up.load(std::memory_order_acquire))
+        << "wheel up must page back to page 0";
+    EXPECT_EQ(1, state.page_after_next.load(std::memory_order_acquire))
+        << "NEXT must flip to page 1";
+    EXPECT_EQ(0, state.page_after_prev.load(std::memory_order_acquire))
+        << "PREV must flip back to page 0";
+    EXPECT_EQ(1, state.tab_after_classes.load(std::memory_order_acquire))
+        << "the CLASSES tab must activate";
+    EXPECT_EQ(2, state.tab_after_editor.load(std::memory_order_acquire))
+        << "the EDITOR tab must activate";
+    EXPECT_EQ(0, state.tab_after_controls.load(std::memory_order_acquire))
+        << "the CONTROLS tab must re-activate";
+    EXPECT_TRUE(state.back_clicked.load(std::memory_order_acquire))
+        << "help must stay open until BACK dismisses it";
 }
 
 TEST(HelpSmoke, help_show_general_help_scrolls_tabs_and_exits_cleanly)
@@ -189,8 +267,7 @@ TEST(HelpSmoke, help_show_general_help_scrolls_tabs_and_exits_cleanly)
     ASSERT_NE(nullptr, thread.get()) << "failed to create injector thread";
 
     ASSERT_EQ(1, show_general_help());
-    EXPECT_TRUE(injector_state.escape_queued.load(std::memory_order_acquire))
-        << "tab clicks must not dismiss help before the Escape event";
+    expect_help_injector_flow(injector_state);
     ASSERT_EQ(0, thread.join());
 }
 
@@ -213,8 +290,7 @@ TEST(HelpSmoke, concrete_sdl_picker_client_delegates_to_general_help)
         help_injector_thread, "sdl_client_help_injector", &injector_state));
     ASSERT_NE(nullptr, thread.get());
     client->show_help();
-    EXPECT_TRUE(injector_state.escape_queued.load(std::memory_order_acquire))
-        << "picker help must remain open until the Escape event";
+    expect_help_injector_flow(injector_state);
     EXPECT_EQ(0, thread.join());
 }
 
@@ -236,8 +312,7 @@ TEST(HelpSmoke, help_button_action_opens_viewer_and_requests_redraw)
     vbutton dispatcher;
     EXPECT_EQ(2, dispatcher.do_call(
                      button_action_id(ButtonAction::ShowHelp), 0));
-    EXPECT_TRUE(injector_state.escape_queued.load(std::memory_order_acquire))
-        << "button-dispatched help must remain open until the Escape event";
+    expect_help_injector_flow(injector_state);
     EXPECT_EQ(0, thread.join());
 }
 
@@ -345,15 +420,24 @@ TEST(HelpSmoke, help_internal_paths_cover_loading_tabs_and_scroll)
     EXPECT_EQ(0, help_testing_exercise_internal_paths());
 }
 
-// #152: the Controls tab shipped three 41-42 char lines against the 39-char
-// frame. After render-time flowing, every line fits and the over-budget
-// lines actually wrapped (the flowed line count grew).
+// #168: the engine-hook exerciser — the null-state (bare-sweep) shape, tab
+// dispatch, pager clamping, and wheel paging, checked step by step.
+TEST(HelpSmoke, help_menu_hooks_cover_dispatch_paging_and_null_state)
+{
+    EXPECT_EQ(0, help_testing_exercise_menu_hooks());
+}
+
+// #168: the full-screen frame flows text to the 50-char budget
+// (help_char_budget(kHelpTextBoxWidth)). Every authored Controls line fits —
+// the helper returns -1 if any wrapped — and the widest line exceeds the old
+// 39-char dialog budget, proving the full-width flow is the one measured.
 TEST(HelpSmoke, controls_help_lines_flow_within_frame_budget)
 {
     const Sint32 max_width = help_testing_controls_flowed_max_width();
-    ASSERT_GT(max_width, 0)
-        << "the over-budget Controls lines did not wrap at all";
-    EXPECT_LE(max_width, 39);
+    ASSERT_GT(max_width, 39)
+        << "a Controls line wrapped against the full-width budget (or the "
+           "wide action-key lines were removed)";
+    EXPECT_LE(max_width, 50);
 }
 
 static int overlong_scenario_injector_thread(void* data)

--- a/tests/integration/test_hire_team.cpp
+++ b/tests/integration/test_hire_team.cpp
@@ -42,7 +42,7 @@ static void cleanup_picker_state()
 // to name the character, which blocks on text input. Instead we test that
 // the hire menu loads, character cycling works, and we can exit cleanly.
 //
-// Flow: Main Menu -> Begin New Game -> (dismiss campaign intro) ->
+// Flow: Main Menu -> Begin New Game -> (accept company name) ->
 //       Team Build -> Hire Troops -> NEXT -> NEXT -> PREV -> Back -> Back
 
 struct HireState {
@@ -68,10 +68,9 @@ static int hire_injector(void* data)
     // §2.2: accept the generated company name at the name-entry screen.
     accept_generated_company_name();
 
-    // Dismiss campaign intro screen
-    SDL_Delay(1000);
-    fprintf(stderr, "  [test] dismissing campaign intro with Escape\n");
-    inject_key_press(SDLK_ESCAPE);
+    // No campaign intro here anymore (issue #186: it moved behind the
+    // campaign select, skipped under TESTING) — an Escape here would BACK
+    // out of the team-build screen instead.
 
     // New games now land on team build first, then enter hire explicitly.
     SDL_Delay(500);

--- a/tests/integration/test_level_progress.cpp
+++ b/tests/integration/test_level_progress.cpp
@@ -44,9 +44,10 @@ static int event_injector_thread(void* data)
     seq->started = true;
 
     // Wait for mainmenu to initialize and complete fadeblack.
-    // mainmenu() calls init_buttons() then fadeblack(1) which takes ~500ms
-    // and eats SDL events during the fade. We wait for the button to exist
-    // then add extra delay so the fade finishes and the event loop is ready.
+    // The main menu's run_menu_screen entry (EnterTransition::FadeWithInitialDraw)
+    // publishes its buttons, then fades out, composes, and fades in — the fade
+    // takes ~500ms and eats SDL events. We wait for the button to exist then add
+    // extra delay so the fade finishes and the event loop is ready.
     wait_for_interactable("continue_game", 5000);
     SDL_Delay(750);
 
@@ -54,8 +55,10 @@ static int event_injector_thread(void* data)
     fprintf(stderr, "  [test] Step 1: clicking continue_game\n");
     interact("continue_game");
 
-    // Wait for create_team_menu to init after fade + level load.
-    // create_team_menu calls fadeblack(0), level_data.load(), fadeblack(1).
+    // Wait for create_team_menu to init after fade + level load. Base Camp
+    // enters with EnterTransition::FadeAroundEntry (a fade-out unless the
+    // post-game teardown already suppressed it, the cold compose, a fade-in);
+    // the level reload happens in the runner loop's reload guard.
     // PROGRESS lives inside the SCENARIO subscreen now.
     SDL_Delay(500);
     wait_for_interactable("scenario", 10000);

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -262,6 +262,10 @@ static bool remote_start_none_is_legacy_faithful(const std::string& name)
     static const std::set<std::string> kLegacyNoRemoteStart = {
         "gameplay_fx", "ui_fx", "graphics_fx",
         "display_settings",
+        // #168: the legacy blocking help dialog ran no remote-start check
+        // either — a joiner parked in HELP launches when the main menu
+        // re-enters, exactly as before the migration.
+        "help",
     };
     return kLegacyNoRemoteStart.count(name) > 0;
 }
@@ -1753,6 +1757,105 @@ TEST(MenuEngine, content_screen_registry_hosts_and_semantics)
         EXPECT_EQ(og::ui::RowState::Hidden,
                   view_scenario->rows[kViewScenarioPrevIndex].state_override(
                       context));
+    }
+}
+
+// #168 HELP: full-screen engine screen. Pin the registry hosting, the spec
+// obligations (BACK carries MENU_REDRAW under exit_on_redraw, no entry fade,
+// wheel frame_tick + MenuSpecRow dispatch), the hotkey set (1/2/3 tabs,
+// PageUp/PageDown pagers, Escape on BACK), the grid relations (tab strip on
+// one baseline at a uniform pitch from the frame's left column; the command
+// band on one baseline), the footer geometry identity with VIEW LEVEL, and
+// the null-state single-page shape the bare sweeps drive.
+TEST(MenuEngine, help_screen_spec_shape_pins)
+{
+    const og::ui::MenuScreenHost& host =
+        og::ui::menu_screen_host(og::ui::MenuScreenId::Help);
+    ASSERT_EQ(og::ui::MenuScreenHost::Kind::Engine, host.kind);
+    const og::ui::MenuScreenSpec& spec = *host.spec;
+    EXPECT_STREQ("help", spec.name);
+    EXPECT_TRUE(spec.exit_on_redraw);
+    EXPECT_EQ(MENU_REDRAW, spec.exit_value);
+    EXPECT_TRUE(spec.polls_lobby);
+    // DELIBERATE: today's help has no entry fade (and #200 is reworking the
+    // FadeAroundEntry path).
+    EXPECT_EQ(og::ui::EnterTransition::None, spec.enter);
+    EXPECT_EQ(kHelpMenuBackIndex, spec.default_highlight);
+    EXPECT_NE(nullptr, spec.frame_tick) << "wheel -> page steps";
+    EXPECT_NE(nullptr, spec.on_spec_row) << "tab/pager dispatch";
+    ASSERT_EQ(kHelpMenuNextIndex + 1, spec.row_count);
+    EXPECT_NE(nullptr, spec.rows[kHelpMenuPrevIndex].state_override);
+    EXPECT_NE(nullptr, spec.rows[kHelpMenuNextIndex].state_override);
+
+    // Hotkeys: digit tabs, pager page keys, Escape on BACK.
+    EXPECT_EQ(KEYSTATE_1, spec.rows[kHelpMenuControlsTabIndex].hotkey);
+    EXPECT_EQ(KEYSTATE_2, spec.rows[kHelpMenuClassesTabIndex].hotkey);
+    EXPECT_EQ(KEYSTATE_3, spec.rows[kHelpMenuEditorTabIndex].hotkey);
+    EXPECT_EQ(KEYSTATE_ESCAPE, spec.rows[kHelpMenuBackIndex].hotkey);
+    EXPECT_EQ(KEYSTATE_PAGEUP, spec.rows[kHelpMenuPrevIndex].hotkey);
+    EXPECT_EQ(KEYSTATE_PAGEDOWN, spec.rows[kHelpMenuNextIndex].hotkey);
+
+    // G3: every MenuSpecRow arg is its own spec ordinal.
+    for (const int row : {kHelpMenuControlsTabIndex, kHelpMenuClassesTabIndex,
+                          kHelpMenuEditorTabIndex, kHelpMenuPrevIndex,
+                          kHelpMenuNextIndex}) {
+        EXPECT_EQ(ButtonAction::MenuSpecRow, spec.rows[row].action)
+            << spec.rows[row].id;
+        EXPECT_EQ(row, spec.rows[row].arg) << spec.rows[row].id;
+    }
+    EXPECT_EQ(ButtonAction::ReturnMenu, spec.rows[kHelpMenuBackIndex].action);
+    EXPECT_EQ(MENU_REDRAW, spec.rows[kHelpMenuBackIndex].arg);
+
+    // Grid relations, not absolutes: the tab strip shares one baseline, one
+    // face size, and a uniform pitch starting on the frame's left column;
+    // the command band shares one baseline and height.
+    for (const int tab : {kHelpMenuControlsTabIndex, kHelpMenuClassesTabIndex,
+                          kHelpMenuEditorTabIndex}) {
+        EXPECT_EQ(kHelpTabY, spec.rows[tab].y) << spec.rows[tab].id;
+        EXPECT_EQ(kHelpTabWidth, spec.rows[tab].w) << spec.rows[tab].id;
+        EXPECT_EQ(kHelpTabHeight, spec.rows[tab].h) << spec.rows[tab].id;
+        EXPECT_EQ(kHelpTabX(tab), spec.rows[tab].x) << spec.rows[tab].id;
+    }
+    EXPECT_EQ(kHelpFrameLeft, spec.rows[kHelpMenuControlsTabIndex].x)
+        << "tab strip starts on the frame's left column";
+    EXPECT_EQ(spec.rows[kHelpMenuClassesTabIndex].x -
+                  spec.rows[kHelpMenuControlsTabIndex].x,
+              spec.rows[kHelpMenuEditorTabIndex].x -
+                  spec.rows[kHelpMenuClassesTabIndex].x)
+        << "tab pitch must be uniform";
+    for (const int row : {kHelpMenuBackIndex, kHelpMenuPrevIndex,
+                          kHelpMenuNextIndex}) {
+        EXPECT_EQ(kHelpFooterY, spec.rows[row].y) << spec.rows[row].id;
+        EXPECT_EQ(kHelpFooterHeight, spec.rows[row].h) << spec.rows[row].id;
+    }
+
+    // Shared-layout identity: the BACK/PREV/NEXT band is the VIEW LEVEL
+    // footer, field by field.
+    const og::ui::MenuScreenSpec& view =
+        *og::ui::menu_screen_host(og::ui::MenuScreenId::ViewScenario).spec;
+    const std::pair<int, int> band[] = {
+        {kHelpMenuBackIndex, kViewScenarioBackIndex},
+        {kHelpMenuPrevIndex, kViewScenarioPrevIndex},
+        {kHelpMenuNextIndex, kViewScenarioNextIndex}};
+    for (const auto& [help_row, view_row] : band) {
+        EXPECT_EQ(view.rows[view_row].x, spec.rows[help_row].x)
+            << spec.rows[help_row].id;
+        EXPECT_EQ(view.rows[view_row].y, spec.rows[help_row].y)
+            << spec.rows[help_row].id;
+        EXPECT_EQ(view.rows[view_row].w, spec.rows[help_row].w)
+            << spec.rows[help_row].id;
+        EXPECT_EQ(view.rows[view_row].h, spec.rows[help_row].h)
+            << spec.rows[help_row].id;
+    }
+
+    // Null state (no open screen): pagers hidden — the single-page shape
+    // the bare G5/gate-lattice sweeps drive.
+    {
+        og::ui::MenuLabelContext context;
+        EXPECT_EQ(og::ui::RowState::Hidden,
+                  spec.rows[kHelpMenuPrevIndex].state_override(context));
+        EXPECT_EQ(og::ui::RowState::Hidden,
+                  spec.rows[kHelpMenuNextIndex].state_override(context));
     }
 }
 

--- a/tests/integration/test_menu_layout.cpp
+++ b/tests/integration/test_menu_layout.cpp
@@ -470,7 +470,7 @@ void check_nav_closed_and_reachable(button* buttons, int count,
 // cluster top-right at y=15 beside the relocated line B, and the bottom
 // command strip BACK | HIRE | SCENARIO | NETWORK | GO at y=178. The TRAIN
 // column is DELETED: the TEAM chip (61,y,10,10) cycles team, the row body
-// (84,y,214,10) opens training, and ^ at x=300 moves a member up. Spec
+// (84,y,214,10) opens training, and ^ at x=303 moves a member up. Spec
 // ordinals group by kind (dep
 // 0-7, row body 8-15, team chip 16-23, pagers 24/25, scenario-line 26,
 // strip 27-31, ready twin 32) so MenuSpecRow args decode positionally. The
@@ -518,8 +518,8 @@ TEST(MenuLayout, createmenu_basecamp_geometry_and_nav)
         {"roster_team_5", "", 61, 115, 10, 10, MenuNav{.up = 20, .down = 22, .left = 5, .right = 13}, false, true},
         {"roster_team_6", "", 61, 129, 10, 10, MenuNav{.up = 21, .down = 23, .left = 6, .right = 14}, false, true},
         {"roster_team_7", "", 61, 143, 10, 10, MenuNav{.up = 22, .down = 31, .left = 7, .right = 15}, false, true},
-        {"roster_page_prev", "<", 263, 15, 14, 10, MenuNav{.down = 8, .right = 25}, true},
-        {"roster_page_next", ">", 302, 15, 14, 10, MenuNav{.down = 8, .left = 24}, true},
+        {"roster_page_prev", "<", 258, 15, 14, 10, MenuNav{.down = 8, .right = 25}, true},
+        {"roster_page_next", ">", 298, 15, 14, 10, MenuNav{.down = 8, .left = 24}, true},
         {"scenario_line", "", 6, 14, 208, 12, MenuNav{.down = 29}, false, true},
         {"back", "BACK", 8, 178, 44, 18, MenuNav{.up = 7, .right = 28}, false},
         {"hire_troops", "HIRE", 58, 178, 50, 18, MenuNav{.up = 7, .left = 27, .right = 29}, false},
@@ -545,23 +545,23 @@ TEST(MenuLayout, createmenu_basecamp_geometry_and_nav)
          MenuNav{.left = 37, .right = 39}, false},
         {"seat_page_next", ">", 287, 164, 8, 10,
          MenuNav{.down = 31, .left = 38}, true},
-        {"add_seat", "+", 297, 164, 14, 10,
+        {"add_seat", "+", 298, 164, 14, 10,
          MenuNav{.down = 31, .left = 39}, false},
-        {"roster_up_0", "^", 300, 45, 9, 10,
+        {"roster_up_0", "^", 303, 45, 9, 10,
          MenuNav{.left = 8}, true},
-        {"roster_up_1", "^", 300, 59, 9, 10,
+        {"roster_up_1", "^", 303, 59, 9, 10,
          MenuNav{.left = 9}, true},
-        {"roster_up_2", "^", 300, 73, 9, 10,
+        {"roster_up_2", "^", 303, 73, 9, 10,
          MenuNav{.left = 10}, true},
-        {"roster_up_3", "^", 300, 87, 9, 10,
+        {"roster_up_3", "^", 303, 87, 9, 10,
          MenuNav{.left = 11}, true},
-        {"roster_up_4", "^", 300, 101, 9, 10,
+        {"roster_up_4", "^", 303, 101, 9, 10,
          MenuNav{.left = 12}, true},
-        {"roster_up_5", "^", 300, 115, 9, 10,
+        {"roster_up_5", "^", 303, 115, 9, 10,
          MenuNav{.left = 13}, true},
-        {"roster_up_6", "^", 300, 129, 9, 10,
+        {"roster_up_6", "^", 303, 129, 9, 10,
          MenuNav{.left = 14}, true},
-        {"roster_up_7", "^", 300, 143, 9, 10,
+        {"roster_up_7", "^", 303, 143, 9, 10,
          MenuNav{.left = 15}, true},
     };
 
@@ -671,6 +671,55 @@ TEST(MenuLayout, createmenu_basecamp_geometry_and_nav)
 
     save.current_campaign = old_campaign;
     (void)picker_createmenu_buttons();
+}
+
+// The menus skill's layout-discipline rule applied to Base Camp: the exact
+// table above happily pinned a crooked right rail for months (>, ^, + and GO
+// each ended on a different column), so the grid is asserted here as
+// RELATIONS — one right edge, one card pitch, one pager cluster.
+TEST(MenuLayout, createmenu_basecamp_grid_relations)
+{
+    button* buttons = picker_createmenu_buttons();
+    const int count = picker_createmenu_button_count();
+    ASSERT_EQ(kCreateMenuButtonCount, count);
+
+    // (a) The right rail is ONE column: every control that reaches it ends on
+    // GO's right edge, which is the panel's inner face edge (8..311).
+    const button& go = buttons[kCreateMenuGoIndex];
+    const int rail_right = go.x + go.sizex;
+    EXPECT_EQ(312, rail_right) << "GO closes the panel's inner grey face";
+    std::vector<int> rail{kBaseCampPageNextIndex, kBaseCampAddSeatIndex,
+                          kCreateMenuReadyIndex};
+    for (int r = 0; r < kBaseCampRosterRowsPerPage; ++r)
+        rail.push_back(kBaseCampMoveUpBase + r);
+    for (const int index : rail)
+    {
+        const button& b = buttons[index];
+        EXPECT_EQ(rail_right, b.x + b.sizex)
+            << b.id << " must co-terminate with GO on the right rail";
+    }
+
+    // (b) The seat cards are one uniform run: equal widths, equal pitch, one
+    // baseline.
+    for (int card = 0; card + 1 < kBaseCampSeatCardsPerPage; ++card)
+    {
+        const button& left = buttons[kBaseCampSeatCardBase + card];
+        const button& right = buttons[kBaseCampSeatCardBase + card + 1];
+        EXPECT_EQ(58, right.x - left.x) << "seat card pitch at card " << card;
+        EXPECT_EQ(left.sizex, right.sizex)
+            << "seat card width at card " << card;
+        EXPECT_EQ(left.y, right.y) << "seat card baseline at card " << card;
+    }
+
+    // (c) The roster pagers are twins straddling the "p/N" strip: the space
+    // between their faces is exactly the strip's reserved slot (3 glyphs plus
+    // the 2px backing pad on each side) plus one 2px gutter per side.
+    const button& prev = buttons[kBaseCampPagePrevIndex];
+    const button& next = buttons[kBaseCampPageNextIndex];
+    EXPECT_EQ(prev.sizex, next.sizex) << "roster pager faces are one size";
+    EXPECT_EQ(prev.y, next.y) << "roster pagers share the header-B baseline";
+    EXPECT_EQ((3 * 6 + 4) + 2 * 2, next.x - (prev.x + prev.sizex))
+        << "pager cluster: strip slot + a 2px gutter on each side";
 }
 
 // The seat rail has its own four-card pager, independent of the eight-row

--- a/tests/integration/test_menu_layout.cpp
+++ b/tests/integration/test_menu_layout.cpp
@@ -466,11 +466,12 @@ void check_nav_closed_and_reachable(button* buttons, int count,
 
 // §2.5 base camp (the reimagined team build) at the §9.14 round-4 grid
 // with the §9.11 (G4) row-click-train shape: 8 deploy/team/row-body trios at
-// 14px pitch from y=45 (padded grey roster panel (6,28)..(313,160)), the page
-// cluster top-right at y=15 beside the relocated line B, and the bottom
+// 14px pitch from y=45 (padded grey roster panel (8,28)..(311,160) —
+// outside-to-outside with the command strip), the page cluster top-right at
+// y=15 beside the relocated line B, and the bottom
 // command strip BACK | HIRE | SCENARIO | NETWORK | GO at y=178. The TRAIN
 // column is DELETED: the TEAM chip (61,y,10,10) cycles team, the row body
-// (84,y,214,10) opens training, and ^ at x=303 moves a member up. Spec
+// (84,y,214,10) opens training, and ^ at x=301 moves a member up. Spec
 // ordinals group by kind (dep
 // 0-7, row body 8-15, team chip 16-23, pagers 24/25, scenario-line 26,
 // strip 27-31, ready twin 32) so MenuSpecRow args decode positionally. The
@@ -520,7 +521,7 @@ TEST(MenuLayout, createmenu_basecamp_geometry_and_nav)
         {"roster_team_7", "", 61, 143, 10, 10, MenuNav{.up = 22, .down = 31, .left = 7, .right = 15}, false, true},
         {"roster_page_prev", "<", 258, 15, 14, 10, MenuNav{.down = 8, .right = 25}, true},
         {"roster_page_next", ">", 298, 15, 14, 10, MenuNav{.down = 8, .left = 24}, true},
-        {"scenario_line", "", 6, 14, 208, 12, MenuNav{.down = 29}, false, true},
+        {"scenario_line", "", 8, 14, 206, 12, MenuNav{.down = 29}, false, true},
         {"back", "BACK", 8, 178, 44, 18, MenuNav{.up = 7, .right = 28}, false},
         {"hire_troops", "HIRE", 58, 178, 50, 18, MenuNav{.up = 7, .left = 27, .right = 29}, false},
         {"scenario", "SCENARIO", 114, 178, 62, 18, MenuNav{.up = 26, .left = 28, .right = 30}, false},
@@ -547,21 +548,21 @@ TEST(MenuLayout, createmenu_basecamp_geometry_and_nav)
          MenuNav{.down = 31, .left = 38}, true},
         {"add_seat", "+", 298, 164, 14, 10,
          MenuNav{.down = 31, .left = 39}, false},
-        {"roster_up_0", "^", 303, 45, 9, 10,
+        {"roster_up_0", "^", 301, 45, 9, 10,
          MenuNav{.left = 8}, true},
-        {"roster_up_1", "^", 303, 59, 9, 10,
+        {"roster_up_1", "^", 301, 59, 9, 10,
          MenuNav{.left = 9}, true},
-        {"roster_up_2", "^", 303, 73, 9, 10,
+        {"roster_up_2", "^", 301, 73, 9, 10,
          MenuNav{.left = 10}, true},
-        {"roster_up_3", "^", 303, 87, 9, 10,
+        {"roster_up_3", "^", 301, 87, 9, 10,
          MenuNav{.left = 11}, true},
-        {"roster_up_4", "^", 303, 101, 9, 10,
+        {"roster_up_4", "^", 301, 101, 9, 10,
          MenuNav{.left = 12}, true},
-        {"roster_up_5", "^", 303, 115, 9, 10,
+        {"roster_up_5", "^", 301, 115, 9, 10,
          MenuNav{.left = 13}, true},
-        {"roster_up_6", "^", 303, 129, 9, 10,
+        {"roster_up_6", "^", 301, 129, 9, 10,
          MenuNav{.left = 14}, true},
-        {"roster_up_7", "^", 303, 143, 9, 10,
+        {"roster_up_7", "^", 301, 143, 9, 10,
          MenuNav{.left = 15}, true},
     };
 
@@ -683,20 +684,29 @@ TEST(MenuLayout, createmenu_basecamp_grid_relations)
     const int count = picker_createmenu_button_count();
     ASSERT_EQ(kCreateMenuButtonCount, count);
 
-    // (a) The right rail is ONE column: every control that reaches it ends on
-    // GO's right edge, which is the panel's inner face edge (8..311).
+    // (a) The right rail is ONE column: every control OUTSIDE the roster
+    // panel ends on GO's right edge, which is the panel's OUTER right edge
+    // (outer bevel 8..311, outside-to-outside with the command strip).
     const button& go = buttons[kCreateMenuGoIndex];
     const int rail_right = go.x + go.sizex;
-    EXPECT_EQ(312, rail_right) << "GO closes the panel's inner grey face";
-    std::vector<int> rail{kBaseCampPageNextIndex, kBaseCampAddSeatIndex,
-                          kCreateMenuReadyIndex};
-    for (int r = 0; r < kBaseCampRosterRowsPerPage; ++r)
-        rail.push_back(kBaseCampMoveUpBase + r);
+    EXPECT_EQ(312, rail_right) << "GO closes the panel's outer right edge";
+    const std::vector<int> rail{kBaseCampPageNextIndex, kBaseCampAddSeatIndex,
+                                kCreateMenuReadyIndex};
     for (const int index : rail)
     {
         const button& b = buttons[index];
         EXPECT_EQ(rail_right, b.x + b.sizex)
             << b.id << " must co-terminate with GO on the right rail";
+    }
+    // The per-row '^' lives INSIDE the panel: it co-terminates with the
+    // panel's inner grey face — GO's right edge minus the panel's 2px bevel
+    // inset.
+    for (int r = 0; r < kBaseCampRosterRowsPerPage; ++r)
+    {
+        const button& b = buttons[kBaseCampMoveUpBase + r];
+        EXPECT_EQ(rail_right - 2, b.x + b.sizex)
+            << b.id << " must hug the panel's inner face (outer edge minus "
+               "the 2px bevel)";
     }
 
     // (b) The seat cards are one uniform run: equal widths, equal pitch, one

--- a/tests/integration/test_new_game.cpp
+++ b/tests/integration/test_new_game.cpp
@@ -68,7 +68,7 @@ static bool wait_for_team_menu(int timeout_ms = kTeamMenuTimeoutMs)
 // This verifies:
 //   1. The begin_new_game button works
 //   2. Save data gets reset on new game
-//   3. The team-build menu appears immediately after the intro
+//   3. The team-build menu appears immediately after founding
 //   4. Networking is available from that menu
 //   5. Navigation back to main menu works
 
@@ -93,19 +93,16 @@ static int new_game_injector(void* data)
     interact("begin_new_game");
 
     // §2.2: BEGIN NEW GAME now opens the name-entry screen first. Accept the
-    // generated company name to found the company and proceed to the intro.
+    // generated company name to found the company.
     wait_for_interactable("company_name_accept", 5000);
     SDL_Delay(750);  // FadeAroundEntry settle
     fprintf(stderr, "  [test] accepting generated company name\n");
     interact("company_name_accept");
 
-    // picker_prepare_new_game_setup then calls read_campaign_intro() which
-    // blocks until input_continue is set (SDLK_ESCAPE keydown triggers this).
-    SDL_Delay(1000);
-    fprintf(stderr, "  [test] dismissing campaign intro with Escape\n");
-    inject_key_press(SDLK_ESCAPE);
-
-    // Now we should be on the team-build menu immediately.
+    // The campaign intro no longer runs inside picker_prepare_new_game_setup
+    // (issue #186: it moved behind the campaign select, whose TESTING
+    // short-circuit skips it here), so the flow proceeds to the team-build
+    // menu without further input.
     SDL_Delay(500);
     if (wait_for_team_menu()) {
         state->saw_team_menu = true;
@@ -134,7 +131,7 @@ TEST(NewGame, begin_new_game) {
     // restart?" prompt is RETIRED — founding a company never destroys the
     // loaded game. Seed save0 with a team member (the exact team_size > 0
     // condition that used to raise the prompt) so this flow proves BEGIN NEW
-    // GAME now goes straight to the intro. Were the prompt still present, the
+    // GAME now founds without asking. Were the prompt still present, the
     // injector — which never answers it — would hang until timeout.
     for (int i = 0; i < MAX_TEAM_SIZE; i++) {
         og::runtime::current_session->myscreen_->save_data.team_list[static_cast<std::size_t>(i)].reset(nullptr);
@@ -297,11 +294,10 @@ static int name_entry_edit_injector(void* data)
         interact("company_name_accept");
     }
 
-    // Dismiss the campaign intro so the flow reaches team build.
-    SDL_Delay(1000);
-    inject_key_press(SDLK_ESCAPE);
-
-    // Unwind back to the main menu so picker_main can hit its Quit gate.
+    // No campaign intro here anymore (issue #186: it moved behind the
+    // campaign select, skipped under TESTING) — the flow reaches team build
+    // on its own. Unwind back to the main menu so picker_main can hit its
+    // Quit gate.
     SDL_Delay(500);
     if (wait_for_team_menu()) {
         state->saw_team_menu = true;
@@ -382,10 +378,8 @@ static int continue_player_count_injector(void* data)
     if (!accept_generated_company_name())
         return 0;
 
-    // picker_prepare_new_game_setup blocks on the campaign intro.
-    SDL_Delay(1000);
-    inject_key_press(SDLK_ESCAPE);
-
+    // picker_prepare_new_game_setup no longer blocks on the campaign intro
+    // (issue #186); the flow lands on Base Camp directly.
     if (!wait_for_team_menu())
         return 0;
     state->saw_initial_base_camp = true;

--- a/tests/integration/test_overpowered_team.cpp
+++ b/tests/integration/test_overpowered_team.cpp
@@ -89,7 +89,7 @@ static bool wait_for_team_menu(int timeout_ms = kTeamMenuTimeoutMs)
 // levels (programmatically), run level 1 at max speed, and confirm that we win.
 //
 // Flow:
-//   Main Menu -> Begin New Game -> (dismiss campaign intro) ->
+//   Main Menu -> Begin New Game -> (accept company name) ->
 //   Hire Menu -> cycle through all types, clicking HIRE ME for each ->
 //   Back -> (cheat stats on hired team) -> GO -> game runs -> win ->
 //   Back -> exits to main menu
@@ -120,10 +120,9 @@ static int op_injector(void* data)
     // §2.2: accept the generated company name at the name-entry screen.
     accept_generated_company_name();
 
-    // Dismiss campaign intro screen (blocks until Escape)
-    SDL_Delay(kMenuTransitionMs);
-    fprintf(stderr, "  [test] dismissing campaign intro\n");
-    inject_key_press(SDLK_ESCAPE);
+    // No campaign intro here anymore (issue #186: it moved behind the
+    // campaign select, skipped under TESTING) — an Escape here would BACK
+    // out of the team-build screen instead.
 
     // New games now land on team build first, then enter hire explicitly.
     SDL_Delay(kUiSettleMs);

--- a/tests/integration/test_pause_menu.cpp
+++ b/tests/integration/test_pause_menu.cpp
@@ -2456,6 +2456,244 @@ TEST(PauseMenuFlow, restart_mission_relaunches_level_through_picker_loop)
 }
 
 // ---------------------------------------------------------------------------
+// Regression (#200): quitting a scenario faded it out TWICE. The teardown in
+// go_menu fades whichever canvas was last presented (World, after the pause
+// menu's exit dance) and clears it, but the UI canvas still held the pause
+// menu image; Base Camp's EnterTransition::FadeAroundEntry then faded THAT
+// out as a second visible transition. On a WIN the results screen presents on
+// the UI canvas, so the second fade was an invisible no-op — hence "only when
+// I quit".
+//
+// Under TESTING every fadeblack lands in FadeBetween's test-mode branch, which
+// traces one line per fade. Counting them across the quit is the pin: the
+// transition from a running mission back into Base Camp is exactly one
+// fade-out (teardown) plus one fade-in (Base Camp entry).
+
+namespace
+{
+
+int count_fade_traces()
+{
+    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    int fades = 0;
+    for (const TraceEntry& entry : g_trace_buffer)
+    {
+        if (entry.category == "video" &&
+            entry.message.find("FadeBetween") != std::string::npos)
+        {
+            ++fades;
+        }
+    }
+    return fades;
+}
+
+struct QuitFadeFlowState {
+    bool started = false;
+    bool finished = false;
+    bool game_started = false;
+    bool returned_to_base_camp = false;
+    int fades_after_quit = -1;
+    const char* failure_message = nullptr;
+};
+
+int fail_quit_fade_flow(QuitFadeFlowState* state, const char* message)
+{
+    fprintf(stderr, "  [test] ERROR: %s\n", message);
+    state->failure_message = message;
+    og::ui::pause_menu_testing_clear_queue();
+
+    if (g_test_in_game.load(std::memory_order_acquire))
+    {
+        og::ui::pause_menu_testing_queue_outcome(
+            og::ui::PauseMenuResult::Quit, /*release_pause=*/false);
+        inject_key_press(SDLK_ESCAPE);
+        int waited_ms = 0;
+        while (g_test_in_game.load(std::memory_order_acquire) &&
+               waited_ms < kRestartStageTimeoutMs)
+        {
+            SDL_Delay(kRestartPollMs);
+            waited_ms += kRestartPollMs;
+        }
+        og::ui::pause_menu_testing_clear_queue();
+    }
+    if (restart_wait_for_team_menu(5'000))
+    {
+        SDL_Delay(250);
+        const auto [back_x, back_y] = ui_canvas_to_window(30.0f, 187.0f);
+        inject_click(static_cast<int>(back_x), static_cast<int>(back_y));
+    }
+    state->finished = true;
+    return 0;
+}
+
+int quit_fade_count_injector(void* data)
+{
+    og::runtime::ensure_thread_session();
+    auto* const state = static_cast<QuitFadeFlowState*>(data);
+    state->started = true;
+
+    // -- Main menu -> Continue -> Base Camp --
+    if (!wait_for_interactable("continue_game", 15'000))
+        return fail_quit_fade_flow(state, "main menu never appeared");
+    SDL_Delay(750); // fadeblack eats events
+    interact("continue_game");
+    {
+        int elapsed = 0;
+        while (elapsed < kRestartStageTimeoutMs &&
+               !has_interactable("hire_troops"))
+        {
+            if (has_interactable("continue_game"))
+                interact("continue_game");
+            SDL_Delay(250);
+            elapsed += 250;
+        }
+    }
+    if (!restart_wait_for_team_menu(kRestartStageTimeoutMs))
+        return fail_quit_fade_flow(state, "team menu did not appear");
+    SDL_Delay(150);
+
+    // -- GO: enter the level through the real go_menu do/while --
+    const int epoch_before =
+        g_test_game_epoch.load(std::memory_order_acquire);
+    {
+        int elapsed = 0;
+        int since_click = 250;
+        while (elapsed < kRestartStageTimeoutMs &&
+               g_test_game_epoch.load(std::memory_order_acquire) ==
+                   epoch_before)
+        {
+            if (since_click >= 250 && has_interactable("go"))
+            {
+                interact("go");
+                since_click = 0;
+            }
+            SDL_Delay(50);
+            elapsed += 50;
+            since_click += 50;
+        }
+    }
+    if (g_test_game_epoch.load(std::memory_order_acquire) == epoch_before)
+        return fail_quit_fade_flow(state, "game never started (epoch unchanged)");
+    state->game_started = true;
+
+    {
+        int waited_ms = 0;
+        while (g_test_game_frame_ticks.load(std::memory_order_acquire) < 3 &&
+               g_test_in_game.load(std::memory_order_acquire) &&
+               waited_ms < kRestartStageTimeoutMs)
+        {
+            SDL_Delay(kRestartPollMs);
+            waited_ms += kRestartPollMs;
+        }
+        if (g_test_game_frame_ticks.load(std::memory_order_acquire) < 3)
+            return fail_quit_fade_flow(state, "game never advanced frames");
+    }
+
+    // The counting window opens here: glad_init's own two fades are long
+    // done, the mission is playing, and nothing fades again until the quit.
+    trace_clear();
+
+    // -- Esc -> QUIT -> confirm (the scripted outcome stands in for the
+    // separately tested menu clicks). --
+    og::ui::pause_menu_testing_clear_queue();
+    og::ui::pause_menu_testing_queue_outcome(
+        og::ui::PauseMenuResult::Quit, /*release_pause=*/false);
+    inject_key_press(SDLK_ESCAPE);
+    {
+        int waited_ms = 0;
+        while (g_test_in_game.load(std::memory_order_acquire) &&
+               waited_ms < kRestartStageTimeoutMs)
+        {
+            SDL_Delay(kRestartPollMs);
+            waited_ms += kRestartPollMs;
+        }
+        if (g_test_in_game.load(std::memory_order_acquire))
+            return fail_quit_fade_flow(state, "QUIT did not exit the mission");
+    }
+
+    state->returned_to_base_camp =
+        restart_wait_for_team_menu(kRestartStageTimeoutMs);
+    if (!state->returned_to_base_camp)
+        return fail_quit_fade_flow(state, "team menu did not return after quit");
+
+    // Both expected fades are in, then settle: a third (the bug) lands right
+    // between them, so the settled total is what separates 2 from 3.
+    {
+        int waited_ms = 0;
+        while (count_fade_traces() < 2 && waited_ms < kRestartStageTimeoutMs)
+        {
+            SDL_Delay(kRestartPollMs);
+            waited_ms += kRestartPollMs;
+        }
+    }
+    SDL_Delay(1'000);
+    state->fades_after_quit = count_fade_traces();
+
+    SDL_Delay(250);
+    const auto [back_x, back_y] = ui_canvas_to_window(30.0f, 187.0f);
+    inject_click(static_cast<int>(back_x), static_cast<int>(back_y));
+
+    state->finished = true;
+    return 0;
+}
+
+} // namespace
+
+TEST(PauseMenuFlow, quit_to_base_camp_fades_out_once)
+{
+    trace_clear();
+    og::ui::pause_menu_testing_clear_queue();
+    picker_testing_yes_or_no_queue_clear();
+
+    screen* const game_screen = og::runtime::current_session->myscreen_;
+    ASSERT_TRUE(game_screen != nullptr);
+    game_screen->save_data.reset();
+    game_screen->save_data.numplayers = 1;
+    game_screen->save_data.current_campaign = "gladiator";
+    game_screen->save_data.current_levels["gladiator"] = 1;
+    game_screen->save_data.scen_num = 1;
+    {
+        // Sturdy team so the level neither wins nor loses underneath the test
+        // (a win would present the results screen and change the fade count).
+        auto soldier = std::make_unique<guy>(FAMILY_SOLDIER);
+        soldier->name = "Leader";
+        soldier->constitution = 200;
+        soldier->armor = 200;
+        game_screen->save_data.team_list[0] = std::move(soldier);
+        game_screen->save_data.team_size = 1;
+    }
+    ASSERT_TRUE(game_screen->save_data.save("save0"));
+
+    QuitFadeFlowState state;
+    SDL_Thread* const thread =
+        SDL_CreateThread(quit_fade_count_injector, "quit_fade_count", &state);
+    ASSERT_TRUE(thread != nullptr);
+
+    g_picker_mainmenu_calls = 0;
+    g_picker_max_mainmenu_calls = 1;
+
+    picker_main(0, nullptr);
+
+    int thread_result = -1;
+    SDL_WaitThread(thread, &thread_result);
+    g_picker_max_mainmenu_calls = 0;
+    og::ui::pause_menu_testing_clear_queue();
+    picker_testing_yes_or_no_queue_clear();
+
+    ASSERT_TRUE(state.finished)
+        << (state.failure_message != nullptr ? state.failure_message
+                                             : "injector did not finish");
+    ASSERT_TRUE(state.game_started) << "GO must start the level";
+    ASSERT_TRUE(state.returned_to_base_camp)
+        << "QUIT must land back in Base Camp";
+    ASSERT_EQ(2, state.fades_after_quit)
+        << "quitting a mission must play exactly one fade-out (go_menu's "
+           "teardown) and one fade-in (Base Camp's entry) — a third fade is "
+           "#200, the stale UI-canvas menu image faded out a second time";
+    ASSERT_EQ(nullptr, state.failure_message) << state.failure_message;
+}
+
+// ---------------------------------------------------------------------------
 // BUG repro (user report, PR #198): local 1-player game, pause menu ADD
 // PLAYER, resume, play, Esc again into the ADDED seat's player screen, cycle
 // INPUT — the app died with "InProcessTransport peer 1 is not connected"

--- a/tests/integration/test_seat_chip.cpp
+++ b/tests/integration/test_seat_chip.cpp
@@ -1,0 +1,238 @@
+// #202 — Base Camp seat-card team chip. End-to-end flow through picker_main
+// and the REAL click dispatch: a pointer click on the card's team-square
+// region cycles the seat's team in place (mouse coordinates stamped by
+// vbutton::leftclick, routed by base_camp_on_spec_row's chip zone), while a
+// click on the card's P#/name region still opens the seat editor. The fast
+// direct-drive pins (value sequence, wrap, denial, foreign/spectator gates,
+// keyboard-FIRE stale-pointer rule) live in test_view_team.cpp; this flow
+// proves the real dispatch path end to end.
+//
+// Lives in the og_test_basecamp group (design G10: heavyweight Layer-F flows
+// never ride og_test_menu_ui).
+
+#include <openglad/core/test_trace.h>
+#include <openglad/interface/button.h>
+#include <openglad/interface/screen.h>
+#include <openglad/resources/company.h>
+#include <openglad/resources/io_common.h>
+#include <openglad/resources/save_data.h>
+#include <gtest/gtest.h>
+#include <SDL3/SDL.h>
+#include "test_input_helpers.h"
+#include "test_interact.h"
+
+#include <string>
+
+// Forward declarations from picker.cpp.
+void picker_main(Sint32 argc, char** argv);
+extern int g_picker_mainmenu_calls;
+extern int g_picker_max_mainmenu_calls;
+
+#include <openglad/interface/ui/picker_ui_state.h>
+static inline PickerState& pks() { return *og::runtime::current_session->picker_; }
+
+namespace {
+
+constexpr int kTeamMenuTimeoutMs = 20000;
+
+void cleanup_picker_state()
+{
+    for (int i = 0; i < 5; i++) {
+        pks().backdrops[static_cast<std::size_t>(i)].reset();
+        pks().backpics[i].free();
+    }
+    clear_allbuttons();
+    og::runtime::current_session->localbuttons_ = nullptr;
+    pks().main_columns_pix.reset();
+    pks().main_columns_data.free();
+    pks().main_title_logo_pix.reset();
+    pks().main_title_logo_data.free();
+}
+
+bool wait_for_team_menu(int timeout_ms = kTeamMenuTimeoutMs)
+{
+    int elapsed = 0;
+    const int poll_interval = 50;
+    while (elapsed < timeout_ms) {
+        if (has_interactable("hire_troops") && has_interactable("networking"))
+            return true;
+        SDL_Delay(poll_interval);
+        elapsed += poll_interval;
+    }
+    fprintf(stderr, "  [interact] TIMEOUT entering team menu (%d ms)\n",
+            timeout_ms);
+    return false;
+}
+
+bool wait_for_trace(const char* category, const char* substring,
+                    int timeout_ms)
+{
+    int elapsed = 0;
+    const int poll_interval = 50;
+    while (elapsed < timeout_ms) {
+        if (trace_contains(category, substring))
+            return true;
+        SDL_Delay(poll_interval);
+        elapsed += poll_interval;
+    }
+    fprintf(stderr, "  [interact] TIMEOUT waiting for trace %s/%s (%d ms)\n",
+            category, substring, timeout_ms);
+    return false;
+}
+
+// The sanctioned coordinate injector, aimed at the card's team-square
+// region instead of the button center: last-few-pixels of the face, well
+// inside the chip zone (card_x+46 .. card right edge), mapped through the
+// same UI-canvas-pinned transform interact() uses.
+bool click_seat_card_chip(const std::string& id)
+{
+    og::runtime::ensure_thread_session();
+    int win_x = -1, win_y = -1;
+    bool found = false;
+    {
+        AllButtonsLock lock;
+        for (int i = 0; i < MAX_BUTTONS; i++) {
+            vbutton* const b =
+                og::runtime::current_session->allbuttons_[static_cast<std::size_t>(i)];
+            if (!b || b->id != id || b->hidden)
+                continue;
+            const int game_x = b->xloc + b->width - 5;
+            const int game_y = b->yloc + b->height / 2;
+            const auto [mapped_x, mapped_y] =
+                ui_canvas_to_window(static_cast<float>(game_x),
+                                    static_cast<float>(game_y));
+            win_x = static_cast<int>(mapped_x);
+            win_y = static_cast<int>(mapped_y);
+            fprintf(stderr,
+                    "  [interact] chip-clicking '%s' at game(%d,%d) win(%d,%d)\n",
+                    id.c_str(), game_x, game_y, win_x, win_y);
+            found = true;
+            break;
+        }
+    }
+    if (found)
+        inject_click(win_x, win_y, 100);
+    else
+        fprintf(stderr, "  [interact] WARNING: '%s' not found\n", id.c_str());
+    return found;
+}
+
+struct SeatChipFlowState {
+    bool started = false;
+    bool finished = false;
+    bool saw_base_camp = false;
+    bool saw_first_cycle = false;
+    bool saw_second_cycle = false;
+    bool editor_opened_on_chip = false;
+    bool editor_opened_on_center = false;
+    std::string founded_slot;
+};
+
+int seat_chip_injector(void* data)
+{
+    og::runtime::ensure_thread_session();
+    auto* state = static_cast<SeatChipFlowState*>(data);
+    state->started = true;
+
+    if (!wait_for_interactable("begin_new_game", 5000))
+        return 0;
+    SDL_Delay(750);
+    interact("begin_new_game");
+    if (!accept_generated_company_name())
+        return 0;
+    if (!wait_for_team_menu())
+        return 0;
+    state->saw_base_camp = true;
+    state->founded_slot = og::data::active_company_slot();
+    SDL_Delay(750);
+    if (!wait_for_interactable("seat_card_0", 5000))
+        return 0;
+    SDL_Delay(300);
+
+    // Chip click 1: the fresh solo seat starts on team 1; classic campaigns
+    // expose all four teams, so the first cycle lands on team 2.
+    fprintf(stderr, "  [test] chip click 1 on seat_card_0\n");
+    if (!click_seat_card_chip("seat_card_0"))
+        return 0;
+    state->saw_first_cycle =
+        wait_for_trace("basecamp", "seat_team player=1 team=2", 5000);
+    SDL_Delay(300);
+    state->editor_opened_on_chip = has_interactable("seat_settings_back");
+
+    // Chip click 2 cycles onward (2 -> 3): in-place cycling is repeatable.
+    fprintf(stderr, "  [test] chip click 2 on seat_card_0\n");
+    if (!click_seat_card_chip("seat_card_0"))
+        return 0;
+    state->saw_second_cycle =
+        wait_for_trace("basecamp", "seat_team player=1 team=3", 5000);
+    SDL_Delay(300);
+    state->editor_opened_on_chip = state->editor_opened_on_chip ||
+        has_interactable("seat_settings_back");
+
+    // A center click (the P#/name region) still opens the seat editor.
+    fprintf(stderr, "  [test] center click on seat_card_0\n");
+    interact("seat_card_0");
+    state->editor_opened_on_center =
+        wait_for_interactable("seat_settings_back", 5000);
+    if (state->editor_opened_on_center) {
+        SDL_Delay(750);
+        interact("seat_settings_back");
+        if (!wait_for_team_menu())
+            return 0;
+        SDL_Delay(300);
+    }
+
+    interact("back");
+    state->finished = true;
+    return 0;
+}
+
+} // namespace
+
+TEST(SeatChip, chip_click_cycles_team_and_card_click_still_opens_editor)
+{
+    struct ClockReset {
+        ~ClockReset() { og::data::set_company_clock_for_tests(std::nullopt); }
+    } clock_reset;
+    struct FoundedCompanyCleanup {
+        std::string slot;
+        ~FoundedCompanyCleanup()
+        {
+            if (slot.empty() || slot == "save0")
+                return;
+            (void)og::data::set_active_company_slot("save0");
+            (void)og::data::delete_company(slot);
+        }
+    } company_cleanup;
+
+    trace_clear();
+    // Outrank any stray company created earlier in this process, even when
+    // the suite runs shuffled within the same second.
+    og::data::set_company_clock_for_tests(4102444800LL); // 2100-01-01 UTC
+
+    SeatChipFlowState state;
+    SDL_Thread* thread =
+        SDL_CreateThread(seat_chip_injector, "seat_chip", &state);
+    ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
+
+    g_picker_mainmenu_calls = 0;
+    g_picker_max_mainmenu_calls = 1;
+    picker_main(0, nullptr);
+    SDL_WaitThread(thread, nullptr);
+
+    cleanup_picker_state();
+    g_picker_max_mainmenu_calls = 0;
+    company_cleanup.slot = state.founded_slot;
+
+    ASSERT_TRUE(state.started);
+    ASSERT_TRUE(state.saw_base_camp) << "flow must reach Base Camp";
+    EXPECT_TRUE(state.saw_first_cycle)
+        << "chip click must cycle the seat team in place (team=2 trace)";
+    EXPECT_TRUE(state.saw_second_cycle)
+        << "a second chip click must cycle onward (team=3 trace)";
+    EXPECT_FALSE(state.editor_opened_on_chip)
+        << "the chip click must not open the seat editor";
+    EXPECT_TRUE(state.editor_opened_on_center)
+        << "a card-center click must still open the seat editor";
+    ASSERT_TRUE(state.finished) << "the complete flow should unwind";
+}

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -11,6 +11,7 @@
 #include <openglad/core/test_trace.h>
 #include <openglad/gameplay/guy.h>
 #include <openglad/interface/button.h>
+#include <openglad/interface/input.h>
 #include <openglad/interface/screen.h>
 #include <openglad/interface/ui/picker_common.h>
 #include <openglad/interface/ui/picker_lobby_client.h>
@@ -27,12 +28,16 @@
 #include <string>
 #include <vector>
 
+#include "../../src/interface/ui/picker_sdl_defs.h"
+
 void picker_main(Sint32 argc, char **argv);
 Sint32 create_team_menu(Sint32 arg1);
 extern int g_picker_mainmenu_calls;
 extern int g_picker_max_mainmenu_calls;
 extern std::atomic_bool g_test_present_pause_requested;
 extern std::atomic_bool g_test_present_paused;
+// Engine keyboard-nav hook (picker_input.cpp, TESTING only).
+extern int g_test_menu_nav_key;
 
 #include <openglad/interface/ui/picker_ui_state.h>
 static inline PickerState &pks() {
@@ -101,15 +106,21 @@ private:
   bool acquired_ = false;
 };
 
+// A frozen 320x200 frame, RGB triplets in row-major order.
+using FramePixels = std::vector<Uint8>;
+// Optional per-shot pixel oracle: runs on the copied frame, after the
+// presenter has resumed. Returning false fails the capture.
+using FrameCheck = bool (*)(const FramePixels &);
+
 // Verify the current canvas and optionally dump it as a binary PPM. Runs on
 // the injector thread. The presenter handshake freezes exactly one completed
 // frame while its pixels are copied, so a blank-frame assertion cannot pass or
 // fail based on overlap with the menu loop's next clear/redraw pass.
-bool capture_frame(const char *name) {
+bool capture_frame(const char *name, FrameCheck check = nullptr) {
   screen *scr = og::runtime::current_session->myscreen_;
   const char *output_dir = std::getenv("UXSHOTS_DIR");
   std::string path;
-  std::vector<Uint8> rgb;
+  FramePixels rgb;
   if (output_dir != nullptr && output_dir[0] != '\0') {
     std::error_code error;
     std::filesystem::create_directories(output_dir, error);
@@ -119,8 +130,10 @@ bool capture_frame(const char *name) {
       return false;
     }
     path = std::string(output_dir) + "/" + name + ".ppm";
-    rgb.reserve(320 * 200 * 3);
   }
+  const bool keep_pixels = !path.empty() || check != nullptr;
+  if (keep_pixels)
+    rgb.reserve(320 * 200 * 3);
 
   std::size_t nonblack_pixels = 0;
   {
@@ -134,13 +147,18 @@ bool capture_frame(const char *name) {
         scr->get_pixel(x, y, &r, &g, &b);
         if (r != 0 || g != 0 || b != 0)
           ++nonblack_pixels;
-        if (!path.empty()) {
+        if (keep_pixels) {
           rgb.push_back(r);
           rgb.push_back(g);
           rgb.push_back(b);
         }
       }
     }
+  }
+
+  if (check != nullptr && !check(rgb)) {
+    fprintf(stderr, "  [uxshot] %s: pixel check FAILED\n", name);
+    return false;
   }
 
   if (!path.empty()) {
@@ -1009,6 +1027,166 @@ TEST(UxShots, m_basecamp_many_seats_and_matchup) {
 
 // --- 13. full-screen help (#168): all three tabs plus a paged state -------
 
+// Folder-tab merge oracle (#201 polish). The active tab and the content frame
+// must read as one surface: across the connector band the active tab's column
+// carries the frame's face color, and the frame's top bevel line is broken
+// there while it survives under every inactive tab.
+struct ProbeRgb {
+  Uint8 r = 0, g = 0, b = 0;
+  bool operator==(const ProbeRgb &) const = default;
+};
+
+ProbeRgb frame_pixel(const FramePixels &rgb, int x, int y) {
+  const std::size_t index =
+      (static_cast<std::size_t>(y) * 320 + static_cast<std::size_t>(x)) * 3;
+  if (index + 2 >= rgb.size())
+    return {};
+  return {rgb[index], rgb[index + 1], rgb[index + 2]};
+}
+
+// Mid-tab column: away from both edge bevels and from the outline's side runs.
+int help_tab_probe_x(int tab) { return kHelpTabX(tab) + kHelpTabWidth / 2; }
+
+// `outline_rows` is how many rows of the active tab's connector band the
+// keyboard-focus outline is allowed to steal (its bottom run draws after the
+// content pass): 0 with no focus, 1 when the active tab is focused.
+bool check_help_tab_merge(const FramePixels &rgb, int active_tab,
+                          int outline_rows) {
+  // Reference colors are read off the frame itself rather than the palette:
+  // the injector thread's session carries its own palette registers, and a
+  // same-frame comparison stays valid through a fade. The face sample sits
+  // deep inside the frame, the bevel sample on the frame's top line right of
+  // the tab strip; a fully black (unrendered) frame collapses them and fails.
+  const ProbeRgb face =
+      frame_pixel(rgb, kHelpFrameRight - 4, kHelpFrameBottom - 4);
+  const ProbeRgb bevel = frame_pixel(rgb, kHelpFrameRight - 20, kHelpFrameTop);
+  if (face == bevel) {
+    fprintf(stderr, "  [uxshot] help merge: face and bevel samples match\n");
+    return false;
+  }
+
+  for (int tab = 0; tab < 3; ++tab) {
+    const int probe_x = help_tab_probe_x(tab);
+    int face_rows = 0;
+    for (int y = kHelpConnectorTop; y <= kHelpConnectorBottom; ++y) {
+      if (frame_pixel(rgb, probe_x, y) == face)
+        ++face_rows;
+    }
+    const int band_rows = kHelpConnectorBottom - kHelpConnectorTop + 1;
+    const int want = (tab == active_tab) ? band_rows - outline_rows : 0;
+    if (face_rows != want) {
+      fprintf(stderr,
+              "  [uxshot] help merge: tab %d connector has %d face rows, "
+              "expected %d\n",
+              tab, face_rows, want);
+      return false;
+    }
+    // The frame's top bevel line: broken under the active tab, intact under
+    // the others.
+    const bool bevel_intact =
+        frame_pixel(rgb, probe_x, kHelpFrameTop) == bevel;
+    if (bevel_intact == (tab == active_tab)) {
+      fprintf(stderr, "  [uxshot] help merge: tab %d frame bevel intact=%d\n",
+              tab, static_cast<int>(bevel_intact));
+      return false;
+    }
+  }
+  return true;
+}
+
+bool check_help_controls_merged(const FramePixels &rgb) {
+  return check_help_tab_merge(rgb, kHelpMenuControlsTabIndex, 0);
+}
+
+bool check_help_classes_merged(const FramePixels &rgb) {
+  return check_help_tab_merge(rgb, kHelpMenuClassesTabIndex, 0);
+}
+
+// The same frame with no keyboard focus, kept as the reference the focus shot
+// diffs against.
+FramePixels g_help_editor_unfocused;
+
+bool check_help_editor_merged(const FramePixels &rgb) {
+  g_help_editor_unfocused = rgb;
+  return check_help_tab_merge(rgb, kHelpMenuEditorTabIndex, 0);
+}
+
+// With the EDITOR tab focused the merge must survive except for the one row
+// the outline's bottom run occupies, and the outline's left, right and top
+// runs must all still be visible around the tab. The outline color is taken
+// from the frame — whatever the focused frame paints where the unfocused one
+// did not — and all three surviving runs must carry it. The runs breathe with
+// the pulse (0..3px outside the face), so each is searched over its band.
+bool check_help_editor_focused(const FramePixels &rgb) {
+  if (!check_help_tab_merge(rgb, kHelpMenuEditorTabIndex, 1))
+    return false;
+  if (g_help_editor_unfocused.size() != rgb.size()) {
+    fprintf(stderr, "  [uxshot] help focus: no unfocused reference frame\n");
+    return false;
+  }
+  const int tab_x = kHelpTabX(kHelpMenuEditorTabIndex);
+  const int pulse = 3;
+  const int run_top = kHelpTabY + 4;
+  const int run_bottom = kHelpTabY + 11;
+
+  // The left run is the outline's first appearance; its color anchors the
+  // other two runs.
+  ProbeRgb outline;
+  bool found_left = false;
+  for (int y = run_top; y <= run_bottom && !found_left; ++y) {
+    for (int x = tab_x - pulse; x <= tab_x; ++x) {
+      const ProbeRgb here = frame_pixel(rgb, x, y);
+      if (here != frame_pixel(g_help_editor_unfocused, x, y)) {
+        outline = here;
+        found_left = true;
+        break;
+      }
+    }
+  }
+  if (!found_left) {
+    fprintf(stderr, "  [uxshot] help focus: outline left run missing\n");
+    return false;
+  }
+  auto run_found = [&](int x0, int x1, int y0, int y1) {
+    for (int y = y0; y <= y1; ++y)
+      for (int x = x0; x <= x1; ++x)
+        if (frame_pixel(rgb, x, y) == outline)
+          return true;
+    return false;
+  };
+  if (!run_found(tab_x + kHelpTabWidth, tab_x + kHelpTabWidth + pulse, run_top,
+                 run_bottom)) {
+    fprintf(stderr, "  [uxshot] help focus: outline right run missing\n");
+    return false;
+  }
+  // Above the tab: at the top of its swing the horizontal run can sit one row
+  // off-canvas, so the band spans the whole outline width — the side runs
+  // reach these rows too, and either way the outline still closes above the
+  // tab. Nothing in the connector can reach this far up.
+  if (!run_found(tab_x - pulse, tab_x + kHelpTabWidth + pulse, 0, kHelpTabY)) {
+    fprintf(stderr, "  [uxshot] help focus: outline top run missing\n");
+    return false;
+  }
+  return true;
+}
+
+// One keyboard-nav step, applied through the engine's testing hook (real key
+// events can't be driven from an injector thread).
+void help_nav_step(int key) {
+  g_test_menu_nav_key = key;
+  SDL_Delay(200);
+}
+
+// Park the pointer over the content frame. interact() leaves the cursor on the
+// button it clicked, and that hover highlight is the same yellow as the
+// keyboard-focus outline — the focus shot can only be told apart from its
+// reference once no button is hovered.
+void help_park_pointer() {
+  const auto [win_x, win_y] = ui_canvas_to_window(300.0f, 100.0f);
+  inject_mouse_motion(static_cast<int>(win_x), static_cast<int>(win_y));
+  SDL_Delay(200);
+}
+
 int help_screen_injector(void *data) {
   og::runtime::ensure_thread_session();
   ShotState *state = static_cast<ShotState *>(data);
@@ -1017,7 +1195,8 @@ int help_screen_injector(void *data) {
   interact("help");
   if (wait_for_interactable("help_tab_classes", 5000)) {
     SDL_Delay(500);
-    state->captures += capture_frame("help_controls");
+    state->captures +=
+        capture_frame("help_controls", &check_help_controls_merged);
     if (wait_for_interactable("help_page_next", 2000)) {
       SDL_Delay(300);
       interact("help_page_next");
@@ -1027,11 +1206,19 @@ int help_screen_injector(void *data) {
     SDL_Delay(300);
     interact("help_tab_classes");
     SDL_Delay(500);
-    state->captures += capture_frame("help_classes");
+    state->captures +=
+        capture_frame("help_classes", &check_help_classes_merged);
     SDL_Delay(300);
     interact("help_tab_editor");
     SDL_Delay(500);
-    state->captures += capture_frame("help_editor");
+    help_park_pointer();
+    state->captures += capture_frame("help_editor", &check_help_editor_merged);
+    // Walk the keyboard highlight from BACK onto the active (EDITOR) tab.
+    help_nav_step(KEY_UP);
+    help_nav_step(KEY_RIGHT);
+    help_nav_step(KEY_RIGHT);
+    state->captures +=
+        capture_frame("help_editor_focus", &check_help_editor_focused);
     SDL_Delay(300);
     interact("help_back");
   }
@@ -1057,7 +1244,7 @@ TEST(UxShots, n_help_screen) {
   cleanup_picker_state();
   g_picker_max_mainmenu_calls = 0;
   ASSERT_TRUE(state.finished);
-  ASSERT_EQ(4, state.captures);
+  ASSERT_EQ(5, state.captures);
 }
 
 TEST(UxShots, i_basecamp_paged) {

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -1007,6 +1007,59 @@ TEST(UxShots, m_basecamp_many_seats_and_matchup) {
   ASSERT_EQ(3, state.captures);
 }
 
+// --- 13. full-screen help (#168): all three tabs plus a paged state -------
+
+int help_screen_injector(void *data) {
+  og::runtime::ensure_thread_session();
+  ShotState *state = static_cast<ShotState *>(data);
+  wait_for_interactable("help", 5000);
+  SDL_Delay(1500); // FadeWithInitialDraw settle on the main menu
+  interact("help");
+  if (wait_for_interactable("help_tab_classes", 5000)) {
+    SDL_Delay(500);
+    state->captures += capture_frame("help_controls");
+    if (wait_for_interactable("help_page_next", 2000)) {
+      SDL_Delay(300);
+      interact("help_page_next");
+      SDL_Delay(500);
+      state->captures += capture_frame("help_controls_p2");
+    }
+    SDL_Delay(300);
+    interact("help_tab_classes");
+    SDL_Delay(500);
+    state->captures += capture_frame("help_classes");
+    SDL_Delay(300);
+    interact("help_tab_editor");
+    SDL_Delay(500);
+    state->captures += capture_frame("help_editor");
+    SDL_Delay(300);
+    interact("help_back");
+  }
+  if (wait_for_interactable("begin_new_game", 10000)) {
+    SDL_Delay(750);
+    interact("quit");
+  }
+  state->finished = true;
+  return 0;
+}
+
+TEST(UxShots, n_help_screen) {
+  trace_clear();
+  reap_all_companies();
+  ShotState state;
+  SDL_Thread *thread =
+      SDL_CreateThread(help_screen_injector, "ux_help", &state);
+  ASSERT_TRUE(thread != nullptr);
+  g_picker_mainmenu_calls = 0;
+  g_picker_max_mainmenu_calls = 2;
+  picker_main(0, nullptr);
+  SDL_WaitThread(thread, nullptr);
+  cleanup_picker_state();
+  g_picker_max_mainmenu_calls = 0;
+  ASSERT_TRUE(state.finished);
+  ASSERT_EQ(4, state.captures);
+}
+
 TEST(UxShots, i_basecamp_paged) {
   trace_clear();
   CompanySlotCleanup cleanup{{"save0"}};

--- a/tests/integration/test_view_team.cpp
+++ b/tests/integration/test_view_team.cpp
@@ -116,6 +116,10 @@ void picker_testing_draw_menu_highlight(const MenuScreenSpec& spec,
 #include <openglad/interface/ui/picker_ui_state.h>
 static inline PickerState& pks() { return *og::runtime::current_session->picker_; }
 
+// From picker_input.cpp (repo pattern: consumers declare locally).
+bool handle_menu_nav(button* buttons, int& highlighted_button,
+                     Sint32& retvalue, bool use_global_vbuttons = true);
+
 namespace {
 
 class AutoStartPickerLobbyClient final : public og::ui::IPickerLobbyClient
@@ -2521,6 +2525,217 @@ TEST(ViewTeam, base_camp_seat_rail_targets_owned_global_seat_and_clamps_page)
     og::ui::install_seat_settings_state_for_screen(nullptr);
     og::ui::install_base_camp_state_for_screen(nullptr);
     save.reset();
+}
+
+namespace
+{
+// #202 pointer-dispatch contract: menu_click_x/y carry the UI-canvas click
+// that activated a button (stamped by the mouse dispatch site), and -1/-1 on
+// every coordinate-free activation. Restore both plus the row stash so a
+// direct on_spec_row drive never leaks into shuffled neighbors.
+struct MenuClickStashGuard
+{
+    ~MenuClickStashGuard()
+    {
+        pks().menu_click_x = -1;
+        pks().menu_click_y = -1;
+        pks().menu_spec_clicked_row = -1;
+    }
+};
+} // namespace
+
+// ---------------------------------------------------------------------------
+// #202: a pointer click on a seat card's team-square region (the 8x8 chip at
+// card_x+48, with 2px grace on its left, out to the card's right edge) cycles
+// the seat's team IN PLACE through the seat editor's exact mutation path —
+// same selectable-team sequence and wrap, same denial popup, same
+// ready-withdraw side effect, same trace — without opening the seat editor.
+// ---------------------------------------------------------------------------
+TEST(ViewTeam, base_camp_seat_chip_pointer_click_cycles_team_in_place)
+{
+    trace_clear();
+    FactoryMappingGuard mapping_guard;
+    MenuClickStashGuard click_guard;
+
+    SaveData& save = og::runtime::current_session->myscreen_->save_data;
+    save.reset();
+    save.numplayers = 1;
+    save.current_campaign = "gladiator";
+    save.save_name = "MY COMPANY";
+
+    NetworkedRosterLobbyClient lobby;
+    lobby.local_indices = {0};
+    lobby.players.push_back(
+        make_foreign_lobby_player(0, "net-me", "MY COMPANY", 0, 0));
+    lobby.players.front().team = 0;
+    ActivePickerLobbyClientGuard client_guard(&lobby);
+
+    og::ui::BaseCampScreenState state;
+    og::ui::base_camp_refresh_rows(state);
+    ASSERT_EQ(1u, state.seats.size());
+    og::ui::install_base_camp_state_for_screen(&state);
+
+    const og::ui::MenuScreenSpec& spec =
+        *og::ui::menu_screen_host(og::ui::MenuScreenId::TeamBuild).spec;
+    ASSERT_NE(nullptr, spec.on_spec_row);
+    button* buttons = picker_createmenu_buttons();
+    const button& card = buttons[kBaseCampSeatCardBase];
+    ASSERT_EQ(57, card.sizex) << "card face width is the chip zone's anchor";
+
+    // Chip-body click (the drawn 8x8 chip starts at card_x+48).
+    pks().menu_click_x = card.x + 52;
+    pks().menu_click_y = card.y + 5;
+    lobby.ready_state = true;
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
+    ASSERT_EQ(1u, lobby.seat_team_calls.size());
+    const std::pair<std::uint8_t, short> first_request{0, 1};
+    EXPECT_EQ(first_request, lobby.seat_team_calls.back())
+        << "classic team 1 advances to team 2";
+    EXPECT_TRUE(trace_contains("basecamp", "seat_team player=1 team=2"));
+    EXPECT_FALSE(lobby.ready_state)
+        << "the chip ride carries the editor's ready-withdraw side effect";
+    ASSERT_EQ(1u, state.seats.size());
+    EXPECT_EQ(1, state.seats[0].team)
+        << "the handler re-collects seats so this frame's chip digit is new";
+
+    // Zone left boundary: card_x+46 (2px grace before the drawn chip).
+    pks().menu_click_x = card.x + 46;
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
+    ASSERT_EQ(2u, lobby.seat_team_calls.size());
+    EXPECT_EQ(2, lobby.seat_team_calls.back().second);
+    EXPECT_TRUE(trace_contains("basecamp", "seat_team player=1 team=3"));
+
+    // Zone right boundary: the card face's last pixel.
+    pks().menu_click_x = card.x + card.sizex - 1;
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
+    ASSERT_EQ(3u, lobby.seat_team_calls.size());
+    EXPECT_EQ(3, lobby.seat_team_calls.back().second);
+    EXPECT_TRUE(trace_contains("basecamp", "seat_team player=1 team=4"));
+
+    // The wrap: classic team 4 advances back to team 1 — the seat editor's
+    // exact sequence (its own test pins the same wrap).
+    pks().menu_click_x = card.x + 52;
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
+    ASSERT_EQ(4u, lobby.seat_team_calls.size());
+    EXPECT_EQ(0, lobby.seat_team_calls.back().second);
+    EXPECT_TRUE(trace_contains("basecamp", "seat_team player=1 team=1"));
+
+    // A denied request pops the editor's exact denial and mutates nothing.
+    lobby.seat_team_accept = false;
+    lobby.ready_state = true;
+    trace_clear();
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
+    ASSERT_EQ(5u, lobby.seat_team_calls.size());
+    EXPECT_TRUE(trace_contains("popup", "CHANGE DENIED"));
+    EXPECT_FALSE(trace_contains("basecamp", "seat_team"));
+    EXPECT_TRUE(lobby.ready_state)
+        << "a denied assignment must not clear ready";
+
+    og::ui::install_base_camp_state_for_screen(nullptr);
+    save.reset();
+}
+
+// ---------------------------------------------------------------------------
+// #202 gating: the chip zone obeys the card's ownership gates. A foreign
+// (networked, non-editable) seat's chip click names the owning company and
+// mutates nothing; a spectator machine's chip click points at + instead.
+// ---------------------------------------------------------------------------
+TEST(ViewTeam, base_camp_seat_chip_click_foreign_seat_stays_inert)
+{
+    trace_clear();
+    FactoryMappingGuard mapping_guard;
+    MenuClickStashGuard click_guard;
+
+    SaveData& save = og::runtime::current_session->myscreen_->save_data;
+    save.reset();
+    save.numplayers = 1;
+    save.current_campaign = "gladiator";
+    save.save_name = "MY COMPANY";
+
+    NetworkedRosterLobbyClient lobby;
+    lobby.local_indices = {1};
+    lobby.players.push_back(
+        make_foreign_lobby_player(0, "net-remote", "Iron Host", 0, 0));
+    lobby.players.push_back(
+        make_foreign_lobby_player(1, "net-me", "MY COMPANY", 0, 0));
+    ActivePickerLobbyClientGuard client_guard(&lobby);
+
+    og::ui::BaseCampScreenState state;
+    og::ui::base_camp_refresh_rows(state);
+    ASSERT_EQ(2u, state.seats.size());
+    og::ui::install_base_camp_state_for_screen(&state);
+
+    const og::ui::MenuScreenSpec& spec =
+        *og::ui::menu_screen_host(og::ui::MenuScreenId::TeamBuild).spec;
+    button* buttons = picker_createmenu_buttons();
+    const button& card = buttons[kBaseCampSeatCardBase];
+
+    // Card 0 is Iron Host's seat: its chip is read-only for this machine.
+    pks().menu_click_x = card.x + 52;
+    pks().menu_click_y = card.y + 5;
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
+    EXPECT_TRUE(trace_contains("popup", "Iron Host"));
+    EXPECT_TRUE(lobby.seat_team_calls.empty())
+        << "a foreign chip click must never issue a team change";
+
+    // Spectator machine (an owned wire seat lingering at zero active local
+    // seats): the chip is inert there too.
+    lobby.active_local_count = 0;
+    og::ui::base_camp_refresh_rows(state);
+    trace_clear();
+    const button& own_card = buttons[kBaseCampSeatCardBase + 1];
+    pks().menu_click_x = own_card.x + 52;
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase + 1, &state));
+    EXPECT_TRUE(trace_contains("popup", "PRESS + TO ADD A PLAYER"))
+        << "a spectator chip click pops, never mutates";
+    EXPECT_TRUE(lobby.seat_team_calls.empty());
+
+    og::ui::install_base_camp_state_for_screen(nullptr);
+    save.reset();
+}
+
+// ---------------------------------------------------------------------------
+// #202 keyboard rule: FIRE on a highlighted seat card is a coordinate-free
+// dispatch — handle_menu_nav must clear any stale pointer stamp left by an
+// earlier chip click, so consuming the row opens the seat editor instead of
+// silently re-cycling the team.
+// ---------------------------------------------------------------------------
+TEST(ViewTeam, base_camp_seat_card_keyboard_fire_clears_stale_pointer)
+{
+    FactoryMappingGuard mapping_guard;
+    MenuClickStashGuard click_guard;
+
+    button* buttons = picker_createmenu_buttons();
+    const int count = picker_createmenu_button_count();
+    vbutton* local = init_buttons(buttons, count);
+    ASSERT_NE(nullptr, local);
+
+    const bool old_nav_enabled = pks().menu_nav_enabled;
+    pks().menu_nav_enabled = true;
+    // A chip click's stamp, gone stale: FIRE must not reuse it.
+    pks().menu_click_x = buttons[kBaseCampSeatCardBase].x + 52;
+    pks().menu_click_y = buttons[kBaseCampSeatCardBase].y + 5;
+    pks().menu_spec_clicked_row = -1;
+
+    InputHardwareState& hw = input_hardware_state();
+    hw.touch_keystate[0][KEY_FIRE] = true;
+    int highlighted = kBaseCampSeatCardBase;
+    Sint32 retvalue = 0;
+    handle_menu_nav(buttons, highlighted, retvalue, true);
+    hw.touch_keystate[0][KEY_FIRE] = false;
+
+    EXPECT_EQ(kBaseCampSeatCardBase, pks().menu_spec_clicked_row)
+        << "FIRE on the card must dispatch the card row";
+    EXPECT_EQ(-1, pks().menu_click_x)
+        << "a keyboard dispatch must clear the stale pointer x";
+    EXPECT_EQ(-1, pks().menu_click_y)
+        << "a keyboard dispatch must clear the stale pointer y";
+
+    // Observe the release so the FIRE latch never leaks into later tests.
+    handle_menu_nav(buttons, highlighted, retvalue, true);
+    pks().menu_nav_enabled = old_nav_enabled;
+    clear_allbuttons();
+    og::runtime::current_session->localbuttons_ = nullptr;
 }
 
 TEST(ViewTeam, seat_settings_draws_selected_identity_and_direction_mode)

--- a/tests/test_input_helpers.h
+++ b/tests/test_input_helpers.h
@@ -7,6 +7,19 @@
 #include <mutex>
 #include <string>
 
+// Push a fake mouse motion event to (x, y) in window coordinates. Moving the
+// pointer off a button is the only way to clear its hover highlight, which a
+// click leaves behind under the cursor.
+inline void inject_mouse_motion(int x, int y)
+{
+    SDL_Event event;
+    memset(&event, 0, sizeof(event));
+    event.type = SDL_EVENT_MOUSE_MOTION;
+    event.motion.x = static_cast<float>(x);
+    event.motion.y = static_cast<float>(y);
+    SDL_PushEvent(&event);
+}
+
 // Push a fake mouse button down event at game coordinates (x, y).
 // Game coordinates are 320x200; with the default viewport these map
 // 1:1 to SDL window coordinates.

--- a/tests/test_interact.h
+++ b/tests/test_interact.h
@@ -146,8 +146,9 @@ inline void interact(const std::string& id)
 // §2.2: after clicking BEGIN NEW GAME, the flow opens the name-entry screen
 // (generated company name, REROLL, editable, ACCEPT). Every injector flow that
 // founds a new game must clear this screen; accepting the generated name is
-// the canonical path into the campaign intro + team build. Returns whether the
-// screen appeared and was accepted.
+// the canonical path into team build (the campaign intro moved behind the
+// campaign select, which the TESTING short-circuit skips). Returns whether
+// the screen appeared and was accepted.
 inline bool accept_generated_company_name(int timeout_ms = 5000)
 {
     if (!wait_for_interactable("company_name_accept", timeout_ms))

--- a/tests/unit/test_picker_common.cpp
+++ b/tests/unit/test_picker_common.cpp
@@ -4521,9 +4521,12 @@ TEST(CampaignPickerLayout, enter_id_sits_below_the_delete_reset_cell)
 TEST(CampaignPickerLayout, no_control_overlaps_another_control)
 {
     const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
-    const std::array<og::ui::PickerRect, 6> distinct = {
+    std::vector<og::ui::PickerRect> distinct = {
         layout.prev, layout.next, layout.choose,
-        layout.cancel, layout.delete_button, layout.id_button};
+        layout.cancel, layout.delete_button, layout.id_button,
+        layout.more_button, layout.desc_box, layout.icon};
+    for (int row = 0; row < layout.list_rows; ++row)
+        distinct.push_back(og::ui::campaign_picker_row_rect(row));
     for (std::size_t i = 0; i < distinct.size(); ++i)
     {
         for (std::size_t j = i + 1; j < distinct.size(); ++j)
@@ -4534,12 +4537,146 @@ TEST(CampaignPickerLayout, no_control_overlaps_another_control)
     }
 }
 
+TEST(CampaignPickerLayout, list_pane_is_a_grid_beside_the_detail_pane)
+{
+    const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
+
+    ASSERT_GT(layout.list_rows, 1);
+    const og::ui::PickerRect row0 = og::ui::campaign_picker_row_rect(0);
+    for (int row = 0; row < layout.list_rows; ++row)
+    {
+        const og::ui::PickerRect rect = og::ui::campaign_picker_row_rect(row);
+        // Alignment as a RELATION: every row shares row 0's edges and pitch.
+        EXPECT_EQ(row0.x, rect.x) << "row " << row << " breaks the left edge";
+        EXPECT_EQ(row0.w, rect.w) << "row " << row << " breaks the width";
+        EXPECT_EQ(row0.y + layout.list_row_pitch * row, rect.y)
+            << "row " << row << " breaks the pitch";
+        // ...and stays inside the declared list block and left of the
+        // detail pane.
+        EXPECT_GE(rect.x, layout.list.x);
+        EXPECT_LE(rect.y + rect.h, layout.list.y + layout.list.h);
+        EXPECT_LE(rect.x + rect.w, layout.detail.x)
+            << "list rows must not reach the detail pane";
+        EXPECT_FALSE(og::ui::picker_rects_overlap(rect, layout.detail));
+    }
+
+    // The pagers sit below the list, sharing its outer edges, with room for
+    // the position readout between them.
+    EXPECT_GE(layout.prev.y, layout.list.y + layout.list.h);
+    EXPECT_EQ(layout.prev.y, layout.next.y) << "pagers share a band";
+    EXPECT_EQ(layout.list.x, layout.prev.x);
+    EXPECT_EQ(layout.list.x + layout.list.w, layout.next.x + layout.next.w);
+    EXPECT_GE(layout.next.x - (layout.prev.x + layout.prev.w), 8 * 6)
+        << "the 'NN of NN' readout needs 8 glyphs between the pagers";
+
+    // The detail pane's stack: icon and description box inside the pane,
+    // MORE below the box flush with the pane's right edge.
+    EXPECT_FALSE(og::ui::picker_rects_overlap(layout.desc_box, layout.icon));
+    EXPECT_GE(layout.icon.y, layout.detail.y);
+    EXPECT_GE(layout.desc_box.x, layout.detail.x);
+    EXPECT_LE(layout.desc_box.x + layout.desc_box.w,
+              layout.detail.x + layout.detail.w);
+    EXPECT_GE(layout.more_button.y, layout.desc_box.y + layout.desc_box.h);
+    EXPECT_EQ(layout.detail.x + layout.detail.w,
+              layout.more_button.x + layout.more_button.w);
+
+    // Row labels: a 6px marker column then an 18-char label budget.
+    EXPECT_EQ(18, layout.list_label_max_chars);
+    EXPECT_EQ(4, layout.desc_rows);
+    EXPECT_EQ(26, layout.desc_max_chars);
+
+    // Everything stays on the 320x200 canvas.
+    for (const og::ui::PickerRect& rect :
+         {layout.list, layout.detail, layout.prev, layout.next,
+          layout.more_button, layout.desc_box})
+    {
+        EXPECT_GE(rect.x, 0);
+        EXPECT_GE(rect.y, 0);
+        EXPECT_LE(rect.x + rect.w, 320);
+        EXPECT_LE(rect.y + rect.h, 200);
+    }
+}
+
+TEST(CampaignPickerLayout, list_paging_helpers_window_the_shelf)
+{
+    using og::ui::campaign_list_clamp_cursor;
+    using og::ui::campaign_list_clamp_offset;
+    using og::ui::campaign_list_offset_for_cursor;
+    using og::ui::campaign_list_page_step;
+
+    // Clamp: a shelf that fits one page never scrolls.
+    EXPECT_EQ(0, campaign_list_clamp_offset(3, 4, 6));
+    EXPECT_EQ(0, campaign_list_clamp_offset(-2, 10, 6));
+    EXPECT_EQ(4, campaign_list_clamp_offset(9, 10, 6));
+    EXPECT_EQ(2, campaign_list_clamp_offset(2, 10, 6));
+    EXPECT_EQ(0, campaign_list_clamp_offset(5, 0, 6));
+
+    // Bringing a cursor on screen scrolls minimally, in both directions.
+    EXPECT_EQ(0, campaign_list_offset_for_cursor(0, 0, 8, 6));
+    EXPECT_EQ(2, campaign_list_offset_for_cursor(7, 0, 8, 6));
+    EXPECT_EQ(2, campaign_list_offset_for_cursor(3, 4, 8, 6))
+        << "the stale offset first clamps to the last page, where 3 is visible";
+    EXPECT_EQ(1, campaign_list_offset_for_cursor(5, 1, 8, 6));
+
+    // Page steps move by a full page and clamp at the shelf's ends.
+    EXPECT_EQ(2, campaign_list_page_step(0, 8, 6, 1));
+    EXPECT_EQ(0, campaign_list_page_step(2, 8, 6, -1));
+    EXPECT_EQ(6, campaign_list_page_step(0, 13, 6, 1));
+    EXPECT_EQ(7, campaign_list_page_step(6, 13, 6, 1));
+    EXPECT_EQ(0, campaign_list_page_step(3, 13, 6, -1));
+
+    // After a page step the cursor is pulled into the window.
+    EXPECT_EQ(2, campaign_list_clamp_cursor(0, 2, 8, 6));
+    EXPECT_EQ(5, campaign_list_clamp_cursor(7, 0, 8, 6));
+    EXPECT_EQ(4, campaign_list_clamp_cursor(4, 2, 8, 6));
+    EXPECT_EQ(0, campaign_list_clamp_cursor(3, 0, 0, 6));
+
+    // Position readout.
+    EXPECT_EQ("3 of 8", og::ui::format_campaign_position_label(2, 8));
+    EXPECT_EQ("1 of 1", og::ui::format_campaign_position_label(0, 1));
+    EXPECT_EQ("8 of 8", og::ui::format_campaign_position_label(9, 8))
+        << "an out-of-range cursor must clamp, not overflow the label";
+    EXPECT_EQ("0 of 0", og::ui::format_campaign_position_label(0, 0));
+}
+
+TEST(CampaignPickerLayout, row_labels_and_description_overflow)
+{
+    const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
+
+    // fit_text_to_chars is the shared trimmer.
+    EXPECT_EQ("abc", og::ui::fit_text_to_chars("abc", 5));
+    EXPECT_EQ("abcde", og::ui::fit_text_to_chars("abcde", 5));
+    EXPECT_EQ("ab...", og::ui::fit_text_to_chars("abcdef", 5));
+    EXPECT_EQ("abc", og::ui::fit_text_to_chars("abcdef", 3))
+        << "budgets of <= 3 clip without an ellipsis";
+    EXPECT_EQ("", og::ui::fit_text_to_chars("abc", 0));
+
+    // Row labels use the list budget.
+    EXPECT_EQ("Gladiator", og::ui::fit_campaign_row_label("Gladiator"));
+    const std::string long_title(40, 'W');
+    const std::string fitted = og::ui::fit_campaign_row_label(long_title);
+    EXPECT_EQ(static_cast<std::size_t>(layout.list_label_max_chars),
+              fitted.size());
+    EXPECT_EQ("...", fitted.substr(fitted.size() - 3));
+
+    // MORE shows exactly when the wrapped description leaves the box.
+    EXPECT_FALSE(og::ui::campaign_description_overflows("Short and sweet."));
+    std::string long_desc;
+    for (int line = 0; line < 12; ++line)
+        long_desc += "A reasonably long line of prose for the box.\n";
+    EXPECT_TRUE(og::ui::campaign_description_overflows(long_desc));
+    EXPECT_FALSE(og::ui::campaign_description_overflows(""));
+}
+
 TEST(CampaignPickerLayout, title_row_clears_every_control_at_any_length)
 {
     const og::ui::CampaignPickerLayout layout = og::ui::campaign_picker_layout();
-    const std::array<og::ui::PickerRect, 7> controls = {
+    std::vector<og::ui::PickerRect> controls = {
         layout.prev, layout.next, layout.choose, layout.cancel,
-        layout.delete_button, layout.reset_button, layout.id_button};
+        layout.delete_button, layout.reset_button, layout.id_button,
+        layout.more_button, layout.icon, layout.desc_box};
+    for (int row = 0; row < layout.list_rows; ++row)
+        controls.push_back(og::ui::campaign_picker_row_rect(row));
 
     for (int chars = 0; chars <= layout.title_max_chars; ++chars)
     {
@@ -4547,6 +4684,9 @@ TEST(CampaignPickerLayout, title_row_clears_every_control_at_any_length)
         EXPECT_GE(title.x, 0) << "title of " << chars << " runs off screen";
         EXPECT_LE(title.x + title.w, 320)
             << "title of " << chars << " runs off screen";
+        // ...and stays inside the detail pane, above the icon.
+        EXPECT_GE(title.x, layout.detail.x);
+        EXPECT_LE(title.x + title.w, layout.detail.x + layout.detail.w);
         for (const og::ui::PickerRect& control : controls)
         {
             EXPECT_FALSE(og::ui::picker_rects_overlap(title, control))
@@ -4557,13 +4697,19 @@ TEST(CampaignPickerLayout, title_row_clears_every_control_at_any_length)
 
 TEST(CampaignPickerLayout, old_geometry_really_did_clip_the_shipped_titles)
 {
-    // Regression witness: the pre-fix ENTER ID rect, kept as a literal so the
-    // pin still describes the bug after the layout moved.
+    // Regression witness, all literals: the pre-list-redesign browser drew
+    // the title centered on x=160 at y=13 and put ENTER ID at {208,10}. A
+    // title of L glyphs spanned 160 +/- 3L on that row, so 17+ characters
+    // reached the button. The redesigned title lives in the detail pane
+    // (y=36), a row no control shares.
     const og::ui::PickerRect old_id_button{208, 10, 52, 10};
+    const auto old_title_rect = [](int chars) {
+        return og::ui::PickerRect{160 - chars * 3, 13, chars * 6, 8};
+    };
     for (const int shipped : {22, 20, 18, 17})
     {
         EXPECT_TRUE(og::ui::picker_rects_overlap(
-            og::ui::campaign_title_rect(shipped), old_id_button))
+            old_title_rect(shipped), old_id_button))
             << shipped << "-char title used to clip ENTER ID";
         EXPECT_FALSE(og::ui::picker_rects_overlap(
             og::ui::campaign_title_rect(shipped),
@@ -4572,13 +4718,13 @@ TEST(CampaignPickerLayout, old_geometry_really_did_clip_the_shipped_titles)
     }
     // 16 chars was the longest that already fit.
     EXPECT_FALSE(og::ui::picker_rects_overlap(
-        og::ui::campaign_title_rect(16), old_id_button));
+        old_title_rect(16), old_id_button));
 }
 
 TEST(CampaignPickerLayout, fit_campaign_title_budget)
 {
     const int budget = og::ui::campaign_picker_layout().title_max_chars;
-    EXPECT_EQ(36, budget);
+    EXPECT_EQ(29, budget);
 
     // Every shipped title is under budget and passes through untouched.
     for (const char* shipped : {"Gladiator", "The Long Season",
@@ -4618,23 +4764,43 @@ TEST(CampaignPickerLayout, rect_overlap_helper_edges)
     EXPECT_FALSE(og::ui::picker_rects_overlap(a, og::ui::PickerRect{0, 0, 10, 10}));
 }
 
-// Keyboard reachability for the browser's nav graph across every visibility
-// variant. handle_menu_nav IGNORES a link into a hidden button (it does not
-// follow it and does not strand focus), so the property worth pinning is
-// that every VISIBLE button is still reachable from the default highlight
-// after ENTER ID moved out of the top row.
+// Keyboard reachability for the browser's nav graph across every COHERENT
+// visibility variant the SDL loop can produce (an empty shelf hides the
+// pagers, OK, and MORE; MORE needs a highlighted entry, so it needs rows).
+// handle_menu_nav IGNORES a link into a hidden button (it does not follow it
+// and does not strand focus), so the property worth pinning is that every
+// VISIBLE button is still reachable from the default highlight.
 TEST(CampaignPickerLayout, nav_variants_keyboard_reachable)
 {
     using og::ui::CampaignPickerVisibility;
     using og::ui::kCampaignPickerButtonCount;
+    using og::ui::kCampaignPickerRowBaseIndex;
+    using og::ui::kCampaignPickerRowCount;
 
+    int variants_checked = 0;
+    for (int visible_rows = 0; visible_rows <= kCampaignPickerRowCount;
+         ++visible_rows)
     for (const bool prev_hidden : {false, true})
     for (const bool next_hidden : {false, true})
     for (const bool choose_hidden : {false, true})
     for (const bool delete_hidden : {false, true})
+    for (const bool more_hidden : {false, true})
     {
+        // Coherence: OK shows exactly when the shelf has entries; no rows
+        // means an empty shelf (nothing to page or expand); a partially
+        // filled page is always the LAST page.
+        if ((visible_rows == 0) != choose_hidden)
+            continue;
+        if (visible_rows == 0 && !(prev_hidden && next_hidden && more_hidden))
+            continue;
+        if (visible_rows > 0 && visible_rows < kCampaignPickerRowCount &&
+            !next_hidden)
+            continue;
+        ++variants_checked;
+
         const CampaignPickerVisibility visibility{prev_hidden, next_hidden,
-                                                  choose_hidden, delete_hidden};
+                                                  choose_hidden, delete_hidden,
+                                                  visible_rows, more_hidden};
         // RESET occupies the DELETE cell, so exactly one of the pair shows.
         std::array<bool, kCampaignPickerButtonCount> hidden{};
         hidden[og::ui::kCampaignPickerPrevIndex] = prev_hidden;
@@ -4644,13 +4810,19 @@ TEST(CampaignPickerLayout, nav_variants_keyboard_reachable)
         hidden[og::ui::kCampaignPickerDeleteIndex] = delete_hidden;
         hidden[og::ui::kCampaignPickerIdIndex] = false;
         hidden[og::ui::kCampaignPickerResetIndex] = !delete_hidden;
+        for (int row = 0; row < kCampaignPickerRowCount; ++row)
+            hidden[static_cast<std::size_t>(kCampaignPickerRowBaseIndex + row)] =
+                row >= visible_rows;
+        hidden[og::ui::kCampaignPickerMoreIndex] = more_hidden;
 
         const auto nav = og::ui::campaign_picker_nav(visibility);
-        const std::string variant = std::string("prev=") +
+        const std::string variant = std::string("rows=") +
+            std::to_string(visible_rows) + " prev=" +
             (prev_hidden ? "hidden" : "shown") + " next=" +
             (next_hidden ? "hidden" : "shown") + " ok=" +
             (choose_hidden ? "hidden" : "shown") + " delete=" +
-            (delete_hidden ? "hidden" : "shown");
+            (delete_hidden ? "hidden" : "shown") + " more=" +
+            (more_hidden ? "hidden" : "shown");
 
         for (const auto& links : nav)
         {
@@ -4700,5 +4872,114 @@ TEST(CampaignPickerLayout, nav_variants_keyboard_reachable)
         EXPECT_EQ(og::ui::kCampaignPickerIdIndex,
                   nav[og::ui::kCampaignPickerResetIndex].down)
             << variant << ": RESET drops onto the button below it";
+        // The visible list rows chain up/down, exiting only at their ends.
+        for (int row = 1; row < visible_rows; ++row)
+        {
+            const int index = kCampaignPickerRowBaseIndex + row;
+            EXPECT_EQ(index - 1, nav[static_cast<std::size_t>(index)].up)
+                << variant << ": row " << row << " must step up its neighbor";
+            EXPECT_EQ(index,
+                      nav[static_cast<std::size_t>(index - 1)].down)
+                << variant << ": row " << (row - 1)
+                << " must step down its neighbor";
+        }
     }
+    ASSERT_EQ(58, variants_checked)
+        << "the coherent-variant enumeration changed shape";
+}
+
+// --- Level browser (SET LEVEL) layout pins (issue #186) ---
+//
+// The reported defects: the legacy pitch pushed row 2's preview frame to the
+// screen bottom, and the description box {130,35,185,110} was painted AFTER
+// the entries, overprinting the stats column (x=75..165) of rows 0-1. The
+// pins below hold the two repaired properties for every row: previews fully
+// on the 200px screen, and the description box strictly right of the widest
+// stats line.
+
+TEST(LevelPickerLayout, preview_rows_fit_the_screen_at_uniform_pitch)
+{
+    const og::ui::LevelPickerLayout layout = og::ui::level_picker_layout();
+
+    ASSERT_EQ(3, layout.row_count);
+    for (int row = 0; row < layout.row_count; ++row)
+    {
+        const int row_y = og::ui::level_picker_row_y(row);
+        EXPECT_EQ(layout.row0_y + layout.row_pitch * row, row_y)
+            << "row " << row << " breaks the pitch";
+        // Title line, then the radar with its 2px frame, fully on screen
+        // even for the largest radar viewport.
+        const int radar_bottom = row_y + layout.radar_dy + layout.radar_max_h;
+        EXPECT_LE(radar_bottom + 2, 200)
+            << "row " << row << "'s preview frame runs off the screen";
+        EXPECT_GE(row_y, 0);
+        // The next row's title clears this row's radar frame.
+        if (row + 1 < layout.row_count)
+        {
+            EXPECT_GE(og::ui::level_picker_row_y(row + 1), radar_bottom + 2);
+        }
+    }
+
+    // The old geometry really did clip: at the legacy pitch the third
+    // preview frame ended below the old OK/CANCEL row's top.
+    const int old_row2_frame_bottom = 5 + 65 * 2 + 10 + 44 + 2;
+    EXPECT_GT(old_row2_frame_bottom, 190)
+        << "regression witness lost its meaning";
+}
+
+TEST(LevelPickerLayout, description_box_clears_the_stats_column)
+{
+    const og::ui::LevelPickerLayout layout = og::ui::level_picker_layout();
+
+    // The widest stats line the browser can draw spans stats_max_chars from
+    // stats_x; the box must start strictly right of it, on every row band.
+    const int stats_right = layout.stats_x + layout.stats_max_chars * 6;
+    EXPECT_LE(stats_right, layout.desc_box.x)
+        << "the description box reaches the stats column";
+    EXPECT_GE(layout.stats_max_chars, 16)
+        << "\"Difficulty: NNNN\" (16 chars) must fit the stats budget";
+
+    // The stats columns of all rows share one left edge, right of the
+    // widest radar frame.
+    EXPECT_GE(layout.stats_x, layout.row_x + layout.radar_max_w + 2);
+
+    // The status column sits right of the longest fitted title and left of
+    // the description box.
+    EXPECT_GE(layout.status_x, layout.row_x + (layout.title_max_chars + 3) * 6);
+    EXPECT_LE(layout.status_x + 7 * 6, layout.desc_box.x)
+        << "\"CLEARED\" must end before the description box";
+
+    // Controls and box never overlap each other.
+    const std::vector<og::ui::PickerRect> distinct = {
+        layout.prev, layout.next, layout.choose, layout.cancel,
+        layout.delete_button, layout.id_button, layout.desc_box};
+    for (std::size_t i = 0; i < distinct.size(); ++i)
+    {
+        for (std::size_t j = i + 1; j < distinct.size(); ++j)
+        {
+            EXPECT_FALSE(og::ui::picker_rects_overlap(distinct[i], distinct[j]))
+                << "controls " << i << " and " << j << " overlap";
+        }
+        EXPECT_GE(distinct[i].x, 0);
+        EXPECT_GE(distinct[i].y, 0);
+        EXPECT_LE(distinct[i].x + distinct[i].w, 320);
+        EXPECT_LE(distinct[i].y + distinct[i].h, 200);
+    }
+
+    // The right column shares one left edge (prev, next, desc box), and the
+    // army-power readout fits between prev and the screen edge.
+    EXPECT_EQ(layout.prev.x, layout.next.x);
+    EXPECT_EQ(layout.prev.x, layout.desc_box.x);
+    EXPECT_GE(layout.army_x, layout.prev.x + layout.prev.w);
+    EXPECT_LE(layout.army_x + 16 * 6, 320)
+        << "\"Army power: NNNN\" (16 chars) must stay on screen";
+}
+
+TEST(LevelPickerLayout, status_labels_match_the_progress_report)
+{
+    // Same precedence as the PROGRESS report: CLEARED wins over CURRENT.
+    EXPECT_STREQ("CLEARED", og::ui::level_row_status_label(true, false));
+    EXPECT_STREQ("CLEARED", og::ui::level_row_status_label(true, true));
+    EXPECT_STREQ("CURRENT", og::ui::level_row_status_label(false, true));
+    EXPECT_STREQ("", og::ui::level_row_status_label(false, false));
 }


### PR DESCRIPTION
Four menu fixes, one per issue.

Fixes #200, fixes #199, fixes #186, fixes #168, fixes #202.

## #200 — quitting a scenario faded out twice

After a pause-menu quit, the last-presented canvas is World while the UI canvas still holds the pause-menu frame; the post-game teardown faded/cleared only World, then Base Camp's `FadeAroundEntry` visibly faded the stale UI image a second time. (A win presents its results on the UI canvas, which is why the completion path always looked right.)

- One-shot `suppress_next_menu_entry_fade_out()` flag, consumed at the top of every `run_menu_screen` call and applied only to the `FadeAroundEntry` fade-out; the cold compose and fade-in are untouched.
- Both teardown sites (native `go_menu`, web `picker_reinit_after_game`) set the flag and now also clear the UI canvas, so every exit path hands the menus a black screen.
- New regression test counts fades via the TESTING `FadeBetween` trace across quit → Base Camp and asserts exactly 2 (teardown fade-out + entry fade-in). Verified red-then-green: with the guard disabled the count is 3.

## #199 — Base Camp layout unaligned

The right rail had four different right edges (`>` at 316, `^` at 309, `+` at 311, GO at 312), the page-indicator strip overpainted the `>` bevel, the foreign-row deploy glyph sat 1px off the owned rows' column, and the EXP header sat up to 30px left of its right-aligned digits.

- New named grid (`kBaseCampPanelRightX` etc.); `>`, all eight `^`, `+`, GO and READY now co-terminate on the panel's inner face at x=312, with the pager cluster at uniform 2px gutters.
- Deploy glyph 27→28, EXP header right-aligned to the data at x=282, seat-card X table deduplicated (buttons and chip overlay share one source).
- New `createmenu_basecamp_grid_relations` test pins the relations (right-edge co-termination, uniform card pitch), not just the literal table — the exact-value pin alone is what let this drift ship green.

Known polish left alone (pre-existing): seat-rail gutter uniformity, the 8px-vs-14px pager face widths, vertical band rhythm, the 9-char seat-label/chip 1px overlap, and the ≥10-page roster indicator overflow (unreachable solo; pre-existing in networked lobbies).

## #186 — better campaign and scenario selector

The campaign browser was a one-at-a-time cycler that mounted every installed campaign archive on open; the level browser clipped its bottom radar off-screen and overprinted its stats column with the description box.

- Campaign browser is now a list + detail pane: scrollable titled list with cursor, active-campaign marker and "N of M" readout on the left; icon, version, authors, power compare, completion, description and contributors on the right. PREV/NEXT page the list; full keyboard nav (58-variant BFS reachability pin).
- Lazy loading: only the highlighted campaign is mounted/parsed; opening the browser no longer mounts every archive. DELETE/RESET are bounds-checked on an empty list; the dead "(more...)" text is now a real MORE button opening the full description.
- `load_campaign` failures now roll back and pop a dialog at both call sites instead of writing a negative `scen_num` into the save; the new-game intro now plays for the campaign you actually chose (it used to play the default campaign's intro before the picker even opened).
- Level browser: rows re-pitched so all three radar previews fit on screen, description box moved clear of the stats column, and rows carry CLEARED/CURRENT markers derived the same way as the PROGRESS report.

## #168 — help is a full-screen menu

The help viewer was a 244x151 dialog over the still-visible main menu (~42% of the canvas unused), with mouse-only tab hit-tests and function-static key latches.

- Help is now an engine-hosted full-screen screen (VIEW LEVEL pattern): tab rows with 1/2/3 hotkeys, BACK with Escape, PREV/NEXT pagers hidden when single-page, wheel maps to page steps. Text flows at 50 chars instead of 39.
- `show_general_help()` keeps its exact contract (name, return, Escape drain), the version string stays visible (the only build-version surface on web), and the web footer strings survive.
- Help-smoke injectors now drive `interact()` ids instead of literal coordinates; the engine's bare-spec/gate-lattice sweeps cover the new spec.

## Verification

- Full `ci-test` gate green on the integrated branch (counts in the checks tab).
- Visual read-backs of Base Camp (solo, paged, networked host), both browsers, and all three help tabs — screenshots below.
- The four fixes were built and tested independently in isolated worktrees, then cherry-picked and re-gated together.

## Screenshots

**Base Camp, solo roster (aligned right rail, EXP column)**

![Base Camp, solo roster (aligned right rail, EXP column)](https://raw.githubusercontent.com/openglad/openglad-screenshots/17df36839fb29bb7111285095cb32d938095f697/pr-201/basecamp_solo.png)

**Base Camp right rail at 6x — one shared edge**

![Base Camp right rail at 6x — one shared edge](https://raw.githubusercontent.com/openglad/openglad-screenshots/17df36839fb29bb7111285095cb32d938095f697/pr-201/basecamp_paged_p1_rail.png)

**Base Camp, paged roster**

![Base Camp, paged roster](https://raw.githubusercontent.com/openglad/openglad-screenshots/17df36839fb29bb7111285095cb32d938095f697/pr-201/basecamp_paged_p1.png)

**Base Camp, networked host (deploy glyph column)**

![Base Camp, networked host (deploy glyph column)](https://raw.githubusercontent.com/openglad/openglad-screenshots/17df36839fb29bb7111285095cb32d938095f697/pr-201/basecamp_net_host.png)

**Campaign browser: list + detail pane**

![Campaign browser: list + detail pane](https://raw.githubusercontent.com/openglad/openglad-screenshots/17df36839fb29bb7111285095cb32d938095f697/pr-201/campaign_browser.png)

**Level browser: radars on-screen, CURRENT marker, clear stats column**

![Level browser: radars on-screen, CURRENT marker, clear stats column](https://raw.githubusercontent.com/openglad/openglad-screenshots/17df36839fb29bb7111285095cb32d938095f697/pr-201/level_browser.png)

**Help — Controls tab, full screen**

![Help — Controls tab, full screen](https://raw.githubusercontent.com/openglad/openglad-screenshots/17df36839fb29bb7111285095cb32d938095f697/pr-201/help_controls.png)

**Help — Controls page 2**

![Help — Controls page 2](https://raw.githubusercontent.com/openglad/openglad-screenshots/17df36839fb29bb7111285095cb32d938095f697/pr-201/help_controls_p2.png)

**Help — Classes tab**

![Help — Classes tab](https://raw.githubusercontent.com/openglad/openglad-screenshots/17df36839fb29bb7111285095cb32d938095f697/pr-201/help_classes.png)

**Help — Editor tab**

![Help — Editor tab](https://raw.githubusercontent.com/openglad/openglad-screenshots/17df36839fb29bb7111285095cb32d938095f697/pr-201/help_editor.png)

## Round 2 (review follow-ups + #202)

**#202 — click the seat card's team square to cycle the player's team.** The card's chip region now cycles the seat team in place through the seat editor's own mutation path (same wrap, same editability gating, same lobby ready-withdraw on change, same CHANGE DENIED popup); clicking anywhere else on the card still opens the seat settings menu, and keyboard FIRE is unchanged. Mechanism: the three `do_call` dispatch sites stamp the live pointer coordinates (or -1/-1 for coordinate-free dispatch), so the card handler can hit-test the chip sub-rect without new buttons, index churn, or stale-mouse misroutes on keyboard dispatch.

**Base Camp panel outside-to-outside.** The roster panel bevel (was 6..313) now spans 8..311, flush with the button columns below it; the `^` column follows the new inner face, and the header strips/GOLD bar move onto the same edge lines.

**Help folder tabs.** The dark underline band under the active tab is gone; the active tab now merges into the content frame (face-color connector erases the tab's bottom bevel and the frame's top bevel across its span). Inactive tabs keep the separating bevel, and the keyboard-focus outline survives four-sided. Pixel oracles in the uxshots probe pin the merge per tab.

**Round 2 screenshots**

![Base Camp, panel flush with buttons](https://raw.githubusercontent.com/openglad/openglad-screenshots/7189c839752e802bd090902f877262f1a7a4a0ef/pr-201/basecamp_solo_v2.png)

![Base Camp networked host, round 2](https://raw.githubusercontent.com/openglad/openglad-screenshots/7189c839752e802bd090902f877262f1a7a4a0ef/pr-201/basecamp_net_host_v2.png)

![Help, active CLASSES tab merged into the frame](https://raw.githubusercontent.com/openglad/openglad-screenshots/7189c839752e802bd090902f877262f1a7a4a0ef/pr-201/help_classes_v2.png)

![Help, keyboard focus on the active tab](https://raw.githubusercontent.com/openglad/openglad-screenshots/7189c839752e802bd090902f877262f1a7a4a0ef/pr-201/help_editor_focus_v2.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
