### PR TITLE
Persist machine-local session knowledge into repo skills

### DIFF
--- a/.claude/skills/openglad-campaign-design/SKILL.md
+++ b/.claude/skills/openglad-campaign-design/SKILL.md
@@ -107,6 +107,20 @@ routing. Consequences for every level layout:
   engine's own act_guard sight test then re-wakes them honestly).
 - Every AI unit follows these rules regardless of origin — placed,
   generator-spawned, or script-converted.
+- Moat/water-ring maps: any roamer whose straight line to the crew
+  crosses the water jitters in place at the edge. On such maps every
+  placed foe must be a posted guard (ambush wake); roamers only where
+  chase ground is open. Gates through wall rings must be ≥3 tiles wide
+  — the beeline AI funnels by wall-sliding and 2-wide mouths stall
+  unattended runs.
+- Teleport-strand rule: NO standable ground across open water anywhere
+  a level has teleporting families (mage/skeleton placed OR
+  generator-spawned) — a boss teleporting onto a decorative islet
+  softlocks kill-all missions. Decorative islets are TREE atolls;
+  bosses that must stay put carry specials_disabled.
+- Diagnosis tool: the `openglad_text` protocol `state` command dumps
+  live entity positions — the fastest way to find a stranded or wedged
+  unit in an unattended run.
 
 Every level whose layout puts ANY blocker between opposing forces must
 ship an unattended-sim stationarity test: run the level headless for
@@ -128,6 +142,44 @@ test per path proven red on a broken tree before the rule ships. A rule
 proven on one construction path and assumed for the rest is the
 standard way levels ship invisible statues, dead triggers, and
 unreachable objectives.
+
+## Palette, art, and font rules
+
+- Palette indices 208–231 are do_cycle-ROTATED every frame (water bands
+  + the fire ramp starting at COLOR_FIRE=224). Static art or effect
+  colors in that range STROBE in-game while headless render tests stay
+  blind (they never run do_cycle). Indices 232–239 are a STATIC copy of
+  the fire ramp — use those for stable warm colors, and pin new effect
+  colors with a test that runs do_cycle in-test.
+- Any `our_palette.cpp` change re-embeds into every generated campaign's
+  PNGs: CI's Campaign Regeneration Drift check regenerates ALL generated
+  campaigns, so run every `scripts/generate_*_campaign.sh` and commit
+  the binary PNG churn, or CI reds. The sprite loader's PLTE contract
+  (og_file.cpp) rejects PNGs whose palette mismatches our_pal_lookup at
+  any entry outside the synthesized-ramp exemption band — don't widen
+  the exemption casually.
+- The bitmap font (pix/text.png) has glyphs 0..124 only, and '&' and '|'
+  are BLANK — briefings and HUD lines using them render holes (use
+  "and", dashes). The apostrophe exists. Budget labels against the
+  actual glyph set, not ASCII.
+
+## Bootstrapping a NEW builtin campaign (the pin list)
+
+- Chicken-and-egg: adding the id to OG_BUILTIN_CAMPAIGN_IDS makes the
+  build compose the tree BEFORE the generator ever ran → "no members
+  collected". Seed a placeholder campaign.yaml once; the generator
+  overwrites the tree.
+- The full registration list (all needed, none optional):
+  OG_BUILTIN_CAMPAIGN_IDS in CMakeLists, the campaign-drift workflow's
+  generator list in .github/workflows/test.yml, test_builtin_archives
+  campaign_ids, picker_common kShelf + its test lists, and the
+  og_add_unit_group registration for the campaign's test file.
+- A 1-level (or newest-level) campaign needs a loop-home exit: no-exit
+  auto-advance targets id+1, which must exist.
+- Generators run FROM REPO ROOT (relative staging paths), and mapgens
+  must build on the shared og::mapgen library — no private helper
+  clones. `og::mapgen::place_living` takes an EXPLICIT hold_post bool;
+  team number never implies guard policy.
 
 ## Story rules (the "story bible" discipline)
 

--- a/.claude/skills/openglad-dev-environment/SKILL.md
+++ b/.claude/skills/openglad-dev-environment/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: openglad-dev-environment
+description: Local development environment for OpenGlad — the nix flake, local-vs-CI configuration divergence, accepted local test failures and standing rulings, git hygiene traps, agent-orchestration traps, and setting up a fresh machine. Use whenever a local test result disagrees with CI, a tool seems missing, a full local ctest run has unexplained reds, worktrees or subagents produce surprising state, or development moves to a new machine.
+---
+
+# OpenGlad dev environment
+
+AGENTS.md is the base contract: everything builds inside `nix develop`,
+tools come from `flake.nix` (add missing ones there — never hand-roll a
+utility a package provides, never apt/snap-install, never source
+~/emsdk), presets only, no in-source configure. This file covers what
+AGENTS.md doesn't: divergence, accepted failures, and traps.
+
+## Local green is not CI green (four known divergences)
+
+1. **VALIDATE_SERIALIZATION=ON** is set in CI's test/drift/asan/tsan
+   lanes and the ci-asan cache, OFF in a default local ci-test build. It
+   round-trips every typed in-process message requiring equality —
+   asymmetric (de)serialization passes locally, fails CI
+   deterministically. Reproduce with the flag or the ci-asan preset.
+2. **The TSan lane compiles with clang -Werror** (incl.
+   tautological-compare); ci-test is GCC and misses that class. Sweep
+   new wire/guard code with clang syntax-only.
+3. **The Campaign Regeneration Drift job builds all standalone tools
+   fresh** (the mapgens + grid_migrate compile headless TUs directly);
+   local ctest never links them. After moving/splitting any
+   headless-shared TU, build the tools locally.
+4. **CI coverage accumulates .gcda across `--repeat until-pass:3`**, so
+   local single-run numbers undercount CI. Judge coverage work by local
+   before/after DELTA, never absolutes (see openglad-test-integrity).
+
+## Accepted local failures and standing rulings
+
+- `emscripten_build_test` fails on machines without `$EMSDK` set — this
+  is ACCEPTED, and the maintainer has explicitly ordered the build
+  script NOT to be patched around it ("emscripten fuckery, not
+  necessary"; a fix was authored and reverted twice). Exclude it from
+  local full-suite runs (`ctest --preset ci-test -E
+  emscripten_build_test`); CI's wasm lanes are unaffected. It reports as
+  a Timeout because the broken build churns past the cap. Do not
+  reintroduce a script fix; do not report it as a regression.
+- The og_unit_sim websocket loopback test and the injector-heavy SDL
+  suites (menu_ui, picker, view, basecamp) are wall-clock flaky under
+  machine load — check `uptime` before trusting a timeout, adjudicate
+  with CI's own `--repeat until-pass:3 --timeout 420` isolated, and get
+  fast signal from headless og_unit_* first.
+- Standing rulings like the emscripten one are invisible to subagents.
+  Any agent that may run the full suite — fixers and gate-runners above
+  all — gets the ruling IN ITS PROMPT, or it will "fix" the accepted
+  failure (this happened twice in one session). Before pushing a branch
+  containing subagent commits, diff the commit list against known
+  rulings.
+
+## cfg clobber hazard
+
+A headless test binary run by hand with no campaign mounted can error
+out mid-session and rewrite the TRACKED `cfg/openglad.yaml` via the cwd
+fallback — the next og_test_io run then fails a settings test with a
+bizarre wrong-value diff. After any manually-run failing headless
+binary: `git status cfg/`, restore if dirty. Tests driving full
+text-client sessions must mount a campaign up front
+(`restore_default_campaigns()` + `mount_campaign_package_with_error`).
+
+## Git hygiene traps (each cost real time)
+
+- `git stash` on an already-committed tree saves nothing, and a later
+  `stash pop` resurrects a FOREIGN old stash entry into a conflicted
+  merge. To baseline-check committed work, use a worktree, never stash.
+- `git checkout <file>` to strip a temp harness WIPES uncommitted
+  sibling edits in that file — and a gate run without rebuilding masks
+  the loss via stale binaries. Strip harness code by text marker; always
+  rebuild before gating.
+- `git add -A` sweeps stray user files (recordings, notes at repo root)
+  into commits. Audit `git status` between gate-run and commit; the
+  gate audit is stale the moment new files appear.
+- Coverage builds: incremental ci-coverage rebuilds leave stale `.gcda`
+  ("overwriting ... different checksum") — delete them after building,
+  before running tests.
+
+## Agent-orchestration traps
+
+- Worktree subagents can spawn at the branch's PARENT (or master), not
+  the launching HEAD — this recurred across many waves. Always state
+  the intended base SHA in the prompt and have the agent verify
+  (`git reset --hard <sha>` + a marker file) before working.
+- Fresh worktrees lack the gitignored `temp/scen/*.fss` parity fixtures
+  (copy from the main tree) and inherit no built assets.
+- High concurrent agent counts trip server-side rate limits (~9
+  concurrent on a shared machine); run waves of ~3 with a barrier.
+  Agents killed mid-edit leave partial trees — `git restore` and rerun
+  rather than debugging half-applied edits.
+- Delegation split (maintainer budget rule, also in AGENTS.md): the
+  expensive tier only for design, review, and irreducibly complex
+  implementation; the cheaper tier for recon, mechanical work, gates,
+  audits, media, PR mechanics. Surface architecture alternatives to the
+  maintainer BEFORE building when a pivot would trash the work.
+
+## Fresh-machine setup (beyond `git clone` + nix)
+
+- `nix develop` provides the toolchain (GCC, cmake/ninja, SDL3, emcc,
+  ffmpeg, imagemagick). Note SDL2 in the shell is sdl2-compat over SDL3,
+  not real SDL2 — CI uses real libsdl2 where it needs SDL2.
+- **gcovr is NOT in the flake** (CI pip-installs it). Local coverage
+  runs need it on PATH; the clean fix is adding it to the flake dev
+  shell.
+- Parity companion: `git worktree add ../openglad-master
+  parity-companion` and build `parity_dump_master` there (SDL2-era —
+  see openglad-parity for the pkg-config recipe).
+- `temp/scen/*.fss` fixtures regenerate via a full ctest run
+  (og_test_level writes them).
+- Relay/Pages deploys read credentials from the gitignored `./env`
+  (never printed — see AGENTS.md Secrets).
+- Playwright browser installs may need a platform override on very new
+  Ubuntu (`PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64`) or the
+  nixpkgs `playwright-driver.browsers` path.

--- a/.claude/skills/openglad-menus/SKILL.md
+++ b/.claude/skills/openglad-menus/SKILL.md
@@ -130,6 +130,18 @@ in `tests/unit/test_platform_headless.cpp`. Grep both whenever
 (readability bars, backing rects) painted in the content pass lands ON TOP of
 buttons and dims them — the MATCHUP pagers shipped at 41% brightness this way.
 Split background fills into a pre-pass before `draw_buttons`; keep text after.
+Content also OVERDRAWS buttons: the main menu's grey SETTINGS heading band
+(drawn in the content pass) once painted over a button placed in its row —
+layout pins don't see overdraw, only screenshot read-back does.
+
+## Borrowing a viewscreen for previews (camera leak)
+
+`screen::relayout_views()` restores view RECTS but never the CAMERA
+(`topx`/`topy` are set once at construction). Anything that borrows
+`viewob[0]` and lets `redraw` copy level visuals onto it must
+RAII-restore topx/topy/control on EVERY exit path — otherwise every
+subsequent menu pixie/backdrop/portrait draw is displaced until level
+start (the HIRE/TRAIN empty-box bug).
 
 ## Blocking subscreens (the only sanctioned pattern)
 
@@ -164,6 +176,10 @@ GO / SET LEVEL / SET CAMPAIGN.
 - The id `back` is shared by several screens: disambiguate with
   `wait_for_interactable_at("back", x, y)` using each screen's unique
   geometry.
+- Under ASan frame-stretch (and heavy load) single clicks get swallowed
+  by menu transitions: use the bounded-retry `click_until_label` idiom
+  (see test_ctf_ui.cpp) — click, wait briefly for the expected label,
+  retry a capped number of times — instead of one click + long wait.
 - `popup_dialog` under TESTING is trace-only — assert via
   `trace_contains("popup", ...)`, nothing to dismiss.
 - Flow tests overwrite `save/save0.gtl`; write your own save first and restore

--- a/.claude/skills/openglad-modding/SKILL.md
+++ b/.claude/skills/openglad-modding/SKILL.md
@@ -340,6 +340,50 @@ ships them in an embedded pack that mounts and unmounts with it.
   death check afterwards, so 0 against a target already at 0 hp kills it.
   Check the target's hp before returning 0.
 
+## Mode/sim scripting traps (paid for across five game-mode builds)
+
+- **`og.add_fx_ob` entities never act**: GameWorld::tick acts oblist +
+  weaplist only; fxlist is passive (exits, stains, flags). An entity
+  needing `on_act` or any per-tick engine act must be spawned with
+  `og.add_ob` (the cloud precedent: oblist FX + NO_COLLIDE). Symptom of
+  getting it wrong: perturbation proofs stay green because the hook
+  never dispatches. Corollary: a never-acting fx entity's replicated
+  `cycle` field is free storage for Lua-driven animation state.
+- **Guard every facing-indexed table**: core specials (soldier
+  whirlwind, archer volley) park `curdir` at a **-1 sentinel**, so
+  `FACING_X[curdir + 1]` indexes nil and kills the script host. Any new
+  facing lookup needs the sentinel guard.
+- **`attack()` refuses friendly fire before the damage gate**
+  (is_friendly early-return), so a same-team `on_damage` arm is
+  unreachable via attack() — test cross-team instead.
+- **Deterministic damage staging**: `compute_base_damage(d) = d -
+  sqrt(d)/2 + rng(floor(sqrt(d)))`; stage `d <= 3.99` so the rng bound
+  is ≤1 and the draw is exactly 0. Reduction = armor/2 capped at
+  amount-1.
+- **ACT_SIT is the directable-but-inert test idiom**; ACT_GUARD
+  self-issues COMMAND_FIRE via find_near_foe and blocks director
+  preemption. The act phase re-faces livings toward `enddir` — stage
+  curdir AND enddir.
+- **Generator pause idiom**: pause = `fire_frequency += 16384` (the
+  authored value rides inside), resume = subtract and clamp `busy`.
+- **Weaplist scans see fire_check probes**: `walker::fire_check` leaves
+  DEAD probe weapons on the weaplist (unpaid, carrier-owned). The
+  discriminator for a genuinely consumed weapon is `death_called()==1`;
+  a naive dead-gate produces phantom releases and mana minting.
+- **Float read boundary**: every walker/stat getter except `s_level`
+  returns FLOAT to Lua, and `og.div` throws "no integer representation"
+  on them — `og.trunc` at the read boundary is part of any metric
+  definition. Also measure engine spawn defaults (e.g. bot base mp is
+  50), never assume loader tables.
+- **No `pairs` means map-shaped manifests need an id-range scan**
+  (`for id = 0, 1023`); array iteration over a map registers nothing —
+  a shipped registration was a silent no-op this way.
+- **Twin-world test fixtures**: two live script-bound worlds resolve
+  bindings against the LAST-constructed one — run twin fixtures
+  strictly sequentially.
+- Palette/art rules for pack sprites (cycled bands, static fire ramp)
+  live in the openglad-campaign-design skill.
+
 ## Gotchas index
 
 - Two RNG draws in one C++ expression: adjudicate per site (above).

--- a/.claude/skills/openglad-networking/SKILL.md
+++ b/.claude/skills/openglad-networking/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: openglad-networking
+description: Networked-multiplayer engineering rules — protocol/snapshot/replay/save version bumps and their test-pin fallout, adding a synchronized sim setting, headless-server vs render divergence, snapshot seeding, and transport/mirror gotchas. Use whenever a task touches net_transport, world_snapshot, GameServer/GameClient, LobbyServer, save/replay formats, adds a lobby-negotiated setting, or debugs desyncs, disconnects, "works locally but mirrors are wrong", or "script/hook doesn't run in real play".
+---
+
+# OpenGlad networking engineering
+
+The authoritative sim runs headless in `GameServer`; every display (SDL,
+text, curses, web) is a mirror fed by snapshots. `docs/ARCHITECTURE.md`
+covers the architecture; this file is the traps.
+
+## Version bumps come as ONE coordinated commit
+
+A wire or snapshot change bumps `kNetworkProtocolVersion`
+(include/openglad/gameplay/net_transport.h), `kSnapshotFormatVersion`, and
+the derived `kReplayFormatVersion` together, plus every literal pin:
+
+- FIVE wire-byte test pins break on a protocol bump — in
+  `tests/unit/test_net_transport.cpp` (protocol + min_protocol bytes) and
+  `tests/unit/test_input_state_net.cpp`. The "wrong_version" rejection
+  test must use a byte != the new current version. The replay
+  rejection-test literal repins too.
+- Payload-offset pins (test_ctf_snapshot and friends) shift when fields
+  are inserted. Serialize new world scalars AFTER existing blocks where
+  possible — that choice alone preserved the CTF offset pins once.
+  Beware silently-stale offsets: two lobby offsets were wrong for months
+  and only surfaced at the next bump; re-derive, don't just +N.
+- `find_first_snapshot_difference` must learn any new field, or unknown
+  fields masquerade as snapshot_hash divergence.
+- Save-format (`.gtl`) bumps are separate but often ride along; legacy
+  saves must keep loading (read-side defaults, never write-side).
+
+## Adding a synchronized sim setting (the template)
+
+Follow the respawn/permadeath/generator-rate template exactly: SaveData
+field → LobbySettings → InitialSetup/world mirror applied in BOTH sync
+twins → snapshot + replay compare. Requirements that were each a review
+finding:
+
+- Defaults byte-identical: the new setting at its default must produce a
+  byte-identical sim (parity-safe by construction).
+- RNG-adjacent knobs scale the COMPARISON, not the draw bound
+  (`draw_a*rate > draw_b*100` in uint64) so identical draws happen at
+  default and the RNG stream never moves.
+- Networked consumers read the SESSION-negotiated flag copied into the
+  peer save, never the on-disk save0 flag (stale by definition).
+- Sim-side clamp the value (crafted saves/snapshots reach it unchecked).
+- End-of-level actions (revive-all, flushes) must fire the SAME TICK the
+  end latches — the server stops ticking afterward; wire them into every
+  exit shape (win, timeout, exit portal, withdraw, abort — there are
+  five, not four).
+
+## Headless sim vs render (the drawcycle class of bug)
+
+If sim logic reads a field, check WHERE it is written: a field only the
+render path writes freezes on the headless server (drawcycle froze and
+hung boomerangs, stopped shield orbits, gave the archmage full map view).
+`scripts/check_render_no_sim_writes.sh` (build dep of og_interface) fails
+if `src/interface/render/` writes any network-synced entity field — keep
+it green rather than exempting it. The parity companion must mirror any
+render-bump a sim behavior depends on (see openglad-parity).
+
+## Snapshot seeding and the hook latch
+
+Three construction paths build a world — direct load+tick, snapshot seed,
+transport-shadow install — and they do NOT share hook guarantees. The
+canonical bug: level `on_load` never ran in real SDL play because the
+tick-0 snapshot seed pre-closed the `last_level_id_` latch, while every
+unit test used the direct path and stayed green. `apply_snapshot` claims
+the latch only for mid-level snapshots (`level_tick_count > 0`); a tick-0
+seed calls `reset_level_progress()`. Rules:
+
+- Any "script/hook works in tests but not in the game" report: check the
+  snapshot-seed path FIRST.
+- Every new level-hook kind gets a snapshot-seeded dispatch test next to
+  the direct-tick one (capture keyframe → reset → apply → tick → assert
+  the side effect).
+- Dormant (spawn-delayed) walkers are excluded from snapshot capture;
+  apply_snapshot must let dormant-absent survive reconciliation and let
+  present-in-snapshot clear dormancy.
+
+## Transport and session gotchas
+
+- **In-process peer 1 is the DISPLAY client**, not a background seat
+  (peer ids start at 1). "peer N is not connected" on a local send names
+  that client's own connection.
+- **Pause/menu suspension starves input freshness**: while a blocking
+  menu holds the loop, forced keyframes → hash-check replies suppress
+  client heartbeats, and every peer's `last_received_input_ms` freezes.
+  Clearing the suspension must restamp freshness
+  (`restamp_input_freshness`), and local runtime clients are
+  `mark_peer_local` — never timeout-disconnected. Any new blocking UI
+  over a live session must pump the transport and respect this.
+- **obmap context swap**: with a server world and a co-located mirror in
+  one process, set `current_game` to the server ctx around
+  `server->step()` and the client ctx around `poll_messages()`, and load
+  each world under its own ctx — or mirror walkers register in the
+  server obmap and the avatar can't move.
+- **EndGame is latched, not stored in the mirror world**: in
+  return-to-lobby mode the server never sets its own `world.end`, so
+  delta snapshots re-serialize `end=0` and clobber a mirror-stored flag.
+  Headless clients latch a session-level PendingEnd.
+- **Mirror family clamp**: snapshot apply must clamp wire family to
+  NUM_FAMILY_SLOTS, not NUM_FAMILIES — pack families above the core
+  range otherwise stamp to 0 on mirrors only. `openglad_text` has no
+  GameClient mirror and CANNOT see mirror bugs; verify mirrors with a
+  client that has one.
+- `GameServer::bind_player` does NOT broadcast ControlChange — follow
+  with `set_player_control` or the new viewport shows nothing.
+- Mock wall clocks: after `set_wall_clock_ms_source`, send one
+  input/tick so freshness stamps land on the mock timeline, or
+  stale-guards silently skip the repro.
+
+## Wire-data hygiene
+
+- CI sets `VALIDATE_SERIALIZATION=ON` (test/drift/asan/tsan lanes); it
+  round-trips every typed message and requires equality — lossy
+  read-side clamps pass a default local build and fail CI
+  deterministically. Reproduce with that flag or the ci-asan preset.
+- Narrow wire types alias: an int8 guard like `>= 256` is tautological
+  (clang -Werror in the TSan lane catches it; GCC ci-test does not), and
+  bytes 128–255 read negative. Sweep new guard code on wire paths with
+  clang syntax-only.
+- Team/identity bytes above the classic 0–3 range (e.g. the FFA band
+  16–31) break hidden assumptions: revive paths that only restore teams
+  <4, packed-slot decodes that overflow, palette lookups. Grep for `< 4`
+  and `NUM_TEAMS`-shaped literals when widening any identity byte.

--- a/.claude/skills/openglad-parity/SKILL.md
+++ b/.claude/skills/openglad-parity/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: openglad-parity
+description: The gameplay parity harness (og_test_parity), master-companion goldens, the mutation canary, and scenario_table.h pin discipline. Use whenever a task edits sim code under src/gameplay or packs/core, touches tests/parity, plans a golden recapture or rebaseline, adds a parity scenario, or asks whether a change "breaks parity" — and before editing ANY file named in a scenario_table.h pin, because a one-line insert silently detooths canary pins.
+---
+
+# OpenGlad parity harness
+
+`og_test_parity` is the determinism gate: each scenario replays a scripted
+sim headlessly and byte-compares the state dump against a golden captured
+from the pre-networking master companion. The sim IS deterministic across
+clean rebuilds — apparent non-determinism is always a stale build or a
+different config sneaking in. Master itself drew AI path-recheck cadence
+and elf projectile spread from libc `rand()`; the harness reproduces that
+stream (`srand(1)` + a cosmetic-RNG override in `parity_runner.cpp`), which
+is why production cannot byte-match master but the harness can — it proves
+gameplay LOGIC given identical RNG, the strongest equivalence available
+against a non-deterministic reference.
+
+## Running it
+
+- **Always from the repo root.** Goldens are cwd-relative: run from
+  `build/ci-test` and every scenario reads as "missing golden" — mass
+  drift that isn't. `ctest --preset ci-test -R '^og_test_parity$'` is the
+  canonical invocation.
+- Fresh worktrees fail the scen99-fixture scenarios until `og_test_level`
+  has run once (it generates the gitignored `temp/scen/scen99.fss`); ctest
+  DEPENDS handles ordering, standalone runs don't. Copy `temp/scen/*.fss`
+  from the main tree when setting up a worktree.
+- `./build/ci-test/parity_runner_smoke --scenario <id> --out <file>`
+  prints the canonical branch StateDump JSON; `--evaluate-facts` runs the
+  predicates. `scripts/parity/diff_dumps.py <dump> tests/parity/golden/<id>.json`
+  (exit 0 = semantic match) is the authoritative branch-vs-golden check.
+- **Stale-table trap** (cost hours): `kScenarios` is `inline constexpr` in
+  `scenario_table.h`, and incremental builds do not reliably recompile the
+  TUs embedding it. Before capturing or measuring, force-clean the dumper
+  and harness object dirs (`rm -rf build/ci-test/CMakeFiles/og_test_parity.dir`
+  and the companion's `parity_dump_master.dir`), rebuild, and verify the
+  dump's `tick` equals the row's budget as a staleness canary.
+- After a failed headless run, `git status cfg/` — a session with nothing
+  mounted rewrites `cfg/openglad.yaml` via the cwd fallback; restore it
+  before trusting later results.
+
+## The master companion
+
+Branch `parity-companion` (pushed to origin) is the master-era tree plus
+recorder-only commits; its worktree conventionally lives at
+`../openglad-master` (`git worktree prune && git worktree add
+../openglad-master parity-companion`, rebuild `parity_dump_master` there
+with the ci-test preset). It is e761-era code needing SDL2: on a machine
+with only SDL3, point `PKG_CONFIG_PATH` at the `sdl2-compat.dev` and
+`SDL2_mixer.dev` pkgconfig dirs (`nix build --no-link --print-out-paths
+'nixpkgs#sdl2-compat.dev'` — `nix shell` alone does NOT set
+PKG_CONFIG_PATH, and the `.pc` files live in the `.dev` outputs).
+
+- `tests/parity/scenario_table.h` and the companion's
+  `tools/parity_scenario_table.h` must be **byte-identical** (`cmp`)
+  before any capture. Commit both trees, companion first.
+- The companion build does not recompile on a header-only table change
+  (source-newer-than-object guard) — delete the dumper's `.o` first or a
+  new id fails with "unknown scenario".
+- If a behavior depends on a render-driven field (the `drawcycle` lesson:
+  render-only counters FREEZE in a headless sim), the companion must
+  replicate the render-loop bump as a cosmetic override — otherwise the
+  golden encodes a frozen artifact and goes green while the real game
+  misbehaves. Never just skip or branch-internal such a scenario.
+- Capturing the same ids into two directories before and after a
+  companion edit and `diff -rq`-ing them is the cheap proof that a
+  companion change moves nothing.
+
+## Goldens and the drift ledger
+
+`tests/parity/golden/DRIFT_LEDGER.md` is the authoritative record of every
+golden that deliberately diverges from the raw companion capture:
+master-era divergences root-caused to specific fixes, and **intentional
+gameplay changes whose goldens were captured from the fixed branch, pinned
+to the fix SHA**. A companion recapture must NEVER be pasted over a
+ledger-blessed golden — the teeth floor can sit inside the cross-arm
+drift. When adjudicating "does the branch match main", match the PR's
+merge base, not the ancient companion: capture companion → diff branch →
+on mismatch reproduce at the merge base → branch==merge-base means bless
+the branch dump + add a ledger row; branch!=merge-base means PR
+regression, never blessed. Any deliberate gameplay fix that moves goldens
+also gets a `docs/GAMEPLAY_FIXES_FROM_CLASSIC.md` row.
+
+## Adding a scenario (the coordinated edits)
+
+1. `tests/parity/scenario_table.h`: `kInputs_*`, `kFamilySpawns_*`,
+   `kFacts_*`, `kMut_*`, and the `ScenarioSpec` row.
+2. `tests/parity/test_parity_scenarios.cpp`: `OG_PARITY_TEST(<id>)` —
+   without it the per-name gtest does not exist.
+3. Mirror the table to the companion (byte-identical), rebuild
+   `parity_dump_master`, capture via
+   `scripts/parity/capture_master_golden.sh <id>`.
+4. `tests/parity/scenario_facts_generated.json` is regenerated by ctest
+   (write_scenario_facts_json) — commit it.
+5. Prove the mutation flips (see canary below) before calling it done.
+
+Sim mechanics that constrain scenario design: SpawnSpec x/y are RAW
+PIXELS (GRID_SIZE is 16); hp predicates are in cents (hp×100); spawns
+PREPEND, so the player walker is the LAST team-0 living in the spawn
+array; a team-0 treasure/prop can steal the player-control takeover —
+spawn props on a non-zero team; only the player team follows the input
+transcript, other teams act as AI; each hit sets `regen_delay=50`, so
+scenarios ending within 50 ticks of combat see no regen drift; treasure
+eating is positional — place consumables at the walker's final stop;
+default fire heading is FACE_UP; dead entities are never reaped once
+`game_ended` latches, so enemy-free arenas reap nothing (park a distant
+hostile TOWER1 to hold `level_done=0`).
+
+## The mutation canary (teeth oracle)
+
+`scripts/parity/run_mutation_canary.sh` applies a scenario's `kMut_*`
+from/to swap to real source, rebuilds, and requires ≥1 predicate flip.
+It is NOT in CI — CI only validates that pin files/lines exist. Facts:
+
+- `--all` exits 1 by design: the `CompareMode::Invariant` rows
+  (`smoke_empty_scen99`, `snapshot_dirty_bits_scen9301`) have no
+  discriminating mutation. The number that matters is GENUINE toothless
+  (`grep -c '0 flips'`), which must be 0.
+- The canary restores files via `git checkout --` and will DESTROY
+  uncommitted changes in mutated files. On a dirty tree, drive mutations
+  by hand: back up bytes → `_apply_mutation.py` → rebuild → gtest filter
+  → restore the backup bytes.
+- C++ canary runs leave the MUTATED binary in build/ci-test — rebuild
+  before running anything else from that tree.
+- Run the FULL suite under a mutation, not a single filter: collateral
+  flips (a mutation that kills a whole Lua chunk reds many rows) are only
+  measurable that way, and named-control greenness is the honesty check.
+
+## Pin discipline (the six known rot modes)
+
+Every pin is `{file, LINE, from-text, to-text}` applied on that exact
+line. `scripts/parity/check_mutation_pins.py` validates anchors and is a
+build dependency of og_test_parity; `--fix` re-points drifted pins — but
+READ THE DIFF after, and know the blind spots:
+
+1. **Line drift**: any insert above a pin in a pinned file shifts it;
+   nothing fails, the teeth just go. After editing ANY sim file, grep it
+   against scenario_table.h pins — this applies to every sim file, not
+   just walker.cpp (a toast commit in a treasure file once broke 4 pins
+   silently).
+2. **Anchors are not teeth**: a pin can resolve perfectly yet mutate a
+   value the engine no longer reads (data moved to YAML/Lua). Only a
+   canary RUN detects this class. After any refactor that changes where a
+   value lives, run the canary, don't just validate anchors.
+3. **Generic to-texts false-positive** the checker's either-side accept:
+   a short to-text like `return false` can substring-match an unrelated
+   line. Only an apply attempt or staged-copy flip run catches it
+   (mutate the staged `build/ci-test/packs` copy per .lua pin, require a
+   flip — ~3s/pin, no rebuild).
+4. **Same-text multiple occurrences**: a mechanical "+N lines" repin can
+   land a pin on the WRONG occurrence of a repeated statement. After any
+   mechanical repin of a text appearing on several lines, re-verify the
+   flip at runtime.
+5. **Lua-syntax-error to-texts** (bare mid-block `return false`) kill the
+   whole chunk on apply and flip rows via collateral damage — fake teeth.
+   Use `do return false end`.
+6. **Boundary-dead predicates**: a mutated value landing exactly ON an
+   inclusive fact bound is inert; the per-fact flip check
+   (`parity_runner_smoke --evaluate-facts` under mutation) is the
+   detector.
+
+`scenario_table.h` is compiled INTO og_test_parity — after editing pins,
+rebuild before trusting the in-suite gate.
+
+## Harness blind spots (check reachability before planning a rebaseline)
+
+- `apply_post_load_spawns` never calls `walker::set_difficulty`, so
+  difficulty-scaling sim changes move ZERO goldens. Verify a change is
+  reachable from the harness before predicting/promising a recapture.
+- The harness is render-blind (both sides headless): render-driven
+  behavior needs direct sim tests, not goldens. `worldz`/`vz` are not in
+  the state dump, so Z arcs are parity-invisible by design (load-bearing).
+- No parity scenario places guards or dormant walkers; act-type-specific
+  code there is uncovered by goldens.
+- Presentation is parity-invisible: sounds, notifications, glyphs, radar
+  colors, damage that never lands. If every perturbation you try is
+  inert, the honest conclusion is "no parity coverage here" — say so
+  rather than inventing a proof.
+
+## Sim-determinism test idioms (unit groups)
+
+`og::sim::set_sim_random_override` only works in TUs compiled with
+`-DTESTING`; `SimRandom::next()` is inline, so og_gameplay's copies ignore
+the override and an installed spy silently records NOTHING — assertions
+on it go vacuous. Instead set `world.rng_.state_ = <constant>` and assert
+observable outcomes. `next(0)` returns early WITHOUT advancing state, so
+"state unchanged across the call" proves no draw happened. Walker
+construction draws from `walker_rng()`, which fixtures redirect, so
+construction never perturbs the world stream.

--- a/.claude/skills/openglad-pr-workflow/SKILL.md
+++ b/.claude/skills/openglad-pr-workflow/SKILL.md
@@ -74,7 +74,36 @@ sign-off, quoted.
    Check `git diff --stat master...HEAD -- '*.md'`; anything named
    *_PLAN.md, *_REPORT.md, *_SUMMARY.md, PHASE*, HANDOFF* is deleted.
    A doc worth keeping goes to docs/ as a human-facing document.
-3. `git status --porcelain` is empty of surprises.
+3. `git status --porcelain` is empty of surprises — audit it BETWEEN the
+   gate run and the commit: `git add -A` has swept stray user files
+   (audio recordings, notes at repo root) into pushed commits before,
+   and a gate audit is stale the moment new files appear.
+4. Branches containing subagent commits: diff the commit list against
+   standing maintainer rulings (accepted failures, rejected fix
+   classes, ordered-reverted changes) before pushing — agents don't
+   know them and generic "make tests pass" prompts point straight at
+   previously-rejected changes.
+
+## GitHub mechanics (each of these burned a session)
+
+- `gh pr edit` is broken on this repo (Projects-classic GraphQL
+  deprecation). Edit PR bodies via
+  `gh api -X PATCH repos/{owner}/{repo}/pulls/N --input file.json`.
+  Never `gh api -f body=@file` — `-f` does not expand `@`; the body
+  becomes the literal string "@file".
+- `gh run watch --exit-status | tail` reads TAIL's exit code — capture
+  gh's own status unpiped, or a failed run reads as green.
+- The OAuth token lacks `workflow` scope: pushes touching
+  `.github/workflows/` are rejected over HTTPS — push those via the SSH
+  remote.
+- A PR that becomes CONFLICTING against master gets NO
+  pull_request-event runs at all (GitHub can't build the merge ref)
+  while push-triggered workflows still run — looks like "CI only runs
+  WASM". Check `gh pr view --json mergeable` first; merge master and
+  the full set fires.
+- Zero CI runs created on a fresh push: check githubstatus.com before
+  debugging — a GitHub Actions outage records events but creates no
+  runs.
 
 ## Web preview delivery paths (know which build the user is playing)
 

--- a/.claude/skills/openglad-test-integrity/SKILL.md
+++ b/.claude/skills/openglad-test-integrity/SKILL.md
@@ -47,6 +47,57 @@ a postcondition, not that the call returned. Every test asserts a
 specific expected value or state transition. Before claiming a coverage
 number, self-audit your new tests against this list.
 
+## Coverage run mechanics (local)
+
+- Judge a change by the local baseline→change DELTA in a worktree, not
+  the absolute number: CI's retried runs accumulate `.gcda` and read
+  higher than any local single pass.
+- Incremental ci-coverage rebuilds leave stale `.gcda` ("overwriting ...
+  different checksum" corrupts the number) — delete them after building,
+  before running tests.
+- Guard style: a one-line `if (!x) return v;` keeps the bad-path return
+  on a covered line; a two-line if/return leaves an uncovered line each.
+- To find CI's exact uncovered functions, read `FNDA:0` records from the
+  run artifact's combined.info; local function HIT/no-hit is reliable
+  even where line counts undercount.
+- A function whose last caller was deleted is dead code that reds the
+  function floor — delete it, don't write a test for it.
+- Coverage-lane unit groups run ~10x slower under instrumentation
+  against a fixed ctest timeout ceiling. When a group nears it, SPLIT
+  the group (new binary + recorder_processes.txt line); never bump the
+  ceiling.
+
+## Entity pointers do not survive the tick (ASan-only bug class)
+
+`GameWorld::tick`'s erase sweep frees dead weapons/effects the same tick
+(living corpses persist). A raw `walker*` held across `tick()` is a
+use-after-free that non-ASan builds "pass" — only the ci-asan preset
+catches it. Idiom: capture `entity_id()` at spawn, judge fate via
+`world().find_by_id(id)` after the tick, and pair a survivor control
+with the reaped entity or the assertion has no teeth. New heavy test
+files run their group under ci-asan locally before push. ASan aborts on
+first error, so after fixing an ASan red, run the WHOLE binary — every
+test after the failure never ran.
+
+## Flaky vs real (adjudication before blame)
+
+- Order-dependence fixes are verified with a ~30-seed `--gtest_shuffle`
+  sweep, not one run. In render tests, compute `world_to_screen_*` only
+  AFTER a settle redraw (the first redraw pans the camera) — the classic
+  passes-in-order, fails-shuffled shape.
+- Known pre-existing shuffle hangs (proven on master; CI runs
+  declaration order and is unaffected): og_test_picker seed 29
+  (promote_orc detail-menu test) and og_test_view seed 7
+  (base_camp_name_tap). Don't attribute these to new tests without
+  reproducing on a clean tree.
+- `Difficulty.submenu_door_flow` (og_test_menu_ui) is load-flaky and DOES
+  hit CI ASan occasionally — a rerun clears it; a missed injector click
+  under load leaves its cycle one short.
+- Never bump a deadline to fix a timing-flaky test: measure the real
+  cost, fix it, then convert the flat delay into a wait-on-condition
+  with a generous ceiling, and prove the wait can still fail by planting
+  a break. Gate cost regressions with counts (call counts), not clocks.
+
 ## Tests that hang (the three known traps)
 
 1. Menu/prompt/picker paths need the injector-thread pattern
@@ -71,3 +122,7 @@ confirm every entry touches only tools/parity_*. A matching
 byte-identical (`cmp`) before any recapture. "All N goldens matched
 after rebasing to a different baseline" is a red flag to investigate,
 never a success report.
+
+For the full parity playbook — running the harness, the drift ledger,
+canary teeth, pin rot modes, and harness blind spots — see the
+openglad-parity skill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ agent, not just Claude.
 | Picker/menu UI changes (buttons, subscreens, labels, menu tests) | [.claude/skills/openglad-menus/SKILL.md](.claude/skills/openglad-menus/SKILL.md) |
 | PR/branch definition of done: riding CI, completion reports, pre-merge sweeps, web previews | [.claude/skills/openglad-pr-workflow/SKILL.md](.claude/skills/openglad-pr-workflow/SKILL.md) |
 | Test and coverage honesty: denominator rules, banned assertions, hang traps, parity goldens | [.claude/skills/openglad-test-integrity/SKILL.md](.claude/skills/openglad-test-integrity/SKILL.md) |
+| Parity harness: goldens, companion, mutation canary, scenario_table.h pins | [.claude/skills/openglad-parity/SKILL.md](.claude/skills/openglad-parity/SKILL.md) |
+| Networking: version bumps, synchronized settings, snapshots, transport/mirror traps | [.claude/skills/openglad-networking/SKILL.md](.claude/skills/openglad-networking/SKILL.md) |
+| Dev environment: local-vs-CI divergence, accepted failures, git/agent traps, new-machine setup | [.claude/skills/openglad-dev-environment/SKILL.md](.claude/skills/openglad-dev-environment/SKILL.md) |
 
 The skill files are plain markdown playbooks — they assume no Claude-specific
 tooling. Follow their checklists and gates exactly; the hard invariants


### PR DESCRIPTION
Development is moving to a new machine. The per-machine agent memory directory does not travel, so this PR migrates its durable knowledge — the traps and invariants relearned across many sessions — into the repo's skill playbooks, where they persist via git and serve every future agent.

## New skills

- **`.claude/skills/openglad-parity/`** — the first in-repo parity playbook: run rules (repo-root requirement, stale inline-constexpr table force-clean, scen99 fixture ordering), the `parity-companion` worktree and its SDL2-era build recipe, DRIFT_LEDGER adjudication (blessed goldens are never overwritten by companion recaptures), the scenario-add workflow, the mutation canary as the teeth oracle, all six known pin-rot modes, harness blind spots (`set_difficulty` unreachable, render-driven fields), and the sim-RNG unit-test idioms.
- **`.claude/skills/openglad-networking/`** — the coordinated protocol/snapshot/replay bump checklist with its literal test-pin fallout, the synchronized-sim-setting template, headless-sim vs render divergence (the drawcycle bug class + `check_render_no_sim_writes.sh`), the snapshot-seed hook latch, and transport/mirror gotchas (pause-starvation restamp, peer 1 = display client, obmap context swap, EndGame latch, `NUM_FAMILY_SLOTS` clamp, `VALIDATE_SERIALIZATION` divergence).
- **`.claude/skills/openglad-dev-environment/`** — local-vs-CI configuration divergence, accepted local failures and the standing `emscripten_build_test` do-not-fix ruling, the cfg clobber hazard, git hygiene traps, agent-orchestration traps, and fresh-machine setup notes.

## Updated skills

- **test-integrity**: coverage run mechanics (delta-not-absolute, stale `.gcda`, one-line guards, group splitting), the ASan tick-UAF idiom, flake adjudication incl. the known pre-existing shuffle hangs.
- **pr-workflow**: GitHub CLI/API traps (`gh pr edit` breakage, `-f body=@file`, piped `run watch`, workflow-scope pushes, conflicting-PR CI silence), stray-file audit, subagent-commit ruling audit.
- **modding**: mode/sim scripting traps from the five game-mode builds (`add_fx_ob` passivity, `curdir` −1 sentinel, fire_check probes, float read boundary, etc.).
- **campaign-design**: palette-cycling/PLTE/font-glyph rules, the new-builtin-campaign bootstrap pin list, water-map AI rules.
- **menus**: borrowed-viewscreen camera-restore trap, `click_until_label` idiom, content-overdraw note.

AGENTS.md indexes the three new skills. Docs-only change — no code, packs, or campaigns touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)