### PR TITLE
Keep HUD specials and player corpses visible

### DIFF
--- a/campaigns/modes/packs/modes.core/lib/mode_core.lua
+++ b/campaigns/modes/packs/modes.core/lib/mode_core.lua
@@ -145,9 +145,9 @@ local function declare_team_win(team)
 end
 
 -- Kill the fresh stain/life-gem drops under a corpse that will never
--- respawn (og.respawn_schedule scrubs for scheduled corpses already;
--- TDM/Onslaught call this for permanent bodies to keep cleric resurrects
--- and score farming away from them).
+-- respawn. Scheduled player corpses keep their stain until revive; mode death
+-- hooks call this for permanent bodies to keep cleric resurrects and score
+-- farming away from them.
 local function scrub_corpse(corpse)
   og.scrub_corpse_stain(corpse:xpos(), corpse:ypos(), corpse:floor())
 end

--- a/docs/modding/og-api.d.lua
+++ b/docs/modding/og-api.d.lua
@@ -570,11 +570,11 @@
 ---@field respawn_anchor_count fun(team: integer): integer # og.respawn_anchor_count(team) — authored start-marker anchors recorded for a team (filled at CTF init / the first scripted tick).
 ---@field respawn_pending fun(entity: og.Walker): boolean # og.respawn_pending(ent) — true while an engine respawn entry (player revive or AI replacement) is queued for this entity id.
 ---@field respawn_pending_count fun(team: integer): integer # og.respawn_pending_count(team) — queued entries for a team (error outside [0, 3]).
----@field respawn_schedule fun(entity: og.Walker, ticks: integer?): boolean # og.respawn_schedule(ent [, ticks]) — queue a dead Living for the engine respawn (dedupe by queued id and live duplicate; queue cap 64 with bot eviction; stai...
+---@field respawn_schedule fun(entity: og.Walker, ticks: integer?): boolean # og.respawn_schedule(ent [, ticks]) — queue a dead Living; player stains survive until fire, while life gems and AI stains scrub at schedule.
 ---@field scare_duration fun(arg1: integer): integer
 ---@field scare_radius fun(arg1: integer): integer
 ---@field scenario_title fun(name: string): string # og.scenario_title(name) → title string ("none" when unreadable).
----@field scrub_corpse_stain fun(x: integer, y: integer, floor: integer?) # og.scrub_corpse_stain(x, y [, floor]) — kill the fresh STAIN/LIFE_GEM drops at a corpse position (its top-left) so a non-respawning body cannot be cleric-res...
+---@field scrub_corpse_stain fun(x: integer, y: integer, floor: integer?) # og.scrub_corpse_stain(x, y [, floor]) — preserve pending-player STAIN drops; otherwise kill fresh STAIN/LIFE_GEM drops at a corpse position (its top-left) so...
 ---@field set_beacon fun(slot: integer, entity: og.Walker?, t: integer?) # og.set_beacon(slot, entity_or_nil [, team]) — mark an entity for the off-screen/radar beacon channel (the Mutant marker, a flag carrier).
 ---@field set_enemy_freeze fun(enemy_freeze: integer)
 ---@field set_entity_hooks fun(entity: og.Walker, hooks: og.EntityHooks) # og.set_entity_hooks(handle, { on_death = fn }) — per-entity overrides, registered from a level script (typically in on_load after finding the entity).

--- a/include/openglad/gameplay/respawn/respawn_state.h
+++ b/include/openglad/gameplay/respawn/respawn_state.h
@@ -155,9 +155,10 @@ void respawn_run_timers(GameWorld& world);
 void respawn_flush_revive_all(GameWorld& world);
 
 // og.respawn_schedule backend: dedupe (already queued / live duplicate),
-// then the shared schedule path (queue cap 64 + bot eviction + stain/
-// life-gem scrub). ticks_override > 0 replaces the resolved delay for this
-// entry. Returns true when a new entry was queued.
+// then the shared schedule path (queue cap 64 + bot eviction). Life gems and
+// AI stains scrub at schedule; player stains remain until fire.
+// ticks_override > 0 replaces the resolved delay for this entry. Returns true
+// when a new entry was queued.
 bool respawn_schedule_corpse(GameWorld& world, walker* corpse,
                              int ticks_override);
 
@@ -171,12 +172,13 @@ int respawn_pending_count(const GameWorld& world, int team);
 bool respawn_spot_clear(GameWorld& world, walker* w, short x, short y,
                         int floor);
 
-// Positional stain scrub (og.scrub_corpse_stain backend): kill fresh STAIN /
-// LIFE_GEM drops whose sprite center lies within 8px Manhattan of the center
-// of a 16px box at (x, y) — the corpse-relative rule of the schedule-path
-// scrub, keyed by position (and optionally floor >= 0) instead of a corpse
-// walker, so Lua can scrub after the corpse is gone. No team filter: the
-// caller's hook context decides which corpses get scrubbed.
+// Positional stain scrub (og.scrub_corpse_stain backend): preserve a STAIN
+// tied to a pending player respawn; otherwise kill fresh STAIN / LIFE_GEM
+// drops whose sprite center lies within 8px Manhattan of the center of a 16px
+// box at (x, y). This is the schedule-path rule keyed by position (and
+// optionally floor >= 0) instead of a corpse walker, so Lua can scrub after
+// the corpse is gone. No team filter: the caller's hook context decides which
+// corpses get scrubbed.
 void respawn_scrub_stains_at(GameWorld& world, short x, short y, int floor);
 
 } // namespace og::sim

--- a/packs/core/families/living-05-cleric.lua
+++ b/packs/core/families/living-05-cleric.lua
@@ -183,6 +183,7 @@ local function raise_skeleton(self)
   return true
 end
 
+-- Raise ghosts ..
 local function raise_ghost(self)
   if self:shifter_down() ~= 0 then
     -- turn undead (identical block to special 2)
@@ -212,6 +213,7 @@ local function raise_ghost(self)
   return true
 end
 
+-- Resurrect our guys ..
 local function resurrect(self)
   local t = og.tuning(self)
   local blood = nearby_corpse(self, t.resurrect_range)
@@ -220,12 +222,14 @@ local function resurrect(self)
   end
   local alive
   if self:is_friendly(blood) then
+    -- normal resurrection
     -- Friendly resurrect: restore the corpse's pre-bloodstain family
     -- at half health.
     alive = og.add_ob("living", blood:s_old_family())
     if not alive then
       return false
     end
+    -- restore our old values ..
     blood:transfer_stats(alive)
     -- max_hp is a C++ float: fdiv is a genuine float half
     alive.hp = og.fdiv(alive.max_hp, 2.0)

--- a/scripts/test_emscripten_build.sh
+++ b/scripts/test_emscripten_build.sh
@@ -27,6 +27,17 @@ if [[ -z "$EMCC_BIN" ]]; then
     exit 77
 fi
 
+# Packaged Emscripten installations may patch their tool locations without
+# teaching --generate-config about those paths. Query the em-config paired
+# with the selected compiler before EM_CONFIG is redirected below.
+EM_CONFIG_BIN="$(dirname "$EMCC_BIN")/em-config"
+EM_LLVM_ROOT=""
+EM_BINARYEN_ROOT=""
+if [[ -x "$EM_CONFIG_BIN" ]]; then
+    EM_LLVM_ROOT="$(env -u EM_CONFIG "$EM_CONFIG_BIN" LLVM_ROOT 2>/dev/null || true)"
+    EM_BINARYEN_ROOT="$(env -u EM_CONFIG "$EM_CONFIG_BIN" BINARYEN_ROOT 2>/dev/null || true)"
+fi
+
 TOOLCHAIN_FILE=""
 if [[ -n "${EMSDK:-}" ]] && [[ -f "$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake" ]]; then
     TOOLCHAIN_FILE="$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake"
@@ -59,10 +70,9 @@ EM_CONFIG="$EM_CONFIG_FILE" "$EMCC_BIN" --generate-config >/dev/null
 
 sed -i '/^CACHE = /d;/^PORTS = /d' "$EM_CONFIG_FILE"
 
-# --generate-config guesses system tool locations (LLVM_ROOT=/usr/bin). Under
-# an emsdk install the toolchain lives in $EMSDK/upstream and node ships inside
-# the SDK, so the isolated config must be pointed there explicitly or every
-# compile fails with "cannot find /usr/bin/llvm-ar".
+# --generate-config can guess system tool locations (LLVM_ROOT=/usr/bin).
+# Point the isolated config at the selected toolchain or every compile fails
+# with errors such as "cannot find /usr/bin/llvm-ar".
 if [[ -n "${EMSDK:-}" ]] && [[ -d "$EMSDK/upstream/bin" ]]; then
     sed -i '/^LLVM_ROOT = /d;/^BINARYEN_ROOT = /d' "$EM_CONFIG_FILE"
     cat >>"$EM_CONFIG_FILE" <<EOF
@@ -76,6 +86,12 @@ EOF
         sed -i '/^NODE_JS = /d' "$EM_CONFIG_FILE"
         printf "NODE_JS = '%s'\n" "$emsdk_node" >>"$EM_CONFIG_FILE"
     fi
+elif [[ -d "$EM_LLVM_ROOT" ]] && [[ -d "$EM_BINARYEN_ROOT" ]]; then
+    sed -i '/^LLVM_ROOT = /d;/^BINARYEN_ROOT = /d' "$EM_CONFIG_FILE"
+    cat >>"$EM_CONFIG_FILE" <<EOF
+LLVM_ROOT = '$EM_LLVM_ROOT'
+BINARYEN_ROOT = '$EM_BINARYEN_ROOT'
+EOF
 fi
 printf '\n' >>"$EM_CONFIG_FILE"
 cat >>"$EM_CONFIG_FILE" <<EOF

--- a/src/gameplay/respawn/respawn.cpp
+++ b/src/gameplay/respawn/respawn.cpp
@@ -153,11 +153,18 @@ void revive_player_walker(GameWorld& world, walker* w, int team)
     return false;
 }
 
+[[nodiscard]] bool same_guy_identity(const guy* lhs, const guy* rhs)
+{
+    return lhs != nullptr && rhs != nullptr && lhs->id == rhs->id &&
+        lhs->owner_player_index == rhs->owner_player_index &&
+        lhs->owner_save_slot == rhs->owner_save_slot;
+}
+
 // True when a live walker is already bound to the corpse's character
 // (a cleric resurrect beat the respawner): the corpse must stay retired.
 // Guy ids are only unique per owning player (each client numbers its roster
-// from its own counter), so identity is the (id, owner) pair — owner tags
-// are kNoOwner for everyone in local play, where bare ids suffice.
+// from its own counter), so identity is the (id, owner-player, save-slot)
+// triple. Owner tags are kNoOwner for local play, where bare ids suffice.
 [[nodiscard]] bool live_duplicate_exists(const GameWorld& world,
                                          const walker* corpse)
 {
@@ -167,11 +174,7 @@ void revive_player_walker(GameWorld& world, walker* w, int team)
     {
         walker* other = uptr.get();
         if (other != nullptr && other != corpse && !other->dead() &&
-            other->myguy != nullptr &&
-            other->myguy->id == corpse->myguy->id &&
-            other->myguy->owner_player_index ==
-                corpse->myguy->owner_player_index &&
-            other->myguy->owner_save_slot == corpse->myguy->owner_save_slot)
+            same_guy_identity(other->myguy, corpse->myguy))
         {
             return true;
         }
@@ -179,20 +182,69 @@ void revive_player_walker(GameWorld& world, walker* w, int team)
     return false;
 }
 
-// Kills the corpse's fresh bloodstain so a cleric cannot resurrect a copy of
-// a walker that the CTF respawner is about to bring back. The fresh
-// LIFE_GEM heart goes with it: respawn cycles would otherwise farm score
-// into the time-limit tiebreaker.
+enum class CorpseDropScrub
+{
+    LifeGemOnly,
+    All,
+};
+
+[[nodiscard]] bool stain_matches_corpse_identity(const walker* stain,
+                                                  const walker* corpse)
+{
+    if (corpse->myguy == nullptr)
+        return stain->myguy == nullptr;
+    return same_guy_identity(stain->myguy, corpse->myguy);
+}
+
+[[nodiscard]] bool stain_belongs_to_pending_player(const GameWorld& world,
+                                                    const walker* stain)
+{
+    if (stain->myguy == nullptr)
+        return false;
+    for (const RespawnEntry& entry : world.respawn.respawn_queue)
+    {
+        if (entry.kind != 0)
+            continue;
+        const walker* corpse = world.find_by_id(entry.walker_entity_id);
+        if (corpse != nullptr &&
+            same_guy_identity(stain->myguy, corpse->myguy) &&
+            stain->team_num() == corpse->team_num() &&
+            stain->floor() == corpse->floor() &&
+            stain->xpos() == corpse->xpos() &&
+            stain->ypos() == corpse->ypos())
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+// LIFE_GEM hearts are retired as soon as any corpse is scheduled: repeated
+// respawns must not farm the time-limit tiebreaker. AI stains go with them,
+// while player stains remain during the countdown for cleric raises and the
+// visible corpse. The player fire paths scrub both drops before reviving (or
+// cancelling for a live duplicate), so no stale stain survives the queue.
 void scrub_corpse_drops_in(const GameWorld::EntityList& list,
-                           const walker* corpse)
+                           const walker* corpse, CorpseDropScrub scrub)
 {
     for (const auto& uptr : list)
     {
         walker* fx = uptr.get();
         if (fx == nullptr || fx->dead() ||
             fx->query_order() != Order::Treasure ||
-            (fx->family() != FAMILY_STAIN && fx->family() != FAMILY_LIFE_GEM) ||
-            fx->team_num() != corpse->team_num())
+            (fx->family() != FAMILY_LIFE_GEM &&
+             (scrub != CorpseDropScrub::All ||
+              fx->family() != FAMILY_STAIN)) ||
+            fx->team_num() != corpse->team_num() ||
+            fx->floor() != corpse->floor())
+        {
+            continue;
+        }
+        // Player stains carry a copied guy: pair them by the same identity
+        // triple that guards duplicate revives. An AI corpse may only sweep
+        // an AI stain, so a nearby player's queued corpse is never collateral.
+        if (fx->family() == FAMILY_STAIN &&
+            !stain_matches_corpse_identity(fx, corpse))
         {
             continue;
         }
@@ -208,10 +260,11 @@ void scrub_corpse_drops_in(const GameWorld::EntityList& list,
     }
 }
 
-void scrub_corpse_stain(GameWorld& world, const walker* corpse)
+void scrub_corpse_drops(GameWorld& world, const walker* corpse,
+                        CorpseDropScrub scrub)
 {
-    scrub_corpse_drops_in(world.fxlist, corpse);
-    scrub_corpse_drops_in(world.oblist, corpse);
+    scrub_corpse_drops_in(world.fxlist, corpse, scrub);
+    scrub_corpse_drops_in(world.oblist, corpse, scrub);
 }
 
 void schedule_respawn(GameWorld& world, walker* corpse)
@@ -275,7 +328,10 @@ void schedule_respawn(GameWorld& world, walker* corpse)
     }
     respawn.respawn_queue.push_back(entry);
 
-    scrub_corpse_stain(world, corpse);
+    scrub_corpse_drops(
+        world, corpse,
+        entry.kind == 0 ? CorpseDropScrub::LifeGemOnly
+                        : CorpseDropScrub::All);
 }
 
 } // namespace
@@ -412,6 +468,7 @@ walker* classic_fire_player_respawn(GameWorld& world,
     walker* w = world.find_by_id(entry.walker_entity_id);
     if (w == nullptr || !w->dead() || w->query_order() != Order::Living)
         return nullptr;
+    scrub_corpse_drops(world, w, CorpseDropScrub::All);
     if (live_duplicate_exists(world, w))
         return nullptr;
     revive_player_walker(world, w, entry.team);
@@ -664,16 +721,18 @@ void respawn_flush_revive_all(GameWorld& world)
     for (const auto& uptr : world.oblist)
     {
         walker* w = uptr.get();
-        if (w != nullptr && w->dead() && w->query_order() == Order::Living &&
-            w->myguy != nullptr && !live_duplicate_exists(world, w))
-        {
-            const unsigned char raw_team = (w->real_team_num() != 255)
-                ? w->real_team_num()
-                : w->team_num();
-            const int team = is_score_team(raw_team) ? raw_team : 0;
-            revive_player_walker(world, w, team);
-            ensure_obmap_registration(world, w);
-        }
+        if (w == nullptr || !w->dead() ||
+            w->query_order() != Order::Living || w->myguy == nullptr)
+            continue;
+        scrub_corpse_drops(world, w, CorpseDropScrub::All);
+        if (live_duplicate_exists(world, w))
+            continue;
+        const unsigned char raw_team = (w->real_team_num() != 255)
+            ? w->real_team_num()
+            : w->team_num();
+        const int team = is_score_team(raw_team) ? raw_team : 0;
+        revive_player_walker(world, w, team);
+        ensure_obmap_registration(world, w);
     }
 }
 
@@ -753,8 +812,18 @@ void respawn_scrub_stains_at(GameWorld& world, short x, short y, int floor)
                 continue;
             const int dx = std::abs((fx->xpos() + fx->sizex() / 2) - (x + 8));
             const int dy = std::abs((fx->ypos() + fx->sizey() / 2) - (y + 8));
-            if (dx + dy <= 8)
-                fx->set_dead(1);
+            if (dx + dy > 8)
+                continue;
+            // A mode may scrub a permanent corpse beside a queued hero. The
+            // positional API has no corpse identity, so preserve any player
+            // stain whose copied guy and exact corpse location resolve to a
+            // pending player entry.
+            if (fx->family() == FAMILY_STAIN &&
+                stain_belongs_to_pending_player(world, fx))
+            {
+                continue;
+            }
+            fx->set_dead(1);
         }
     };
     scrub_list(world.fxlist);

--- a/src/gameplay/script/bindings_entity.cpp
+++ b/src/gameplay/script/bindings_entity.cpp
@@ -2455,11 +2455,11 @@ int og_effective_team_mask(lua_State* L)
     return 1;
 }
 
-// og.respawn_schedule(ent [, ticks]) — queue a dead Living for the engine
-// respawn (dedupe by queued id and live duplicate; queue cap 64 with bot
-// eviction; stain/life-gem scrub). ticks overrides the resolved match
-// delay for this entry (error when not positive). Returns true when a new
-// entry was queued.
+// og.respawn_schedule(ent [, ticks]) — queue a dead Living; player stains
+// survive until fire, while life gems and AI stains scrub at schedule. Dedupe
+// is by queued id and live duplicate; queue cap 64 evicts a bot. ticks
+// overrides the resolved match delay (error when not positive). Returns true
+// when a new entry was queued.
 int og_respawn_schedule(lua_State* L)
 {
     GameWorld* world = world_arg(L);
@@ -2559,10 +2559,10 @@ int og_spawn_spot_clear(lua_State* L)
     return 1;
 }
 
-// og.scrub_corpse_stain(x, y [, floor]) — kill the fresh STAIN/LIFE_GEM
-// drops at a corpse position (its top-left) so a non-respawning body
-// cannot be cleric-resurrected into a duplicate or farm gem score. floor
-// omitted scrubs every floor.
+// og.scrub_corpse_stain(x, y [, floor]) — preserve pending-player STAIN
+// drops; otherwise kill fresh STAIN/LIFE_GEM drops at a corpse position (its
+// top-left) so a permanent body cannot be resurrected or farm gem score.
+// floor omitted scrubs every floor.
 int og_scrub_corpse_stain(lua_State* L)
 {
     GameWorld* world = world_arg(L);

--- a/src/interface/score_panel.cpp
+++ b/src/interface/score_panel.cpp
@@ -746,96 +746,122 @@ short new_score_panel(screen* s, short /*do_it*/)
                       scared_ticks, scared_seconds);
             }
 
-            if (s->viewob[players]->prefs[PREF_SCORE] == PREF_SCORE_ON)
-            {
-                // Score, bottom left corner
-                int special_offset = -24;
+            // Score, bottom left corner
+            int special_offset = -24;
+            Sint32 score_bottom = bm;
 #ifdef USE_TOUCH_INPUT
-                // Upper left instead
-                int bm = tm + 54;
-                special_offset = 0;
+            // Upper left instead
+            score_bottom = tm + 54;
+            special_offset = 0;
 #endif
 
-                // Draw box, if needed
-                if (draw_button)
-                    s->draw_button(lm+1, bm-26, lm+98, bm-2, 1, 1);
+            int special_y = score_bottom + special_offset;
+            const bool compact_score_panel =
+                s->numviews > 2 && !(s->numviews == 3 && players == 0);
+            // Don't show score and XP (clutter) when in a small viewport
+            if (compact_score_panel)
+                special_y = score_bottom - 8;
 
+            const bool show_score =
+                s->viewob[players]->prefs[PREF_SCORE] == PREF_SCORE_ON;
+
+            // Draw box, if needed
+            if (draw_button)
+            {
+                if (show_score)
+                {
+                    s->draw_button(lm+1, score_bottom-26, lm+98,
+                                   score_bottom-2, 1, 1);
+                }
+                else
+                {
+                    Sint32 special_box_bottom = special_y + 6;
+#ifdef USE_TOUCH_INPUT
+                    if (s->alternate_name[fam][spc] != "NONE")
+                    {
+                        special_box_bottom = std::max(
+                            special_box_bottom,
+                            score_bottom + special_offset + 14);
+                    }
+#endif
+                    s->draw_button(lm+1, special_y-2, lm+98,
+                                   special_box_bottom, 1, 1);
+                }
+            }
+
+            if (show_score)
+            {
                 const bool can_show_team_score = is_valid_score_team(control->team_num());
-                if (!can_show_team_score)
+                if (can_show_team_score)
+                {
+                    // Get our score ..
+                    const unsigned char team_num = control->team_num();
+                    myscore = s->world_.m_score[team_num];
+                    if (scorecountup[team_num] > myscore)
+                        scorecountup[team_num] = myscore;
+                    if (scorecountup[team_num] < myscore)
+                    {
+                        scorecountup[team_num]++;
+                        scorecountup[team_num] += static_cast<Uint32>(rng((myscore - scorecountup[team_num]))/12);
+                    }
+                    if (scorecountup[team_num] > myscore)
+                        scorecountup[team_num] = myscore;
+
+                    // above should count up the score towards the current amount
+                    if (!compact_score_panel)
+                    {
+                        message = std::format("SC: {}", scorecountup[team_num]);
+                        mytext.write_xy(lm+2, score_bottom-8, message.c_str(), static_cast<unsigned char>(text_color), static_cast<short>(1));
+
+                        // Level or exp, 2nd bottom left
+                        if (control->myguy)
+                            message = std::format("XP: {}", control->myguy->exp);
+                        else
+                            message = std::format("LEVEL: {}", control->stats()->level());
+                        mytext.write_xy(lm+2, score_bottom-16, message.c_str(), static_cast<unsigned char>(text_color), static_cast<short>(1));
+                    }
+                }
+                else if (!compact_score_panel)
                 {
                     message = "SC: 0";
-                    mytext.write_xy(lm+2, bm-8, message.c_str(), static_cast<unsigned char>(text_color), static_cast<short>(1));
-                    continue;
+                    mytext.write_xy(lm+2, score_bottom-8, message.c_str(), static_cast<unsigned char>(text_color), static_cast<short>(1));
                 }
+            }
 
-                // Get our score ..
-                const unsigned char team_num = control->team_num();
-                myscore = s->world_.m_score[team_num];
-                if (scorecountup[team_num] > myscore)
-                    scorecountup[team_num] = myscore;
-                if (scorecountup[team_num] < myscore)
-                {
-                    scorecountup[team_num]++;
-                    scorecountup[team_num] += static_cast<Uint32>(rng((myscore - scorecountup[team_num]))/12);
-                }
-                if (scorecountup[team_num] > myscore)
-                    scorecountup[team_num] = myscore;
+            // Currently-select special
+            if (control->shifter_down() &&
+                s->alternate_name[fam][spc] != "NONE")
+                message = std::format("SPC: {}", s->alternate_name[fam][spc]);
+            else
+                message = std::format("SPC: {}", s->special_name[fam][spc]);
 
-                // above should count up the score towards the current amount
-                int special_y = bm + special_offset;
-                // Don't show score and XP (clutter) when in a small viewport
-                if (s->numviews > 2 && !(s->numviews == 3 && players == 0))
-                {
-                    special_y = bm - 8;
-                }
-                else
-                {
-                    message = std::format("SC: {}", scorecountup[team_num]);
-                    mytext.write_xy(lm+2, bm-8, message.c_str(), static_cast<unsigned char>(text_color), static_cast<short>(1));
-
-                    // Level or exp, 2nd bottom left
-                    if (control->myguy)
-                        message = std::format("XP: {}", control->myguy->exp);
-                    else
-                        message = std::format("LEVEL: {}", control->stats()->level());
-                    mytext.write_xy(lm+2, bm-16, message.c_str(), static_cast<unsigned char>(text_color), static_cast<short>(1));
-                }
-
-                // Currently-select special
-                if (control->shifter_down() &&
-                    s->alternate_name[fam][spc] != "NONE")
-                    message = std::format("SPC: {}", s->alternate_name[fam][spc]);
-                else
-                    message = std::format("SPC: {}", s->special_name[fam][spc]);
-
-                // Disabled-special signifier: a walker whose specials are
-                // switched off (the level's NPC flag) can NEVER fire the
-                // listed special, no matter its MP — grey the line out so it
-                // reads as unavailable rather than merely unaffordable (RED).
-                if (control->specials_disabled())
-                {
-                    mytext.write_xy(lm+2, special_y, message.c_str(), static_cast<unsigned char>(GREY), static_cast<short>(1));
-                    TRACE("hud", "spc_disabled fam=%d spc=%d", fam, spc);
-                }
-                else if (control->stats()->magicpoints() >= control->stats()->special_cost(spc))
-                    mytext.write_xy(lm+2, special_y, message.c_str(), static_cast<unsigned char>(text_color), static_cast<short>(1));
-                else
-                    mytext.write_xy(lm+2, special_y, message.c_str(), static_cast<unsigned char>(RED), static_cast<short>(1));
+            // Disabled-special signifier: a walker whose specials are
+            // switched off (the level's NPC flag) can NEVER fire the
+            // listed special, no matter its MP — grey the line out so it
+            // reads as unavailable rather than merely unaffordable (RED).
+            if (control->specials_disabled())
+            {
+                mytext.write_xy(lm+2, special_y, message.c_str(), static_cast<unsigned char>(GREY), static_cast<short>(1));
+                TRACE("hud", "spc_disabled fam=%d spc=%d", fam, spc);
+            }
+            else if (control->stats()->magicpoints() >= control->stats()->special_cost(spc))
+                mytext.write_xy(lm+2, special_y, message.c_str(), static_cast<unsigned char>(text_color), static_cast<short>(1));
+            else
+                mytext.write_xy(lm+2, special_y, message.c_str(), static_cast<unsigned char>(RED), static_cast<short>(1));
 
 #ifdef USE_TOUCH_INPUT
-                // Alternate special name (if not "NONE")
-                if (s->alternate_name[fam][spc] != "NONE")
-                {
-                    message = std::format("ALT: {}", s->alternate_name[fam][spc]);
-                    if (control->specials_disabled())
-                        mytext.write_xy(lm+2, bm + special_offset + 8, message.c_str(), static_cast<unsigned char>(GREY), static_cast<short>(1));
-                    else if (control->stats()->magicpoints() >= control->stats()->special_cost(spc))
-                        mytext.write_xy(lm+2, bm + special_offset + 8, message.c_str(), static_cast<unsigned char>(text_color), static_cast<short>(1));
-                    else
-                        mytext.write_xy(lm+2, bm + special_offset + 8, message.c_str(), static_cast<unsigned char>(RED), static_cast<short>(1));
-                }
-#endif
+            // Alternate special name (if not "NONE")
+            if (s->alternate_name[fam][spc] != "NONE")
+            {
+                message = std::format("ALT: {}", s->alternate_name[fam][spc]);
+                if (control->specials_disabled())
+                    mytext.write_xy(lm+2, score_bottom + special_offset + 8, message.c_str(), static_cast<unsigned char>(GREY), static_cast<short>(1));
+                else if (control->stats()->magicpoints() >= control->stats()->special_cost(spc))
+                    mytext.write_xy(lm+2, score_bottom + special_offset + 8, message.c_str(), static_cast<unsigned char>(text_color), static_cast<short>(1));
+                else
+                    mytext.write_xy(lm+2, score_bottom + special_offset + 8, message.c_str(), static_cast<unsigned char>(RED), static_cast<short>(1));
             }
+#endif
 
             // Number of allies, upper right
             if (s->viewob[players]->prefs[PREF_FOES] == PREF_FOES_ON)

--- a/tests/integration/test_glad_hud.cpp
+++ b/tests/integration/test_glad_hud.cpp
@@ -346,6 +346,115 @@ TEST_F(GladHud, glad_score_panel_and_new_score_panel_modes)
     v->control = control_pointer_is_live(og::runtime::current_session->myscreen_->level_runtime_data(), old_control) ? old_control : nullptr;
 }
 
+TEST_F(GladHud, quarter_screen_special_is_always_visible)
+{
+    screen* const s = og::runtime::current_session->myscreen_;
+
+    struct ViewSetRestore
+    {
+        screen* scr;
+        short numviews;
+        std::array<std::unique_ptr<viewscreen>, MAX_VIEWS> views;
+
+        explicit ViewSetRestore(screen* screen_ptr)
+            : scr(screen_ptr), numviews(screen_ptr->numviews)
+        {
+            for (int i = 0; i < MAX_VIEWS; ++i)
+                views[static_cast<std::size_t>(i)] = std::move(scr->viewob[i]);
+        }
+
+        ~ViewSetRestore()
+        {
+            for (int i = 0; i < MAX_VIEWS; ++i)
+                scr->viewob[i].reset();
+            for (int i = 0; i < MAX_VIEWS; ++i)
+                scr->viewob[i] = std::move(views[static_cast<std::size_t>(i)]);
+            scr->numviews = numviews;
+            scr->relayout_views();
+        }
+    } restore_views{s};
+
+    s->numviews = 4;
+    s->initialize_views();
+
+    std::array<std::unique_ptr<walker>, 4> controls;
+    constexpr std::array<unsigned char, 4> kTeams = {0, 16, 17, 1};
+    constexpr std::array<char, 4> kScorePrefs = {
+        PREF_SCORE_OFF, PREF_SCORE_ON, PREF_SCORE_OFF, PREF_SCORE_ON};
+    constexpr std::array<char, 4> kOverlayPrefs = {
+        PREF_OVERLAY_ON, PREF_OVERLAY_ON, PREF_OVERLAY_OFF, PREF_OVERLAY_OFF};
+    for (int i = 0; i < 4; ++i)
+    {
+        const std::size_t seat = static_cast<std::size_t>(i);
+        controls[seat] = make_player(kTeams[seat]);
+        ASSERT_NE(nullptr, controls[seat]);
+        walker* const control = controls[seat].get();
+        control->set_user(static_cast<signed char>(i));
+        control->set_current_special(1); // Soldier CHARGE
+        control->stats()->set_magicpoints(1000.0f);
+
+        viewscreen* const view = s->viewob[i].get();
+        ASSERT_NE(nullptr, view);
+        view->control = control;
+        view->prefs[PREF_OVERLAY] = kOverlayPrefs[seat];
+        view->prefs[PREF_LIFE] = PREF_LIFE_OFF;
+        view->prefs[PREF_SCORE] = kScorePrefs[seat];
+        view->prefs[PREF_FOES] = PREF_FOES_OFF;
+    }
+
+    s->clearbuffer();
+    ASSERT_EQ(1, new_score_panel(s, 1));
+    const auto actual = capture_rendered_frame(*s);
+
+    s->clearbuffer();
+    for (int i = 0; i < 4; ++i)
+    {
+        const viewscreen* const view = s->viewob[i].get();
+        if (kOverlayPrefs[static_cast<std::size_t>(i)] == PREF_OVERLAY_ON)
+        {
+            const int box_top =
+                view->endy - (kScorePrefs[static_cast<std::size_t>(i)] == PREF_SCORE_ON
+                                  ? 26
+                                  : 10);
+            s->draw_button(view->xloc + 1, box_top,
+                           view->xloc + 98, view->endy - 2, 1, 1);
+        }
+        const unsigned char text_color =
+            kOverlayPrefs[static_cast<std::size_t>(i)] == PREF_OVERLAY_ON
+                ? static_cast<unsigned char>(DARK_BLUE)
+                : static_cast<unsigned char>(YELLOW);
+        s->text_normal.write_xy(view->xloc + 2, view->endy - 8,
+                                "SPC: CHARGE",
+                                text_color,
+                                static_cast<short>(1));
+    }
+    const auto expected = capture_rendered_frame(*s);
+
+    for (int i = 0; i < 4; ++i)
+    {
+        const viewscreen* const view = s->viewob[i].get();
+        std::vector<unsigned char> actual_row;
+        std::vector<unsigned char> expected_row;
+        for (int y = view->endy - 28; y < view->endy; ++y)
+        {
+            for (int x = view->xloc; x < view->xloc + 100; ++x)
+            {
+                const std::size_t offset = static_cast<std::size_t>(y * 320 + x);
+                actual_row.push_back(actual[offset]);
+                expected_row.push_back(expected[offset]);
+            }
+        }
+        EXPECT_EQ(expected_row, actual_row)
+            << "seat " << i << " must show its exact current-special row"
+            << " (team=" << static_cast<int>(kTeams[static_cast<std::size_t>(i)])
+            << ", score_pref="
+            << static_cast<int>(kScorePrefs[static_cast<std::size_t>(i)])
+            << ", overlay_pref="
+            << static_cast<int>(kOverlayPrefs[static_cast<std::size_t>(i)])
+            << ")";
+    }
+}
+
 // Regression: a network client renders a single local viewport (players == 0),
 // but its controlled walker carries the server-global player slot in user()
 // (set by GameServer::bind_player and shipped to the client in the snapshot).
@@ -1254,7 +1363,7 @@ TEST_F(GladHud, score_panel_greys_special_line_when_specials_disabled)
     v->control = controlp;
     v->prefs[PREF_OVERLAY] = PREF_OVERLAY_OFF; // no button box pixels
     v->prefs[PREF_LIFE] = PREF_LIFE_OFF;
-    v->prefs[PREF_SCORE] = PREF_SCORE_ON;      // the SPC line lives here
+    v->prefs[PREF_SCORE] = PREF_SCORE_ON;      // keep the legacy SC/XP rows on
     v->prefs[PREF_FOES] = PREF_FOES_OFF;
 
     // The SPC line draws at (lm+2, bm-24) = (2, 176) for the full pane.

--- a/tests/parity/scenario_table.h
+++ b/tests/parity/scenario_table.h
@@ -1272,7 +1272,7 @@ inline constexpr Mutation kMut_family_skeleton_init = {
 };
 
 inline constexpr Mutation kMut_family_cleric_init = {
-    "packs/core/families/living-05-cleric.lua", 310,
+    "packs/core/families/living-05-cleric.lua", 314,
     "hp = 120",
     "hp = 12000",
     "Cranks CLERIC HP; flips WalkerFamilyCount(CLERIC,1,1) (one extra alive) and WalkerDiedByFinal(CLERIC)."
@@ -3582,7 +3582,7 @@ inline constexpr FactPredicate kFacts_special_cleric_2_scen99[] = {
 };
 
 inline constexpr Mutation kMut_special_cleric_2_scen99 = {
-    "packs/core/families/living-05-cleric.lua", 310,
+    "packs/core/families/living-05-cleric.lua", 314,
     "hp = 120",
     "hp = 12000",
     "Cranks the FAMILY_CLERIC init HP; the caster no longer dies during the per-slot cycle/fire dance, flipping any predicate that depends on the caster's post-special HP / position / death state."
@@ -3601,7 +3601,7 @@ inline constexpr FactPredicate kFacts_special_cleric_3_scen99[] = {
 };
 
 inline constexpr Mutation kMut_special_cleric_3_scen99 = {
-    "packs/core/families/living-05-cleric.lua", 310,
+    "packs/core/families/living-05-cleric.lua", 314,
     "hp = 120",
     "hp = 12000",
     "Cranks the FAMILY_CLERIC init HP; the caster no longer dies during the per-slot cycle/fire dance, flipping any predicate that depends on the caster's post-special HP / position / death state."
@@ -3620,7 +3620,7 @@ inline constexpr FactPredicate kFacts_special_cleric_4_scen99[] = {
 };
 
 inline constexpr Mutation kMut_special_cleric_4_scen99 = {
-    "packs/core/families/living-05-cleric.lua", 310,
+    "packs/core/families/living-05-cleric.lua", 314,
     "hp = 120",
     "hp = 12000",
     "Cranks the FAMILY_CLERIC init HP; the caster no longer dies during the per-slot cycle/fire dance, flipping any predicate that depends on the caster's post-special HP / position / death state."
@@ -4875,7 +4875,7 @@ inline constexpr FactPredicate kFacts_special_cleric_heal_ally_scen99[] = {
         "consequence: the successful heal adds one SOUND_HEAL on top of the 13 combat sounds; a refused heal emits nothing and the floor collapses to 13"),
 };
 inline constexpr Mutation kMut_special_cleric_heal_ally_scen99 = {
-    "packs/core/families/living-05-cleric.lua", 352,
+    "packs/core/families/living-05-cleric.lua", 356,
     "heal_range = 60",
     "heal_range = 1",
     "Collapses the cleric HEAL friend-acquisition radius so find_friends_in_range yields friend_count<=1 and heal_or_mace returns false before charging or healing. The team-0 big orc keeps its wounded 172 HP (17200 cents), below WalkerHpRangeAtFinalTick's 25000 floor, and the SOUND_HEAL that lifted play_sound to 14 disappears."
@@ -4915,7 +4915,7 @@ inline constexpr FactPredicate kFacts_cleric_raise_skeleton_scen99[] = {
         "invariant: the caster is never engaged (the ally does the killing), so it finishes at 117/120 (11700 cents) -- proof the skeleton came from the raise and not from a melee-driven code path"),
 };
 inline constexpr Mutation kMut_cleric_raise_skeleton_scen99 = {
-    "packs/core/families/living-05-cleric.lua", 360,
+    "packs/core/families/living-05-cleric.lua", 364,
     "raise_skeleton_range = 60",
     "raise_skeleton_range = 1",
     "Collapses the RAISE UNDEAD corpse reach so nearby_corpse's `distance < range` test fails on the Manhattan-23 bloodstain and raise_skeleton returns false. No LIVING_SKELETON is summoned: WalkerFamilyCount(FAMILY_SKELETON, 1, 1) sees 0, WalkerAliveAtFinal fails, and team-0 alive drops from 3 to 2."
@@ -4951,7 +4951,7 @@ inline constexpr FactPredicate kFacts_cleric_raise_ghost_scen99[] = {
         "invariant: the caster never fights, so it finishes at 117/120 (11700 cents) at the dump"),
 };
 inline constexpr Mutation kMut_cleric_raise_ghost_scen99 = {
-    "packs/core/families/living-05-cleric.lua", 361,
+    "packs/core/families/living-05-cleric.lua", 365,
     "raise_ghost_range = 30",
     "raise_ghost_range = 1",
     "Collapses the RAISE GHOST corpse reach below the Manhattan-23 bloodstain, so nearby_corpse returns nil and raise_ghost returns false before do_summon. No LIVING_GHOST enters oblist: WalkerFamilyCount(FAMILY_GHOST, 1, 1) sees 0, WalkerAliveAtFinal fails, and team-0 alive drops from 3 to 2."
@@ -5034,7 +5034,7 @@ inline constexpr FactPredicate kFacts_cleric_resurrect_friendly_scen99[] = {
         "invariant: the executioner stalls 12 px clear of the caster, so the cleric finishes at 91/120 (9100 cents) -- proof the cast landed while the caster was un-shoved. The 200-cent window is the one-regen-tick spread between the branch dump (9100) and a companion recapture (9000)."),
 };
 inline constexpr Mutation kMut_cleric_resurrect_friendly_scen99 = {
-    "packs/core/families/living-05-cleric.lua", 231,
+    "packs/core/families/living-05-cleric.lua", 235,
     "    alive.hp = og.fdiv(alive.max_hp, 2.0)",
     "    alive.hp = og.fdiv(alive.max_hp, 4.0)",
     "Quarters the friendly-RESURRECT revival health instead of halving it. The rebuilt soldier returns at 31 of 120 HP (3100 cents) rather than 61 (6100), dropping out of WalkerHpRangeAtFinalTick's [5000, 6500] window while every other predicate still holds -- an isolated hit on the branch-specific half-health rule."

--- a/tests/unit/test_modes_onslaught.cpp
+++ b/tests/unit/test_modes_onslaught.cpp
@@ -1167,9 +1167,8 @@ TEST_F(ModesOnslaught, bot_corpses_are_scrubbed_heroes_are_not)
     EXPECT_FALSE(stain_alive_at(fx.world(), bx, by))
         << "the bot's fresh stain is scrubbed";
 
-    // The hero corpse is NOT hook-scrubbed: it enters the respawn queue
-    // instead (og.respawn_schedule scrubs scheduled corpses engine-side,
-    // so the distinguishing observable is the booked revive).
+    // The hero corpse is NOT hook-scrubbed: it enters the respawn queue and
+    // keeps its stain through the countdown for cleric raises.
     const int hx = hero->xpos();
     const int hy = hero->ypos();
     fx.red->setxy(static_cast<short>(hx - 20), static_cast<short>(hy));
@@ -1183,6 +1182,8 @@ TEST_F(ModesOnslaught, bot_corpses_are_scrubbed_heroes_are_not)
             hero_booked = true;
     }
     EXPECT_TRUE(hero_booked) << "hero corpses respawn instead of scrubbing";
+    EXPECT_TRUE(stain_alive_at(fx.world(), hx, hy))
+        << "a queued hero leaves a raisable corpse during the countdown";
 }
 
 // ===========================================================================

--- a/tests/unit/test_pack_lua_paths.cpp
+++ b/tests/unit/test_pack_lua_paths.cpp
@@ -47,6 +47,9 @@
 #include <openglad/core/pixdefs.h>
 #include <openglad/gameplay/weap.h>
 #include <openglad/gameplay/families/weapon_family_descriptor.h>
+#include <openglad/resources/game_mode.h>
+#include <openglad/resources/progression.h>
+#include <openglad/resources/save_data.h>
 
 #include <gtest/gtest.h>
 
@@ -600,6 +603,103 @@ TEST(PackLuaCleric, resurrecting_a_friendly_corpse_restores_its_family)
               raised->stats()->max_hitpoints() / 2.0f + 0.01f)
         << "resurrection returns a man at half health";
     EXPECT_NE(0, stain->dead());
+    EXPECT_EQ(0u, guard.count()) << guard.message();
+}
+
+// Permadeath removes a deployed character only when they finish the level
+// dead. RESURRECT transfers the character record from the real bloodstain to
+// a new living body, so the ordinary local win fold must put that same person
+// back in the company roster. This deliberately uses no respawn or network
+// ownership state.
+TEST(PackLuaCleric,
+     a_resurrected_character_returns_to_the_roster_with_permadeath_on)
+{
+    og::test::mount_core_pack();
+    const FamilyDescriptor& desc = describe_family(FAMILY_CLERIC);
+    og::test::ScopedHookFailureGuard guard;
+
+    TestGameWorld tw;
+    GameWorld& world = tw.world();
+    SaveData& save = tw.save;
+    save.reset();
+    save.keep_fallen_heroes = 0;
+    world.keep_fallen_heroes = 0;
+    save.current_campaign = "gladiator";
+    save.scen_num = 1;
+
+    guy original(FAMILY_SOLDIER);
+    original.id = 73;
+    original.name = "RETURNING HERO";
+    original.exp = 100u;
+    original.deployed = true;
+    save.team_list[0] = std::make_unique<guy>(original);
+    save.team_size = 1;
+
+    walker* cleric = make_cleric(world, 10);
+    ASSERT_NE(nullptr, cleric);
+    walker* fallen = spawn(
+        world, Order::Living, FAMILY_SOLDIER, 11, 10, 1);
+    ASSERT_NE(nullptr, fallen);
+    fallen->set_owned_myguy(std::make_unique<guy>(original));
+    fallen->set_real_team_num(255);
+    constexpr std::uint32_t kSessionExp = 777u;
+    fallen->myguy->exp = kSessionExp;
+
+    fallen->set_dead(1);
+    ASSERT_TRUE(fallen->death());
+    walker* stain = find_family(world, Order::Treasure, FAMILY_STAIN);
+    ASSERT_NE(nullptr, stain) << "a roster character must leave a bloodstain";
+    ASSERT_NE(nullptr, stain->myguy)
+        << "the real death path must put the character record on the stain";
+    EXPECT_EQ(original.id, stain->myguy->id);
+    EXPECT_EQ(original.name, stain->myguy->name);
+    EXPECT_EQ(kSessionExp, stain->myguy->exp);
+
+    cleric->set_current_special(4);
+    ASSERT_TRUE(og::test::do_special(desc, cleric));
+
+    walker* resurrected = find_family(world, Order::Living, FAMILY_SOLDIER);
+    ASSERT_NE(nullptr, resurrected);
+    ASSERT_NE(fallen, resurrected);
+    ASSERT_NE(nullptr, resurrected->myguy);
+    EXPECT_EQ(0, resurrected->dead());
+    EXPECT_EQ(original.id, resurrected->myguy->id);
+    EXPECT_EQ(original.name, resurrected->myguy->name);
+    EXPECT_EQ(kSessionExp, resurrected->myguy->exp);
+    EXPECT_NE(0, fallen->dead());
+
+    int dead_copies = 0;
+    int live_copies = 0;
+    for (const auto& ob : world.oblist)
+    {
+        if (ob == nullptr || ob->myguy == nullptr ||
+            ob->myguy->id != original.id)
+        {
+            continue;
+        }
+        if (ob->dead())
+            ++dead_copies;
+        else
+            ++live_copies;
+    }
+    EXPECT_EQ(1, dead_copies);
+    EXPECT_EQ(1, live_copies);
+
+    og::progression::WinFoldContext fold;
+    fold.finished_level = save.scen_num;
+    fold.outcome.next_level = -1;
+    og::progression::apply_win_fold(
+        save, world, fold, og::mode::classic_progression());
+
+    ASSERT_EQ(1, static_cast<int>(save.team_size))
+        << "permadeath must drop the dead body and retain its live resurrection";
+    ASSERT_NE(nullptr, save.team_list[0]);
+    EXPECT_EQ(original.id, save.team_list[0]->id);
+    EXPECT_EQ(original.name, save.team_list[0]->name);
+    EXPECT_EQ(original.family, save.team_list[0]->family);
+    EXPECT_EQ(kSessionExp, save.team_list[0]->exp)
+        << "the live resurrection, not the stale pre-level entry, was folded";
+    EXPECT_TRUE(save.team_list[0]->deployed);
     EXPECT_EQ(0u, guard.count()) << guard.message();
 }
 

--- a/tests/unit/test_respawn_engine.cpp
+++ b/tests/unit/test_respawn_engine.cpp
@@ -1,8 +1,8 @@
 // Respawn engine tests (retargeted off the retired CTF engine): player
-// revive-in-place, AI respawns, stain/gem scrubbing, win-latch revive-all,
-// queue capping, spawn probes, and the team-wipe / input gates — all through
-// the scripted-mode frame (Lua owns eligibility via og.respawn_schedule;
-// respawn_schedule_corpse is that binding's backend).
+// revive-in-place, AI respawns, player-stain lifetime, stain/gem scrubbing,
+// win-latch revive-all, queue capping, spawn probes, and the team-wipe / input
+// gates — all through the scripted-mode frame (Lua owns eligibility via
+// og.respawn_schedule; respawn_schedule_corpse is that binding's backend).
 
 #include <gtest/gtest.h>
 
@@ -182,6 +182,45 @@ int live_stains_for_team(GameWorld& world, int team)
     return count;
 }
 
+int live_stains_for_character(GameWorld& world, int team, int floor,
+                              const guy* identity,
+                              const walker* position = nullptr)
+{
+    const auto matches = [team, floor, identity,
+                          position](const walker* stain) {
+        if (stain == nullptr || stain->dead() ||
+            stain->query_order() != Order::Treasure ||
+            stain->family() != FAMILY_STAIN ||
+            stain->team_num() != static_cast<unsigned char>(team) ||
+            stain->floor() != floor ||
+            (position != nullptr &&
+             (stain->xpos() != position->xpos() ||
+              stain->ypos() != position->ypos())))
+        {
+            return false;
+        }
+        if (identity == nullptr)
+            return stain->myguy == nullptr;
+        return stain->myguy != nullptr && stain->myguy->id == identity->id &&
+            stain->myguy->owner_player_index ==
+                identity->owner_player_index &&
+            stain->myguy->owner_save_slot == identity->owner_save_slot;
+    };
+
+    int count = 0;
+    for (const auto& uptr : world.fxlist)
+    {
+        if (matches(uptr.get()))
+            count++;
+    }
+    for (const auto& uptr : world.oblist)
+    {
+        if (matches(uptr.get()))
+            count++;
+    }
+    return count;
+}
+
 } // namespace
 
 TEST(RespawnEngine, player_corpse_revives_in_place_with_control_preserved)
@@ -273,7 +312,7 @@ TEST(RespawnEngine, ai_respawn_spawns_fresh_walker_of_same_family_level_team)
     ASSERT_TRUE(arena.world().respawn.respawn_queue.empty());
 }
 
-TEST(RespawnEngine, scheduling_scrubs_the_fresh_corpse_stain)
+TEST(RespawnEngine, ai_scheduling_scrubs_the_fresh_corpse_stain)
 {
     RespawnArena arena;
     walker* bot = arena.fx.spawn_living(FAMILY_SOLDIER, 1, 480, 700);
@@ -285,6 +324,213 @@ TEST(RespawnEngine, scheduling_scrubs_the_fresh_corpse_stain)
     ASSERT_TRUE(arena.schedule(bot));
     ASSERT_EQ(0, live_stains_for_team(arena.world(), 1))
         << "scheduling a respawn must kill the corpse stain";
+}
+
+TEST(RespawnEngine, player_corpse_stain_survives_until_the_respawn_fires)
+{
+    RespawnArena arena;
+    walker* runner = arena.runner;
+    runner->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    runner->myguy->id = 41;
+    runner->set_user(0);
+
+    arena.kill(runner);
+    ASSERT_EQ(1, live_stains_for_team(arena.world(), 0))
+        << "a player death must create its corpse before scheduling";
+
+    ASSERT_TRUE(arena.schedule(runner));
+    EXPECT_EQ(1, live_stains_for_team(arena.world(), 0))
+        << "a queued multiplayer player must leave its corpse behind";
+
+    arena.fx.tick(5);
+    EXPECT_TRUE(runner->dead());
+    EXPECT_EQ(1, live_stains_for_team(arena.world(), 0))
+        << "the corpse must remain for the whole respawn countdown";
+
+    arena.fx.tick();
+    EXPECT_FALSE(runner->dead());
+    EXPECT_EQ(0, live_stains_for_team(arena.world(), 0))
+        << "reviving the player retires the now-stale corpse";
+}
+
+TEST(RespawnEngine, nearby_player_respawns_scrub_only_their_own_stain)
+{
+    RespawnArena arena;
+    walker* first = arena.runner;
+    first->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    first->myguy->id = 71;
+    first->myguy->owner_player_index = 0;
+    first->myguy->owner_save_slot = 0;
+
+    walker* second = arena.fx.spawn_living(FAMILY_SOLDIER, 0, 324, 320);
+    second->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    second->myguy->id = 72;
+    second->myguy->owner_player_index = 0;
+    second->myguy->owner_save_slot = 0;
+
+    arena.kill(first);
+    ASSERT_TRUE(arena.schedule(first, 2));
+    arena.kill(second);
+    ASSERT_TRUE(arena.schedule(second, 5));
+    ASSERT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, first->myguy));
+    ASSERT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, second->myguy));
+
+    arena.fx.tick(2);
+
+    EXPECT_FALSE(first->dead());
+    EXPECT_EQ(0, live_stains_for_character(
+                     arena.world(), 0, 0, first->myguy));
+    EXPECT_TRUE(second->dead());
+    EXPECT_TRUE(og::sim::respawn_pending_for(arena.world(), second));
+    EXPECT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, second->myguy))
+        << "the first fire must not consume a nearby teammate's corpse";
+
+    arena.fx.tick(3);
+    EXPECT_FALSE(second->dead());
+    EXPECT_EQ(0, live_stains_for_character(
+                     arena.world(), 0, 0, second->myguy));
+}
+
+TEST(RespawnEngine, respawn_fire_scrubs_only_the_corpses_floor)
+{
+    RespawnArena arena;
+    walker* ground = arena.runner;
+    ground->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    ground->myguy->id = 73;
+    ground->myguy->owner_player_index = 0;
+    ground->myguy->owner_save_slot = 0;
+
+    arena.kill(ground);
+    ASSERT_TRUE(arena.schedule(ground, 2));
+
+    walker* upper = arena.fx.spawn_living(FAMILY_SOLDIER, 0, 320, 320);
+    upper->change_floor(1);
+    upper->set_owned_myguy(std::make_unique<guy>(*ground->myguy));
+    arena.kill(upper);
+    ASSERT_TRUE(arena.schedule(upper, 5));
+    ASSERT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, ground->myguy));
+    ASSERT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 1, upper->myguy));
+
+    arena.fx.tick(2);
+
+    EXPECT_FALSE(ground->dead());
+    EXPECT_TRUE(upper->dead());
+    EXPECT_EQ(0, live_stains_for_character(
+                     arena.world(), 0, 0, ground->myguy));
+    EXPECT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 1, upper->myguy))
+        << "same-position identity on another floor is not this corpse";
+
+    arena.fx.tick(3);
+    EXPECT_TRUE(upper->dead()) << "the live duplicate cancels its revive";
+    EXPECT_EQ(0, live_stains_for_character(
+                     arena.world(), 0, 1, upper->myguy));
+}
+
+TEST(RespawnEngine, ai_scheduling_does_not_scrub_a_nearby_player_stain)
+{
+    RespawnArena arena;
+    walker* player = arena.runner;
+    player->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    player->myguy->id = 74;
+
+    walker* bot = arena.fx.spawn_living(FAMILY_SOLDIER, 0, 324, 320);
+    arena.kill(player);
+    ASSERT_TRUE(arena.schedule(player, 5));
+    arena.kill(bot);
+    ASSERT_EQ(1, live_stains_for_character(arena.world(), 0, 0, nullptr));
+
+    ASSERT_TRUE(arena.schedule(bot, 2));
+
+    EXPECT_EQ(0, live_stains_for_character(arena.world(), 0, 0, nullptr))
+        << "AI scheduling still retires its own stain";
+    EXPECT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, player->myguy))
+        << "an AI corpse must not sweep a nearby player's stain";
+}
+
+TEST(RespawnEngine, positional_scrub_preserves_only_pending_player_stains)
+{
+    RespawnArena arena;
+    walker* pending = arena.runner;
+    pending->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    pending->myguy->id = 75;
+
+    walker* permanent = arena.fx.spawn_living(FAMILY_SOLDIER, 0, 324, 320);
+    permanent->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    permanent->myguy->id = 76;
+
+    arena.kill(pending);
+    ASSERT_TRUE(arena.schedule(pending, 5));
+    arena.kill(permanent);
+    ASSERT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, pending->myguy));
+    ASSERT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, permanent->myguy));
+
+    og::sim::respawn_scrub_stains_at(
+        arena.world(), permanent->xpos(), permanent->ypos(), permanent->floor());
+
+    EXPECT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, pending->myguy))
+        << "a nearby mode scrub must preserve the queued player's corpse";
+    EXPECT_EQ(0, live_stains_for_character(
+                     arena.world(), 0, 0, permanent->myguy))
+        << "the unscheduled permanent corpse is still scrubbed";
+}
+
+TEST(RespawnEngine, positional_scrub_matches_pending_stain_location)
+{
+    RespawnArena arena;
+    walker* pending = arena.runner;
+    pending->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    pending->myguy->id = 77;
+    pending->myguy->owner_player_index = 0;
+    pending->myguy->owner_save_slot = 0;
+    arena.kill(pending);
+    ASSERT_TRUE(arena.schedule(pending, 5));
+
+    walker* upper = arena.fx.spawn_living(FAMILY_SOLDIER, 0, 320, 320);
+    upper->change_floor(1);
+    upper->set_owned_myguy(std::make_unique<guy>(*pending->myguy));
+    arena.kill(upper);
+
+    walker* far = arena.fx.spawn_living(FAMILY_SOLDIER, 0, 480, 320);
+    far->set_owned_myguy(std::make_unique<guy>(*pending->myguy));
+    arena.kill(far);
+
+    ASSERT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, pending->myguy, pending));
+    ASSERT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 1, upper->myguy, upper));
+    ASSERT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, far->myguy, far));
+
+    og::sim::respawn_scrub_stains_at(
+        arena.world(), upper->xpos(), upper->ypos(), upper->floor());
+
+    EXPECT_EQ(0, live_stains_for_character(
+                     arena.world(), 0, 1, upper->myguy, upper))
+        << "same identity and position on another floor is permanent";
+    EXPECT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, pending->myguy, pending));
+    EXPECT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, far->myguy, far));
+
+    og::sim::respawn_scrub_stains_at(
+        arena.world(), far->xpos(), far->ypos(), far->floor());
+
+    EXPECT_EQ(0, live_stains_for_character(
+                     arena.world(), 0, 0, far->myguy, far))
+        << "same identity on the same floor but another position is permanent";
+    EXPECT_EQ(1, live_stains_for_character(
+                     arena.world(), 0, 0, pending->myguy, pending))
+        << "the exact queued corpse stain remains protected";
 }
 
 TEST(RespawnEngine, live_duplicate_character_cancels_the_revive)
@@ -355,6 +601,8 @@ TEST(RespawnEngine, fire_time_live_duplicate_cancels_the_revive)
     runner->myguy->id = 8;
     arena.kill(runner);
     ASSERT_TRUE(arena.schedule(runner)) << "no duplicate yet: schedule holds";
+    ASSERT_EQ(1, live_stains_for_team(arena.world(), 0))
+        << "the queued player's stain survives until fire";
 
     // The character comes back through another door while the timer runs
     // (save merge, cleric resurrect): the FIRE must re-check, not trust the
@@ -366,6 +614,8 @@ TEST(RespawnEngine, fire_time_live_duplicate_cancels_the_revive)
     arena.fx.tick(7);
     EXPECT_TRUE(runner->dead()) << "fire-time duplicate cancels the revive";
     EXPECT_FALSE(duplicate->dead());
+    EXPECT_EQ(0, live_stains_for_team(arena.world(), 0))
+        << "a cancelled fire must still retire the queued corpse stain";
     EXPECT_TRUE(arena.world().respawn.respawn_queue.empty());
 }
 
@@ -402,6 +652,7 @@ TEST(RespawnEngine, win_latch_flush_revives_all_player_corpses)
     ASSERT_TRUE(arena.schedule(runner));
     ASSERT_EQ(1u, arena.world().respawn.respawn_queue.size());
     ASSERT_TRUE(runner->dead());
+    ASSERT_EQ(1, live_stains_for_team(arena.world(), 0));
 
     // og.declare_winner: first arming flushes the respawn engine (D2)
     // before winner math, and the engine re-asserts the win every tick.
@@ -412,7 +663,50 @@ TEST(RespawnEngine, win_latch_flush_revives_all_player_corpses)
     ASSERT_EQ(1, arena.world().mode.winner_team);
     ASSERT_FALSE(runner->dead())
         << "match end must revive pending player corpses before the merge";
+    ASSERT_EQ(0, live_stains_for_team(arena.world(), 0))
+        << "flush fire retires the queued player's stain";
     ASSERT_TRUE(arena.world().respawn.respawn_queue.empty());
+}
+
+TEST(RespawnEngine, win_latch_flush_revives_an_unqueued_player_and_scrubs_stain)
+{
+    RespawnArena arena;
+    walker* runner = arena.runner;
+    runner->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    runner->myguy->id = 42;
+
+    arena.kill(runner);
+    ASSERT_TRUE(arena.world().respawn.respawn_queue.empty());
+    ASSERT_EQ(1, live_stains_for_team(arena.world(), 0));
+
+    og::sim::respawn_flush_revive_all(arena.world());
+
+    EXPECT_FALSE(runner->dead())
+        << "the win flush catches a death not yet booked by the mode hook";
+    EXPECT_EQ(0, live_stains_for_team(arena.world(), 0))
+        << "the direct flush path retires the player's stain";
+    EXPECT_TRUE(arena.world().respawn.respawn_queue.empty());
+}
+
+TEST(RespawnEngine, win_latch_flush_scrubs_an_unqueued_duplicate_corpse)
+{
+    RespawnArena arena;
+    walker* runner = arena.runner;
+    runner->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    runner->myguy->id = 43;
+
+    arena.kill(runner);
+    ASSERT_EQ(1, live_stains_for_team(arena.world(), 0));
+    walker* duplicate = arena.fx.spawn_living(FAMILY_SOLDIER, 0, 256, 320);
+    duplicate->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    duplicate->myguy->id = 43;
+
+    og::sim::respawn_flush_revive_all(arena.world());
+
+    EXPECT_TRUE(runner->dead()) << "the live duplicate cancels direct revive";
+    EXPECT_FALSE(duplicate->dead());
+    EXPECT_EQ(0, live_stains_for_team(arena.world(), 0))
+        << "duplicate cancellation must not leave a stale corpse stain";
 }
 
 TEST(RespawnEngine, queue_cap_evicts_oldest_ai_entry_for_a_player)
@@ -554,7 +848,7 @@ TEST(RespawnEngine, same_guy_id_under_a_different_owner_does_not_block_revive)
 }
 
 // Player corpses drop a LIFE_GEM centered on the body; respawn scheduling
-// must scrub it (and the stain) or respawn cycles farm tiebreaker score.
+// must scrub the gem immediately or respawn cycles farm tiebreaker score.
 TEST(RespawnEngine, scheduling_scrubs_the_corpse_life_gem)
 {
     RespawnArena arena;


### PR DESCRIPTION
## Summary

- Always render each live player's `SPC` HUD row, even when score display is off or an FFA/Mutant fighter uses a band-team id outside the classic score array.
- Keep a dead player character's corpse stain visible for the whole respawn countdown. Life gems and AI stains still scrub immediately; revive, cancellation, and win-flush paths retire only the matching player stain.
- Match corpse cleanup by character identity, team, floor, and death position so nearby or duplicate corpses are not removed accidentally.
- Keep isolated Emscripten verification working with packaged/Nix toolchains as well as emsdk installs.

## Proof

Deterministic engine captures from the same fixtures and cameras, scaled 2×
with nearest-neighbor filtering for readability. Before is `9ffef804`; after
is `de4386d80b30`.

### #211 — current special in every quarter-screen HUD

| Before | After |
|:--:|:--:|
| ![#211 before: only the bottom-right player shows SPC CHARGE, while the band-team pane falls back to SC 0](https://raw.githubusercontent.com/openglad/openglad-screenshots/79da70d05347b25e8f18b9c8f16ababc89d04459/pr-216/211-before.png) | ![#211 after: all four players show SPC CHARGE](https://raw.githubusercontent.com/openglad/openglad-screenshots/79da70d05347b25e8f18b9c8f16ababc89d04459/pr-216/211-after.png) |

### #215 — player corpse retained during the respawn countdown

| Before | After |
|:--:|:--:|
| ![#215 before: respawn countdown and cleric with bare grass at the player death spot](https://raw.githubusercontent.com/openglad/openglad-screenshots/79da70d05347b25e8f18b9c8f16ababc89d04459/pr-216/215-before.png) | ![#215 after: the player corpse marker remains beside the cleric during the same countdown](https://raw.githubusercontent.com/openglad/openglad-screenshots/79da70d05347b25e8f18b9c8f16ababc89d04459/pr-216/215-after.png) |

## Verification
- `PackLuaCleric.a_resurrected_character_returns_to_the_roster_with_permadeath_on` — real death → `RESURRECT` → classic permadeath win fold

- `cmake --build --preset ci-test -j2`
- `ctest --preset ci-test --output-on-failure` — 59/59 passed
- `./scripts/build_web.sh`
- `python3 scripts/modding/check_api_stubs.py`
- `python3 scripts/check_luals.py`
- `python3 scripts/parity/check_mutation_pins.py` — 217/217 anchors valid
- explicit `USE_TOUCH_INPUT` warnings-as-errors compile
- pre-merge heritage audit of 46 unique deleted comment lines

Fixes #211
Fixes #215

