### PR TITLE
Add modern gameplay dynamics ruleset

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -265,6 +265,16 @@ and viewscreen layout. See
 [Resolution, zoom, and smoothing](resolution-and-scaling.md) for the sizing,
 resource limits, and legacy-config behavior.
 
+`GameWorld::dynamics_ruleset` is a deterministic, host-authoritative session
+axis. **Classic** preserves Gladiator's stop-to-turn cadence exactly. **Modern**
+snaps a player's facing to current movement intent before movement, firing, or
+special dispatch, and turns an unshifted Yell into a breakaway when at least two
+eligible hostile bodies are in contact: those foes face outward immediately,
+then receive four forced walk ticks. The Difficulty menu persists a local
+`gameplay/dynamics` preference for newly created matches; company GTL files do
+not store it. Lobby settings, initial setup, snapshots, and replays carry the
+live session value.
+
 ### Session and Context
 
 **`GameSession`** is the RAII root that owns all runtime state. Multiple sessions can coexist in a single process (see [Concurrent Sessions](#concurrent-sessions)).
@@ -554,11 +564,13 @@ contribute up to 4 local seats, with up to 16 seats lobby-wide. The same
 machinery also runs single-player and local split-screen — see [Local Transport
 Shadow](#local-transport-shadow).
 
-The current network compatibility line is lobby/gameplay protocol **v12**, world
-snapshot format **v10**, and replay format **v14**. Protocol v12 replaces the
-flattened CTF snapshot block with the generic RespawnState + ModeState blocks
-(every scripted mode replicates through them) and appends
-`LobbySettings.shared_teams`; v9 added stable, server-issued lobby seat
+The current network compatibility line is lobby/gameplay protocol **v13**, world
+snapshot format **v11**, and replay format **v15**. Protocol v13 appends the
+host-authoritative `DynamicsRuleset` to lobby settings, initial setup,
+snapshots, and replay state. Protocol v12 replaced the flattened CTF snapshot
+block with the generic RespawnState + ModeState blocks (every scripted mode
+replicates through them) and appended `LobbySettings.shared_teams`; v9 added
+stable, server-issued lobby seat
 identity and authoritative per-recipient ownership on top of the
 Company/Base Camp multiplayer state introduced by v8. Team changes
 and exact-seat removal use that identity rather than the mutable dense `P#`.
@@ -726,9 +738,10 @@ modes schedule through `og.respawn_schedule` (eligibility is Lua's) and repositi
 `on_respawn`; corpses persist in `oblist` so control bindings and per-player save merging
 survive, and team wipes never end an undecided scripted match.
 
-`RespawnState` and `ModeState` replicate as their own `WorldSnapshot` blocks (snapshot v10,
-protocol v12, replay v14), so mirrors, late joiners, replays, and the curses/text HUDs need no
-extra wire messages — a mid-join keyframe restore carries a running match. Match settings
+`RespawnState` and `ModeState` replicate as their own `WorldSnapshot` blocks (introduced in
+snapshot v10; the current envelope is snapshot v11, protocol v13, replay v15), so mirrors,
+late joiners, replays, and the curses/text HUDs need no extra wire messages — a mid-join
+keyframe restore carries a running match. Match settings
 (`ctf_team_count`/`ctf_capture_limit`/`ctf_respawn_ticks`/`ctf_strip_scenario_troops` — the
 storage names keep their historical prefix; Lua reads them as `og.match_setting`) follow the
 versioned SaveData (GTL v10) → LobbySettings → game start → `GameWorld::ctf_requested_*` path.

--- a/include/openglad/gameplay/dynamics_ruleset.h
+++ b/include/openglad/gameplay/dynamics_ruleset.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+
+namespace og::sim {
+
+// Host-authoritative movement/combat feel. Classic preserves Gladiator's
+// stop-to-turn cadence; Modern enables the responsive input rules introduced
+// for issue #205. The explicit wire values are part of snapshots and replays.
+enum class DynamicsRuleset : std::uint8_t {
+    Classic = 0,
+    Modern = 1,
+};
+
+constexpr std::uint8_t
+dynamics_ruleset_value(DynamicsRuleset ruleset) noexcept
+{
+    return static_cast<std::uint8_t>(ruleset);
+}
+
+constexpr bool is_valid_dynamics_ruleset(DynamicsRuleset ruleset) noexcept
+{
+    return ruleset == DynamicsRuleset::Classic ||
+           ruleset == DynamicsRuleset::Modern;
+}
+
+constexpr DynamicsRuleset dynamics_ruleset_from_value(
+    std::uint8_t value,
+    DynamicsRuleset fallback = DynamicsRuleset::Classic) noexcept
+{
+    const auto ruleset = static_cast<DynamicsRuleset>(value);
+    return is_valid_dynamics_ruleset(ruleset) ? ruleset : fallback;
+}
+
+} // namespace og::sim

--- a/include/openglad/gameplay/game_world.h
+++ b/include/openglad/gameplay/game_world.h
@@ -22,6 +22,7 @@
 #include <openglad/core/decordefs.h>
 #include <openglad/core/tower_constants.h>
 #include <openglad/core/weather.h>
+#include <openglad/gameplay/dynamics_ruleset.h>
 #include <openglad/gameplay/mode/mode_state.h>
 #include <openglad/gameplay/respawn/respawn_state.h>
 #include <openglad/gameplay/pixie_data.h>
@@ -427,6 +428,11 @@ public:
     std::uint32_t m_score[4] = {};
     short my_team = 0;
     short allied_mode = 0;
+    // Host-authoritative movement/combat feel. The engine-level default stays
+    // Classic so parity harnesses and hand-built worlds retain legacy timing;
+    // frontends seed fresh sessions from their Modern-by-default preference.
+    og::sim::DynamicsRuleset dynamics_ruleset =
+        og::sim::DynamicsRuleset::Classic;
     short ctf_requested_team_count = 0;
     short ctf_requested_capture_limit = 0;
     short ctf_requested_respawn_ticks = 0;

--- a/include/openglad/gameplay/lobby_server.h
+++ b/include/openglad/gameplay/lobby_server.h
@@ -29,6 +29,7 @@ struct LobbySaveDataEquivalent {
     std::int16_t cross_control = 0;
     // Host-only infinite-gold setting (protocol v11; see LobbySettings).
     std::int16_t infinite_gold = 0;
+    DynamicsRuleset dynamics_ruleset = DynamicsRuleset::Classic;
     std::vector<LobbyCharacterSlot> team_list;
 
     bool operator==(const LobbySaveDataEquivalent&) const = default;

--- a/include/openglad/gameplay/lobby_state.h
+++ b/include/openglad/gameplay/lobby_state.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <openglad/core/constants.h>
+#include <openglad/gameplay/dynamics_ruleset.h>
 #include <openglad/gameplay/mode/mode_state.h>
 
 #include <cstddef>
@@ -233,6 +234,10 @@ struct LobbySettings {
     // instead of comparing campaign ids. sanitize_settings keeps it in
     // {0, 1}.
     std::int16_t shared_teams = 0;
+    // Host-authoritative gameplay feel (protocol v13). Fresh-session
+    // frontends may request Modern, while the DTO default remains Classic so
+    // omitted/test-authored settings preserve legacy behavior.
+    DynamicsRuleset dynamics_ruleset = DynamicsRuleset::Classic;
 
     bool operator==(const LobbySettings&) const = default;
 };

--- a/include/openglad/gameplay/net_transport.h
+++ b/include/openglad/gameplay/net_transport.h
@@ -124,7 +124,11 @@ constexpr std::uint8_t net_message_type_value(NetMessageType message_type) noexc
 // sanitized to {0,1}), appended after infinite_gold — the lobby's
 // shared-teams rule now rides the wire instead of comparing campaign ids.
 // Replay format moves to v14.
-inline constexpr std::uint8_t kNetworkProtocolVersion = 12;
+// v13: modern gameplay dynamics (issue #205). LobbySettings and InitialSetup
+// append a DynamicsRuleset byte; WorldSnapshot appends the same
+// host-authoritative byte and moves to snapshot format v11. Replay format
+// moves to v15 and records the ruleset in both its header and initial snapshot.
+inline constexpr std::uint8_t kNetworkProtocolVersion = 13;
 
 // Global networked player-index cap (seats across ALL peers). Distinct from
 // MAX_PLAYERS, which stays 4 and caps the seats of ONE machine (input slots,
@@ -248,6 +252,7 @@ struct InitialSetupMessage {
     std::int16_t current_scenario = 0;
     std::int16_t respawn_mode = 0;
     std::int16_t generator_rate = 0;
+    DynamicsRuleset dynamics_ruleset = DynamicsRuleset::Classic;
     std::vector<InitialSetupGuyData> guys;
     std::vector<std::int32_t> completed_levels;
     // Keyed by GLOBAL player index (u8-count-prefixed on the wire).

--- a/include/openglad/gameplay/replay.h
+++ b/include/openglad/gameplay/replay.h
@@ -14,10 +14,10 @@ class GameWorld;
 
 namespace og::sim {
 
-// v14 records protocol-v12 snapshots/input frames (snapshot v10: the CTF
-// world block is replaced by the RespawnState + ModeState blocks). v13
-// readers must reject the new protocol byte and vice versa.
-inline constexpr std::uint8_t kReplayFormatVersion = 14;
+// v15 records protocol-v13 snapshots/input frames (snapshot v11 adds the
+// host-authoritative DynamicsRuleset byte). v14 readers must reject the new
+// protocol byte and vice versa.
+inline constexpr std::uint8_t kReplayFormatVersion = 15;
 inline constexpr std::size_t kReplayHeaderSize = 32;
 
 enum class ReplayIoError : std::uint8_t {
@@ -35,6 +35,7 @@ struct ReplayHeader {
     std::int32_t level_id = 0;
     std::uint8_t player_count = 0;
     std::int8_t timer_wait = 0;
+    DynamicsRuleset dynamics_ruleset = DynamicsRuleset::Classic;
     std::int16_t my_team = 0;
     std::int16_t allied_mode = 0;
     std::int16_t difficulty = 100;

--- a/include/openglad/gameplay/sim_input_handler.h
+++ b/include/openglad/gameplay/sim_input_handler.h
@@ -19,6 +19,11 @@ class GameWorld;
 
 namespace og::sim {
 class SimEventLog;
+
+// Modern Yell breakaway tuning. Keep these named: they are deliberately
+// small, playtest-facing values rather than family balance data.
+inline constexpr int kBreakawayWalkTicks = 4;
+inline constexpr float kBreakawayRecoveryTicks = 4.0f;
 }
 
 // Result of processing one player's input through the sim layer.

--- a/include/openglad/gameplay/world_snapshot.h
+++ b/include/openglad/gameplay/world_snapshot.h
@@ -32,7 +32,7 @@ namespace og::sim {
 inline constexpr std::size_t kEntitySnapshotDirtyMaskWords = 2;
 inline constexpr std::int32_t kNoGuyId = -1;
 inline constexpr std::uint8_t kNoPausePlayerIndex = 0xff;
-inline constexpr std::uint8_t kSnapshotFormatVersion = 10;
+inline constexpr std::uint8_t kSnapshotFormatVersion = 11;
 inline constexpr std::uint8_t kSnapshotProtocolVersion = kNetworkProtocolVersion;
 inline constexpr std::uint8_t kDeltaPayloadUncompressedFlag = 0x01;
 inline constexpr std::size_t kDeltaPayloadHeaderSize = 1;
@@ -264,6 +264,8 @@ struct WorldSnapshot {
     std::array<std::uint8_t, kMaxGlobalPlayers> player_machine = {
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    // Snapshot v11 / protocol v13: host-authoritative gameplay feel.
+    DynamicsRuleset dynamics_ruleset = DynamicsRuleset::Classic;
 
     std::uint8_t grid_width = 0;
     std::uint8_t grid_height = 0;

--- a/include/openglad/interface/button.h
+++ b/include/openglad/interface/button.h
@@ -190,6 +190,7 @@ Sint32 change_respawn_delay();
 Sint32 change_permadeath();
 Sint32 change_generator_rate();
 Sint32 change_infinite_gold(); // DIFFICULTY infinite-gold toggle (session-only)
+Sint32 change_dynamics_ruleset(); // DIFFICULTY Classic/Modern host rule
 Sint32 change_depth_fx(); // GRAPHICS FX depth selector (cfg effects/depth_fx)
 Sint32 change_resolution(); // DISPLAY resolution selector (cfg graphics/width+height)
 Sint32 change_zoom(); // DISPLAY zoom selector (cfg graphics/zoom)
@@ -319,9 +320,9 @@ enum class ButtonAction : Sint32
     ToggleScreenShake = 84,
     OpenGameplayFxSettings = 85,
     OpenUiFxSettings = 86,
-    // DIFFICULTY subscreen: the main-menu DIFFICULTY door plus the four
-    // match-rule cyclers that live inside it (the difficulty cycler itself
-    // reuses SetDifficulty = 24).
+    // DIFFICULTY subscreen: the main-menu DIFFICULTY door and its first
+    // match-rule actions (the difficulty cycler itself reuses
+    // SetDifficulty = 24; later rows remain append-only below).
     OpenDifficultyMenu = 87,
     CycleRespawnMode = 88,
     CycleRespawnDelay = 89,
@@ -371,6 +372,8 @@ enum class ButtonAction : Sint32
     CycleGameSpeed = 103,
     ToggleColorCycling = 104,
     BrightnessAdjust = 105,
+    // #205 DIFFICULTY row: host-authoritative Classic/Modern gameplay feel.
+    ToggleDynamicsRuleset = 106,
 };
 
 inline constexpr Sint32 button_action_id(ButtonAction action)

--- a/include/openglad/interface/ui/menu_model.h
+++ b/include/openglad/interface/ui/menu_model.h
@@ -83,6 +83,8 @@ enum class PickerMenuCommand : std::int32_t
     CloudSetPassphrase, // set/replace the passphrase (stores the derived key)
     CloudUpload,        // upload the active company to the relay vault
     CloudDownload,      // download + install the vault's company
+    // #205 DIFFICULTY row: Classic/Modern host-authoritative gameplay feel.
+    ToggleDynamicsRuleset,
 };
 
 struct PickerMenuItem

--- a/include/openglad/interface/ui/picker_common.h
+++ b/include/openglad/interface/ui/picker_common.h
@@ -319,7 +319,10 @@ int add_recruit_to_team(SaveData& save, std::unique_ptr<guy> recruit, int team_n
 std::unique_ptr<guy> create_recruit(int family, int team_num, const SaveData& save);
 
 // Reset save data for a new game: clear team, reset gold.
-void reset_for_new_game(SaveData& save);
+void reset_for_new_game(
+    SaveData& save,
+    og::sim::DynamicsRuleset dynamics_ruleset =
+        og::sim::DynamicsRuleset::Modern);
 
 // Ensure team has at least one member.  Creates recruits from the
 // families list, falling back to FAMILY_SOLDIER if the list is empty.
@@ -413,6 +416,11 @@ void cycle_generator_rate(SaveData& save);
 // Toggle infinite gold: infinite_gold 0 (classic economy) <-> 1 (free
 // purchases). SESSION-ONLY, so no company autosave follows a toggle.
 void toggle_infinite_gold(SaveData& save);
+
+// Toggle the host-authoritative gameplay feel. SESSION-ONLY: this carrier is
+// broadcast through LobbySettings and copied into GameWorld, never written to
+// a company GTL. Frontends separately persist the local preference in cfg.
+void toggle_dynamics_ruleset(SaveData& save);
 
 // True when hire/train purchases are free for this session.
 [[nodiscard]] bool gold_is_infinite(const SaveData& save) noexcept;
@@ -857,6 +865,10 @@ std::string format_generator_rate_label(const SaveData& save);
 
 // "Infinite Gold: Off" / "Infinite Gold: On".
 std::string format_infinite_gold_label(const SaveData& save);
+
+// Compact Difficulty-row label, deliberately kept to 12 characters:
+// "Modern Pace" / "Classic Pace".
+std::string format_dynamics_ruleset_label(const SaveData& save);
 
 // --- Company screens: label formatters (design §2.2/§2.3) ---
 // (The §2.2 "file: <slug>.gtl" preview formatter was DELETED — §9.3/F2:

--- a/include/openglad/resources/gparser.h
+++ b/include/openglad/resources/gparser.h
@@ -16,6 +16,8 @@
  */
 #pragma once
 
+#include <openglad/gameplay/dynamics_ruleset.h>
+
 #include <string>
 #include <map>
 
@@ -41,6 +43,12 @@ public:
     // persisted config.
     void apply_override(const std::string& category, const std::string& setting, const std::string& value);
     std::string get_setting(const std::string& category, const std::string& setting);
+
+    // Local preference that seeds a newly created match. The live match uses
+    // the host-authoritative LobbySettings/GameWorld value instead. Unknown
+    // and absent values normalize to the fresh-session default, Modern.
+    [[nodiscard]] og::sim::DynamicsRuleset dynamics_ruleset_preference();
+    void set_dynamics_ruleset_preference(og::sim::DynamicsRuleset ruleset);
 	bool is_on(const std::string& category, const std::string& setting);
 
 	// Persisted settings. save_settings() serializes exactly this map.
@@ -51,4 +59,3 @@ public:
 
 // Global cfg_store instance, owned at file scope in data/gparser.cpp.
 extern cfg_store cfg;
-

--- a/include/openglad/resources/save_data.h
+++ b/include/openglad/resources/save_data.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <openglad/gameplay/dynamics_ruleset.h>
+
 #include <cstdint>
 #include <array>
 #include <span>
@@ -97,6 +99,14 @@ public:
     // file (like cross_control), which also keeps every company autosave
     // from baking a cheat balance into the player's file.
     short infinite_gold = 0;
+    // Gameplay feel (protocol v13): host-authoritative during a lobby, but
+    // seeded from this machine's gameplay/dynamics preference for every new
+    // session. SESSION-ONLY — never serialized to the company GTL. The
+    // resource-layer carrier defaults Modern because new frontends do; the
+    // authoritative GameWorld default remains Classic for parity-safe direct
+    // construction and old/test-authored setup records.
+    og::sim::DynamicsRuleset dynamics_ruleset =
+        og::sim::DynamicsRuleset::Modern;
     // Tower Climb persistence (GTL v13; docs/tower-triple-design.md D2/D6).
     // Floors climbed is DERIVED (scen_num - kTowerGateLevel), never stored as
     // a run counter; only the lifetime best and the current run's generation

--- a/src/gameplay/game_client.cpp
+++ b/src/gameplay/game_client.cpp
@@ -54,6 +54,8 @@ void apply_initial_setup_to_world(GameWorld& world,
     world.current_scenario = message.current_scenario;
     world.respawn_mode = message.respawn_mode;
     world.generator_rate = message.generator_rate;
+    world.dynamics_ruleset = og::sim::dynamics_ruleset_from_value(
+        og::sim::dynamics_ruleset_value(message.dynamics_ruleset));
     world.completed_levels.clear();
     for (const std::int32_t level_id : message.completed_levels)
         world.completed_levels.insert(level_id);

--- a/src/gameplay/game_server.cpp
+++ b/src/gameplay/game_server.cpp
@@ -1374,6 +1374,7 @@ InitialSetupMessage GameServer::build_initial_setup(PeerId peer_id) const
     message.current_scenario = world_.current_scenario;
     message.respawn_mode = world_.respawn_mode;
     message.generator_rate = world_.generator_rate;
+    message.dynamics_ruleset = world_.dynamics_ruleset;
     message.guys = collect_initial_setup_guys(world_);
     message.completed_levels.assign(world_.completed_levels.begin(),
                                     world_.completed_levels.end());

--- a/src/gameplay/game_world.cpp
+++ b/src/gameplay/game_world.cpp
@@ -1567,6 +1567,7 @@ void GameWorld::clear()
         m_score[i] = 0;
     my_team = 0;
     allied_mode = 0;
+    dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
     current_scenario = 0;
     current_palette_id = 0;
     pending_exit_prompt = false;

--- a/src/gameplay/lobby_server.cpp
+++ b/src/gameplay/lobby_server.cpp
@@ -34,6 +34,7 @@ og::sim::LobbySettings make_default_lobby_settings()
     settings.scenario_id = kDefaultScenarioId;
     settings.difficulty = kDefaultDifficulty;
     settings.allied_mode = kDefaultAlliedMode;
+    settings.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
     return settings;
 }
 
@@ -113,6 +114,8 @@ og::sim::LobbySettings sanitize_settings(const og::sim::LobbySettings& requested
         sanitized.infinite_gold = fallback.infinite_gold;
     if (sanitized.shared_teams != 0 && sanitized.shared_teams != 1)
         sanitized.shared_teams = fallback.shared_teams;
+    if (!og::sim::is_valid_dynamics_ruleset(sanitized.dynamics_ruleset))
+        sanitized.dynamics_ruleset = fallback.dynamics_ruleset;
     return sanitized;
 }
 
@@ -1342,6 +1345,7 @@ LobbySaveDataEquivalent LobbyServer::build_save_data_equivalent() const
     equivalent.keep_fallen_heroes = state_.settings.keep_fallen_heroes;
     equivalent.cross_control = state_.settings.cross_control;
     equivalent.infinite_gold = state_.settings.infinite_gold;
+    equivalent.dynamics_ruleset = state_.settings.dynamics_ruleset;
     equivalent.current_campaign = state_.settings.campaign_id.empty()
         ? std::string(kDefaultCampaignId)
         : state_.settings.campaign_id;

--- a/src/gameplay/net_transport.cpp
+++ b/src/gameplay/net_transport.cpp
@@ -357,6 +357,8 @@ void append_lobby_settings(std::vector<std::uint8_t>& payload,
     append_i16(payload, settings.cross_control);
     append_i16(payload, settings.infinite_gold);
     append_i16(payload, settings.shared_teams);
+    append_u8(payload,
+              og::sim::dynamics_ruleset_value(settings.dynamics_ruleset));
 }
 
 og::sim::LobbySettings read_lobby_settings(PayloadReader& reader)
@@ -377,6 +379,8 @@ og::sim::LobbySettings read_lobby_settings(PayloadReader& reader)
     settings.cross_control = reader.read_i16();
     settings.infinite_gold = reader.read_i16();
     settings.shared_teams = reader.read_i16();
+    settings.dynamics_ruleset =
+        static_cast<og::sim::DynamicsRuleset>(reader.read_u8());
     return settings;
 }
 
@@ -496,6 +500,7 @@ std::vector<std::uint8_t> serialize_initial_setup_message(
     append_i16(payload, message.current_scenario);
     append_i16(payload, message.respawn_mode);
     append_i16(payload, message.generator_rate);
+    append_u8(payload, dynamics_ruleset_value(message.dynamics_ruleset));
     append_u32(payload, static_cast<std::uint32_t>(message.guys.size()));
     for (const auto& guy : message.guys)
         append_initial_setup_guy(payload, guy);
@@ -529,6 +534,8 @@ std::optional<InitialSetupMessage> deserialize_initial_setup_message(
             message.current_scenario = reader.read_i16();
             message.respawn_mode = reader.read_i16();
             message.generator_rate = reader.read_i16();
+            message.dynamics_ruleset = dynamics_ruleset_from_value(
+                reader.read_u8());
             const std::uint32_t guy_count = reader.read_u32();
             if (!reader.ok() ||
                 guy_count >
@@ -752,6 +759,18 @@ std::optional<LobbyState> deserialize_lobby_state_message(
         bytes, kLobbyStateMessageType,
         [](PayloadReader& reader, LobbyState& state) {
             state.settings = read_lobby_settings(reader);
+            // A LobbyState is authoritative server output, so accepting an
+            // unknown ruleset here would install an invalid simulation mode
+            // on clients. Client-authored SettingsChange messages deliberately
+            // retain their raw value so LobbyServer can apply its current-value
+            // fallback while sanitizing the request.
+            if (!reader.ok() ||
+                !is_valid_dynamics_ruleset(
+                    state.settings.dynamics_ruleset))
+            {
+                reader.fail();
+                return;
+            }
             state.host_player_id = reader.read_u8();
             state.last_start_denial = reader.read_u8();
             state.last_start_request_id = reader.read_u32();

--- a/src/gameplay/replay.cpp
+++ b/src/gameplay/replay.cpp
@@ -483,6 +483,7 @@ bool compare_world_snapshot(const WorldSnapshot& expected,
     OG_REPLAY_COMPARE(ctf_requested_strip_scenario_troops);
     OG_REPLAY_COMPARE(respawn_mode);
     OG_REPLAY_COMPARE(generator_rate);
+    OG_REPLAY_COMPARE(dynamics_ruleset);
     OG_REPLAY_COMPARE(grid_width);
     OG_REPLAY_COMPARE(grid_height);
     OG_REPLAY_COMPARE(grid_dirty);
@@ -711,7 +712,7 @@ std::vector<std::uint8_t> serialize_replay(const ReplayHeader& header,
     bytes.push_back(header.version);
     bytes.push_back(header.player_count);
     bytes.push_back(static_cast<std::uint8_t>(header.timer_wait));
-    bytes.push_back(0);
+    bytes.push_back(dynamics_ruleset_value(header.dynamics_ruleset));
     write_u32_le(bytes, header.initial_rng_state);
     write_u32_le(bytes, static_cast<std::uint32_t>(header.level_id));
     write_i16_le(bytes, header.my_team);
@@ -759,6 +760,13 @@ std::optional<ReplayData> deserialize_replay(std::span<const std::uint8_t> bytes
 
     replay.header.player_count = bytes[5];
     replay.header.timer_wait = static_cast<std::int8_t>(bytes[6]);
+    replay.header.dynamics_ruleset =
+        static_cast<DynamicsRuleset>(bytes[7]);
+    if (!is_valid_dynamics_ruleset(replay.header.dynamics_ruleset))
+    {
+        set_error(out_error, ReplayIoError::InvalidHeader);
+        return std::nullopt;
+    }
     replay.header.initial_rng_state = read_u32_le(bytes, 8);
     replay.header.level_id = static_cast<std::int32_t>(read_u32_le(bytes, 12));
     replay.header.my_team = read_i16_le(bytes, 16);
@@ -806,6 +814,13 @@ std::optional<ReplayData> deserialize_replay(std::span<const std::uint8_t> bytes
             deserialize_snapshot(initial_snapshot_bytes);
     }
     catch (const std::runtime_error&)
+    {
+        set_error(out_error, ReplayIoError::MalformedData);
+        return std::nullopt;
+    }
+
+    if (replay.header.dynamics_ruleset !=
+        replay.initial_snapshot.dynamics_ruleset)
     {
         set_error(out_error, ReplayIoError::MalformedData);
         return std::nullopt;
@@ -909,7 +924,19 @@ std::vector<std::uint8_t> ReplayRecorder::serialize() const
 bool ReplayRecorder::write_file(const std::filesystem::path& path,
                                 ReplayIoError* out_error) const
 {
+    if (!is_valid_dynamics_ruleset(header_.dynamics_ruleset))
+    {
+        set_error(out_error, ReplayIoError::InvalidHeader);
+        return false;
+    }
+
     if (header_.campaign_id.empty() || !has_initial_snapshot_)
+    {
+        set_error(out_error, ReplayIoError::MalformedData);
+        return false;
+    }
+
+    if (header_.dynamics_ruleset != initial_snapshot_.dynamics_ruleset)
     {
         set_error(out_error, ReplayIoError::MalformedData);
         return false;

--- a/src/gameplay/sim_input_handler.cpp
+++ b/src/gameplay/sim_input_handler.cpp
@@ -13,6 +13,8 @@
 #include <openglad/core/constants.h>
 #include <openglad/gameplay/game_world.h>
 #include <openglad/gameplay/input_state.h>
+#include <openglad/gameplay/families/family_descriptor.h>
+#include <openglad/gameplay/families/family_registry.h>
 #include <openglad/gameplay/sim_control_policy.h>
 #include <openglad/gameplay/sim_emit.h>
 #include <openglad/gameplay/statistics.h>
@@ -21,6 +23,162 @@
 #include <openglad/core/test_trace.h>
 
 #include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+struct BreakawayTarget
+{
+    walker* target = nullptr;
+    short dx = 0;
+    short dy = 0;
+};
+
+[[nodiscard]] bool z_ranges_overlap(const walker& lhs, const walker& rhs)
+{
+    // A zero height is the legacy full-height sentinel used by ob_pass_check.
+    if (lhs.sizez() <= 0 || rhs.sizez() <= 0)
+        return true;
+    const float lhs_top = lhs.worldz() + static_cast<float>(lhs.sizez());
+    const float rhs_top = rhs.worldz() + static_cast<float>(rhs.sizez());
+    return lhs_top > rhs.worldz() && rhs_top > lhs.worldz();
+}
+
+[[nodiscard]] std::int32_t axis_gap(std::int32_t a_start,
+                                    std::int32_t a_size,
+                                    std::int32_t b_start,
+                                    std::int32_t b_size)
+{
+    const std::int32_t a_end = a_start + a_size;
+    const std::int32_t b_end = b_start + b_size;
+    return std::max({b_start - a_end, a_start - b_end, 0});
+}
+
+[[nodiscard]] int contact_padding(const walker& control)
+{
+    const float step = control.stepsize();
+    if (!std::isfinite(step))
+        return 1;
+    const float bounded = std::clamp(step, 1.0f,
+                                     static_cast<float>(GRID_SIZE));
+    return static_cast<int>(std::ceil(bounded));
+}
+
+[[nodiscard]] bool is_breakaway_contact(const walker& control,
+                                        const walker& target,
+                                        int padding)
+{
+    if (&target == &control || target.dead() || target.dormant() ||
+        target.query_order() != Order::Living ||
+        target.stats() == nullptr ||
+        target.floor() != control.floor() || control.is_friendly(&target) ||
+        !z_ranges_overlap(control, target))
+    {
+        return false;
+    }
+
+    const FamilyDescriptor* const family =
+        get_family_descriptor(target.family());
+    if ((family != nullptr && family->is_stationary) ||
+        target.stats()->query_bit_flags(BIT_NO_COLLIDE))
+    {
+        return false;
+    }
+
+    return axis_gap(control.xpos(), control.sizex(),
+                    target.xpos(), target.sizex()) <= padding &&
+           axis_gap(control.ypos(), control.sizey(),
+                    target.ypos(), target.sizey()) <= padding;
+}
+
+[[nodiscard]] short unit_delta(std::int32_t delta)
+{
+    return static_cast<short>((delta > 0) - (delta < 0));
+}
+
+[[nodiscard]] std::pair<short, short> breakaway_direction(
+    const walker& control, const walker& target, std::size_t stable_ordinal)
+{
+    const std::int32_t dx =
+        (static_cast<std::int32_t>(target.xpos()) * 2 + target.sizex()) -
+        (static_cast<std::int32_t>(control.xpos()) * 2 + control.sizex());
+    const std::int32_t dy =
+        (static_cast<std::int32_t>(target.ypos()) * 2 + target.sizey()) -
+        (static_cast<std::int32_t>(control.ypos()) * 2 + control.sizey());
+    if (dx != 0 || dy != 0)
+        return {unit_delta(dx), unit_delta(dy)};
+
+    // Interpenetrating equal-centre bodies have no geometric "outward".
+    // Entity id is stable across snapshots/replays; list order is the stable
+    // construction fallback for headless fixtures and pre-id entities.
+    static constexpr std::array<std::pair<short, short>, NUM_FACINGS>
+        kFallbackDirections = {{{0, -1}, {1, -1}, {1, 0}, {1, 1},
+                                {0, 1}, {-1, 1}, {-1, 0}, {-1, -1}}};
+    const std::size_t key = target.entity_id() != 0
+        ? static_cast<std::size_t>(target.entity_id() - 1)
+        : stable_ordinal;
+    return kFallbackDirections[key % kFallbackDirections.size()];
+}
+
+[[nodiscard]] bool breakaway_actionable(const walker& control,
+                                        short player_num)
+{
+    return control.user() == player_num && control.act_type() == ACT_CONTROL &&
+           control.ani_type() == ANI_WALK && control.busy() <= 0.0f &&
+           control.stats() != nullptr &&
+           control.stats()->frozen_delay() == 0 &&
+           control.stats()->commands.empty();
+}
+
+bool apply_modern_breakaway(GameWorld& level, walker& control,
+                            short player_num)
+{
+    if (level.dynamics_ruleset != og::sim::DynamicsRuleset::Modern ||
+        !breakaway_actionable(control, player_num))
+    {
+        return false;
+    }
+
+    const int padding = contact_padding(control);
+    std::vector<BreakawayTarget> contacts;
+    contacts.reserve(4);
+    std::size_t stable_ordinal = 0;
+    for (const auto& owned : level.oblist)
+    {
+        walker* const target = owned.get();
+        if (target != nullptr &&
+            is_breakaway_contact(control, *target, padding))
+        {
+            const auto [dx, dy] =
+                breakaway_direction(control, *target, stable_ordinal);
+            contacts.push_back({target, dx, dy});
+        }
+        ++stable_ordinal;
+    }
+
+    if (contacts.size() < 2)
+        return false;
+
+    for (const BreakawayTarget& contact : contacts)
+    {
+        contact.target->face_delta(contact.dx, contact.dy);
+        // Make the outward snap visible even if the ensuing forced walk is
+        // blocked. Preserve attack poses and their animation cycles.
+        if (contact.target->ani_type() == ANI_WALK)
+            contact.target->set_frame_from_current_walk_animation();
+        contact.target->stats()->force_command(
+            COMMAND_WALK, og::sim::kBreakawayWalkTicks,
+            contact.dx, contact.dy);
+    }
+    control.set_busy(std::max(control.busy(),
+                              og::sim::kBreakawayRecoveryTicks));
+    return true;
+}
+
+} // namespace
 
 walker* sim_find_next_control(GameWorld& level, short my_team)
 {
@@ -239,18 +397,23 @@ SimInputResult sim_process_player_input(
         && !pi.is_held(InputAction::Shift)
         && !pi.is_held(InputAction::Cheat))
     {
-        for (auto& uptr : level.oblist)
+        const bool did_breakaway =
+            apply_modern_breakaway(level, *control, player_num);
+        if (!did_breakaway)
         {
-            walker* w = uptr.get();
-            if (w && (w->query_order() == Order::Living) &&
-                (w->act_type() != ACT_CONTROL) &&
-                (w->team_num() == control->team_num()) &&
-                (!w->leader()))
+            for (auto& uptr : level.oblist)
             {
-                w->set_leader(control);
-                // Remove any current foe ..
-                w->set_foe(nullptr);
-                w->stats()->force_command(COMMAND_FOLLOW, 100, 0, 0);
+                walker* w = uptr.get();
+                if (w && (w->query_order() == Order::Living) &&
+                    (w->act_type() != ACT_CONTROL) &&
+                    (w->team_num() == control->team_num()) &&
+                    (!w->leader()))
+                {
+                    w->set_leader(control);
+                    // Remove any current foe ..
+                    w->set_foe(nullptr);
+                    w->stats()->force_command(COMMAND_FOLLOW, 100, 0, 0);
+                }
             }
         }
         control->set_yo_delay(30);
@@ -337,6 +500,31 @@ SimInputResult sim_process_player_input(
     // Make sure we're not performing some queued action ..
     if (control->stats()->commands.empty())
     {
+        const int walkx = pi.move_x();
+        const int walky = pi.move_y();
+        if (level.dynamics_ruleset == og::sim::DynamicsRuleset::Modern &&
+            (walkx != 0 || walky != 0))
+        {
+            // Resolve intent before actions: movement, weapon heading and
+            // specials all observe the same direction on this tick.
+            control->face_delta(static_cast<short>(walkx),
+                                static_cast<short>(walky));
+            // Stationary/zero-step actors still need a nonzero aim vector:
+            // init_fire() and directional specials read lastx/lasty before
+            // walkstep() reaches the stationary-family branch.
+            if (control->stepsize() == 0.0f)
+            {
+                control->set_lastx(static_cast<float>(walkx));
+                control->set_lasty(static_cast<float>(walky));
+            }
+            // A blocked walk normally leaves its frame untouched. Refresh
+            // only the walk pose so a successful snap is visible even when
+            // the requested translation is obstructed; never disturb an
+            // attack animation or its cycle.
+            if (control->ani_type() == ANI_WALK)
+                control->set_frame_from_current_walk_animation();
+        }
+
         #ifndef USE_TOUCH_INPUT
         control->set_shifter_down(pi.is_held(InputAction::Shift) ? 1 : 0);
         #else
@@ -357,9 +545,6 @@ SimInputResult sim_process_player_input(
         // Holding Special key for rapid use (MP cost naturally rate-limits)
         if (pi.is_held(InputAction::Special))
             control->special();
-
-        int walkx = pi.move_x();
-        int walky = pi.move_y();
 
         if (walkx != 0 || walky != 0)
         {

--- a/src/gameplay/world_snapshot.cpp
+++ b/src/gameplay/world_snapshot.cpp
@@ -982,6 +982,8 @@ void serialize_world_state(std::vector<std::uint8_t>& buffer,
     append_u8(buffer, snapshot.control_policy);
     for (const std::uint8_t machine : snapshot.player_machine)
         append_u8(buffer, machine);
+    append_u8(buffer,
+              og::sim::dynamics_ruleset_value(snapshot.dynamics_ruleset));
 }
 
 void deserialize_world_state(ByteReader& reader, og::sim::WorldSnapshot& snapshot)
@@ -1021,6 +1023,8 @@ void deserialize_world_state(ByteReader& reader, og::sim::WorldSnapshot& snapsho
     snapshot.control_policy = reader.read_u8("world.control_policy");
     for (std::uint8_t& machine : snapshot.player_machine)
         machine = reader.read_u8("world.player_machine");
+    snapshot.dynamics_ruleset = og::sim::dynamics_ruleset_from_value(
+        reader.read_u8("world.dynamics_ruleset"));
 }
 
 void serialize_grid_state(std::vector<std::uint8_t>& buffer,
@@ -2671,6 +2675,7 @@ og::sim::WorldSnapshot capture_snapshot_impl(GameWorld& world,
     snapshot.generator_rate = world.generator_rate;
     snapshot.control_policy = world.control_policy;
     snapshot.player_machine = world.player_machine;
+    snapshot.dynamics_ruleset = world.dynamics_ruleset;
 
     std::unordered_set<int> seen_guy_ids;
     capture_entity_list(world.oblist, snapshot.oblist, snapshot.guy_snapshots,
@@ -3128,6 +3133,9 @@ bool apply_snapshot(GameWorld& world, const WorldSnapshot& snapshot)
     world.generator_rate = snapshot.generator_rate;
     world.control_policy = snapshot.control_policy;
     world.player_machine = snapshot.player_machine;
+    world.dynamics_ruleset = is_valid_dynamics_ruleset(snapshot.dynamics_ruleset)
+        ? snapshot.dynamics_ruleset
+        : DynamicsRuleset::Classic;
 
     GuyStorage guy_storage;
     GuyLookup guy_lookup;
@@ -3232,6 +3240,8 @@ void apply_delta(WorldSnapshot& baseline, const WorldSnapshot& delta)
     baseline.generator_rate = delta.generator_rate;
     baseline.control_policy = delta.control_policy;
     baseline.player_machine = delta.player_machine;
+    baseline.dynamics_ruleset = dynamics_ruleset_from_value(
+        dynamics_ruleset_value(delta.dynamics_ruleset));
 
     apply_delta_grid(baseline, delta);
     baseline.guy_snapshots = delta.guy_snapshots;

--- a/src/interface/level_runtime_data.cpp
+++ b/src/interface/level_runtime_data.cpp
@@ -290,6 +290,10 @@ void replace_loaded_world_state(LevelRuntimeData* level, GameWorld& loaded_world
         loaded_world.ctf_requested_strip_scenario_troops;
     dst.respawn_mode = loaded_world.respawn_mode;
     dst.generator_rate = loaded_world.generator_rate;
+    // The level-file scratch world is never authoritative for session rules
+    // that the file format does not carry. Keep dynamics, roster persistence,
+    // ownership policy, and the machine map already installed on dst;
+    // game-start setup and snapshots are their authoritative writers.
     dst.respawn = std::move(loaded_world.respawn);
     dst.mode = loaded_world.mode;
     dst.current_scenario = loaded_world.current_scenario;
@@ -633,6 +637,7 @@ void LevelRuntimeData::attach_world(GameWorld* world)
                   std::begin(next_world->m_score));
         next_world->my_team = old_world->my_team;
         next_world->allied_mode = old_world->allied_mode;
+        next_world->dynamics_ruleset = old_world->dynamics_ruleset;
         next_world->ctf_requested_team_count = old_world->ctf_requested_team_count;
         next_world->ctf_requested_capture_limit = old_world->ctf_requested_capture_limit;
         next_world->ctf_requested_respawn_ticks = old_world->ctf_requested_respawn_ticks;
@@ -640,6 +645,11 @@ void LevelRuntimeData::attach_world(GameWorld* world)
             old_world->ctf_requested_strip_scenario_troops;
         next_world->respawn_mode = old_world->respawn_mode;
         next_world->generator_rate = old_world->generator_rate;
+        next_world->keep_fallen_heroes = old_world->keep_fallen_heroes;
+        // Unlike the level-file replacement above, attach_world transfers the
+        // live world itself (including its installed ownership policy).
+        next_world->control_policy = old_world->control_policy;
+        next_world->player_machine = old_world->player_machine;
         next_world->respawn = std::move(old_world->respawn);
         next_world->mode = old_world->mode;
         next_world->current_scenario = old_world->current_scenario;

--- a/src/interface/replay_runtime.cpp
+++ b/src/interface/replay_runtime.cpp
@@ -158,6 +158,7 @@ bool og::runtime::initialize_replay_screen(screen& game_screen,
     game_screen.save_data.numplayers = header.player_count;
     game_screen.save_data.my_team = header.my_team;
     game_screen.save_data.allied_mode = header.allied_mode;
+    game_screen.save_data.dynamics_ruleset = header.dynamics_ruleset;
 
     game_screen.numviews = desired_views;
     game_screen.cleanup(desired_views);
@@ -180,6 +181,8 @@ bool og::runtime::initialize_replay_screen(screen& game_screen,
     og::sim::apply_snapshot(game_screen.world(), initial_snapshot);
     game_screen.save_data.my_team = game_screen.world().my_team;
     game_screen.save_data.allied_mode = game_screen.world().allied_mode;
+    game_screen.save_data.dynamics_ruleset =
+        game_screen.world().dynamics_ruleset;
     assign_replay_views(game_screen, initial_snapshot);
     game_screen.world().timer_wait = header.timer_wait;
     player.reset();
@@ -207,6 +210,7 @@ void og::runtime::begin_replay_recording(screen& game_screen)
         .level_id = game_screen.world().id,
         .player_count = static_cast<std::uint8_t>(game_screen.save_data.numplayers),
         .timer_wait = game_screen.world().timer_wait,
+        .dynamics_ruleset = game_screen.world().dynamics_ruleset,
         .my_team = game_screen.save_data.my_team,
         .allied_mode = game_screen.save_data.allied_mode,
         .difficulty = game_screen.world().difficulty,

--- a/src/interface/screen.cpp
+++ b/src/interface/screen.cpp
@@ -1304,6 +1304,7 @@ void screen::sync_world_from_save_data()
         og::mode::current_progression().clamp_respawn_mode(save_data.respawn_mode);
     world_.generator_rate = save_data.generator_rate;
     world_.keep_fallen_heroes = save_data.keep_fallen_heroes;
+    world_.dynamics_ruleset = save_data.dynamics_ruleset;
     world_.current_scenario = save_data.scen_num;
     for (int i = 0; i < 4; ++i)
         world_.m_score[i] = save_data.m_score[i];
@@ -1322,6 +1323,7 @@ void screen::sync_save_data_from_world()
 {
     save_data.my_team = world_.my_team;
     save_data.allied_mode = world_.allied_mode;
+    save_data.dynamics_ruleset = world_.dynamics_ruleset;
     save_data.scen_num = world_.current_scenario;
     for (int i = 0; i < 4; ++i)
         save_data.m_score[i] = world_.m_score[i];

--- a/src/interface/ui/button.cpp
+++ b/src/interface/ui/button.cpp
@@ -764,6 +764,8 @@ bool picker_try_intercept_button_action(Sint32 whatfunc, Sint32 call_arg, Sint32
         return change_generator_rate();
     case ButtonAction::ToggleInfiniteGold:
         return change_infinite_gold();
+    case ButtonAction::ToggleDynamicsRuleset:
+        return change_dynamics_ruleset();
     case ButtonAction::HostGame:
     case ButtonAction::JoinGame:
     case ButtonAction::Networking:

--- a/src/interface/ui/menu_binding.cpp
+++ b/src/interface/ui/menu_binding.cpp
@@ -70,6 +70,8 @@ std::string menu_item_label(const PickerMenuItem& item,
         return format_generator_rate_label(save);
     case PickerMenuCommand::ToggleInfiniteGold:
         return format_infinite_gold_label(save);
+    case PickerMenuCommand::ToggleDynamicsRuleset:
+        return format_dynamics_ruleset_label(save);
     default:
         return std::string(item.label);
     }

--- a/src/interface/ui/menu_model.cpp
+++ b/src/interface/ui/menu_model.cpp
@@ -76,15 +76,18 @@ constexpr std::array<PickerMenuItem, 7> kScenarioItems = {{
 
 // The DIFFICULTY submenu: session difficulty plus the match rules that ride
 // SaveData (respawns, respawn delay, permadeath, generator rate, infinite
-// gold). Defaults keep classic behavior; the terminal clients present it as a
-// nested list. Append new rows before "back" — Back stays last.
-constexpr std::array<PickerMenuItem, 7> kDifficultyMenuItems = {{
+// gold, dynamics). All existing rules default to classic behavior; Dynamics
+// defaults Modern for new sessions while retaining an explicit Classic
+// choice. Terminal clients present this as a nested list. Append new rows
+// before "back" — Back stays last.
+constexpr std::array<PickerMenuItem, 8> kDifficultyMenuItems = {{
     {"difficulty", "Difficulty", PickerMenuCommand::SetDifficulty},
     {"respawn_mode", "Respawns", PickerMenuCommand::CycleRespawnMode},
     {"respawn_delay", "Respawn Delay", PickerMenuCommand::CycleRespawnDelay},
     {"permadeath", "Permadeath", PickerMenuCommand::TogglePermadeath},
     {"generator_rate", "Generators", PickerMenuCommand::CycleGeneratorRate},
     {"infinite_gold", "Infinite Gold", PickerMenuCommand::ToggleInfiniteGold},
+    {"dynamics", "Dynamics", PickerMenuCommand::ToggleDynamicsRuleset},
     {"back", "Back", PickerMenuCommand::Back},
 }};
 

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -207,13 +207,20 @@ std::string infinite_gold_row_label(const MenuLabelContext& context)
         : std::string("Infinite Gold: Off");
 }
 
+std::string dynamics_ruleset_row_label(const MenuLabelContext& context)
+{
+    return context.save != nullptr
+        ? format_dynamics_ruleset_label(*context.save)
+        : std::string("Modern Pace");
+}
+
 constexpr GateBinding kHostOnlyGate{.gate = MenuGate::HostOnly};
 
 constexpr MenuButtonSpec kDifficultyRows[] = {
     {.id = "difficulty_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
      .x = 10, .y = 10, .w = 50, .h = 15,
      .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT,
-     .nav = {.up = 5, .down = 1}},
+     .nav = {.up = 7, .down = 1}},
     {.id = "difficulty", .label = "Difficulty: Battle",
      .x = 90, .y = 35, .w = 140, .h = 15,
      .action = ButtonAction::SetDifficulty, .arg = -1,
@@ -247,8 +254,14 @@ constexpr MenuButtonSpec kDifficultyRows[] = {
     {.id = "infinite_gold", .label = "Infinite Gold: Off",
      .x = 90, .y = 150, .w = 140, .h = 15,
      .action = ButtonAction::ToggleInfiniteGold, .arg = -1,
-     .nav = {.up = 5, .down = 0},
+     .nav = {.up = 5, .down = 7},
      .label_binding = {.formatter = &infinite_gold_row_label},
+     .gate = kHostOnlyGate},
+    {.id = "dynamics", .label = "Modern Pace",
+     .x = 90, .y = 173, .w = 140, .h = 15,
+     .action = ButtonAction::ToggleDynamicsRuleset, .arg = -1,
+     .nav = {.up = 6, .down = 0},
+     .label_binding = {.formatter = &dynamics_ruleset_row_label},
      .gate = kHostOnlyGate},
 };
 

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -3044,6 +3044,32 @@ Sint32 change_infinite_gold()
    return MENU_OK;
 }
 
+// Gameplay feel is session-only like infinite gold, but also a local
+// preference: a host's selection seeds its next genuinely new match. A
+// joiner's host-gated Difficulty screen cannot overwrite its own preference.
+Sint32 change_dynamics_ruleset()
+{
+   SaveData& save = og::runtime::current_session->myscreen_->save_data;
+   og::ui::toggle_dynamics_ruleset(save);
+
+   refresh_difficulty_menu_button_label(
+       kDifficultyMenuDynamicsIndex,
+       og::ui::format_dynamics_ruleset_label(save));
+
+   cfg.set_dynamics_ruleset_preference(save.dynamics_ruleset);
+   cfg.save_settings();
+
+   if (og::runtime::current_session->game_.world != nullptr)
+       og::runtime::current_session->game_.world->dynamics_ruleset =
+           save.dynamics_ruleset;
+   og::runtime::current_session->myscreen_->world().dynamics_ruleset =
+       save.dynamics_ruleset;
+
+   picker_lobby_sync_settings_from_save();
+
+   return MENU_OK;
+}
+
 // GRAPHICS FX depth selector: step cfg effects/depth_fx one value. Pure
 // cfg, no save/lobby state — main_options() persists cfg on exit like every
 // FX toggle. The row's label re-derives from cfg on both surfaces every

--- a/src/interface/ui/picker_common.cpp
+++ b/src/interface/ui/picker_common.cpp
@@ -672,10 +672,12 @@ std::unique_ptr<guy> create_recruit(int family, int team_num, const SaveData& sa
     return recruit;
 }
 
-void reset_for_new_game(SaveData& save)
+void reset_for_new_game(SaveData& save,
+                        og::sim::DynamicsRuleset dynamics_ruleset)
 {
     save.reset();
     save.totalcash = kNewGameStartingGold;
+    save.dynamics_ruleset = dynamics_ruleset;
 }
 
 void ensure_team_populated(SaveData& save, const std::vector<int>& families, int team_num)
@@ -856,6 +858,14 @@ void cycle_generator_rate(SaveData& save)
 void toggle_infinite_gold(SaveData& save)
 {
     save.infinite_gold = static_cast<short>(save.infinite_gold != 0 ? 0 : 1);
+}
+
+void toggle_dynamics_ruleset(SaveData& save)
+{
+    save.dynamics_ruleset =
+        save.dynamics_ruleset == og::sim::DynamicsRuleset::Modern
+            ? og::sim::DynamicsRuleset::Classic
+            : og::sim::DynamicsRuleset::Modern;
 }
 
 bool gold_is_infinite(const SaveData& save) noexcept
@@ -2062,6 +2072,13 @@ std::string format_generator_rate_label(const SaveData& save)
 std::string format_infinite_gold_label(const SaveData& save)
 {
     return gold_is_infinite(save) ? "Infinite Gold: On" : "Infinite Gold: Off";
+}
+
+std::string format_dynamics_ruleset_label(const SaveData& save)
+{
+    return save.dynamics_ruleset == og::sim::DynamicsRuleset::Modern
+        ? "Modern Pace"
+        : "Classic Pace";
 }
 
 // --- Company screens: label formatters (design §2.2/§2.3) ---

--- a/src/interface/ui/picker_lobby_client.cpp
+++ b/src/interface/ui/picker_lobby_client.cpp
@@ -687,6 +687,7 @@ private:
         settings.keep_fallen_heroes = save.keep_fallen_heroes;
         settings.cross_control = save.cross_control;
         settings.infinite_gold = save.infinite_gold;
+        settings.dynamics_ruleset = save.dynamics_ruleset;
         // Protocol v12: the shared-teams rule rides the wire, derived from
         // the campaign's matchup: yaml key (the joiner may lack the package).
         settings.shared_teams = og::ui::is_versus_campaign(save) ? 1 : 0;
@@ -888,6 +889,7 @@ private:
         save.keep_fallen_heroes = state_->settings.keep_fallen_heroes;
         save.cross_control = state_->settings.cross_control;
         save.infinite_gold = state_->settings.infinite_gold;
+        save.dynamics_ruleset = state_->settings.dynamics_ruleset;
         save.numplayers = static_cast<unsigned char>(
             spectator_mode_
                 ? 0

--- a/src/interface/ui/picker_main_menu.cpp
+++ b/src/interface/ui/picker_main_menu.cpp
@@ -30,6 +30,7 @@
 #include <openglad/interface/ui/picker_ui_state.h>
 #include <openglad/interface/ui/picker_common.h>
 #include <openglad/resources/company.h>
+#include <openglad/resources/gparser.h>
 
 #include "picker_sdl_defs.h"
 
@@ -63,7 +64,8 @@ bool picker_prepare_new_game_setup()
     // Reset the save data so we have a fresh, new team: a new game always
     // starts on the default campaign, so the mounted package must not be
     // whatever campaign the previous session or match left selected.
-	og::ui::reset_for_new_game(game->save_data);
+	og::ui::reset_for_new_game(game->save_data,
+                                   cfg.dynamics_ruleset_preference());
 
     // §2.2: the display name lives in the 40-byte save_name; the filename is a
     // derived, collision-probed slug (SaveData::reset does not touch

--- a/src/interface/ui/picker_sdl_defs.h
+++ b/src/interface/ui/picker_sdl_defs.h
@@ -501,7 +501,8 @@ inline constexpr int kDifficultyMenuRespawnDelayIndex = 3;
 inline constexpr int kDifficultyMenuPermadeathIndex = 4;
 inline constexpr int kDifficultyMenuGeneratorRateIndex = 5;
 inline constexpr int kDifficultyMenuInfiniteGoldIndex = 6;
-inline constexpr int kDifficultyMenuButtonCount = 7;
+inline constexpr int kDifficultyMenuDynamicsIndex = 7;
+inline constexpr int kDifficultyMenuButtonCount = 8;
 
 // Per-frame host gating for the DIFFICULTY subscreen: every settings row is
 // LobbySettings-backed (difficulty included), so a non-host joiner sees only

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -372,7 +372,7 @@ void sync_difficulty_menu_visibility(button* buttons,
         sync_button_hidden_state(buttons, index);
     }
     buttons[kDifficultyMenuBackIndex].nav.up =
-        host_controls_visible ? kDifficultyMenuInfiniteGoldIndex : -1;
+        host_controls_visible ? kDifficultyMenuDynamicsIndex : -1;
     buttons[kDifficultyMenuBackIndex].nav.down =
         host_controls_visible ? kDifficultyMenuDifficultyIndex : -1;
 

--- a/src/platform/curses/curses_app.cpp
+++ b/src/platform/curses/curses_app.cpp
@@ -186,6 +186,7 @@ int run_curses_app(const AppOptions& options, int argc, char* argv[])
         // starting team. (The in-menu Networking submenu offers the same with a
         // hand-built team.)
         SaveData save;
+        save.dynamics_ruleset = cfg.dynamics_ruleset_preference();
         save.current_campaign = options.campaign;
         save.scen_num = static_cast<short>(options.level);
         save.numplayers = 1;

--- a/src/platform/curses/curses_network.cpp
+++ b/src/platform/curses/curses_network.cpp
@@ -269,6 +269,7 @@ og::sim::LobbyMessage make_settings_message(const SaveData& save, int difficulty
     settings.keep_fallen_heroes = save.keep_fallen_heroes;
     settings.cross_control = save.cross_control;
     settings.infinite_gold = save.infinite_gold;
+    settings.dynamics_ruleset = save.dynamics_ruleset;
     // Protocol v12: shared-teams rule rides the wire (matchup: versus).
     settings.shared_teams = og::ui::is_versus_campaign(save) ? 1 : 0;
 
@@ -360,6 +361,7 @@ og::sim::LobbySaveDataEquivalent build_join_save_equivalent_from_state(
     equivalent.keep_fallen_heroes = state.settings.keep_fallen_heroes;
     equivalent.cross_control = state.settings.cross_control;
     equivalent.infinite_gold = state.settings.infinite_gold;
+    equivalent.dynamics_ruleset = state.settings.dynamics_ruleset;
 
     std::vector<OrderedLobbyGameplaySlot> ordered_slots;
     for (std::size_t player_order = 0; player_order < state.players.size();

--- a/src/platform/curses/curses_picker_client.cpp
+++ b/src/platform/curses/curses_picker_client.cpp
@@ -41,6 +41,7 @@
 #include <openglad/resources/campaign_metadata.h>
 #include <openglad/resources/company.h>
 #include <openglad/resources/gloader.h>
+#include <openglad/resources/gparser.h>
 #include <openglad/resources/io_common.h>
 #include <openglad/resources/level_data_hooks.h>
 #include <openglad/resources/save_data.h>
@@ -777,6 +778,7 @@ CursesPickerClient::CursesPickerClient(ITerminal& term, IClock& clock,
                                        const CursesPickerOptions& options)
     : term_(term), clock_(clock), config_(config), options_(options)
 {
+    save_data_.dynamics_ruleset = cfg.dynamics_ruleset_preference();
     // Match TextPickerClient: guarantee a starting team exists immediately.
     if (config_.team_families.empty())
         config_.team_families.push_back(FAMILY_SOLDIER);
@@ -967,6 +969,15 @@ void CursesPickerClient::handle_menu_item(PickerMenuId menu_id,
             menu.show_text("Infinite Gold",
                 {og::ui::format_infinite_gold_label(save_data_)});
             break;
+        case PickerMenuCommand::ToggleDynamicsRuleset:
+            // SESSION-ONLY in GTL; cfg remembers this machine's preference.
+            // Joiners never reach this host-gated action in a live lobby.
+            og::ui::toggle_dynamics_ruleset(save_data_);
+            cfg.set_dynamics_ruleset_preference(save_data_.dynamics_ruleset);
+            cfg.save_settings();
+            menu.show_text("Dynamics",
+                {og::ui::format_dynamics_ruleset_label(save_data_)});
+            break;
         default:
             break;
         }
@@ -1087,7 +1098,8 @@ bool CursesPickerClient::prepare_new_game()
         break;
     }
 
-    og::ui::reset_for_new_game(save_data_);
+    og::ui::reset_for_new_game(save_data_,
+                               cfg.dynamics_ruleset_preference());
     og::ui::ensure_team_populated(save_data_);
     // The display name lives in the 40-byte save_name; the filename stays this
     // client's own slot (config_.save_name, [SAVE-R2]).

--- a/src/platform/sdl/game_session.cpp
+++ b/src/platform/sdl/game_session.cpp
@@ -204,6 +204,12 @@ GameSession::GameSession(const Config& session_cfg)
             cfg_.numviews,
             cfg_.create_display);
         myscreen_ = screen_owner_.get();
+        // The carrier is session-only: load() never overwrites it, while a
+        // true new-game reset re-seeds it from this same local preference.
+        myscreen_->save_data.dynamics_ruleset =
+            cfg.dynamics_ruleset_preference();
+        myscreen_->world().dynamics_ruleset =
+            myscreen_->save_data.dynamics_ruleset;
         myscreen_->set_render_interpolation_speed_factor(
             g_game_speed_factor_);
         game_.save = &myscreen_->save_data;

--- a/src/platform/sdl/glad_gameplay.cpp
+++ b/src/platform/sdl/glad_gameplay.cpp
@@ -109,6 +109,7 @@ void apply_lobby_game_start_config(
     save.keep_fallen_heroes = static_cast<short>(config_save.keep_fallen_heroes);
     save.cross_control = static_cast<short>(config_save.cross_control);
     save.infinite_gold = static_cast<short>(config_save.infinite_gold);
+    save.dynamics_ruleset = config_save.dynamics_ruleset;
     // The old network handoff collapsed every allied-mode client onto team 0.
     // allied_mode remains in the save/replay format, but Base Camp's explicit
     // per-seat assignment is now authoritative in every mode.

--- a/src/platform/sdl/local_transport_shadow.cpp
+++ b/src/platform/sdl/local_transport_shadow.cpp
@@ -721,6 +721,7 @@ void apply_initial_setup_to_client_save(
     gameplay_screen.save_data.my_team = static_cast<short>(message.my_team);
     gameplay_screen.save_data.allied_mode =
         static_cast<short>(message.allied_mode);
+    gameplay_screen.save_data.dynamics_ruleset = message.dynamics_ruleset;
 
     std::set<int>& completed =
         gameplay_screen.save_data
@@ -2143,12 +2144,16 @@ void reset_local_transport_shadow(GameSession& session, screen& gameplay_screen)
         {
             return;
         }
-        // cross_control is SESSION-only (never serialized), so the slot
-        // round-trip through disk just dropped it — carry the lobby-config
-        // value from the display save (the same dropped-field trap
+        // These settings are SESSION-only (never serialized), so the slot
+        // round-trip through disk just dropped them — carry the live launch
+        // values from the display save (the same dropped-field trap
         // copy_headless_server_save_data guards against on the headless path).
         server_screen->save_data.cross_control =
             gameplay_screen.save_data.cross_control;
+        server_screen->save_data.infinite_gold =
+            gameplay_screen.save_data.infinite_gold;
+        server_screen->save_data.dynamics_ruleset =
+            gameplay_screen.save_data.dynamics_ruleset;
         prepare_server_session_for_gameplay(*runtime->server_session);
         og::sim::apply_snapshot(
             server_screen->world(),
@@ -2420,10 +2425,14 @@ void reset_network_host_transport_shadow(
         {
             return;
         }
-        // Session-only cross_control dropped by the disk round-trip — carry
-        // it (see reset_local_transport_shadow above).
+        // Session-only rules dropped by the disk round-trip — carry every one
+        // (see reset_local_transport_shadow above).
         server_screen->save_data.cross_control =
             gameplay_screen.save_data.cross_control;
+        server_screen->save_data.infinite_gold =
+            gameplay_screen.save_data.infinite_gold;
+        server_screen->save_data.dynamics_ruleset =
+            gameplay_screen.save_data.dynamics_ruleset;
 
         prepare_server_session_for_gameplay(*runtime->server_session);
         og::sim::apply_snapshot(

--- a/src/platform/sdl/picker_lobby_network_client.cpp
+++ b/src/platform/sdl/picker_lobby_network_client.cpp
@@ -1587,6 +1587,7 @@ og::sim::LobbySaveDataEquivalent build_save_data_equivalent_from_state(
     equivalent.keep_fallen_heroes = state.settings.keep_fallen_heroes;
     equivalent.cross_control = state.settings.cross_control;
     equivalent.infinite_gold = state.settings.infinite_gold;
+    equivalent.dynamics_ruleset = state.settings.dynamics_ruleset;
 
     for (const AppliedLobbySlot& slot : collect_applied_lobby_slots(state))
     {
@@ -1641,6 +1642,7 @@ LobbyStateApplyResult apply_lobby_state_to_save(
     save.keep_fallen_heroes = state.settings.keep_fallen_heroes;
     save.cross_control = state.settings.cross_control;
     save.infinite_gold = state.settings.infinite_gold;
+    save.dynamics_ruleset = state.settings.dynamics_ruleset;
     save.numplayers = static_cast<unsigned char>(
         spectator_mode
             ? 0u
@@ -1952,6 +1954,7 @@ og::sim::LobbyMessage make_settings_message(const SaveData& save)
     settings.keep_fallen_heroes = save.keep_fallen_heroes;
     settings.cross_control = save.cross_control;
     settings.infinite_gold = save.infinite_gold;
+    settings.dynamics_ruleset = save.dynamics_ruleset;
     // Protocol v12: shared-teams rule rides the wire (matchup: versus).
     settings.shared_teams = og::ui::is_versus_campaign(save) ? 1 : 0;
 

--- a/src/platform/text/text_picker.cpp
+++ b/src/platform/text/text_picker.cpp
@@ -14,6 +14,7 @@
 #include <openglad/resources/company.h>
 #include <openglad/resources/gloader.h>
 #include <openglad/resources/io_common.h>
+#include <openglad/resources/gparser.h>
 #include <openglad/resources/level_data_hooks.h>
 #include <openglad/interface/level_runtime_data.h>
 #include <openglad/interface/platform_bridge.h>
@@ -85,6 +86,7 @@ public:
     explicit TextPickerClient(TextPickerConfig& config, TextPickerError* error)
         : config_(config), error_(error)
     {
+        save_data_.dynamics_ruleset = cfg.dynamics_ruleset_preference();
         ensure_team_initialized();
         // Terminal slot authority ([SAVE-R2]): company-level writes must
         // target this client's chosen slot (default "text_quicksave"), never
@@ -179,7 +181,7 @@ public:
         // §2.2: found the company FIRST (generated name, reroll, editable).
         std::string company_name = prompt_new_company_name();
 
-        reset_for_new_game(save_data_);
+        reset_for_new_game(save_data_, cfg.dynamics_ruleset_preference());
         ensure_team_populated(save_data_);
         // The display name lives in the 40-byte save_name; the filename stays
         // this terminal client's own slot (config_.save_name, [SAVE-R2]).
@@ -884,6 +886,18 @@ private:
             // here this one deliberately skips the settings autosave tail.
             toggle_infinite_gold(save_data_);
             std::printf("%s\n", format_infinite_gold_label(save_data_).c_str());
+            break;
+        case PickerMenuCommand::ToggleDynamicsRuleset:
+            // SESSION-ONLY in the company file, but persistent as this
+            // machine's preference for the next newly created match.
+            toggle_dynamics_ruleset(save_data_);
+            cfg.set_dynamics_ruleset_preference(save_data_.dynamics_ruleset);
+            cfg.save_settings();
+            if (og::runtime::current_session->game_.world != nullptr)
+                og::runtime::current_session->game_.world->dynamics_ruleset =
+                    save_data_.dynamics_ruleset;
+            std::printf("%s\n",
+                        format_dynamics_ruleset_label(save_data_).c_str());
             break;
         default:
             break;

--- a/src/platform/text/text_protocol.cpp
+++ b/src/platform/text/text_protocol.cpp
@@ -484,6 +484,11 @@ int run_text_protocol_session(const TextProtocolArgs& args)
     text_ctx.rng = &world.rng_;
     set_gameplay_rng_override(&text_ctx.rng);
     SaveData save;
+    // The protocol runner is also the gameplay backend for both terminal
+    // pickers. Seed each fresh run from the same machine preference their
+    // Difficulty menus edit; GameWorld itself deliberately defaults Classic
+    // for parity and hand-built simulations.
+    save.dynamics_ruleset = cfg.dynamics_ruleset_preference();
     save.current_campaign = args.campaign;
     save.scen_num = static_cast<short>(args.level);
     save.numplayers = 1;
@@ -537,6 +542,8 @@ int run_text_protocol_session(const TextProtocolArgs& args)
         set_gameplay_rng_override(nullptr);
         return 1;
     }
+
+    world.dynamics_ruleset = save.dynamics_ruleset;
 
     // Derive placed-walker stats from their authored levels, exactly like
     // the production loaders (game.cpp load_saved_game and

--- a/src/resources/gparser.cpp
+++ b/src/resources/gparser.cpp
@@ -215,6 +215,10 @@ bool cfg_store::load_settings()
     // start. 6 == og::sim::DEFAULT_TIMER_WAIT == the SPEED 8 the old in-game
     // options menu showed.
     apply_setting("gameplay", "timer_wait", "6");
+    // New matches use responsive turning and the contact-breakaway Yell.
+    // GameWorld itself stays Classic by default so direct/parity construction
+    // cannot silently opt into branch behavior.
+    apply_setting("gameplay", "dynamics", "modern");
 
     apply_setting("effects", "gore", "on");
     apply_setting("effects", "mini_hp_bar", "on");
@@ -487,4 +491,20 @@ void cfg_store::commandline(int &argc, char **&argv)
 bool cfg_store::is_on(const std::string& category, const std::string& setting)
 {
     return get_setting(category, setting) == "on";
+}
+
+og::sim::DynamicsRuleset cfg_store::dynamics_ruleset_preference()
+{
+    return get_setting("gameplay", "dynamics") == "classic"
+        ? og::sim::DynamicsRuleset::Classic
+        : og::sim::DynamicsRuleset::Modern;
+}
+
+void cfg_store::set_dynamics_ruleset_preference(
+    og::sim::DynamicsRuleset ruleset)
+{
+    apply_setting("gameplay", "dynamics",
+                  ruleset == og::sim::DynamicsRuleset::Classic
+                      ? "classic"
+                      : "modern");
 }

--- a/src/server/headless_server_runtime.cpp
+++ b/src/server/headless_server_runtime.cpp
@@ -93,6 +93,7 @@ void sync_world_from_save_data(GameWorld& world, const SaveData& save)
         og::mode::current_progression().clamp_respawn_mode(save.respawn_mode);
     world.generator_rate = save.generator_rate;
     world.keep_fallen_heroes = save.keep_fallen_heroes;
+    world.dynamics_ruleset = save.dynamics_ruleset;
     world.current_scenario = save.scen_num;
     for (int index = 0; index < MAX_PLAYERS; ++index)
         world.m_score[index] = save.m_score[index];
@@ -305,12 +306,17 @@ void copy_headless_server_save_data(SaveData& destination,
     destination.ctf_capture_limit = source.ctf_capture_limit;
     destination.ctf_respawn_ticks = source.ctf_respawn_ticks;
     destination.ctf_strip_scenario_troops = source.ctf_strip_scenario_troops;
+    destination.respawn_mode = source.respawn_mode;
+    destination.generator_rate = source.generator_rate;
+    destination.keep_fallen_heroes = source.keep_fallen_heroes;
     // Cross-control (protocol v8): session-only match setting; must survive
     // the server/checkpoint copies like the other lobby-negotiated settings
     // (the documented dropped-field bug class, design §4.1).
     destination.cross_control = source.cross_control;
     // Infinite gold (protocol v11): same session-only dropped-field rule.
     destination.infinite_gold = source.infinite_gold;
+    // Gameplay feel (protocol v13): session-only and host-authoritative.
+    destination.dynamics_ruleset = source.dynamics_ruleset;
     // Tower run state (GTL v13) must ride the server/checkpoint copies:
     // advance_cursor regenerates floors from tower_run_seed and merges
     // tower_best_floor, and on_run_ended re-writes both to save0 — a copy
@@ -355,6 +361,7 @@ void apply_headless_lobby_game_start_config(
     save.keep_fallen_heroes = static_cast<short>(config_save.keep_fallen_heroes);
     save.cross_control = static_cast<short>(config_save.cross_control);
     save.infinite_gold = static_cast<short>(config_save.infinite_gold);
+    save.dynamics_ruleset = config_save.dynamics_ruleset;
     save.my_team = 0;
 
     for (auto& member : save.team_list)
@@ -382,6 +389,7 @@ void sync_headless_server_save_data_from_world(SaveData& save,
 {
     save.my_team = world.my_team;
     save.allied_mode = world.allied_mode;
+    save.dynamics_ruleset = world.dynamics_ruleset;
     save.scen_num = static_cast<short>(world.current_scenario);
     save.current_levels[save.current_campaign] = save.scen_num;
     for (int index = 0; index < MAX_PLAYERS; ++index)

--- a/tests/coverage_internal/picker_team_build_internal.inc
+++ b/tests/coverage_internal/picker_team_build_internal.inc
@@ -458,7 +458,7 @@ int picker_team_build_testing_exercise_internal_paths()
     // BACK's vertical cycle is rewired and the highlight is pulled onto BACK.
     for (int i = 0; i < 11; ++i)
         buttons[i].hidden = false;
-    buttons[kDifficultyMenuBackIndex].nav.up = kDifficultyMenuInfiniteGoldIndex;
+    buttons[kDifficultyMenuBackIndex].nav.up = kDifficultyMenuDynamicsIndex;
     buttons[kDifficultyMenuBackIndex].nav.down = kDifficultyMenuDifficultyIndex;
     int diff_highlight = kDifficultyMenuGeneratorRateIndex;
     client.host_visible = false;
@@ -470,6 +470,7 @@ int picker_team_build_testing_exercise_internal_paths()
         buttons[kDifficultyMenuPermadeathIndex].hidden &&
         buttons[kDifficultyMenuGeneratorRateIndex].hidden &&
         buttons[kDifficultyMenuInfiniteGoldIndex].hidden &&
+        buttons[kDifficultyMenuDynamicsIndex].hidden &&
         buttons[kDifficultyMenuBackIndex].nav.up == -1 &&
         buttons[kDifficultyMenuBackIndex].nav.down == -1 &&
         diff_highlight == kDifficultyMenuBackIndex);
@@ -479,8 +480,9 @@ int picker_team_build_testing_exercise_internal_paths()
     check(!buttons[kDifficultyMenuDifficultyIndex].hidden &&
         !buttons[kDifficultyMenuGeneratorRateIndex].hidden &&
         !buttons[kDifficultyMenuInfiniteGoldIndex].hidden &&
+        !buttons[kDifficultyMenuDynamicsIndex].hidden &&
         buttons[kDifficultyMenuBackIndex].nav.up ==
-            kDifficultyMenuInfiniteGoldIndex &&
+            kDifficultyMenuDynamicsIndex &&
         buttons[kDifficultyMenuBackIndex].nav.down ==
             kDifficultyMenuDifficultyIndex);
 

--- a/tests/coverage_internal/text_picker_internal.inc
+++ b/tests/coverage_internal/text_picker_internal.inc
@@ -147,6 +147,8 @@ public:
     ScopedTextPickerInternalState()
         : active_company_before_(og::data::active_company_slot())
         , mounted_campaign_before_(get_mounted_campaign())
+        , cfg_data_before_(cfg.data)
+        , cfg_overrides_before_(cfg.overrides)
         , session_(og::runtime::current_session)
         , difficulty_before_(session_ != nullptr
               ? session_->current_difficulty_
@@ -154,6 +156,7 @@ public:
         , world_(session_ != nullptr ? session_->game_.world : nullptr)
         , world_difficulty_before_(world_ != nullptr ? world_->difficulty : 0)
     {
+        capture_file("cfg/openglad.yaml");
         capture_file("save/missing-text-picker-save.gtl");
         capture_file("save/missing-text-picker-save.tmp.gtl");
         capture_file("save/helper-slot.gtl");
@@ -236,6 +239,8 @@ public:
             session_->current_difficulty_ = difficulty_before_;
         if (world_ != nullptr)
             world_->difficulty = world_difficulty_before_;
+        cfg.data = cfg_data_before_;
+        cfg.overrides = cfg_overrides_before_;
         restore_ok_ =
             og::data::set_active_company_slot(active_company_before_) &&
             restore_ok_;
@@ -422,6 +427,8 @@ private:
 
     std::string active_company_before_;
     std::string mounted_campaign_before_;
+    decltype(cfg.data) cfg_data_before_;
+    decltype(cfg.overrides) cfg_overrides_before_;
     og::runtime::SessionState* session_ = nullptr;
     int difficulty_before_ = 0;
     GameWorld* world_ = nullptr;
@@ -435,6 +442,8 @@ private:
 
 int text_picker_testing_exercise_internal_paths()
 {
+    const auto cfg_data_before = cfg.data;
+    const auto cfg_overrides_before = cfg.overrides;
     ScopedTextPickerInternalState state_restore;
     if (!state_restore.ready())
         return -1;
@@ -523,7 +532,7 @@ int text_picker_testing_exercise_internal_paths()
             check(false);
             return;
         }
-        const short previous = current();
+        const auto previous = current();
         client.handle_menu_item(PickerMenuId::Difficulty, *item);
         const bool changed = current() != previous;
         for (int step = 1; step < period; ++step)
@@ -540,12 +549,14 @@ int text_picker_testing_exercise_internal_paths()
         [&] { return save.generator_rate; });
     check_difficulty_rule(PickerMenuCommand::ToggleInfiniteGold, 2,
         [&] { return save.infinite_gold; });
+    check_difficulty_rule(PickerMenuCommand::ToggleDynamicsRuleset, 2,
+        [&] { return save.dynamics_ruleset; });
     // The main-menu DIFFICULTY door runs the nested submenu loop: toggle
     // permadeath twice, then back — a round trip that leaves save untouched.
     if (const PickerMenuItem* door =
             find_picker_menu_item(PickerMenuId::Main, PickerMenuCommand::OpenDifficultyMenu)) {
         const short previous_permadeath = save.keep_fallen_heroes;
-        ScopedCinRedirect input("4\n4\n7\n");
+        ScopedCinRedirect input("4\n4\n8\n");
         client.handle_menu_item(PickerMenuId::Main, *door);
         check(save.keep_fallen_heroes == previous_permadeath);
     } else {
@@ -909,6 +920,8 @@ int text_picker_testing_exercise_internal_paths()
     }
 
     check(state_restore.restore());
+    check(cfg.data == cfg_data_before &&
+          cfg.overrides == cfg_overrides_before);
 
     return failed ? -failed_check : 0;
 }

--- a/tests/curses/curses_network_internal.inc
+++ b/tests/curses/curses_network_internal.inc
@@ -128,14 +128,15 @@ int curses_network_testing_exercise_internal_helpers()
     check(join_message.kind() == og::sim::LobbyMessageKind::Join &&
         settings_message.kind() == og::sim::LobbyMessageKind::SettingsChange);
 
-    // The settings message carries the difficulty-submenu match rules from
-    // the save: respawn mode/delay, permadeath, and the generator rate.
+    // The settings message carries every difficulty-submenu match rule from
+    // the save, including the session-only rules.
     save.ctf_respawn_ticks = 60;
     save.respawn_mode = 2;
     save.generator_rate = 50;
     save.keep_fallen_heroes = 1;
     save.cross_control = 1;
     save.infinite_gold = 1;
+    save.dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
     const og::sim::LobbyMessage rules_message = make_settings_message(save, 5);
     const auto* rules = std::get_if<og::sim::LobbySettingsChangeMessage>(
         &rules_message.payload);
@@ -146,13 +147,16 @@ int curses_network_testing_exercise_internal_helpers()
         rules->settings.generator_rate == 50 &&
         rules->settings.keep_fallen_heroes == 1 &&
         rules->settings.cross_control == 1 &&
-        rules->settings.infinite_gold == 1);
+        rules->settings.infinite_gold == 1 &&
+        rules->settings.dynamics_ruleset ==
+            og::sim::DynamicsRuleset::Classic);
     save.ctf_respawn_ticks = 0;
     save.respawn_mode = 0;
     save.generator_rate = 0;
     save.keep_fallen_heroes = 0;
     save.cross_control = 0;
     save.infinite_gold = 0;
+    save.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
 
     og::sim::LobbyState state;
     state.settings.campaign_id = "";
@@ -180,6 +184,8 @@ int curses_network_testing_exercise_internal_helpers()
     colliding_slots_state.settings.campaign_id =
         "gladiator";
     colliding_slots_state.settings.scenario_id = 1;
+    colliding_slots_state.settings.dynamics_ruleset =
+        og::sim::DynamicsRuleset::Classic;
     og::sim::LobbyPlayer colliding_player = player;
     colliding_player.player_index = 3;
     colliding_player.character_slots.clear();
@@ -197,7 +203,9 @@ int curses_network_testing_exercise_internal_helpers()
         colliding_equivalent.team_list[0].character.name == "first" &&
         colliding_equivalent.team_list[1].character.name == "second" &&
         colliding_equivalent.team_list[0].owner_player_index == 3 &&
-        colliding_equivalent.team_list[0].owner_save_slot == 7);
+        colliding_equivalent.team_list[0].owner_save_slot == 7 &&
+        colliding_equivalent.dynamics_ruleset ==
+            og::sim::DynamicsRuleset::Classic);
 
     // The wire roster is bounded by SaveData's real 24-slot capacity. Verify
     // that an oversized, otherwise valid roster is rejected rather than

--- a/tests/curses/test_curses_picker_client.cpp
+++ b/tests/curses/test_curses_picker_client.cpp
@@ -62,6 +62,35 @@ using og::ui::TextPickerConfig;
 
 namespace {
 
+class ScopedDynamicsPreference
+{
+public:
+    explicit ScopedDynamicsPreference(og::sim::DynamicsRuleset ruleset)
+    {
+        const auto category = cfg.data.find("gameplay");
+        if (category != cfg.data.end())
+        {
+            const auto setting = category->second.find("dynamics");
+            if (setting != category->second.end())
+                previous_ = setting->second;
+        }
+        cfg.set_dynamics_ruleset_preference(ruleset);
+    }
+
+    ~ScopedDynamicsPreference()
+    {
+        if (previous_)
+            cfg.apply_setting("gameplay", "dynamics", *previous_);
+        else if (auto category = cfg.data.find("gameplay");
+                 category != cfg.data.end())
+            category->second.erase("dynamics");
+        (void)cfg.save_settings();
+    }
+
+private:
+    std::optional<std::string> previous_;
+};
+
 // Bundles the terminal/clock/config + client so each test reads compactly.
 // A generous 40x100 grid leaves room for every menu the picker draws.
 struct PickerFixture {
@@ -2509,6 +2538,47 @@ TEST(CursesPickerClient, infinite_gold_toggles)
     EXPECT_NE(f.t().dump().find("Infinite Gold: Off"), std::string::npos);
 }
 
+TEST(CursesPickerClient, dynamics_ruleset_toggles_and_persists_preference)
+{
+    ScopedDynamicsPreference preference(og::sim::DynamicsRuleset::Modern);
+    PickerFixture f;
+    const auto* item = og::ui::find_picker_menu_item(
+        PickerMenuId::Difficulty, PickerMenuCommand::ToggleDynamicsRuleset);
+    ASSERT_NE(item, nullptr);
+    ASSERT_EQ(og::sim::DynamicsRuleset::Modern,
+              f.save().dynamics_ruleset);
+
+    dismiss(f.t());
+    f.client.handle_menu_item(PickerMenuId::Difficulty, *item);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              f.save().dynamics_ruleset);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              cfg.dynamics_ruleset_preference());
+    EXPECT_NE(f.t().dump().find("Classic Pace"), std::string::npos);
+
+    dismiss(f.t());
+    f.client.handle_menu_item(PickerMenuId::Difficulty, *item);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              f.save().dynamics_ruleset);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              cfg.dynamics_ruleset_preference());
+    EXPECT_NE(f.t().dump().find("Modern Pace"), std::string::npos);
+}
+
+TEST(CursesPickerClient, true_new_game_reseeds_local_dynamics_preference)
+{
+    ScopedDynamicsPreference preference(og::sim::DynamicsRuleset::Modern);
+    PickerFixture f;
+    // Model the authoritative host value a joiner just adopted. It must not
+    // become this machine's preference for the next genuinely new company.
+    f.save().dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
+
+    f.t().push_special(KeyCode::Enter);
+    ASSERT_TRUE(f.client.prepare_new_game());
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              f.save().dynamics_ruleset);
+}
+
 // The submenu rows render the live settings from options_/SaveData, and Esc
 // cancels to Back (like every non-Main menu).
 TEST(CursesPickerClient, difficulty_submenu_labels_format_from_save)
@@ -2519,6 +2589,7 @@ TEST(CursesPickerClient, difficulty_submenu_labels_format_from_save)
     f.save().keep_fallen_heroes = 1;
     f.save().generator_rate = 200;
     f.save().infinite_gold = 1;
+    f.save().dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
 
     f.t().push_special(KeyCode::Escape);
     const auto* item = f.client.present_menu(PickerMenuId::Difficulty);
@@ -2533,6 +2604,7 @@ TEST(CursesPickerClient, difficulty_submenu_labels_format_from_save)
     EXPECT_NE(dump.find("Permadeath: Off"), std::string::npos) << dump;
     EXPECT_NE(dump.find("Generators: Frenzy"), std::string::npos) << dump;
     EXPECT_NE(dump.find("Infinite Gold: On"), std::string::npos) << dump;
+    EXPECT_NE(dump.find("Classic Pace"), std::string::npos) << dump;
 }
 
 // run_picker reaches the nested Difficulty submenu from the Main menu door and

--- a/tests/integration/test_difficulty.cpp
+++ b/tests/integration/test_difficulty.cpp
@@ -8,8 +8,10 @@
 #include <SDL3/SDL.h>
 #include "test_input_helpers.h"
 #include "test_interact.h"
+#include "test_save_state_guard.h"
 #include <openglad/resources/save_data.h>
 #include <openglad/resources/io_common.h>
+#include <openglad/resources/gparser.h>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -23,7 +25,31 @@ extern int g_picker_mainmenu_calls;
 extern int g_picker_max_mainmenu_calls;
 
 #include <openglad/interface/ui/picker_ui_state.h>
+#include "../../src/interface/ui/picker_sdl_defs.h"
 static inline PickerState& pks() { return *og::runtime::current_session->picker_; }
+
+namespace {
+
+class ScopedCfgMaps
+{
+public:
+    ScopedCfgMaps()
+        : data_(cfg.data), overrides_(cfg.overrides)
+    {
+    }
+
+    ~ScopedCfgMaps()
+    {
+        cfg.data = std::move(data_);
+        cfg.overrides = std::move(overrides_);
+    }
+
+private:
+    decltype(cfg.data) data_;
+    decltype(cfg.overrides) overrides_;
+};
+
+} // namespace
 
 
 static void cleanup_picker_state()
@@ -42,11 +68,11 @@ static void cleanup_picker_state()
 
 // Test: The main-menu DIFFICULTY button is a DOOR into the blocking
 // DIFFICULTY subscreen (unique BACK id "difficulty_back"), which holds the
-// difficulty cycler plus the five match-rule settings.
+// difficulty cycler plus the six match-rule settings.
 //
 // Flow: Main Menu -> DIFFICULTY door -> cycle every setting a full cycle
 // (difficulty x3, respawns x3, delay x3, permadeath x2, generators x3,
-// infinite gold x2 — all back to their defaults) -> BACK -> GAME SETTINGS
+// infinite gold x2, dynamics x2 — all back to their defaults) -> BACK -> GAME SETTINGS
 // -> BACK -> return
 //
 // This used to tour PLAYER SETTINGS and all four player-count outlines here,
@@ -64,6 +90,7 @@ struct DifficultyState {
     bool started;
     bool finished;
     bool entered_submenu;
+    bool saw_classic_dynamics;
     bool cycled_settings;
 };
 
@@ -76,6 +103,27 @@ static void interact_times(const std::string& id, int times)
         interact(id);
         SDL_Delay(300);
     }
+}
+
+static bool wait_for_interactable_label(const std::string& id,
+                                        const std::string& expected,
+                                        int timeout_ms = 5000)
+{
+    constexpr int poll_interval_ms = 50;
+    for (int elapsed = 0; elapsed < timeout_ms;
+         elapsed += poll_interval_ms)
+    {
+        for (const Interactable& item : get_interactables())
+        {
+            if (item.id == id && !item.hidden && item.label == expected)
+                return true;
+        }
+        SDL_Delay(poll_interval_ms);
+    }
+    fprintf(stderr,
+            "  [test] TIMEOUT waiting for '%s' label '%s' (%d ms)\n",
+            id.c_str(), expected.c_str(), timeout_ms);
+    return false;
 }
 
 static int difficulty_injector(void* data)
@@ -104,6 +152,37 @@ static int difficulty_injector(void* data)
     interact_times("permadeath", 2);     // On -> Off -> On
     interact_times("generator_rate", 3); // Normal -> Calm -> Frenzy -> Normal
     interact_times("infinite_gold", 2);  // Off -> On -> Off
+    fprintf(stderr, "  [test] toggling dynamics to Classic\n");
+    interact("dynamics");
+    const bool live_classic_label =
+        wait_for_interactable_label("dynamics", "Classic Pace");
+    std::string descriptor_label;
+    {
+        AllButtonsLock lock;
+        descriptor_label =
+            pks().difficulty_menu_buttons[kDifficultyMenuDynamicsIndex].label;
+    }
+    const SaveData& classic_save =
+        og::runtime::current_session->myscreen_->save_data;
+    state->saw_classic_dynamics =
+        live_classic_label &&
+        classic_save.dynamics_ruleset == og::sim::DynamicsRuleset::Classic &&
+        cfg.dynamics_ruleset_preference() ==
+            og::sim::DynamicsRuleset::Classic &&
+        og::runtime::current_session->myscreen_->world().dynamics_ruleset ==
+            og::sim::DynamicsRuleset::Classic &&
+        descriptor_label == "Classic Pace";
+    EXPECT_TRUE(state->saw_classic_dynamics)
+        << "the first click must update the live row, descriptor, preference, "
+           "SaveData, and GameWorld to Classic";
+
+    // The label changes on button-down; wait through the matching release so
+    // the next press is a distinct edge instead of being dropped as held.
+    SDL_Delay(300);
+    fprintf(stderr, "  [test] toggling dynamics back to Modern\n");
+    interact("dynamics");
+    EXPECT_TRUE(wait_for_interactable_label("dynamics", "Modern Pace"));
+    SDL_Delay(300);
     state->cycled_settings = true;
 
     // Leave the subscreen.
@@ -132,6 +211,10 @@ static int difficulty_injector(void* data)
 
 TEST(Difficulty, submenu_door_flow) {
     trace_clear();
+    og::test::ScopedPhysicalFileState config_file(
+        std::filesystem::path(get_user_path()) / "cfg" / "openglad.yaml");
+    ASSERT_TRUE(config_file.ready()) << config_file.error().message();
+    ScopedCfgMaps restore_cfg;
 
     SaveData& save = og::runtime::current_session->myscreen_->save_data;
     save.scen_num = 1;
@@ -142,10 +225,12 @@ TEST(Difficulty, submenu_door_flow) {
     save.keep_fallen_heroes = 0;
     save.generator_rate = 0;
     save.infinite_gold = 0;
+    save.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    cfg.set_dynamics_ruleset_preference(og::sim::DynamicsRuleset::Modern);
     save.save("save0");
     og::runtime::current_session->current_difficulty_ = 1;
 
-    DifficultyState state = { false, false, false, false };
+    DifficultyState state = { false, false, false, false, false };
     SDL_Thread* thread = SDL_CreateThread(difficulty_injector, "difficulty_test", &state);
     ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
 
@@ -162,6 +247,8 @@ TEST(Difficulty, submenu_door_flow) {
 
     ASSERT_TRUE(state.finished) << "injector thread should have completed";
     ASSERT_TRUE(state.entered_submenu) << "DIFFICULTY door should open the subscreen";
+    ASSERT_TRUE(state.saw_classic_dynamics)
+        << "the first dynamics click should select Classic exactly";
     ASSERT_TRUE(state.cycled_settings) << "should have cycled every setting";
 
     // Full cycles restore every setting to its default.
@@ -173,6 +260,60 @@ TEST(Difficulty, submenu_door_flow) {
     EXPECT_EQ(0, after.keep_fallen_heroes) << "permadeath should be back at On";
     EXPECT_EQ(0, after.generator_rate) << "generators should be back at Normal";
     EXPECT_EQ(0, after.infinite_gold) << "infinite gold should be back at Off";
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern, after.dynamics_ruleset)
+        << "dynamics should be back at Modern";
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              cfg.dynamics_ruleset_preference());
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              og::runtime::current_session->myscreen_->world()
+                  .dynamics_ruleset);
+}
+
+TEST(Difficulty, dynamics_ruleset_never_reaches_the_save_file)
+{
+    SaveData& save = og::runtime::current_session->myscreen_->save_data;
+    const auto dynamics_before = save.dynamics_ruleset;
+
+    const std::filesystem::path save_dir =
+        std::filesystem::path(get_user_path()) / "save";
+    const std::filesystem::path classic_path =
+        save_dir / "test_dynamics_classic.gtl";
+    const std::filesystem::path modern_path =
+        save_dir / "test_dynamics_modern.gtl";
+
+    save.dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
+    ASSERT_TRUE(save.save("test_dynamics_classic"));
+    save.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    ASSERT_TRUE(save.save("test_dynamics_modern"));
+
+    const auto read_all = [](const std::filesystem::path& path) {
+        std::ifstream in(path, std::ios::binary);
+        return std::vector<char>((std::istreambuf_iterator<char>(in)),
+                                 std::istreambuf_iterator<char>());
+    };
+    const std::vector<char> classic_bytes = read_all(classic_path);
+    const std::vector<char> modern_bytes = read_all(modern_path);
+    ASSERT_FALSE(classic_bytes.empty());
+    EXPECT_EQ(classic_bytes.size(), modern_bytes.size());
+    EXPECT_EQ(classic_bytes, modern_bytes)
+        << "session dynamics must not change any company byte";
+
+    SaveData reopened;
+    ASSERT_TRUE(reopened.load("test_dynamics_classic"));
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              reopened.dynamics_ruleset)
+        << "a file cannot override the fresh frontend default";
+
+    save.dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
+    ASSERT_TRUE(save.load("test_dynamics_modern"));
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              save.dynamics_ruleset)
+        << "in-place load preserves the live session carrier";
+
+    save.dynamics_ruleset = dynamics_before;
+    std::error_code ec;
+    std::filesystem::remove(classic_path, ec);
+    std::filesystem::remove(modern_path, ec);
 }
 
 // Infinite gold is a SESSION-ONLY setting: the wallet is never inflated and

--- a/tests/integration/test_game_loop.cpp
+++ b/tests/integration/test_game_loop.cpp
@@ -1294,11 +1294,19 @@ TEST(GameLoop,
     screen* const game_screen = og::runtime::current_session->myscreen_;
     ASSERT_TRUE(game_screen != nullptr);
 
+    const short previous_cross_control = game_screen->save_data.cross_control;
+    const short previous_infinite_gold = game_screen->save_data.infinite_gold;
+    const auto previous_dynamics = game_screen->save_data.dynamics_ruleset;
+
     game_screen->save_data.reset();
     game_screen->save_data.current_campaign = "gladiator";
     game_screen->save_data.current_levels[game_screen->save_data.current_campaign] = 1;
     game_screen->save_data.scen_num = 1;
     game_screen->save_data.numplayers = 1;
+    game_screen->save_data.cross_control = 1;
+    game_screen->save_data.infinite_gold = 1;
+    game_screen->save_data.dynamics_ruleset =
+        og::sim::DynamicsRuleset::Classic;
     ASSERT_TRUE(game_screen->save_data.save("save0"));
 
     glad_init();
@@ -1328,6 +1336,15 @@ TEST(GameLoop,
     }
 
     EXPECT_TRUE(og::runtime::local_transport_active(gameplay_session));
+    screen* const server_screen =
+        og::runtime::local_transport_shadow_testing_server_screen(
+            gameplay_session);
+    ASSERT_NE(nullptr, server_screen);
+    EXPECT_EQ(1, server_screen->save_data.cross_control);
+    EXPECT_EQ(1, server_screen->save_data.infinite_gold);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              server_screen->save_data.dynamics_ruleset)
+        << "all session-only settings must survive the GTL reload";
     EXPECT_EQ(1, game_screen->world().current_palette_id);
     EXPECT_TRUE(std::equal(std::begin(game_screen->bluepalette),
                            std::end(game_screen->bluepalette),
@@ -1338,6 +1355,9 @@ TEST(GameLoop,
 
     og::runtime::clear_local_transport_shadow(gameplay_session);
     game_screen->world().delete_objects();
+    game_screen->save_data.cross_control = previous_cross_control;
+    game_screen->save_data.infinite_gold = previous_infinite_gold;
+    game_screen->save_data.dynamics_ruleset = previous_dynamics;
 }
 
 TEST(GameLoop, local_transport_shadow_guard_paths_without_runtime)

--- a/tests/integration/test_gparser_unit.cpp
+++ b/tests/integration/test_gparser_unit.cpp
@@ -120,6 +120,31 @@ TEST(GparserUnit, gparser_apply_get_and_is_on_paths)
     ASSERT_TRUE(!local_cfg.is_on("graphics", "fullscreen"));
 }
 
+TEST(GparserUnit, dynamics_preference_defaults_normalizes_and_cycles_storage)
+{
+    cfg_store local_cfg;
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              local_cfg.dynamics_ruleset_preference())
+        << "a missing preference uses the fresh-session default";
+
+    local_cfg.set_dynamics_ruleset_preference(
+        og::sim::DynamicsRuleset::Classic);
+    EXPECT_EQ("classic", local_cfg.get_setting("gameplay", "dynamics"));
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              local_cfg.dynamics_ruleset_preference());
+
+    local_cfg.set_dynamics_ruleset_preference(
+        og::sim::DynamicsRuleset::Modern);
+    EXPECT_EQ("modern", local_cfg.get_setting("gameplay", "dynamics"));
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              local_cfg.dynamics_ruleset_preference());
+
+    local_cfg.apply_setting("gameplay", "dynamics", "unknown");
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              local_cfg.dynamics_ruleset_preference())
+        << "unknown text normalizes to Modern";
+}
+
 TEST(GparserUnit, gparser_commandline_switches_and_unknown_arg)
 {
     cfg_store local_cfg;
@@ -224,9 +249,34 @@ TEST(GparserUnit, gparser_load_settings_reports_missing_config_and_keeps_default
     ASSERT_EQ("on", local_cfg.get_setting("sound", "sound"));
     ASSERT_EQ("normal", local_cfg.get_setting("graphics", "render"));
     ASSERT_EQ("on", local_cfg.get_setting("effects", "gore"));
+    ASSERT_EQ("modern", local_cfg.get_setting("gameplay", "dynamics"));
+    ASSERT_EQ(og::sim::DynamicsRuleset::Modern,
+              local_cfg.dynamics_ruleset_preference());
 
     fs::remove_all(isolated_cwd, ec);
     fs::create_directories(unit_config_file().parent_path(), ec);
+}
+
+TEST(GparserUnit, classic_dynamics_preference_survives_save_and_reload)
+{
+    og::test::ScopedPhysicalFileState config_state(unit_config_file());
+    ASSERT_TRUE(config_state.ready()) << config_state.error().message();
+    heal_unit_filesystem();
+    write_unit_config(
+        "gameplay:\n"
+        "  dynamics: classic\n");
+
+    cfg_store first;
+    ASSERT_TRUE(first.load_settings());
+    ASSERT_EQ(og::sim::DynamicsRuleset::Classic,
+              first.dynamics_ruleset_preference());
+    ASSERT_TRUE(first.save_settings());
+
+    cfg_store second;
+    ASSERT_TRUE(second.load_settings());
+    EXPECT_EQ("classic", second.get_setting("gameplay", "dynamics"));
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              second.dynamics_ruleset_preference());
 }
 
 TEST(GparserUnit, gparser_load_settings_parses_mapping_sequence_and_alias)

--- a/tests/integration/test_level_data_unit.cpp
+++ b/tests/integration/test_level_data_unit.cpp
@@ -5,6 +5,7 @@
 #include <openglad/gameplay/guy.h>
 #include <openglad/gameplay/statistics.h>
 #include <openglad/gameplay/sim_event_log.h>
+#include <openglad/gameplay/sim_control_policy.h>
 #include <openglad/core/irandom.h>
 #include <openglad/legacy/base.h>
 #include <memory>
@@ -25,6 +26,9 @@
 #include <openglad/interface/level_render.h>
 #include <openglad/core/constants.h>
 #include "test_gameplay_context_scope.h"
+#include "test_save_state_guard.h"
+
+void replace_loaded_world_state(LevelRuntimeData* level, GameWorld& loaded_world);
 
 // --- From test_level_data_coverage_push.cpp ---
 namespace detail_level_data_coverage_push {
@@ -986,6 +990,73 @@ TEST(LevelDataUnit, level_data_r15_ctor_hooks_add_paths_and_clear)
 
 // --- From test_level_data_r16.cpp ---
 namespace detail_level_data_r16 {
+TEST(LevelDataUnit,
+     level_data_r16_loaded_world_preserves_session_rules_and_carries_level_state)
+{
+    LevelRuntimeData level(9509, true);
+    GameWorld& destination = level.world();
+    destination.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    destination.keep_fallen_heroes = 1;
+    destination.control_policy = og::sim::kControlPolicyOwnerLocked;
+    destination.player_machine.fill(og::sim::kPlayerMachineNone);
+    destination.player_machine[3] =
+        og::sim::encode_player_machine(2, true);
+
+    GameWorld loaded;
+    loaded.allied_mode = 1;
+    loaded.ctf_requested_team_count = 4;
+    loaded.ctf_requested_capture_limit = 7;
+    loaded.ctf_requested_respawn_ticks = 900;
+    loaded.ctf_requested_strip_scenario_troops = 3;
+    loaded.respawn_mode = 2;
+    loaded.generator_rate = 50;
+
+    replace_loaded_world_state(&level, loaded);
+
+    EXPECT_EQ(1, destination.allied_mode);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              destination.dynamics_ruleset)
+        << "a level-file scratch world cannot replace the session ruleset";
+    EXPECT_EQ(4, destination.ctf_requested_team_count);
+    EXPECT_EQ(7, destination.ctf_requested_capture_limit);
+    EXPECT_EQ(900, destination.ctf_requested_respawn_ticks);
+    EXPECT_EQ(3, destination.ctf_requested_strip_scenario_troops);
+    EXPECT_EQ(2, destination.respawn_mode);
+    EXPECT_EQ(50, destination.generator_rate);
+    EXPECT_EQ(1, destination.keep_fallen_heroes)
+        << "a level-file scratch world cannot replace roster persistence";
+    EXPECT_EQ(og::sim::kControlPolicyOwnerLocked,
+              destination.control_policy)
+        << "a level file cannot replace the installed session policy";
+    EXPECT_EQ(og::sim::encode_player_machine(2, true),
+              destination.player_machine[3]);
+}
+
+TEST(LevelDataUnit,
+     level_data_r16_file_load_preserves_unserialized_session_rules)
+{
+    og::test::ScopedCampaignMountState restore_mount;
+    restore_default_campaigns();
+    ASSERT_EQ(CampaignPackageIoError::None,
+              mount_campaign_package_with_error("gladiator"));
+
+    LevelRuntimeData level(1, true);
+    SaveData save;
+    std::int32_t freeze = 0;
+    og::sim::SimEventLog events;
+    FixedRandom rng{0};
+    ScopedGameplayContext gameplay(level, save, events, cfg);
+    level.set_sim_context(&save, &freeze, &events, &rng, &cfg);
+    level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    level.world().keep_fallen_heroes = 1;
+
+    ASSERT_TRUE(level.load());
+
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              level.world().dynamics_ruleset);
+    EXPECT_EQ(1, level.world().keep_fallen_heroes);
+}
+
 TEST(LevelDataUnit, level_data_r16_external_world_teardown_detaches_level)
 {
     LevelRuntimeData level(9510, true);
@@ -995,12 +1066,25 @@ TEST(LevelDataUnit, level_data_r16_external_world_teardown_detaches_level)
     FixedRandom rng{0};
     level.create_new_grid();
     level.set_sim_context(&save, &freeze, &events, &rng, &cfg);
+    level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    level.world().keep_fallen_heroes = 1;
+    level.world().control_policy = og::sim::kControlPolicyOwnerLocked;
+    level.world().player_machine.fill(og::sim::kPlayerMachineNone);
+    level.world().player_machine[5] =
+        og::sim::encode_player_machine(1, true);
 
     {
         GameWorld external_world;
         level.attach_world(&external_world);
         ASSERT_TRUE(&level.world() == &external_world);
         ASSERT_TRUE(static_cast<bool>(external_world.entity_factory));
+        EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+                  external_world.dynamics_ruleset);
+        EXPECT_EQ(1, external_world.keep_fallen_heroes);
+        EXPECT_EQ(og::sim::kControlPolicyOwnerLocked,
+                  external_world.control_policy);
+        EXPECT_EQ(og::sim::encode_player_machine(1, true),
+                  external_world.player_machine[5]);
 
         walker* spawned = level.add_ob(Order::Living, FAMILY_SOLDIER);
         ASSERT_TRUE(spawned != nullptr);
@@ -1011,6 +1095,13 @@ TEST(LevelDataUnit, level_data_r16_external_world_teardown_detaches_level)
     ASSERT_TRUE(static_cast<bool>(level.world().entity_factory));
     ASSERT_TRUE(level.numobs == 1);
     ASSERT_TRUE(level.world().oblist.size() == 1);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              level.world().dynamics_ruleset);
+    EXPECT_EQ(1, level.world().keep_fallen_heroes);
+    EXPECT_EQ(og::sim::kControlPolicyOwnerLocked,
+              level.world().control_policy);
+    EXPECT_EQ(og::sim::encode_player_machine(1, true),
+              level.world().player_machine[5]);
 
     walker* spawned2 = level.add_ob(Order::Living, FAMILY_ARCHER);
     ASSERT_TRUE(spawned2 != nullptr);

--- a/tests/integration/test_menu_layout.cpp
+++ b/tests/integration/test_menu_layout.cpp
@@ -2211,7 +2211,7 @@ TEST(MenuLayout, graphics_fx_options_grid_geometry_and_nav)
 }
 
 // DIFFICULTY subscreen (the main-menu DIFFICULTY door): unique BACK id + the
-// six match-rule rows in one centered 140px column on the FX row pitch.
+// seven match-rule rows in one centered 140px column on the FX row pitch.
 // Static labels are the default-state formatter outputs; the screen re-derives
 // every row from session/save each frame, so also pin that every label the
 // formatters can produce fits the 140px face (23 chars at 6px/char).
@@ -2225,6 +2225,7 @@ TEST(MenuLayout, difficulty_menu_layout_and_nav)
         {"permadeath", "Permadeath: On", 90, 104},
         {"generator_rate", "Generators: Normal", 90, 127},
         {"infinite_gold", "Infinite Gold: Off", 90, 150},
+        {"dynamics", "Modern Pace", 90, 173},
     };
     button* buttons = picker_difficulty_menu_buttons();
     const int count = picker_difficulty_menu_button_count();
@@ -2240,6 +2241,9 @@ TEST(MenuLayout, difficulty_menu_layout_and_nav)
     EXPECT_EQ("permadeath", buttons[kDifficultyMenuPermadeathIndex].id);
     EXPECT_EQ("generator_rate", buttons[kDifficultyMenuGeneratorRateIndex].id);
     EXPECT_EQ("infinite_gold", buttons[kDifficultyMenuInfiniteGoldIndex].id);
+    EXPECT_EQ("dynamics", buttons[kDifficultyMenuDynamicsIndex].id);
+    EXPECT_EQ(button_action_id(ButtonAction::ToggleDynamicsRuleset),
+              buttons[kDifficultyMenuDynamicsIndex].myfun);
 
     // Every dynamic label across the full value cycles stays within the
     // 140px face budget.
@@ -2266,11 +2270,15 @@ TEST(MenuLayout, difficulty_menu_layout_and_nav)
         EXPECT_LE(static_cast<int>(og::ui::format_infinite_gold_label(save).size()) * 6,
                   face_width)
             << og::ui::format_infinite_gold_label(save);
+        EXPECT_LE(static_cast<int>(og::ui::format_dynamics_ruleset_label(save).size()) * 6,
+                  face_width)
+            << og::ui::format_dynamics_ruleset_label(save);
         og::ui::cycle_respawn_mode(save);
         og::ui::cycle_respawn_delay(save);
         og::ui::toggle_permadeath(save);
         og::ui::cycle_generator_rate(save);
         og::ui::toggle_infinite_gold(save);
+        og::ui::toggle_dynamics_ruleset(save);
     }
 
     // Non-host (networked joiner) variant: every settings row is

--- a/tests/integration/test_menu_model.cpp
+++ b/tests/integration/test_menu_model.cpp
@@ -415,8 +415,8 @@ TEST(MenuModel, difficulty_menu_definition_and_lookup)
     ASSERT_EQ(static_cast<int>(PickerMenuId::Difficulty), static_cast<int>(def.id))
         << "difficulty definition should report difficulty id";
     ASSERT_TRUE(def.title == "Difficulty");
-    ASSERT_EQ(7u, def.items.size())
-        << "difficulty menu: cycle + the five match rules + back";
+    ASSERT_EQ(8u, def.items.size())
+        << "difficulty menu: cycle + the six match rules + back";
 
     const struct
     {
@@ -429,6 +429,7 @@ TEST(MenuModel, difficulty_menu_definition_and_lookup)
         {"permadeath", PickerMenuCommand::TogglePermadeath},
         {"generator_rate", PickerMenuCommand::CycleGeneratorRate},
         {"infinite_gold", PickerMenuCommand::ToggleInfiniteGold},
+        {"dynamics", PickerMenuCommand::ToggleDynamicsRuleset},
         {"back", PickerMenuCommand::Back},
     };
     for (const auto& want : kExpected)
@@ -447,7 +448,7 @@ TEST(MenuModel, difficulty_menu_definition_and_lookup)
     // The match-rule entries live only in the submenu.
     for (const char* submenu_id :
          {"respawn_mode", "respawn_delay", "permadeath", "generator_rate",
-          "infinite_gold"})
+          "infinite_gold", "dynamics"})
     {
         ASSERT_TRUE(find_picker_menu_item(PickerMenuId::Main, submenu_id) == nullptr)
             << submenu_id << " should not appear in the main menu";
@@ -558,11 +559,11 @@ TEST(MenuModel, company_screens_cancel_to_back_and_leak_nowhere)
     // door is appended last. Main exposes both stable Help and Quit actions.
     // TeamBuild is unchanged (its ctf_troops row stays resolvable but
     // dormant); Scenario grew the appended troops row; Difficulty grew the
-    // appended infinite-gold row.
+    // appended infinite-gold and dynamics rows.
     ASSERT_EQ(9u, picker_menu_definition(PickerMenuId::Main).items.size());
     ASSERT_EQ(12u, picker_menu_definition(PickerMenuId::TeamBuild).items.size());
     ASSERT_EQ(7u, picker_menu_definition(PickerMenuId::Scenario).items.size());
-    ASSERT_EQ(7u, picker_menu_definition(PickerMenuId::Difficulty).items.size());
+    ASSERT_EQ(8u, picker_menu_definition(PickerMenuId::Difficulty).items.size());
 
     // load_company resolves by id and by command and keeps its 1-based
     // position 8 (the text-drive index contract); the appended cloud door is

--- a/tests/integration/test_options_menu.cpp
+++ b/tests/integration/test_options_menu.cpp
@@ -1358,13 +1358,14 @@ int menu_difficulty_injector(void* data)
         state->saw_options = true;
 
         struct RowPlan { const char* id; int clicks; };
-        static const RowPlan kRows[6] = {
+        static const RowPlan kRows[7] = {
             {"difficulty", 3},     // Battle -> Slaughter -> Skirmish -> Battle
             {"respawn_mode", 4},   // Off -> Heroes -> Everyone -> Team 1 -> Off
             {"respawn_delay", 3},  // Normal -> Fast -> Slow -> Normal
             {"permadeath", 2},     // On -> Off -> On
             {"generator_rate", 3}, // Normal -> Calm -> Frenzy -> Normal
             {"infinite_gold", 2},  // Off -> On -> Off
+            {"dynamics", 2},       // Modern -> Classic -> Modern
         };
         bool all_rows = true;
         for (const RowPlan& row : kRows) {
@@ -1407,6 +1408,7 @@ TEST(OptionsMenu, zz_capture_menu_difficulty)
     const short keep_before = save.keep_fallen_heroes;
     const short rate_before = save.generator_rate;
     const short gold_before = save.infinite_gold;
+    const auto dynamics_before = save.dynamics_ruleset;
 
     menu_capture::CaptureState state = {};
     menu_capture::run_capture_flow("menu_difficulty",
@@ -1426,6 +1428,7 @@ TEST(OptionsMenu, zz_capture_menu_difficulty)
     EXPECT_EQ(keep_before, after.keep_fallen_heroes);
     EXPECT_EQ(rate_before, after.generator_rate);
     EXPECT_EQ(gold_before, after.infinite_gold);
+    EXPECT_EQ(dynamics_before, after.dynamics_ruleset);
 }
 
 TEST(OptionsMenu, zz_capture_menu_tour)

--- a/tests/integration/test_picker_network_client.cpp
+++ b/tests/integration/test_picker_network_client.cpp
@@ -147,6 +147,8 @@ struct PickerSaveStateGuard
     short keep_fallen_heroes = 0;
     short cross_control = 0;
     short infinite_gold = 0;
+    og::sim::DynamicsRuleset dynamics_ruleset =
+        og::sim::DynamicsRuleset::Modern;
     std::unique_ptr<guy> team_list[MAX_TEAM_SIZE];
 
     explicit PickerSaveStateGuard(SaveData& save_in)
@@ -163,6 +165,7 @@ struct PickerSaveStateGuard
         , keep_fallen_heroes(save.keep_fallen_heroes)
         , cross_control(save.cross_control)
         , infinite_gold(save.infinite_gold)
+        , dynamics_ruleset(save.dynamics_ruleset)
     {
         for (int i = 0; i < MAX_TEAM_SIZE; ++i)
             team_list[i] = std::move(save.team_list[static_cast<std::size_t>(i)]);
@@ -182,6 +185,7 @@ struct PickerSaveStateGuard
         save.keep_fallen_heroes = keep_fallen_heroes;
         save.cross_control = cross_control;
         save.infinite_gold = infinite_gold;
+        save.dynamics_ruleset = dynamics_ruleset;
         for (int i = 0; i < MAX_TEAM_SIZE; ++i)
             save.team_list[static_cast<std::size_t>(i)] = std::move(team_list[i]);
     }
@@ -1760,6 +1764,7 @@ TEST(PickerNetworkClient,
     PickerSaveStateGuard host_save_guard(host_save);
     PickerRuntimeGuard runtime_guard;
     prepare_single_member_network_save(host_save, 0, "Host");
+    host_save.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
     g_start_game_requested = false;
 
     og::ui::PickerHostGameOptions host_options;
@@ -3003,9 +3008,24 @@ TEST(PickerNetworkClient,
     initial_setup.current_scenario = 1;
     initial_setup.my_team = 1;
     initial_setup.allied_mode = 0;
+    initial_setup.dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
+    gameplay_screen->save_data.dynamics_ruleset =
+        og::sim::DynamicsRuleset::Modern;
+    gameplay_screen->world().dynamics_ruleset =
+        og::sim::DynamicsRuleset::Modern;
     server_transport->send_initial_setup(
         join_peer_id,
         std::make_shared<og::sim::InitialSetupMessage>(initial_setup));
+
+    ASSERT_TRUE(wait_until([&] {
+        og::runtime::local_transport_shadow_finish_tick(*active_game_session());
+        return gameplay_screen->save_data.dynamics_ruleset ==
+                   og::sim::DynamicsRuleset::Classic &&
+            gameplay_screen->world().dynamics_ruleset ==
+                   og::sim::DynamicsRuleset::Classic;
+    })) << "InitialSetup alone must replace the joiner's stale local dynamics "
+           "preference before any snapshot can mask the copy gap";
+
     og::sim::WorldSnapshot initial_snapshot =
         og::sim::capture_keyframe_snapshot(gameplay_screen->world());
     // The display world is reused across picker tests. Make this synthetic
@@ -3062,6 +3082,7 @@ TEST(PickerNetworkClient,
     next_setup.current_scenario = 2;
     next_setup.my_team = 1;
     next_setup.allied_mode = 0;
+    next_setup.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
     server_transport->send_initial_setup(
         join_peer_id,
         std::make_shared<og::sim::InitialSetupMessage>(next_setup));
@@ -3069,7 +3090,11 @@ TEST(PickerNetworkClient,
     ASSERT_TRUE(wait_until([&] {
         og::runtime::local_transport_shadow_finish_tick(*active_game_session());
         return gameplay_screen->world().current_scenario == 2 &&
-            gameplay_screen->world().end == 0;
+            gameplay_screen->world().end == 0 &&
+            gameplay_screen->save_data.dynamics_ruleset ==
+                og::sim::DynamicsRuleset::Modern &&
+            gameplay_screen->world().dynamics_ruleset ==
+                og::sim::DynamicsRuleset::Modern;
     })) << "a later InitialSetup should revive the same client runtime";
     EXPECT_EQ(1, gameplay_screen->viewob[0]->my_team);
 
@@ -5049,6 +5074,8 @@ TEST(PickerNetworkClient, benched_slot_stays_out_of_level_and_cross_control_prop
         ~CrossControlRestore() { save.cross_control = prev; }
     } cross_control_restore{host_save, host_save.cross_control};
     host_save.cross_control = 1;
+    host_save.infinite_gold = 1;
+    host_save.dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
     g_start_game_requested = false;
     set_game_speed(0.0f);
 
@@ -5120,8 +5147,8 @@ TEST(PickerNetworkClient, benched_slot_stays_out_of_level_and_cross_control_prop
     cleanup.join_client = join_client.get();
     ASSERT_NE(nullptr, cleanup.host_session);
 
-    // Converge, and require the joiner to have LEARNED cross_control=1 from
-    // the host's settings echo (§4.4 propagation; sanitize keeps {0,1}).
+    // Converge, and require the joiner to have learned every session-only
+    // rule from the host's settings echo.
     ASSERT_TRUE(wait_until([&] {
         host_client->poll_and_apply();
         bool join_converged = false;
@@ -5131,12 +5158,15 @@ TEST(PickerNetworkClient, benched_slot_stays_out_of_level_and_cross_control_prop
             join_converged = status_lines_contain_exact(
                                  join_client->status_lines(),
                                  "Lobby: 2 players") &&
-                join_session.myscreen_->save_data.cross_control == 1;
+                join_session.myscreen_->save_data.cross_control == 1 &&
+                join_session.myscreen_->save_data.infinite_gold == 1 &&
+                join_session.myscreen_->save_data.dynamics_ruleset ==
+                    og::sim::DynamicsRuleset::Classic;
         }
         return status_lines_contain_exact(host_client->status_lines(),
                                           "Lobby: 2 players") &&
             join_converged;
-    })) << "the joiner must converge AND adopt the host's cross_control=1";
+    })) << "the joiner must converge and adopt all host session rules";
 
     ASSERT_TRUE(host_save.save("save0"));
     ASSERT_TRUE(ready_up_joiners(*host_client,
@@ -5159,6 +5189,9 @@ TEST(PickerNetworkClient, benched_slot_stays_out_of_level_and_cross_control_prop
     ASSERT_EQ(3u, host_start_config->save_data.team_list.size())
         << "the benched slot must be filtered out of the game-start roster";
     EXPECT_EQ(1, host_start_config->save_data.cross_control);
+    EXPECT_EQ(1, host_start_config->save_data.infinite_gold);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              host_start_config->save_data.dynamics_ruleset);
     {
         auto host_scope = cleanup.host_session->activate();
         ActivePickerLobbyClientGuard active_client(host_client.get());
@@ -5173,6 +5206,9 @@ TEST(PickerNetworkClient, benched_slot_stays_out_of_level_and_cross_control_prop
         ASSERT_EQ(3u, join_start_config->save_data.team_list.size())
             << "the joiner mirror must filter the benched slot identically";
         EXPECT_EQ(1, join_start_config->save_data.cross_control);
+        EXPECT_EQ(1, join_start_config->save_data.infinite_gold);
+        EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+                  join_start_config->save_data.dynamics_ruleset);
         ActivePickerLobbyClientGuard active_client(join_client.get());
         ready_screen_for_game_start(
             *join_session.myscreen_, &*join_start_config);
@@ -5223,6 +5259,11 @@ TEST(PickerNetworkClient, benched_slot_stays_out_of_level_and_cross_control_prop
             << "the benched character must never enter the level";
         EXPECT_EQ(1, static_cast<int>(server_screen->save_data.cross_control))
             << "cross_control must survive the headless save-data copy chain";
+        EXPECT_EQ(1, static_cast<int>(server_screen->save_data.infinite_gold))
+            << "infinite_gold must survive the GTL reload into the host shadow";
+        EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+                  server_screen->save_data.dynamics_ruleset)
+            << "dynamics must survive the GTL reload into the host shadow";
         ASSERT_NE(nullptr, alpha);
         ASSERT_NE(nullptr, joiner);
         EXPECT_FALSE(alpha->is_friendly(joiner));
@@ -8588,9 +8629,9 @@ TEST(WebSocketServerFdLifecycle,
 
 // ---------------------------------------------------------------------------
 // Difficulty-submenu settings must replicate through the lobby wire: the
-// host cycles Respawns/Generators (plus delay and permadeath) exactly as the
-// subscreen callbacks do (pure cycler + sync_settings_from_save) and the
-// joiner's save must reflect every value; a second cycle round must land too.
+// host cycles every SaveData-backed rule exactly as the subscreen callbacks do
+// (pure cycler + sync_settings_from_save) and the joiner's save must reflect
+// every value; a second cycle round must land too.
 // ---------------------------------------------------------------------------
 #include <openglad/interface/ui/picker_common.h>
 
@@ -8665,7 +8706,8 @@ TEST(PickerNetworkClient, host_and_join_difficulty_settings_sync_to_joiner_save)
             join_lobby_ready;
     })) << "host and join should converge on a two-player lobby";
 
-    // The joiner starts on the defaults (all zero = classic behavior).
+    // The joiner starts on the defaults: the preserved rules are zero while
+    // a genuinely fresh lobby explicitly seeds Modern dynamics.
     {
         auto join_scope = join_session.activate();
         const SaveData& join_save = join_session.myscreen_->save_data;
@@ -8674,18 +8716,21 @@ TEST(PickerNetworkClient, host_and_join_difficulty_settings_sync_to_joiner_save)
         EXPECT_EQ(0, static_cast<int>(join_save.keep_fallen_heroes));
         EXPECT_EQ(0, static_cast<int>(join_save.ctf_respawn_ticks));
         EXPECT_EQ(0, static_cast<int>(join_save.infinite_gold));
+        EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+                  join_save.dynamics_ruleset);
     }
 
     // Host cycles: Respawns Off->Heroes, Generators Normal->Calm->Frenzy,
-    // Delay Normal->Fast, Permadeath On->Off, Infinite Gold Off->On — then
-    // one settings sync, the exact shape of the difficulty-subscreen button
-    // callbacks.
+    // Delay Normal->Fast, Permadeath On->Off, Infinite Gold Off->On, and
+    // Dynamics Modern->Classic — then one settings sync, the exact shape of
+    // the difficulty-subscreen button callbacks.
     og::ui::cycle_respawn_mode(host_save);   // 0 -> 1 (Heroes)
     og::ui::cycle_generator_rate(host_save); // 0 -> 50 (Calm)
     og::ui::cycle_generator_rate(host_save); // 50 -> 200 (Frenzy)
     og::ui::cycle_respawn_delay(host_save);  // 0 -> 60 ticks (Fast)
     og::ui::toggle_permadeath(host_save);    // keep_fallen_heroes = 1
     og::ui::toggle_infinite_gold(host_save); // infinite_gold = 1
+    og::ui::toggle_dynamics_ruleset(host_save); // Modern -> Classic
     host_client->sync_settings_from_save();
 
     ASSERT_TRUE(wait_until([&] {
@@ -8699,7 +8744,9 @@ TEST(PickerNetworkClient, host_and_join_difficulty_settings_sync_to_joiner_save)
                 join_save.generator_rate == 200 &&
                 join_save.ctf_respawn_ticks == 60 &&
                 join_save.keep_fallen_heroes == 1 &&
-                join_save.infinite_gold == 1;
+                join_save.infinite_gold == 1 &&
+                join_save.dynamics_ruleset ==
+                    og::sim::DynamicsRuleset::Classic;
         }
         return join_synced;
     })) << "the joiner's save must reflect the host's difficulty settings";
@@ -8726,6 +8773,7 @@ TEST(PickerNetworkClient, host_and_join_difficulty_settings_sync_to_joiner_save)
     // one-shot initial-state copy.
     og::ui::cycle_respawn_mode(host_save);   // 1 -> 2 (Everyone)
     og::ui::cycle_generator_rate(host_save); // 200 -> 0 (Normal)
+    og::ui::toggle_dynamics_ruleset(host_save); // Classic -> Modern
     host_client->sync_settings_from_save();
 
     ASSERT_TRUE(wait_until([&] {
@@ -8738,7 +8786,9 @@ TEST(PickerNetworkClient, host_and_join_difficulty_settings_sync_to_joiner_save)
             join_synced = join_save.respawn_mode == 2 &&
                 join_save.generator_rate == 0 &&
                 join_save.ctf_respawn_ticks == 60 &&
-                join_save.keep_fallen_heroes == 1;
+                join_save.keep_fallen_heroes == 1 &&
+                join_save.dynamics_ruleset ==
+                    og::sim::DynamicsRuleset::Modern;
         }
         return join_synced;
     })) << "a second settings cycle must replicate to the joiner too";
@@ -8750,6 +8800,8 @@ TEST(PickerNetworkClient, host_and_join_difficulty_settings_sync_to_joiner_save)
     EXPECT_EQ(60, static_cast<int>(host_save.ctf_respawn_ticks));
     EXPECT_EQ(1, static_cast<int>(host_save.keep_fallen_heroes));
     EXPECT_EQ(1, static_cast<int>(host_save.infinite_gold));
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              host_save.dynamics_ruleset);
 
     {
         auto join_scope = join_session.activate();

--- a/tests/integration/test_replay.cpp
+++ b/tests/integration/test_replay.cpp
@@ -292,6 +292,8 @@ void run_replay_roundtrip(int player_count)
         og::runtime::current_session->current_difficulty_;
     og::runtime::current_session->current_difficulty_ = 2;
     configure_replay_team(game_screen.save_data, player_count);
+    game_screen.save_data.dynamics_ruleset =
+        og::sim::DynamicsRuleset::Modern;
 
     const std::string save_name =
         std::format("test_phase11_replay_{}", player_count);
@@ -331,6 +333,7 @@ void run_replay_roundtrip(int player_count)
         .level_id = live_world.id,
         .player_count = static_cast<std::uint8_t>(player_count),
         .timer_wait = live_world.timer_wait,
+        .dynamics_ruleset = live_world.dynamics_ruleset,
         .my_team = game_screen.save_data.my_team,
         .allied_mode = game_screen.save_data.allied_mode,
         .difficulty = live_world.difficulty,
@@ -383,6 +386,10 @@ void run_replay_roundtrip(int player_count)
     EXPECT_EQ(recorder.header().level_id, player.header().level_id);
     EXPECT_EQ(recorder.header().player_count, player.header().player_count);
     EXPECT_EQ(recorder.header().timer_wait, player.header().timer_wait);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              player.header().dynamics_ruleset);
+    EXPECT_EQ(recorder.header().dynamics_ruleset,
+              player.header().dynamics_ruleset);
     EXPECT_EQ(recorder.header().my_team, player.header().my_team);
     EXPECT_EQ(recorder.header().allied_mode, player.header().allied_mode);
     EXPECT_EQ(recorder.header().difficulty, player.header().difficulty);
@@ -401,9 +408,13 @@ void run_replay_roundtrip(int player_count)
     game_screen.save_data.numplayers = 0;
     game_screen.save_data.my_team = static_cast<short>(player.header().my_team + 1);
     game_screen.save_data.allied_mode = static_cast<short>(1 - player.header().allied_mode);
+    game_screen.save_data.dynamics_ruleset =
+        og::sim::DynamicsRuleset::Classic;
     ASSERT_EQ(0, game_screen.save_data.team_size);
     game_screen.world().rng_.state_ = 0u;
     game_screen.world().difficulty = 1;
+    game_screen.world().dynamics_ruleset =
+        og::sim::DynamicsRuleset::Classic;
     og::runtime::current_session->current_difficulty_ = 0;
     ASSERT_TRUE(og::runtime::initialize_replay_screen(game_screen, player))
         << "replay runtime should seed RNG and load the replay world";
@@ -416,6 +427,10 @@ void run_replay_roundtrip(int player_count)
     ASSERT_EQ(player.header().timer_wait, replay_screen_world.timer_wait);
     ASSERT_EQ(player.header().my_team, game_screen.save_data.my_team);
     ASSERT_EQ(player.header().allied_mode, game_screen.save_data.allied_mode);
+    ASSERT_EQ(og::sim::DynamicsRuleset::Modern,
+              game_screen.save_data.dynamics_ruleset);
+    ASSERT_EQ(og::sim::DynamicsRuleset::Modern,
+              replay_screen_world.dynamics_ruleset);
     ASSERT_EQ(player.header().difficulty, replay_screen_world.difficulty);
     ASSERT_EQ(0, game_screen.save_data.team_size);
     EXPECT_EQ(expected_control_ids,
@@ -506,15 +521,15 @@ TEST(Replay, phase11_roundtrip_matches_final_state_for_four_players)
     run_replay_roundtrip(4);
 }
 
-TEST(Replay, format_version_14_rejects_v13)
+TEST(Replay, format_version_15_rejects_v14)
 {
-    static_assert(og::sim::kReplayFormatVersion == 14);
+    static_assert(og::sim::kReplayFormatVersion == 15);
     std::array<std::uint8_t, og::sim::kReplayHeaderSize> old_header{};
     old_header[0] = static_cast<std::uint8_t>('O');
     old_header[1] = static_cast<std::uint8_t>('G');
     old_header[2] = static_cast<std::uint8_t>('R');
     old_header[3] = static_cast<std::uint8_t>('P');
-    old_header[4] = 13;
+    old_header[4] = 14;
 
     og::sim::ReplayIoError error = og::sim::ReplayIoError::None;
     EXPECT_FALSE(og::sim::deserialize_replay(old_header, &error).has_value());
@@ -564,6 +579,7 @@ TEST(Replay, initialize_replay_screen_rejects_unsafe_campaign_ids)
                 .level_id = live_world.id,
                 .player_count = 1,
                 .timer_wait = live_world.timer_wait,
+                .dynamics_ruleset = live_world.dynamics_ruleset,
                 .my_team = game_screen.save_data.my_team,
                 .allied_mode = game_screen.save_data.allied_mode,
                 .difficulty = live_world.difficulty,

--- a/tests/integration/test_sim_input_unit.cpp
+++ b/tests/integration/test_sim_input_unit.cpp
@@ -9,6 +9,7 @@
 #include <openglad/gameplay/input_state.h>
 #include <openglad/gameplay/sim_event_log.h>
 #include <openglad/core/irandom.h>
+#include <openglad/core/pixdefs.h>
 #include <openglad/legacy/base.h>
 #include <memory>
 #include <string>
@@ -681,3 +682,672 @@ TEST(SimInputUnit, sim_control_owner_locked_switch_char_falls_back_to_own)
     ASSERT_TRUE(result.control_hp_changed);
 }
 } // namespace detail_sim_control_enforcement
+
+namespace detail_modern_dynamics {
+namespace {
+
+class CountingRandom final : public IRandom
+{
+public:
+    std::uint32_t next(std::uint32_t max_exclusive) override
+    {
+        ++calls;
+        (void)max_exclusive;
+        return 0;
+    }
+
+    std::uint32_t calls = 0;
+};
+
+struct SimInputFixture {
+    LevelRuntimeData level{1, true};
+    SaveData save;
+    std::int32_t enemy_freeze = 0;
+    og::sim::SimEventLog events;
+    CountingRandom rng;
+    ScopedGameplayContext gameplay;
+
+    SimInputFixture()
+        : gameplay(level, save, events, cfg)
+    {
+        level.create_new_grid();
+        level.set_sim_context(&save, &enemy_freeze, &events, &rng, &cfg);
+    }
+};
+
+walker* add_living(SimInputFixture& fx, unsigned char team,
+                   short x, short y, signed char user = -1,
+                   short floor = 0)
+{
+    auto owned = std::make_unique<living>();
+    static PixieData test_sprite(
+        NUM_FACINGS, 16, 16,
+        new unsigned char[NUM_FACINGS * 16 * 16]{});
+    owned->set_data(test_sprite);
+    owned->set_order_family(Order::Living, FAMILY_SOLDIER);
+    bind_test_entity_sim_context(fx.level, owned.get());
+    owned->set_sizex(16);
+    owned->set_sizey(16);
+    owned->set_stepsize(1.0f);
+    owned->set_normal_stepsize(1.0f);
+    owned->set_floor(floor);
+    owned->setxy(x, y);
+    owned->set_team_num(team);
+    owned->set_real_team_num(255);
+    owned->set_dead(0);
+    owned->set_user(user);
+    owned->set_act_type(user == -1 ? ACT_RANDOM : ACT_CONTROL);
+    owned->set_owned_myguy(std::make_unique<guy>(FAMILY_SOLDIER));
+    walker* const result = owned.get();
+    fx.level.world().oblist.push_back(std::move(owned));
+    return result;
+}
+
+walker* add_nonliving(SimInputFixture& fx, Order order, unsigned char team,
+                      short x, short y)
+{
+    auto owned = std::make_unique<walker>();
+    owned->set_order_family(order, FAMILY_KNIFE);
+    bind_test_entity_sim_context(fx.level, owned.get());
+    owned->set_sizex(16);
+    owned->set_sizey(16);
+    owned->set_stepsize(1.0f);
+    owned->set_normal_stepsize(1.0f);
+    owned->setxy(x, y);
+    owned->set_team_num(team);
+    owned->set_real_team_num(255);
+    owned->set_dead(0);
+    walker* const result = owned.get();
+    fx.level.world().oblist.push_back(std::move(owned));
+    return result;
+}
+
+walker* add_control(SimInputFixture& fx)
+{
+    return add_living(fx, 0, 80, 80, 0);
+}
+
+SimInputResult process(SimInputFixture& fx, walker*& control,
+                       SimInputDebounce& debounce, const InputState& input)
+{
+    static std::string special_names[NUM_FAMILIES][NUM_SPECIALS] = {};
+    return sim_process_player_input(input.players[0], control,
+                                    fx.level.world(), 0, 0, debounce,
+                                    special_names, &fx.events);
+}
+
+void process_right(SimInputFixture& fx, walker*& control,
+                   SimInputDebounce& debounce,
+                   bool press_fire = false,
+                   bool press_special = false)
+{
+    InputState input;
+    input.clear();
+    input.players[0].held[static_cast<int>(InputAction::MoveRight)] = true;
+    input.players[0].pressed[static_cast<int>(InputAction::Fire)] = press_fire;
+    input.players[0].pressed[static_cast<int>(InputAction::Special)] = press_special;
+    process(fx, control, debounce, input);
+}
+
+SimInputResult process_yell(SimInputFixture& fx, walker*& control,
+                            SimInputDebounce& debounce)
+{
+    InputState input;
+    input.clear();
+    input.players[0].pressed[static_cast<int>(InputAction::Yell)] = true;
+    return process(fx, control, debounce, input);
+}
+
+void reset_facing_left(walker* control)
+{
+    control->setxy(80, 80);
+    control->set_curdir(FACE_LEFT);
+    control->set_enddir(FACE_LEFT);
+    control->set_lastx(-1.0f);
+    control->set_lasty(0.0f);
+}
+
+void assign_direction_ani(walker* w)
+{
+    constexpr int kAniRows = NUM_FACINGS * (ANI_SLIME_SPLIT + 1);
+    static std::array<std::array<signed char, 4>, kAniRows> seqs{};
+    static std::array<signed char*, kAniRows> rows{};
+    static bool initialized = false;
+    if (!initialized)
+    {
+        for (int i = 0; i < kAniRows; ++i)
+        {
+            const signed char frame =
+                static_cast<signed char>(i % NUM_FACINGS);
+            seqs[static_cast<std::size_t>(i)] = {frame, frame, frame, -1};
+            rows[static_cast<std::size_t>(i)] =
+                seqs[static_cast<std::size_t>(i)].data();
+        }
+        initialized = true;
+    }
+    w->ani = rows.data();
+}
+
+void assert_forced_walk(const walker* target, int count,
+                        int dx, int dy, std::size_t queue_size = 1)
+{
+    ASSERT_EQ(queue_size, target->stats()->commands.size());
+    const command& pushed = target->stats()->commands.front();
+    ASSERT_EQ(COMMAND_WALK, pushed.commandtype);
+    ASSERT_EQ(count, pushed.commandcount);
+    ASSERT_EQ(dx, pushed.com1);
+    ASSERT_EQ(dy, pushed.com2);
+    ASSERT_TRUE(pushed.forced);
+}
+
+} // namespace
+
+TEST(SimInputUnit, modern_dynamics_moves_on_the_direction_change_tick)
+{
+    SimInputFixture fx;
+    walker* control = add_control(fx);
+    SimInputDebounce debounce{};
+
+    reset_facing_left(control);
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
+    process_right(fx, control, debounce);
+    ASSERT_EQ(80, control->xpos());
+    ASSERT_EQ(80, control->ypos());
+    ASSERT_EQ(FACE_LEFT, control->curdir());
+    ASSERT_EQ(FACE_RIGHT, control->enddir());
+    ASSERT_EQ(1.0f, control->lastx());
+    ASSERT_EQ(0.0f, control->lasty());
+
+    reset_facing_left(control);
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    process_right(fx, control, debounce);
+    ASSERT_EQ(81, control->xpos());
+    ASSERT_EQ(80, control->ypos());
+    ASSERT_EQ(FACE_RIGHT, control->curdir());
+    ASSERT_EQ(FACE_RIGHT, control->enddir());
+    ASSERT_EQ(1.0f, control->lastx());
+    ASSERT_EQ(0.0f, control->lasty());
+}
+
+TEST(SimInputUnit, dynamics_turn_cadence_is_exact_for_45_90_and_180_degrees)
+{
+    struct TurnCase
+    {
+        short start_dir;
+        std::array<short, 4> classic_after_act;
+        int turn_ticks;
+    };
+    constexpr std::array<TurnCase, 3> cases = {{
+        {FACE_UP_RIGHT, {FACE_RIGHT, 0, 0, 0}, 1},
+        {FACE_UP, {FACE_UP_RIGHT, FACE_RIGHT, 0, 0}, 2},
+        {FACE_LEFT,
+         {FACE_UP_LEFT, FACE_UP, FACE_UP_RIGHT, FACE_RIGHT}, 4},
+    }};
+
+    for (const TurnCase& turn_case : cases)
+    {
+        SCOPED_TRACE(turn_case.turn_ticks);
+        {
+            SimInputFixture fx;
+            fx.level.world().dynamics_ruleset =
+                og::sim::DynamicsRuleset::Classic;
+            walker* control = add_control(fx);
+            control->set_curdir(static_cast<signed char>(turn_case.start_dir));
+            control->set_enddir(static_cast<char>(turn_case.start_dir));
+            SimInputDebounce debounce{};
+
+            for (int tick = 0; tick < turn_case.turn_ticks; ++tick)
+            {
+                process_right(fx, control, debounce);
+                ASSERT_EQ(80, control->xpos());
+                ASSERT_EQ(FACE_RIGHT, control->enddir());
+                ASSERT_EQ(1, control->act());
+                ASSERT_EQ(turn_case.classic_after_act[static_cast<std::size_t>(tick)],
+                          control->curdir());
+                ASSERT_EQ(80, control->xpos());
+            }
+            process_right(fx, control, debounce);
+            ASSERT_EQ(81, control->xpos());
+            ASSERT_EQ(FACE_RIGHT, control->curdir());
+            ASSERT_EQ(FACE_RIGHT, control->enddir());
+        }
+
+        {
+            SimInputFixture fx;
+            fx.level.world().dynamics_ruleset =
+                og::sim::DynamicsRuleset::Modern;
+            walker* control = add_control(fx);
+            control->set_curdir(static_cast<signed char>(turn_case.start_dir));
+            control->set_enddir(static_cast<char>(turn_case.start_dir));
+            SimInputDebounce debounce{};
+
+            process_right(fx, control, debounce);
+            ASSERT_EQ(81, control->xpos());
+            ASSERT_EQ(FACE_RIGHT, control->curdir());
+            ASSERT_EQ(FACE_RIGHT, control->enddir());
+        }
+    }
+}
+
+TEST(SimInputUnit, modern_dynamics_resolves_facing_before_fire_and_special)
+{
+    SimInputFixture fx;
+    walker* control = add_control(fx);
+    assign_direction_ani(control);
+    control->set_fire_frequency(5.0f);
+    SimInputDebounce debounce{};
+
+    reset_facing_left(control);
+    control->set_ani_type(ANI_WALK);
+    control->set_cycle(0);
+    control->set_busy(0.0f);
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
+    process_right(fx, control, debounce, /*press_fire=*/true);
+    ASSERT_EQ(80, control->xpos());
+    ASSERT_EQ(FACE_LEFT, control->curdir());
+    ASSERT_EQ(FACE_RIGHT, control->enddir());
+    ASSERT_EQ(ANI_ATTACK, control->ani_type());
+    ASSERT_EQ(1, control->cycle());
+    ASSERT_EQ(FACE_LEFT, control->frame());
+    ASSERT_EQ(5.0f, control->busy());
+
+    reset_facing_left(control);
+    control->set_ani_type(ANI_WALK);
+    control->set_cycle(0);
+    control->set_busy(0.0f);
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    process_right(fx, control, debounce, /*press_fire=*/true);
+    ASSERT_EQ(81, control->xpos());
+    ASSERT_EQ(FACE_RIGHT, control->curdir());
+    ASSERT_EQ(FACE_RIGHT, control->enddir());
+    ASSERT_EQ(ANI_ATTACK, control->ani_type());
+    ASSERT_EQ(2, control->cycle());
+    ASSERT_EQ(FACE_RIGHT, control->frame());
+    ASSERT_EQ(5.0f, control->busy());
+
+    // Soldier special 1 (charge) records lastx/lasty in COMMAND_RUSH. Pin
+    // that Modern resolves the new direction before dispatching the special.
+    control->stats()->clear_command();
+    reset_facing_left(control);
+    control->set_ani_type(ANI_WALK);
+    control->set_cycle(0);
+    control->set_busy(0.0f);
+    control->set_current_special(1);
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
+    process_right(fx, control, debounce, false, /*press_special=*/true);
+    ASSERT_EQ(1u, control->stats()->commands.size());
+    ASSERT_EQ(COMMAND_RUSH, control->stats()->commands.front().commandtype);
+    ASSERT_EQ(3, control->stats()->commands.front().commandcount);
+    ASSERT_EQ(-1, control->stats()->commands.front().com1);
+    ASSERT_EQ(0, control->stats()->commands.front().com2);
+
+    control->stats()->clear_command();
+    reset_facing_left(control);
+    control->set_ani_type(ANI_WALK);
+    control->set_cycle(0);
+    control->set_busy(0.0f);
+    control->set_current_special(1);
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    process_right(fx, control, debounce, false, /*press_special=*/true);
+    ASSERT_EQ(1u, control->stats()->commands.size());
+    ASSERT_EQ(COMMAND_RUSH, control->stats()->commands.front().commandtype);
+    ASSERT_EQ(3, control->stats()->commands.front().commandcount);
+    ASSERT_EQ(1, control->stats()->commands.front().com1);
+    ASSERT_EQ(0, control->stats()->commands.front().com2);
+}
+
+TEST(SimInputUnit, modern_dynamics_refreshes_blocked_walk_facing_frame)
+{
+    SimInputFixture fx;
+    walker* control = add_control(fx);
+    fx.level.world().grid.data[static_cast<std::size_t>(
+        5 * fx.level.world().grid.w + 6)] = PIX_WALL2;
+    assign_direction_ani(control);
+    reset_facing_left(control);
+    control->set_ani_type(ANI_WALK);
+    control->set_cycle(1);
+    control->set_frame(FACE_LEFT);
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    SimInputDebounce debounce{};
+
+    process_right(fx, control, debounce);
+
+    ASSERT_EQ(80, control->xpos());
+    ASSERT_EQ(80, control->ypos());
+    ASSERT_EQ(FACE_RIGHT, control->curdir());
+    ASSERT_EQ(FACE_RIGHT, control->enddir());
+    ASSERT_EQ(FACE_RIGHT, control->frame());
+    ASSERT_EQ(1, control->cycle());
+    ASSERT_EQ(ANI_WALK, control->ani_type());
+}
+
+TEST(SimInputUnit, modern_dynamics_respects_frozen_and_command_gates)
+{
+    SimInputFixture fx;
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    walker* control = add_control(fx);
+    SimInputDebounce debounce{};
+
+    reset_facing_left(control);
+    control->stats()->set_frozen_delay(2);
+    process_right(fx, control, debounce);
+    ASSERT_EQ(80, control->xpos());
+    ASSERT_EQ(FACE_LEFT, control->curdir());
+    ASSERT_EQ(FACE_LEFT, control->enddir());
+    ASSERT_EQ(1, control->stats()->frozen_delay());
+
+    control->stats()->set_frozen_delay(0);
+    control->stats()->add_command(COMMAND_SEARCH, 5, 0, 0);
+    reset_facing_left(control);
+    process_right(fx, control, debounce);
+    ASSERT_EQ(80, control->xpos());
+    ASSERT_EQ(FACE_LEFT, control->curdir());
+    ASSERT_EQ(FACE_LEFT, control->enddir());
+    ASSERT_EQ(1u, control->stats()->commands.size());
+    ASSERT_EQ(COMMAND_SEARCH,
+              control->stats()->commands.front().commandtype);
+    ASSERT_EQ(5, control->stats()->commands.front().commandcount);
+}
+
+TEST(SimInputUnit, modern_dynamics_zero_step_actor_aims_before_firing)
+{
+    SimInputFixture fx;
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    walker* control = add_control(fx);
+    control->set_order_family(Order::Living, FAMILY_TOWER1);
+    control->set_stepsize(0.0f);
+    control->set_normal_stepsize(0.0f);
+    control->set_curdir(FACE_LEFT);
+    control->set_enddir(FACE_LEFT);
+    control->set_lastx(0.0f);
+    control->set_lasty(0.0f);
+    control->set_fire_frequency(5.0f);
+    control->set_ani_type(ANI_WALK);
+    control->set_cycle(0);
+    assign_direction_ani(control);
+    SimInputDebounce debounce{};
+
+    process_right(fx, control, debounce, /*press_fire=*/true);
+
+    ASSERT_EQ(80, control->xpos());
+    ASSERT_EQ(80, control->ypos());
+    ASSERT_EQ(FACE_RIGHT, control->curdir());
+    ASSERT_EQ(FACE_RIGHT, control->enddir());
+    ASSERT_EQ(1.0f, control->lastx());
+    ASSERT_EQ(0.0f, control->lasty());
+    ASSERT_EQ(ANI_ATTACK, control->ani_type());
+    ASSERT_EQ(1, control->cycle());
+    ASSERT_EQ(FACE_RIGHT, control->frame());
+    ASSERT_EQ(5.0f, control->busy());
+}
+
+TEST(SimInputUnit, modern_yell_breakaway_pushes_two_contacts_and_replaces_rally)
+{
+    SimInputFixture fx;
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    walker* control = add_control(fx);
+    walker* const left = add_living(fx, 1, 63, 80);
+    walker* const right = add_living(fx, 1, 97, 80);
+    walker* const ally = add_living(fx, 0, 160, 80);
+    left->set_curdir(FACE_UP);
+    left->set_enddir(FACE_UP);
+    right->set_curdir(FACE_UP);
+    right->set_enddir(FACE_UP);
+    SimInputDebounce debounce{};
+    const std::uint32_t rng_calls_before = fx.rng.calls;
+
+    const SimInputResult result = process_yell(fx, control, debounce);
+
+    ASSERT_EQ(rng_calls_before, fx.rng.calls);
+    ASSERT_EQ(SOUND_YO, result.play_sound);
+    ASSERT_EQ("Yo!", result.notify_text);
+    ASSERT_EQ(control, result.notify_source);
+    ASSERT_EQ(30, control->yo_delay());
+    ASSERT_EQ(og::sim::kBreakawayRecoveryTicks, control->busy());
+    ASSERT_EQ(63, left->xpos());
+    ASSERT_EQ(97, right->xpos());
+    ASSERT_EQ(FACE_LEFT, left->curdir());
+    ASSERT_EQ(FACE_LEFT, left->enddir());
+    ASSERT_EQ(-1.0f, left->lastx());
+    ASSERT_EQ(0.0f, left->lasty());
+    ASSERT_EQ(FACE_RIGHT, right->curdir());
+    ASSERT_EQ(FACE_RIGHT, right->enddir());
+    ASSERT_EQ(1.0f, right->lastx());
+    ASSERT_EQ(0.0f, right->lasty());
+    assert_forced_walk(left, og::sim::kBreakawayWalkTicks, -1, 0);
+    assert_forced_walk(right, og::sim::kBreakawayWalkTicks, 1, 0);
+    ASSERT_EQ(nullptr, ally->leader());
+    ASSERT_TRUE(ally->stats()->commands.empty());
+    ASSERT_EQ(2u, fx.events.size());
+    ASSERT_EQ(og::sim::EventKind::PlaySound, fx.events.events()[0].kind);
+    ASSERT_EQ(static_cast<std::uint32_t>(SOUND_YO),
+              fx.events.events()[0].a);
+    ASSERT_EQ(og::sim::EventKind::Notification,
+              fx.events.events()[1].kind);
+    ASSERT_EQ("Yo!", fx.events.events()[1].text);
+
+    // A repeated press inside the shared Yell cooldown cannot stack walks.
+    fx.events.clear();
+    const SimInputResult repeat = process_yell(fx, control, debounce);
+    ASSERT_EQ(-1, repeat.play_sound);
+    ASSERT_TRUE(repeat.notify_text.empty());
+    ASSERT_EQ(29, control->yo_delay());
+    ASSERT_EQ(0u, fx.events.size());
+    assert_forced_walk(left, og::sim::kBreakawayWalkTicks, -1, 0);
+    assert_forced_walk(right, og::sim::kBreakawayWalkTicks, 1, 0);
+
+    for (int tick = 0; tick < og::sim::kBreakawayWalkTicks; ++tick)
+    {
+        ASSERT_EQ(1, left->act());
+        ASSERT_EQ(1, right->act());
+    }
+    ASSERT_EQ(59, left->xpos());
+    ASSERT_EQ(101, right->xpos());
+    ASSERT_TRUE(left->stats()->commands.empty());
+    ASSERT_TRUE(right->stats()->commands.empty());
+}
+
+TEST(SimInputUnit, modern_yell_needs_two_contacts_and_classic_keeps_rally)
+{
+    {
+        SimInputFixture fx;
+        fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+        walker* control = add_control(fx);
+        walker* const only_foe = add_living(fx, 1, 63, 80);
+        walker* const ally = add_living(fx, 0, 160, 80);
+        only_foe->set_curdir(FACE_UP);
+        only_foe->set_enddir(FACE_UP);
+        SimInputDebounce debounce{};
+
+        process_yell(fx, control, debounce);
+
+        ASSERT_EQ(FACE_UP, only_foe->curdir());
+        ASSERT_EQ(FACE_UP, only_foe->enddir());
+        ASSERT_TRUE(only_foe->stats()->commands.empty());
+        ASSERT_EQ(control, ally->leader());
+        ASSERT_EQ(1u, ally->stats()->commands.size());
+        ASSERT_EQ(COMMAND_FOLLOW,
+                  ally->stats()->commands.front().commandtype);
+        ASSERT_EQ(100, ally->stats()->commands.front().commandcount);
+        ASSERT_EQ(0.0f, control->busy());
+    }
+
+    {
+        SimInputFixture fx;
+        fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
+        walker* control = add_control(fx);
+        walker* const left = add_living(fx, 1, 63, 80);
+        walker* const right = add_living(fx, 1, 97, 80);
+        walker* const ally = add_living(fx, 0, 160, 80);
+        left->set_curdir(FACE_UP);
+        left->set_enddir(FACE_UP);
+        right->set_curdir(FACE_DOWN);
+        right->set_enddir(FACE_DOWN);
+        SimInputDebounce debounce{};
+
+        process_yell(fx, control, debounce);
+
+        ASSERT_EQ(FACE_UP, left->curdir());
+        ASSERT_EQ(FACE_UP, left->enddir());
+        ASSERT_EQ(FACE_DOWN, right->curdir());
+        ASSERT_EQ(FACE_DOWN, right->enddir());
+        ASSERT_TRUE(left->stats()->commands.empty());
+        ASSERT_TRUE(right->stats()->commands.empty());
+        ASSERT_EQ(control, ally->leader());
+        ASSERT_EQ(COMMAND_FOLLOW,
+                  ally->stats()->commands.front().commandtype);
+        ASSERT_EQ(30, control->yo_delay());
+        ASSERT_EQ(0.0f, control->busy());
+    }
+}
+
+TEST(SimInputUnit, modern_yell_forced_walk_expires_against_an_obstacle)
+{
+    SimInputFixture fx;
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    walker* control = add_control(fx);
+    walker* const left = add_living(fx, 1, 63, 80);
+    walker* const right = add_living(fx, 1, 97, 80);
+    walker* const blocker =
+        add_nonliving(fx, Order::Generator, 1, 48, 80);
+    ASSERT_NE(nullptr, blocker);
+    assign_direction_ani(left);
+    left->set_ani_type(ANI_WALK);
+    left->set_cycle(1);
+    left->set_frame(FACE_UP);
+    SimInputDebounce debounce{};
+
+    process_yell(fx, control, debounce);
+    ASSERT_EQ(FACE_LEFT, left->frame());
+    ASSERT_EQ(1, left->cycle());
+    ASSERT_EQ(ANI_WALK, left->ani_type());
+    for (int tick = 0; tick < og::sim::kBreakawayWalkTicks; ++tick)
+    {
+        ASSERT_EQ(1, left->act());
+        ASSERT_EQ(1, right->act());
+    }
+
+    ASSERT_EQ(63, left->xpos());
+    ASSERT_EQ(FACE_LEFT, left->curdir());
+    ASSERT_EQ(ANI_WALK, left->ani_type());
+    ASSERT_EQ(101, right->xpos());
+    ASSERT_EQ(FACE_RIGHT, right->curdir());
+    ASSERT_TRUE(left->stats()->commands.empty());
+    ASSERT_TRUE(right->stats()->commands.empty());
+}
+
+TEST(SimInputUnit, modern_yell_filters_non_contacts_and_preserves_queue_tail)
+{
+    SimInputFixture fx;
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    walker* control = add_control(fx);
+    walker* const left = add_living(fx, 1, 63, 80);
+    walker* const right = add_living(fx, 1, 97, 80);
+    walker* const friendly = add_living(fx, 0, 80, 63);
+    walker* const other_floor = add_living(fx, 1, 80, 97, -1, 1);
+    walker* const dead = add_living(fx, 1, 80, 63);
+    walker* const dormant = add_living(fx, 1, 80, 97);
+    walker* const weapon = add_nonliving(fx, Order::Weapon, 1, 63, 80);
+    walker* const gap_two = add_living(fx, 1, 98, 80);
+    walker* const above = add_living(fx, 1, 80, 63);
+    walker* const stationary = add_living(fx, 1, 63, 80);
+    walker* const no_collide = add_living(fx, 1, 97, 80);
+    dead->set_dead(1);
+    dormant->set_dormant(true);
+    above->set_sizez(8);
+    above->set_worldz(16.0f);
+    stationary->set_order_family(Order::Living, FAMILY_TOWER1);
+    no_collide->stats()->set_bit_flags(BIT_NO_COLLIDE, 1);
+    control->set_sizez(8);
+    control->set_worldz(0.0f);
+    left->stats()->add_command(COMMAND_SEARCH, 7, 0, 0);
+    SimInputDebounce debounce{};
+
+    process_yell(fx, control, debounce);
+
+    assert_forced_walk(left, og::sim::kBreakawayWalkTicks, -1, 0, 2);
+    ASSERT_EQ(COMMAND_SEARCH, left->stats()->commands.back().commandtype);
+    ASSERT_EQ(7, left->stats()->commands.back().commandcount);
+    assert_forced_walk(right, og::sim::kBreakawayWalkTicks, 1, 0);
+    ASSERT_TRUE(friendly->stats()->commands.empty());
+    ASSERT_TRUE(other_floor->stats()->commands.empty());
+    ASSERT_TRUE(dead->stats()->commands.empty());
+    ASSERT_TRUE(dormant->stats()->commands.empty());
+    ASSERT_TRUE(weapon->stats()->commands.empty());
+    ASSERT_TRUE(gap_two->stats()->commands.empty());
+    ASSERT_TRUE(above->stats()->commands.empty());
+    ASSERT_TRUE(stationary->stats()->commands.empty());
+    ASSERT_TRUE(no_collide->stats()->commands.empty());
+}
+
+TEST(SimInputUnit, modern_yell_requires_actionable_control)
+{
+    for (int blocked_case = 0; blocked_case < 4; ++blocked_case)
+    {
+        SCOPED_TRACE(blocked_case);
+        SimInputFixture fx;
+        fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+        walker* control = add_control(fx);
+        walker* const left = add_living(fx, 1, 63, 80);
+        walker* const right = add_living(fx, 1, 97, 80);
+        switch (blocked_case)
+        {
+            case 0:
+                control->stats()->set_frozen_delay(2);
+                break;
+            case 1:
+                control->set_ani_type(ANI_ATTACK);
+                break;
+            case 2:
+                control->stats()->add_command(COMMAND_SEARCH, 5, 0, 0);
+                break;
+            case 3:
+                control->set_busy(2.0f);
+                break;
+            default:
+                FAIL() << "unexpected actionable-gate case";
+        }
+        SimInputDebounce debounce{};
+
+        process_yell(fx, control, debounce);
+
+        ASSERT_TRUE(left->stats()->commands.empty());
+        ASSERT_TRUE(right->stats()->commands.empty());
+        ASSERT_EQ(30, control->yo_delay());
+        if (blocked_case == 0)
+        {
+            ASSERT_EQ(1, control->stats()->frozen_delay());
+        }
+        if (blocked_case == 2)
+        {
+            ASSERT_EQ(1u, control->stats()->commands.size());
+            ASSERT_EQ(COMMAND_SEARCH,
+                      control->stats()->commands.front().commandtype);
+            ASSERT_EQ(5, control->stats()->commands.front().commandcount);
+        }
+        if (blocked_case == 3)
+        {
+            ASSERT_EQ(2.0f, control->busy());
+        }
+    }
+}
+
+TEST(SimInputUnit, modern_yell_coincident_fallback_is_stable)
+{
+    SimInputFixture fx;
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    walker* control = add_control(fx);
+    walker* const first = add_living(fx, 1, 80, 80);
+    walker* const second = add_living(fx, 1, 80, 80);
+    SimInputDebounce debounce{};
+
+    process_yell(fx, control, debounce);
+
+    // Control is oblist ordinal 0, so pre-id contacts use ordinals 1 and 2.
+    assert_forced_walk(first, og::sim::kBreakawayWalkTicks, 1, -1);
+    assert_forced_walk(second, og::sim::kBreakawayWalkTicks, 1, 0);
+    ASSERT_EQ(FACE_UP_RIGHT, first->curdir());
+    ASSERT_EQ(FACE_RIGHT, second->curdir());
+}
+
+} // namespace detail_modern_dynamics

--- a/tests/integration/test_sim_input_unit.cpp
+++ b/tests/integration/test_sim_input_unit.cpp
@@ -1332,22 +1332,47 @@ TEST(SimInputUnit, modern_yell_requires_actionable_control)
     }
 }
 
-TEST(SimInputUnit, modern_yell_coincident_fallback_is_stable)
+TEST(SimInputUnit, modern_yell_coincident_zero_id_uses_stable_ordinal_fallback)
 {
     SimInputFixture fx;
     fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
     walker* control = add_control(fx);
     walker* const first = add_living(fx, 1, 80, 80);
     walker* const second = add_living(fx, 1, 80, 80);
+    first->set_snapshot_entity_id(0);
+    second->set_snapshot_entity_id(0);
     SimInputDebounce debounce{};
 
     process_yell(fx, control, debounce);
 
-    // Control is oblist ordinal 0, so pre-id contacts use ordinals 1 and 2.
+    ASSERT_EQ(0u, first->entity_id());
+    ASSERT_EQ(0u, second->entity_id());
+    // Control is oblist ordinal 0, so zero-id contacts use ordinals 1 and 2.
     assert_forced_walk(first, og::sim::kBreakawayWalkTicks, 1, -1);
     assert_forced_walk(second, og::sim::kBreakawayWalkTicks, 1, 0);
     ASSERT_EQ(FACE_UP_RIGHT, first->curdir());
     ASSERT_EQ(FACE_RIGHT, second->curdir());
+}
+
+TEST(SimInputUnit, modern_yell_coincident_nonordinal_ids_map_stably)
+{
+    SimInputFixture fx;
+    fx.level.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    walker* control = add_control(fx);
+    walker* const first = add_living(fx, 1, 80, 80);
+    walker* const second = add_living(fx, 1, 80, 80);
+    first->set_snapshot_entity_id(8);
+    second->set_snapshot_entity_id(5);
+    SimInputDebounce debounce{};
+
+    process_yell(fx, control, debounce);
+
+    ASSERT_EQ(8u, first->entity_id());
+    ASSERT_EQ(5u, second->entity_id());
+    assert_forced_walk(first, og::sim::kBreakawayWalkTicks, -1, -1);
+    assert_forced_walk(second, og::sim::kBreakawayWalkTicks, 0, 1);
+    ASSERT_EQ(FACE_UP_LEFT, first->curdir());
+    ASSERT_EQ(FACE_DOWN, second->curdir());
 }
 
 } // namespace detail_modern_dynamics

--- a/tests/integration/test_snapshot_size_benchmark.cpp
+++ b/tests/integration/test_snapshot_size_benchmark.cpp
@@ -241,6 +241,7 @@ RecordedBenchmarkReplay record_benchmark_replay(screen& game_screen)
         .level_id = world.id,
         .player_count = static_cast<std::uint8_t>(game_screen.save_data.numplayers),
         .timer_wait = world.timer_wait,
+        .dynamics_ruleset = world.dynamics_ruleset,
         .my_team = game_screen.save_data.my_team,
         .allied_mode = game_screen.save_data.allied_mode,
         .difficulty = world.difficulty,
@@ -428,6 +429,7 @@ TEST(SnapshotSizeBenchmark,
     og::sim::ReplayIoError io_error = og::sim::ReplayIoError::None;
     ASSERT_TRUE(player.load_file(recorded.path, &io_error));
     ASSERT_EQ(og::sim::ReplayIoError::None, io_error);
+    EXPECT_EQ(world.dynamics_ruleset, player.header().dynamics_ruleset);
     ASSERT_EQ(static_cast<std::size_t>(kWarmupTicks + kCatchupDeltaTicks),
               player.frame_count());
 

--- a/tests/parity/parity_runner.cpp
+++ b/tests/parity/parity_runner.cpp
@@ -464,6 +464,9 @@ RunOutcome run_scenario(const ScenarioSpec& spec)
     out.loaded = level.load();
 
     GameWorld& world = level.world();
+    // Reference captures are always Gladiator/Classic behavior. Keep that
+    // contract explicit so frontend defaults can never change parity runs.
+    world.dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
     world.my_team = spec.player_team;
 
     if (spec.fresh_arena)

--- a/tests/parity/scenario_table.h
+++ b/tests/parity/scenario_table.h
@@ -1129,7 +1129,7 @@ inline constexpr Mutation kMut_smoke_inputs_no_move = {
 };
 
 inline constexpr Mutation kMut_smoke_tick_freeze = {
-    "src/gameplay/game_world.cpp", 1682,
+    "src/gameplay/game_world.cpp", 1683,
     "tick_count_++;",
     "tick_count_ += 0;",
     "Stops the per-tick world counter from advancing, freezing the schema-v1 tick field at 0. smoke_empty_scen99 flips TickReached(1) through --evaluate-facts because its Invariant gtest checks capture determinism; smoke_nonempty_scen99 flips TickReached(60) and its SemanticParity result."
@@ -1157,7 +1157,7 @@ inline constexpr Mutation kMut_exit_neuter = {
 };
 
 inline constexpr Mutation kMut_snapshot_dirty = {
-    "src/gameplay/game_world.cpp", 1680,
+    "src/gameplay/game_world.cpp", 1681,
     "level_done = 2;",
     "level_done = []{ static int _n = 0; return _n++; }();",
     "Uses a static-counter level_done assignment so successive run_scenario() captures differ. The value flows into the snapshot and breaks dual-capture byte equality, flipping the Invariant determinism check."
@@ -3235,7 +3235,7 @@ inline constexpr FactPredicate kFacts_event_set_end_emission_scen99[] = {
 };
 
 inline constexpr Mutation kMut_event_set_end_emission = {
-    "src/gameplay/game_world.cpp", 1803,
+    "src/gameplay/game_world.cpp", 1804,
     "level_done = 0;",
     "level_done = 2;",
     "Neuters the enemy-alive guard in GameWorld::tick's normal living-act loop (the branch that runs for awake enemies; the sibling guards cover dormant, frozen, and weapon walkers): instead of resetting level_done to 0 when a live non-friendly Living enemy acts, it forces level_done to stay 2. With enemies still alive the level_done==2 completion check latches game_ended and the server layer pushes EventKind::SetEnd, so the arena's set_end suppression is broken and the event sneaks through. (Re-anchored after the dormant-guard feature added an earlier textual twin the pin had silently drifted onto.)"

--- a/tests/unit/test_game_world_entity_ids.cpp
+++ b/tests/unit/test_game_world_entity_ids.cpp
@@ -523,10 +523,12 @@ TEST_F(GameWorldEntityIdsFixture, clear_resets_removed_entity_id_log_for_new_wor
 
     ASSERT_EQ(1, world.remove_ob(living));
     ASSERT_FALSE(world.removed_entity_ids().empty());
+    world.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
 
     world.clear();
 
     EXPECT_TRUE(world.removed_entity_ids().empty());
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic, world.dynamics_ruleset);
 }
 
 TEST_F(GameWorldEntityIdsFixture, empty_list_removals_and_self_move_are_noops)

--- a/tests/unit/test_headless_server_runtime.cpp
+++ b/tests/unit/test_headless_server_runtime.cpp
@@ -751,16 +751,20 @@ TEST_F(HeadlessServerRuntimeTest,
            "posture: byte-identical to Auto)";
 }
 
-// §3.4 dropped-field bug class: the server/checkpoint copies must carry the
-// GTL v14 company fields — the last-played timestamp explicitly, the per-guy
-// deploy flag via the guy deep copies. (The tower fields were the previous
-// instance of this bug class; the copy is an explicit field list, so every
-// new SaveData member needs a line there AND a pin here.)
-TEST(HeadlessServerSaveCopy, copy_carries_v14_company_fields)
+// Dropped-field bug class: the explicit server/checkpoint copy must carry
+// every session rule as well as the GTL v14 company fields. The last-played
+// timestamp is copied directly and each deploy flag rides its deep-copied guy;
+// every new SaveData member needs both a copy line and an exact pin here.
+TEST(HeadlessServerSaveCopy, copy_carries_company_and_session_fields)
 {
     SaveData source;
     source.last_played_unix_s = 0x0A0B0C0D0E0F1011LL;
     source.cross_control = 1; // session-only v8 setting must ride the copy
+    source.infinite_gold = 1;
+    source.respawn_mode = 3;
+    source.generator_rate = 200;
+    source.keep_fallen_heroes = 1;
+    source.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
     source.team_list[0] = std::make_unique<guy>(FAMILY_SOLDIER);
     source.team_list[0]->name = "BROUGHT";
     source.team_list[0]->deployed = true;
@@ -772,6 +776,11 @@ TEST(HeadlessServerSaveCopy, copy_carries_v14_company_fields)
     SaveData destination;
     destination.last_played_unix_s = 42; // must be overwritten, not merged
     destination.cross_control = 0;
+    destination.infinite_gold = 0;
+    destination.respawn_mode = 0;
+    destination.generator_rate = 0;
+    destination.keep_fallen_heroes = 0;
+    destination.dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
 
     og::server::copy_headless_server_save_data(destination, source);
 
@@ -779,6 +788,12 @@ TEST(HeadlessServerSaveCopy, copy_carries_v14_company_fields)
         << "timestamp must survive the server/checkpoint copy";
     EXPECT_EQ(1, (int)destination.cross_control)
         << "cross_control must survive the server/checkpoint copy";
+    EXPECT_EQ(1, (int)destination.infinite_gold);
+    EXPECT_EQ(3, (int)destination.respawn_mode);
+    EXPECT_EQ(200, (int)destination.generator_rate);
+    EXPECT_EQ(1, (int)destination.keep_fallen_heroes);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              destination.dynamics_ruleset);
     ASSERT_TRUE(destination.team_list[0] != nullptr);
     ASSERT_TRUE(destination.team_list[1] != nullptr);
     EXPECT_NE(destination.team_list[0].get(), source.team_list[0].get())

--- a/tests/unit/test_input_state_net.cpp
+++ b/tests/unit/test_input_state_net.cpp
@@ -130,7 +130,7 @@ TEST(InputStateNet, serialize_emits_expected_wire_format)
     input.quit_requested = true;
 
     constexpr std::array<std::uint8_t, og::sim::kSerializedInputStateSize> expected = {
-        0x0c, 0x02, 0x15, 0x00,
+        0x0d, 0x02, 0x15, 0x00,
         0x00, 0x00, 0x00, 0x00,
         0x01,
         0x01, 0x80, 0x01, 0x80,
@@ -146,7 +146,7 @@ TEST(InputStateNet, serialize_emits_expected_wire_format)
 TEST(InputStateNet, deserialize_reads_expected_wire_format)
 {
     constexpr std::array<std::uint8_t, og::sim::kSerializedInputStateSize> bytes = {
-        0x0c, 0x02, 0x15, 0x00,
+        0x0d, 0x02, 0x15, 0x00,
         0x00, 0x00, 0x00, 0x00,
         0x00,
         0x24, 0x00, 0x40, 0x02,

--- a/tests/unit/test_lobby_server.cpp
+++ b/tests/unit/test_lobby_server.cpp
@@ -1493,6 +1493,9 @@ TEST(LobbyServer, sanitize_difficulty_submenu_settings)
     EXPECT_EQ(0, server.state().settings.keep_fallen_heroes);
     EXPECT_EQ(0, server.state().settings.cross_control);
     EXPECT_EQ(0, server.state().settings.infinite_gold);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              server.state().settings.dynamics_ruleset)
+        << "fresh lobbies default to modern dynamics";
 
     // In-range values pass through and reach the game-start equivalent.
     og::sim::LobbySettings valid = make_ctf_lobby_settings();
@@ -1513,6 +1516,28 @@ TEST(LobbyServer, sanitize_difficulty_submenu_settings)
     EXPECT_EQ(1, server.build_save_data_equivalent().cross_control);
     EXPECT_EQ(1, server.state().settings.infinite_gold);
     EXPECT_EQ(1, server.build_save_data_equivalent().infinite_gold);
+
+    // Both dynamics rulesets are valid. A crafted enum value falls back to
+    // the last accepted host value and the game-start equivalent carries it.
+    og::sim::LobbySettings classic_dynamics = server.state().settings;
+    classic_dynamics.dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
+    transport.queue_lobby_message(
+        11u, make_settings_change_message(classic_dynamics));
+    server.poll_incoming_messages();
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              server.state().settings.dynamics_ruleset);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              server.build_save_data_equivalent().dynamics_ruleset);
+
+    og::sim::LobbySettings junk_dynamics = server.state().settings;
+    junk_dynamics.dynamics_ruleset =
+        static_cast<og::sim::DynamicsRuleset>(9);
+    transport.queue_lobby_message(
+        11u, make_settings_change_message(junk_dynamics));
+    server.poll_incoming_messages();
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              server.state().settings.dynamics_ruleset)
+        << "unknown wire values fall back to the accepted host ruleset";
 
     // respawn_mode outside {0,1,2,3} falls back to the current value.
     og::sim::LobbySettings junk_mode = make_ctf_lobby_settings();

--- a/tests/unit/test_menu_spec.cpp
+++ b/tests/unit/test_menu_spec.cpp
@@ -480,6 +480,7 @@ TEST(MenuSpec, difficulty_menu_model_labels_pin_the_default_screen)
         "Permadeath: On",
         "Generators: Normal",
         "Infinite Gold: Off",
+        "Modern Pace",
         "Back",
     };
     EXPECT_EQ(expected, labels);

--- a/tests/unit/test_mode_snapshot.cpp
+++ b/tests/unit/test_mode_snapshot.cpp
@@ -1,4 +1,5 @@
-// Mode snapshot replication (snapshot v10): capture/apply round trips, wire
+// Mode snapshot replication (snapshot v11; mode block introduced in v10):
+// capture/apply round trips, wire
 // serialization in keyframe and delta form, hostile-input count caps and
 // text-termination hardening, and the snapshot-restore equivalence proof
 // that the replicated RespawnState + ModeState blocks are the complete

--- a/tests/unit/test_net_transport.cpp
+++ b/tests/unit/test_net_transport.cpp
@@ -227,6 +227,8 @@ og::sim::LobbyState make_lobby_state_for_test()
     state.settings.infinite_gold = 1;
     // v12: versus-campaign shared-teams flag (the thirteenth i16).
     state.settings.shared_teams = 1;
+    // v13: host-authoritative gameplay dynamics byte.
+    state.settings.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
     state.host_player_id = 1u;
     state.last_start_denial =
         og::sim::start_denial_reason_value(
@@ -256,7 +258,7 @@ TEST(NetTransport, header_helpers_roundtrip_envelope)
     std::vector<std::uint8_t> bytes;
     og::sim::append_transport_header(bytes, og::sim::kHelloMessageType, 0x2211u);
 
-    const std::vector<std::uint8_t> expected = {0x0c, 0x01, 0x11, 0x22};
+    const std::vector<std::uint8_t> expected = {0x0d, 0x01, 0x11, 0x22};
     EXPECT_EQ(expected, bytes);
 
     og::sim::TransportEnvelope envelope;
@@ -315,6 +317,7 @@ TEST(NetTransport, initial_setup_full_roundtrip_and_decode_received_message)
     expected.my_team = 1;
     expected.allied_mode = 0;
     expected.respawn_mode = 3;
+    expected.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
     expected.current_scenario = 6;
     expected.guys.push_back(make_initial_setup_guy_for_test());
     expected.completed_levels = {1, 2, 3};
@@ -334,6 +337,30 @@ TEST(NetTransport, initial_setup_full_roundtrip_and_decode_received_message)
     EXPECT_EQ(og::sim::TypedReceivedMessageKind::InitialSetup, typed.kind);
     ASSERT_NE(nullptr, typed.initial_setup);
     EXPECT_EQ(expected, *typed.initial_setup);
+}
+
+TEST(NetTransport, dynamics_ruleset_wire_values_are_bounded)
+{
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              og::sim::dynamics_ruleset_from_value(0));
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              og::sim::dynamics_ruleset_from_value(1));
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              og::sim::dynamics_ruleset_from_value(2));
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              og::sim::dynamics_ruleset_from_value(
+                  0xff, og::sim::DynamicsRuleset::Modern));
+
+    auto bytes = og::sim::serialize_initial_setup_message(
+        og::sim::InitialSetupMessage{});
+    // Empty InitialSetup's appended dynamics byte directly precedes the guy
+    // count at offset 38 (including the four-byte transport header).
+    ASSERT_EQ(111u, bytes.size());
+    bytes[37] = 0xffu;
+    const auto decoded = og::sim::deserialize_initial_setup_message(bytes);
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              decoded->dynamics_ruleset);
 }
 
 TEST(NetTransport, lobby_message_variants_roundtrip_and_decode)
@@ -443,6 +470,48 @@ TEST(NetTransport, lobby_state_roundtrip_and_decode_received_message)
     EXPECT_EQ(expected, *typed.lobby_state);
 }
 
+TEST(NetTransport,
+     dynamics_ruleset_validation_distinguishes_requests_from_authority)
+{
+    og::sim::LobbySettings invalid_settings;
+    invalid_settings.dynamics_ruleset =
+        static_cast<og::sim::DynamicsRuleset>(0xffu);
+    const og::sim::LobbyMessage request{
+        .payload = og::sim::LobbySettingsChangeMessage{
+            .player_index = 1u,
+            .settings = std::move(invalid_settings),
+        },
+    };
+    const auto request_bytes = og::sim::serialize_lobby_message(request);
+    const auto decoded_request =
+        og::sim::deserialize_lobby_message(request_bytes);
+    ASSERT_TRUE(decoded_request.has_value());
+    const auto& settings_change =
+        std::get<og::sim::LobbySettingsChangeMessage>(
+            decoded_request->payload);
+    EXPECT_EQ(0xffu,
+              og::sim::dynamics_ruleset_value(
+                  settings_change.settings.dynamics_ruleset))
+        << "LobbyServer must receive the raw request value to apply its "
+           "current-setting fallback";
+
+    auto authoritative_bytes =
+        og::sim::serialize_lobby_state_message(og::sim::LobbyState{});
+    // Empty LobbyState wire layout (protocol v13): the dynamics byte is the
+    // last byte of the 32-byte settings payload, after the 4-byte envelope.
+    ASSERT_EQ(52u, authoritative_bytes.size());
+    ASSERT_EQ(0u, authoritative_bytes[35]);
+    authoritative_bytes[35] = 0xffu;
+    EXPECT_FALSE(
+        og::sim::deserialize_lobby_state_message(authoritative_bytes)
+            .has_value());
+    EXPECT_EQ(
+        og::sim::TypedReceivedMessageKind::Malformed,
+        og::sim::decode_received_message(
+            {.peer_id = 9u, .data = authoritative_bytes})
+            .kind);
+}
+
 TEST(NetTransport, lobby_remove_seat_rejects_truncated_stable_token)
 {
     og::sim::LobbyMessage message;
@@ -482,6 +551,9 @@ TEST(NetTransport, v8_deploy_company_cross_control_and_denial_fields_round_trip)
         << "protocol v11 appends infinite_gold after cross_control";
     EXPECT_EQ(1, decoded_state->settings.shared_teams)
         << "protocol v12 appends shared_teams after infinite_gold";
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              decoded_state->settings.dynamics_ruleset)
+        << "protocol v13 appends gameplay dynamics after shared_teams";
     EXPECT_EQ(og::sim::start_denial_reason_value(
                   og::sim::StartDenialReason::MachinesNotReady),
               decoded_state->last_start_denial);
@@ -980,8 +1052,8 @@ TEST(NetTransport, serialize_hello_emits_expected_wire_format)
 
     constexpr std::array<std::uint8_t, og::sim::kSerializedHelloMessageSize>
         expected = {
-            0x0c, 0x01, 0x17, 0x00,
-            0x0c, 0x0c, 0x03,
+            0x0d, 0x01, 0x17, 0x00,
+            0x0d, 0x0d, 0x03,
             0x00, 0x01, 0x02, 0x03,
             0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b,
@@ -1035,13 +1107,13 @@ TEST(NetTransport, deserialize_initial_setup_rejects_oversized_counts)
         og::sim::InitialSetupMessage{});
 
     auto oversized_guy_count = std::vector<std::uint8_t>(bytes.begin(), bytes.end());
-    write_u32_le(oversized_guy_count, 37, 0xffffffffu);
+    write_u32_le(oversized_guy_count, 38, 0xffffffffu);
     EXPECT_FALSE(
         og::sim::deserialize_initial_setup_message(oversized_guy_count)
             .has_value());
 
     auto oversized_level_count = std::vector<std::uint8_t>(bytes.begin(), bytes.end());
-    write_u32_le(oversized_level_count, 41, 0xffffffffu);
+    write_u32_le(oversized_level_count, 42, 0xffffffffu);
     EXPECT_FALSE(
         og::sim::deserialize_initial_setup_message(oversized_level_count)
             .has_value());
@@ -2225,6 +2297,7 @@ TEST(NetTransport, game_server_broadcast_current_state_uses_raw_fallback)
     fixture.world().tick_count_ = 3u;
     fixture.world().my_team = 2;
     fixture.world().current_palette_id = 1;
+    fixture.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
 
     server.broadcast_current_state(og::sim::SnapshotCaptureMode::Peek,
                                    og::sim::EventDeliveryMode::Skip);
@@ -2249,6 +2322,8 @@ TEST(NetTransport, game_server_broadcast_current_state_uses_raw_fallback)
     ASSERT_TRUE(initial_setup.has_value());
     EXPECT_EQ(2, initial_setup->my_team);
     EXPECT_EQ(fixture.world().id, initial_setup->level_id);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              initial_setup->dynamics_ruleset);
 
     ASSERT_TRUE(og::sim::decode_transport_envelope(
         transport.sent_messages()[1].data,
@@ -2737,11 +2812,11 @@ TEST(NetTransport, lobby_state_and_messages_roundtrip)
 TEST(NetTransport,
      deserialize_lobby_messages_rejects_unknown_kinds_and_oversized_counts)
 {
-    // Wire layout of an empty LobbyState (protocol v12): 4-byte transport
+    // Wire layout of an empty LobbyState (protocol v13): 4-byte transport
     // header, then the settings block (4-byte empty campaign string + 13 i16
-    // fields and the authored-team-mask u8 = 31 bytes), then the 1-byte host
+    // fields, authored-team-mask u8, and dynamics u8 = 32 bytes), then the 1-byte host
     // player id, 1-byte last_start_denial echo, and u32 request correlation —
-    // so player-count sits at offset 41. A trailing u8 local-seat-id count
+    // so player-count sits at offset 42. A trailing u8 local-seat-id count
     // follows the players, then a u32 recipient-specific Join acknowledgement
     // and a bool recipient-host flag.
     const auto empty_state_bytes =
@@ -2749,7 +2824,7 @@ TEST(NetTransport,
     auto oversized_player_count =
         std::vector<std::uint8_t>(empty_state_bytes.begin(),
                                   empty_state_bytes.end());
-    write_u32_le(oversized_player_count, 41, 0xffffffffu);
+    write_u32_le(oversized_player_count, 42, 0xffffffffu);
     EXPECT_FALSE(
         og::sim::deserialize_lobby_state_message(oversized_player_count)
             .has_value());
@@ -2802,9 +2877,9 @@ TEST(NetTransport,
                                   player_state_bytes.end());
     // First player record (v9): index u8 + seat-id u32 + machine-id u32 +
     // empty-name u32 + empty-company u32 + team i16 + ready/host bools =
-    // 21 bytes after the player-count u32 at 41 (v12 settings block), putting
-    // its slot-count u32 at 66.
-    write_u32_le(oversized_slot_count, 66, 0xffffffffu);
+    // 21 bytes after the player-count u32 at 42 (v13 settings block), putting
+    // its slot-count u32 at 67.
+    write_u32_le(oversized_slot_count, 67, 0xffffffffu);
     EXPECT_FALSE(
         og::sim::deserialize_lobby_state_message(oversized_slot_count)
             .has_value());
@@ -2827,6 +2902,7 @@ TEST(NetTransport, game_client_dispatches_callbacks_for_runtime_state)
     ASSERT_NE(nullptr, second);
     first->setxy(32, 32);
     second->setxy(48, 48);
+    fixture.world().dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
 
     og::sim::InitialSetupMessage initial_setup;
     initial_setup.level_id = fixture.world().id;
@@ -2839,6 +2915,7 @@ TEST(NetTransport, game_client_dispatches_callbacks_for_runtime_state)
     initial_setup.pixmaxy = fixture.world().pixmaxy;
     initial_setup.my_team = fixture.world().my_team;
     initial_setup.allied_mode = fixture.world().allied_mode;
+    initial_setup.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
     initial_setup.current_scenario = fixture.world().current_scenario;
     initial_setup.controlled_entity_ids = {
         first->entity_id(), 0u, 0u, 0u};
@@ -2898,6 +2975,7 @@ TEST(NetTransport, game_client_dispatches_callbacks_for_runtime_state)
 
     og::sim::GameClient client(transport, 7u, &fixture.world());
     std::vector<bool> initial_setup_transition_flags;
+    std::vector<og::sim::DynamicsRuleset> initial_setup_applied_rulesets;
     std::vector<std::uint32_t> mapped_entity_ids;
     std::vector<std::uint32_t> resolved_entity_ids;
     std::vector<std::uint8_t> synced_palette_ids;
@@ -2909,6 +2987,8 @@ TEST(NetTransport, game_client_dispatches_callbacks_for_runtime_state)
     client.set_initial_setup_callback(
         [&](const og::sim::InitialSetupMessage&, bool is_level_transition) {
             initial_setup_transition_flags.push_back(is_level_transition);
+            initial_setup_applied_rulesets.push_back(
+                fixture.world().dynamics_ruleset);
         });
     client.set_control_mapping_callback(
         [&](const og::sim::ControlledEntityIds& controlled_entity_ids,
@@ -2946,7 +3026,13 @@ TEST(NetTransport, game_client_dispatches_callbacks_for_runtime_state)
 
     ASSERT_TRUE(client.baseline().has_value());
     EXPECT_EQ(1u, client.baseline()->tick_count);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              fixture.world().dynamics_ruleset);
     ASSERT_EQ((std::vector<bool>{false}), initial_setup_transition_flags);
+    ASSERT_EQ((std::vector<og::sim::DynamicsRuleset>{
+                  og::sim::DynamicsRuleset::Modern}),
+              initial_setup_applied_rulesets)
+        << "InitialSetup must install dynamics before its callback and snapshot";
     ASSERT_GE(mapped_entity_ids.size(), 2u);
     EXPECT_EQ(second->entity_id(), mapped_entity_ids.back());
     EXPECT_EQ(second->entity_id(), resolved_entity_ids.back());

--- a/tests/unit/test_picker_common.cpp
+++ b/tests/unit/test_picker_common.cpp
@@ -1627,6 +1627,7 @@ TEST(PickerCommon, reset_for_new_game_sets_gold)
     SaveData save;
     save.totalcash = 0;
     save.m_totalcash[0] = 0;
+    save.dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
 
     og::ui::reset_for_new_game(save);
 
@@ -1634,6 +1635,10 @@ TEST(PickerCommon, reset_for_new_game_sets_gold)
     ASSERT_TRUE(save.m_totalcash[0] == 5000);
     // totalcash is now also set by reset_for_new_game
     ASSERT_TRUE(save.totalcash == og::ui::kNewGameStartingGold);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern, save.dynamics_ruleset);
+
+    og::ui::reset_for_new_game(save, og::sim::DynamicsRuleset::Classic);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic, save.dynamics_ruleset);
 }
 
 // --- CTF scenario-troops toggle & label ---
@@ -2689,6 +2694,35 @@ TEST(PickerCommon, format_infinite_gold_label)
     EXPECT_LE(og::ui::format_infinite_gold_label(save).size(), 23u);
 }
 
+TEST(PickerCommon, toggle_dynamics_ruleset_round_trips_and_normalizes)
+{
+    SaveData save;
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern, save.dynamics_ruleset)
+        << "fresh frontend carriers default to Modern";
+
+    og::ui::toggle_dynamics_ruleset(save);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic, save.dynamics_ruleset);
+    og::ui::toggle_dynamics_ruleset(save);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern, save.dynamics_ruleset);
+
+    save.dynamics_ruleset = static_cast<og::sim::DynamicsRuleset>(9);
+    og::ui::toggle_dynamics_ruleset(save);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern, save.dynamics_ruleset)
+        << "an invalid carrier value normalizes to the fresh-session default";
+}
+
+TEST(PickerCommon, format_dynamics_ruleset_label_is_exact_and_compact)
+{
+    SaveData save;
+    save.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    EXPECT_EQ("Modern Pace", og::ui::format_dynamics_ruleset_label(save));
+    EXPECT_EQ(11u, og::ui::format_dynamics_ruleset_label(save).size());
+
+    save.dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
+    EXPECT_EQ("Classic Pace", og::ui::format_dynamics_ruleset_label(save));
+    EXPECT_EQ(12u, og::ui::format_dynamics_ruleset_label(save).size());
+}
+
 TEST(PickerCommon, can_afford_and_format_wallet_amount)
 {
     SaveData save;
@@ -2850,6 +2884,13 @@ TEST(PickerCommon, difficulty_submenu_labels_fit_140px_rows)
     {
         save.infinite_gold = gold;
         labels.push_back(og::ui::format_infinite_gold_label(save));
+    }
+    for (og::sim::DynamicsRuleset ruleset :
+         {og::sim::DynamicsRuleset::Classic,
+          og::sim::DynamicsRuleset::Modern})
+    {
+        save.dynamics_ruleset = ruleset;
+        labels.push_back(og::ui::format_dynamics_ruleset_label(save));
     }
     for (int difficulty : {0, 1, 2})
         labels.push_back(og::ui::format_difficulty_label(difficulty));

--- a/tests/unit/test_platform_headless.cpp
+++ b/tests/unit/test_platform_headless.cpp
@@ -913,7 +913,7 @@ TEST(PlatformHeadless, text_picker_drives_menu_options_team_and_campaign_paths)
     // (1=set_campaign, 2=set_level, 3=view_scenario, 4=matchup, 5=progress,
     // 6=troops, 7=back). Main 3=difficulty opens the DIFFICULTY submenu
     // (1=difficulty, 2=respawns, 3=respawn delay, 4=permadeath,
-    // 5=generators, 6=infinite gold, 7=back).
+    // 5=generators, 6=infinite gold, 7=dynamics, 8=back).
     const std::string input =
         "bad\r\n"   // main: invalid choice; terminal CR is trimmed
         "3\n"       // main: difficulty -> DIFFICULTY submenu
@@ -924,7 +924,9 @@ TEST(PlatformHeadless, text_picker_drives_menu_options_team_and_campaign_paths)
         "5\n"       // difficulty: cycle generators
         "6\n"       // difficulty: toggle infinite gold
         "6\n"       // difficulty: toggle infinite gold back off
-        "7\n"       // difficulty: back -> main
+        "7\n"       // difficulty: toggle dynamics
+        "7\n"       // difficulty: toggle dynamics back
+        "8\n"       // difficulty: back -> main
         "4\n"       // main: level edit (unavailable)
         "5\n"       // main: options
         "newslot\n"

--- a/tests/unit/test_replay.cpp
+++ b/tests/unit/test_replay.cpp
@@ -165,12 +165,14 @@ TEST(Replay, file_roundtrip_preserves_header_and_frames)
         .level_id = 42,
         .player_count = 2,
         .timer_wait = 7,
+        .dynamics_ruleset = og::sim::DynamicsRuleset::Modern,
         .my_team = 3,
         .allied_mode = 1,
         .difficulty = 125,
         .campaign_id = "gladiator",
     };
-    const og::sim::WorldSnapshot initial_snapshot = make_initial_snapshot();
+    og::sim::WorldSnapshot initial_snapshot = make_initial_snapshot();
+    initial_snapshot.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
 
     og::sim::ReplayRecorder recorder(header);
     recorder.set_initial_snapshot(initial_snapshot);
@@ -195,6 +197,7 @@ TEST(Replay, file_roundtrip_preserves_header_and_frames)
     EXPECT_EQ(header.level_id, player.header().level_id);
     EXPECT_EQ(header.player_count, player.header().player_count);
     EXPECT_EQ(header.timer_wait, player.header().timer_wait);
+    EXPECT_EQ(header.dynamics_ruleset, player.header().dynamics_ruleset);
     EXPECT_EQ(header.my_team, player.header().my_team);
     EXPECT_EQ(header.allied_mode, player.header().allied_mode);
     EXPECT_EQ(header.difficulty, player.header().difficulty);
@@ -326,6 +329,18 @@ TEST(Replay, deserialize_rejects_each_malformed_replay_section)
         0u);
     expect_rejection(short_header, og::sim::ReplayIoError::InvalidHeader);
 
+    auto invalid_dynamics = bytes;
+    invalid_dynamics[7] = 0xffu;
+    expect_rejection(invalid_dynamics,
+                     og::sim::ReplayIoError::InvalidHeader);
+
+    auto mismatched_dynamics = bytes;
+    ASSERT_EQ(0u, mismatched_dynamics[7]);
+    mismatched_dynamics[7] =
+        og::sim::dynamics_ruleset_value(og::sim::DynamicsRuleset::Modern);
+    expect_rejection(mismatched_dynamics,
+                     og::sim::ReplayIoError::MalformedData);
+
     auto too_many_players = bytes;
     too_many_players[5] = static_cast<std::uint8_t>(MAX_PLAYERS + 1);
     expect_rejection(too_many_players, og::sim::ReplayIoError::MalformedData);
@@ -396,6 +411,28 @@ TEST(Replay, recorder_write_file_requires_self_contained_bootstrap_data)
 
     EXPECT_FALSE(missing_snapshot.write_file(path, &io_error));
     EXPECT_EQ(og::sim::ReplayIoError::MalformedData, io_error);
+
+    og::sim::ReplayRecorder invalid_dynamics({
+        .version = og::sim::kReplayFormatVersion,
+        .player_count = 1,
+        .dynamics_ruleset =
+            static_cast<og::sim::DynamicsRuleset>(0xffu),
+        .campaign_id = "gladiator",
+    });
+    invalid_dynamics.set_initial_snapshot(make_initial_snapshot());
+    EXPECT_FALSE(invalid_dynamics.write_file(path, &io_error));
+    EXPECT_EQ(og::sim::ReplayIoError::InvalidHeader, io_error);
+
+    og::sim::ReplayRecorder mismatched_dynamics({
+        .version = og::sim::kReplayFormatVersion,
+        .player_count = 1,
+        .dynamics_ruleset = og::sim::DynamicsRuleset::Modern,
+        .campaign_id = "gladiator",
+    });
+    mismatched_dynamics.set_initial_snapshot(make_initial_snapshot());
+    EXPECT_FALSE(mismatched_dynamics.write_file(path, &io_error));
+    EXPECT_EQ(og::sim::ReplayIoError::MalformedData, io_error);
+    EXPECT_FALSE(std::filesystem::exists(path));
 }
 
 TEST(Replay, find_first_snapshot_difference_reports_nested_field)
@@ -473,6 +510,13 @@ TEST(Replay, snapshot_difference_formats_all_field_value_kinds)
         expected.current_palette_id = 2u;
         actual.current_palette_id = 9u;
         expect_diff(expected, actual, "current_palette_id", "2", "9");
+    }
+
+    {
+        og::sim::WorldSnapshot expected;
+        og::sim::WorldSnapshot actual = expected;
+        actual.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+        expect_diff(expected, actual, "dynamics_ruleset", "0", "1");
     }
 
     {

--- a/tests/unit/test_session_raii.cpp
+++ b/tests/unit/test_session_raii.cpp
@@ -2,6 +2,7 @@
 
 #include <openglad/resources/gparser.h> // cfg
 #include <openglad/legacy/base.h> // myscreen
+#include <openglad/interface/screen.h>
 #include <openglad/interface/render/view.h> // theprefs
 
 #include <algorithm>
@@ -12,6 +13,29 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+
+namespace {
+
+class ScopedCfgMaps
+{
+public:
+    ScopedCfgMaps()
+        : data_(cfg.data), overrides_(cfg.overrides)
+    {
+    }
+
+    ~ScopedCfgMaps()
+    {
+        cfg.data = std::move(data_);
+        cfg.overrides = std::move(overrides_);
+    }
+
+private:
+    decltype(cfg.data) data_;
+    decltype(cfg.overrides) overrides_;
+};
+
+} // namespace
 
 TEST(SessionRaii, game_session_headless_restores_legacy_globals)
 {
@@ -142,6 +166,27 @@ TEST(SessionRaii, game_session_cfg_accessible)
     // Verify the global cfg_store is always accessible (no session indirection needed).
     // cfg is a global object declared in gparser.h.
     (void)cfg; // Just verify it's accessible
+}
+
+TEST(SessionRaii, game_session_seeds_save_and_world_from_dynamics_preference)
+{
+    ScopedCfgMaps restore_cfg;
+    cfg.overrides["gameplay"].erase("dynamics");
+
+    og::runtime::GameSession::Config session_cfg;
+    session_cfg.create_display = false;
+    session_cfg.install_legacy_globals = false;
+
+    for (const og::sim::DynamicsRuleset expected : {
+             og::sim::DynamicsRuleset::Classic,
+             og::sim::DynamicsRuleset::Modern})
+    {
+        cfg.set_dynamics_ruleset_preference(expected);
+        og::runtime::GameSession session(session_cfg);
+        ASSERT_NE(nullptr, session.myscreen_);
+        EXPECT_EQ(expected, session.myscreen_->save_data.dynamics_ruleset);
+        EXPECT_EQ(expected, session.myscreen_->world().dynamics_ruleset);
+    }
 }
 
 TEST(SessionRaii, session_accessors_and_base_transport_state_report_owned_values)

--- a/tests/unit/test_world_snapshot.cpp
+++ b/tests/unit/test_world_snapshot.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <limits>
 #include <list>
 #include <span>
 #include <type_traits>
@@ -589,6 +590,7 @@ void expect_world_snapshot_eq(const og::sim::WorldSnapshot& expected,
     EXPECT_EQ(expected.generator_rate, actual.generator_rate);
     EXPECT_EQ(expected.control_policy, actual.control_policy);
     EXPECT_EQ(expected.player_machine, actual.player_machine);
+    EXPECT_EQ(expected.dynamics_ruleset, actual.dynamics_ruleset);
     EXPECT_EQ(expected.grid_width, actual.grid_width);
     EXPECT_EQ(expected.grid_height, actual.grid_height);
     EXPECT_EQ(expected.grid_dirty, actual.grid_dirty);
@@ -2410,11 +2412,11 @@ TEST(WorldSnapshot, deserialize_snapshot_and_delta_reject_oversized_payloads_and
         decode_delta_payload_for_test(delta_bytes);
 
     // Offset of grid.full_grid_size in a default delta payload: format byte +
-    // 514 bytes of world state (72 pre-block scalars, the v10 respawn block
+    // 515 bytes of world state (72 pre-block scalars, the v10 respawn block
     // at its empty size 9, the fixed 404-byte mode block, the 8 match-knob
     // bytes, and the trailing respawn_mode/generator_rate/control_policy/
-    // player_machine 21) + 4 grid bytes.
-    constexpr std::size_t kEntityCountOffset = 519;
+    // player_machine/dynamics 22) + 4 grid bytes.
+    constexpr std::size_t kEntityCountOffset = 520;
     ASSERT_GE(raw_payload.size(), kEntityCountOffset + sizeof(std::uint32_t));
     raw_payload[kEntityCountOffset + 0] = 0xffu;
     raw_payload[kEntityCountOffset + 1] = 0xffu;
@@ -3205,6 +3207,7 @@ TEST(WorldSnapshot, control_policy_and_player_machine_map_round_trip_to_mirror)
     fill_world_grid(source, PIX_GRASS1);
 
     source.control_policy = 1;
+    source.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
     // Machine 0 deployed (bit7 set over id 0), machine 3 not deployed, the
     // rest unbound (0xff sentinel). The default map is all-0xff.
     source.player_machine[0] = 0x80; // deployed machine, id 0
@@ -3214,6 +3217,8 @@ TEST(WorldSnapshot, control_policy_and_player_machine_map_round_trip_to_mirror)
     const og::sim::WorldSnapshot keyframe =
         og::sim::capture_keyframe_snapshot(source);
     EXPECT_EQ(1, keyframe.control_policy);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              keyframe.dynamics_ruleset);
     EXPECT_EQ(0x80, keyframe.player_machine[0]);
     EXPECT_EQ(0x83, keyframe.player_machine[1]);
     EXPECT_EQ(0x03, keyframe.player_machine[2]);
@@ -3222,24 +3227,89 @@ TEST(WorldSnapshot, control_policy_and_player_machine_map_round_trip_to_mirror)
     const std::vector<std::uint8_t> bytes = og::sim::serialize_snapshot(keyframe);
     const og::sim::WorldSnapshot decoded = og::sim::deserialize_snapshot(bytes);
     EXPECT_EQ(1, decoded.control_policy);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              decoded.dynamics_ruleset);
     EXPECT_EQ(source.player_machine, decoded.player_machine);
 
     TestGameWorld mirror_fx;
     GameWorld& mirror = mirror_fx.world();
     configure_snapshot_test_services(mirror);
     ASSERT_EQ(0, mirror.control_policy);
+    ASSERT_EQ(og::sim::DynamicsRuleset::Classic,
+              mirror.dynamics_ruleset);
     ASSERT_EQ(0xff, mirror.player_machine[0]);
     og::sim::apply_snapshot(mirror, decoded);
     EXPECT_EQ(1, mirror.control_policy)
         << "control_policy must reach the mirror world through apply";
     EXPECT_EQ(source.player_machine, mirror.player_machine)
         << "player_machine map must reach the mirror world through apply";
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              mirror.dynamics_ruleset)
+        << "the host-authoritative dynamics ruleset must reach the mirror";
 
     // Delta merge carries both fields onto a stale baseline.
     og::sim::WorldSnapshot baseline;
     og::sim::apply_delta(baseline, decoded);
     EXPECT_EQ(1, baseline.control_policy);
     EXPECT_EQ(source.player_machine, baseline.player_machine);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Modern,
+              baseline.dynamics_ruleset);
+
+    og::sim::WorldSnapshot classic = decoded;
+    classic.dynamics_ruleset = og::sim::DynamicsRuleset::Classic;
+    EXPECT_NE(og::sim::compute_snapshot_hash(classic),
+              og::sim::compute_snapshot_hash(decoded))
+        << "ruleset changes must participate in deterministic hash checks";
+
+    og::sim::WorldSnapshot invalid_delta;
+    invalid_delta.dynamics_ruleset =
+        static_cast<og::sim::DynamicsRuleset>(0xff);
+    baseline.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    og::sim::apply_delta(baseline, invalid_delta);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              baseline.dynamics_ruleset)
+        << "direct delta DTOs must not install unknown enum values";
+}
+
+TEST(WorldSnapshot, serialized_delta_normalizes_invalid_dynamics_ruleset)
+{
+    og::sim::WorldSnapshot delta;
+    delta.dynamics_ruleset = og::sim::DynamicsRuleset::Modern;
+    const std::vector<std::uint8_t> encoded =
+        og::sim::serialize_delta(delta);
+    std::vector<std::uint8_t> raw_payload =
+        decode_delta_payload_for_test(encoded);
+
+    // Snapshot v11's default delta payload is the format byte, 515-byte
+    // world-state block, 12-byte empty grid block, and four empty u32 list
+    // counts. Dynamics is the final world-state byte at raw offset 515.
+    constexpr std::size_t kDynamicsRulesetOffset = 515u;
+    ASSERT_EQ(544u, raw_payload.size());
+    ASSERT_EQ(og::sim::kSnapshotFormatVersion, raw_payload[0]);
+    ASSERT_EQ(
+        og::sim::dynamics_ruleset_value(og::sim::DynamicsRuleset::Modern),
+        raw_payload[kDynamicsRulesetOffset]);
+    raw_payload[kDynamicsRulesetOffset] = 0xffu;
+
+    const std::size_t framed_payload_size =
+        og::sim::kDeltaPayloadHeaderSize + raw_payload.size();
+    ASSERT_LE(framed_payload_size,
+              static_cast<std::size_t>(
+                  std::numeric_limits<std::uint16_t>::max()));
+    std::vector<std::uint8_t> malformed;
+    og::sim::append_transport_header(
+        malformed,
+        og::sim::kDeltaSnapshotMessageType,
+        static_cast<std::uint16_t>(framed_payload_size));
+    malformed.push_back(og::sim::kDeltaPayloadUncompressedFlag);
+    malformed.insert(malformed.end(),
+                     raw_payload.begin(),
+                     raw_payload.end());
+
+    const og::sim::WorldSnapshot decoded =
+        og::sim::deserialize_delta(malformed);
+    EXPECT_EQ(og::sim::DynamicsRuleset::Classic,
+              decoded.dynamics_ruleset);
 }
 
 // Level-entry spawn points ride the entity snapshot: recorded values must

--- a/tests/unit/test_world_snapshot_coverage.cpp
+++ b/tests/unit/test_world_snapshot_coverage.cpp
@@ -25,13 +25,13 @@
 namespace
 {
 
-// Snapshot v10: one format byte followed by 514 bytes of fixed/default world
+// Snapshot v11: one format byte followed by 515 bytes of fixed/default world
 // state before the grid block (72 pre-block scalars + the empty respawn
-// block 9 + the fixed mode block 404 + 8 match-knob bytes + 21 trailing
-// scalar/player_machine bytes). Keeping this wire pin explicit makes
+// block 9 + the fixed mode block 404 + 8 match-knob bytes + 22 trailing
+// scalar/player_machine/dynamics bytes). Keeping this wire pin explicit makes
 // malformed payload tests fail loudly when the format is deliberately
 // revised.
-constexpr std::size_t kSerializedWorldStateBytes = 514;
+constexpr std::size_t kSerializedWorldStateBytes = 515;
 constexpr std::size_t kGridOffset = 1 + kSerializedWorldStateBytes;
 constexpr std::size_t kGridDirtyOffset = kGridOffset + 2;
 constexpr std::size_t kGridFullResendOffset = kGridOffset + 3;

--- a/tests/unit/unit_main.cpp
+++ b/tests/unit/unit_main.cpp
@@ -163,6 +163,12 @@ int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
 
+    // Some unit tests construct a real screen, whose sound object opens an
+    // SDL audio device.  Keep that path deterministic on headless runners:
+    // the legacy sound setup exits successfully when no device is available,
+    // which would otherwise make CTest mistake a truncated suite for a pass.
+    setenv("SDL_AUDIODRIVER", "dummy", 1);
+
     const auto test_config_dir = std::filesystem::temp_directory_path() /
         ("openglad_test_" + std::to_string(getpid()));
     std::filesystem::create_directories(test_config_dir);


### PR DESCRIPTION
Closes #205.

## What changed

- Added a host-authoritative Classic/Modern gameplay setting. Fresh sessions default to Modern; Classic remains available from Main Menu > Difficulty and preserves Gladiator timing.
- Modern movement resolves player facing before movement, firing, and specials, so a direction change can move on the same simulation tick.
- Modern unshifted Yell becomes a contextual breakaway when at least two eligible hostile bodies are in contact. Targets snap outward immediately, then receive four deterministic forced walk ticks; those ticks start already facing outward instead of being spent turning.
- Carried the setting through SDL, curses, text, lobby/start handoff, local/headless server copies, snapshots, and replays. Company GTL files remain byte-identical because this is a session preference.
- Bumped network protocol to 13, snapshot format to 11, and replay format to 15. Classic parity remains explicitly pinned and no reference golden changed.

## Playtest

1. Open Main Menu > Difficulty and leave Modern Pace selected.
2. Reverse direction while moving and try direction + Fire/Special on the same press.
3. Let two or more enemies crowd against you, then press unshifted Yell. They should face away immediately and walk outward for four ticks without a turn-in-place delay.
4. Switch to Classic Pace and compare: movement keeps the original stop-to-turn cadence and Yell keeps its original ally-rally behavior.
5. If possible, verify host/join play: only the host can change Pace, and every peer should use the selected setting.

## Verification

- cmake --build --preset ci-test
- ctest --preset ci-test --output-on-failure: 59/59 targets passed, including native, parity, curses/text/headless, networking, and Emscripten (699.89 s)
- og_unit_sim: 703 tests run, 702 passed, 1 expected live-relay skip
- Dedicated menu capture passed; Classic Pace and Modern Pace frames were inspected for fit, alignment, and navigation
- Mutation canaries: 217/217 anchored
- Heritage comment audit: 47 unique deleted comment lines checked, zero pre-2020 losses
