### PR TITLE
Menu UI polish: self-laying seat rail, one fade rule, pinned VIEW LEVEL camera, injector-race class fix (#243 #237 #251 #257)

### DIFF
--- a/.claude/skills/openglad-dev-environment/SKILL.md
+++ b/.claude/skills/openglad-dev-environment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openglad-dev-environment
-description: Local development environment for OpenGlad — the nix flake, local-vs-CI configuration divergence, accepted local test failures and standing rulings, git hygiene traps, agent-orchestration traps, and setting up a fresh machine. Use whenever a local test result disagrees with CI, a tool seems missing, a full local ctest run has unexplained reds, worktrees or subagents produce surprising state, or development moves to a new machine.
+description: Local development environment for OpenGlad — the nix flake, tmpfs build-dir placement and cleanup, local-vs-CI configuration divergence, accepted local test failures and standing rulings, git hygiene traps, agent-orchestration traps, and setting up a fresh machine. Use whenever you are about to configure or build any preset, a local test result disagrees with CI, a tool seems missing, a full local ctest run has unexplained reds, worktrees or subagents produce surprising state, or development moves to a new machine.
 ---
 
 # OpenGlad dev environment
@@ -10,6 +10,48 @@ tools come from `flake.nix` (add missing ones there — never hand-roll a
 utility a package provides, never apt/snap-install, never source
 ~/emsdk), presets only, no in-source configure. This file covers what
 AGENTS.md doesn't: divergence, accepted failures, and traps.
+
+## Builds live in tmpfs
+
+`/tmp` is tmpfs on this machine (~61G). Build trees go in
+`/tmp/openglad-builds/<checkout>/<preset>`, where `<checkout>` is the
+basename of the source tree — so the main repo and each worktree get
+their own subfolder and never collide. Presets hardcode `binaryDir` to
+`${sourceDir}/build/<preset>`, so the mechanism is a per-preset
+symlink, not a `-B` override (`cmake --build --preset` would ignore
+one). Before configuring ANY preset, run this idempotent snippet:
+
+```bash
+preset=ci-test                      # whichever preset you're building
+tgt="/tmp/openglad-builds/$(basename "$PWD")/$preset"
+mkdir -p "$tgt" build
+[ -L "build/$preset" ] || rm -rf "build/$preset"
+ln -sfn "$tgt" "build/$preset"
+```
+
+- Run it EVERY time before `cmake --preset ...`: tmpfs is wiped on
+  reboot, leaving `build/<preset>` a dangling symlink that makes
+  configure fail; the `mkdir -p` heals it.
+- Symlink per-preset only — never the whole `build/` dir. `build/media`
+  (capture tooling output) and other non-preset contents stay real.
+- RAM is shared and each preset tree runs to a few GB (more when
+  FetchContent builds SDL3), so cleanup is part of the workflow, not
+  optional.
+
+**Cleanup.** When a build tree is no longer needed (task done, branch
+merged, preset abandoned), `rm -rf` its tmpfs dir and the symlink. And
+whenever you're about to build — or otherwise notice the folder —
+sweep anything over a day old plus the dangling symlinks it leaves:
+
+```bash
+find /tmp/openglad-builds -mindepth 2 -maxdepth 2 \
+  ! -newermt '1 day ago' -exec rm -rf {} + 2>/dev/null
+find build -maxdepth 1 -xtype l -delete 2>/dev/null
+```
+
+(Preset-dir mtime is a good staleness proxy: ninja rewrites
+`.ninja_log` at the build root on every build.) The parity companion
+worktree's build follows the same pattern.
 
 ## Local green is not CI green (four known divergences)
 

--- a/.claude/skills/openglad-menus/SKILL.md
+++ b/.claude/skills/openglad-menus/SKILL.md
@@ -139,6 +139,19 @@ Content also OVERDRAWS buttons: the main menu's grey SETTINGS heading band
 (drawn in the content pass) once painted over a button placed in its row —
 layout pins don't see overdraw, only screenshot read-back does.
 
+Two palette traps in the same family:
+
+- **A dimmed face can eat its own bevels.** `GREY` (the RowState::Disabled
+  face) resolves to the SAME shade as `BUTTON_RIGHT`/`BUTTON_BOTTOM`, so a
+  disabled row drew as a card with a flat right edge until `vbutton::dimmed`
+  stepped those two edges one shade darker. Any new face color needs the same
+  check against 11..15.
+- **A band of raw backdrop between two opaque things reads as a defect.** The
+  title art runs behind every picker screen; an 8px gutter framed a fragment
+  of its grey blade so exactly that reviewers read it as a stray glyph. Paint
+  a band its own ground (pre-buttons, opaque) when chrome floats in it — that
+  also makes the local and networked frames identical there.
+
 ## Borrowing a viewscreen for previews (camera leak)
 
 `screen::relayout_views()` restores view RECTS but never the CAMERA

--- a/.claude/skills/openglad-menus/SKILL.md
+++ b/.claude/skills/openglad-menus/SKILL.md
@@ -96,10 +96,15 @@ the constants silently relabels the wrong button. Append new rows at the end;
 when a restructure is unavoidable, update the constants, the per-frame sync
 code, and the layout tests in the same change.
 
-Base Camp has two independent page windows: eight roster rows and four
-player-seat cards. The **SEATS**, **<**, card, and **>** controls have their own
-indices and navigation. Do not couple seat paging to roster paging, and keep
-both arrows hidden unless the seat list spans multiple pages.
+Base Camp has exactly one page window: the eight roster rows. The seat rail
+below it is not paged — it is this machine's four fixed slots (ordinals
+35..38), and remote seats never appear there. A slot holding one of this
+machine's seats draws a card; a bare slot is the ADD PLAYER door on the same
+ordinal (LOBBY FULL and dimmed when the lobby has no room, hidden outright
+past what the device can seat). Ordinals 33, 34, 39 and 40 are parked spares
+— the retired `[+]` and the two seat pagers — re-parked every frame. The
+header's line B carries the players/machines census that the rail no longer
+shows.
 
 Two consumers select TEXT menu items by 1-based position and break silently
 on reorders: `scripts/test_text_picker_interactive.sh` and the scripted drive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,16 @@ add_custom_target(check_render_no_sim_writes
     VERBATIM
 )
 
+# Every fadeblack() caller is classified in scripts/fadeblack_sites.txt: fade
+# ownership (#237) only holds while the set of screens that fade stays the
+# deliberate one. See the script header.
+add_custom_target(check_fadeblack_sites
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/check_fadeblack_sites.sh
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Checking every fadeblack() call site is classified"
+    VERBATIM
+)
+
 # --------------------------------------------------------------------------
 # Python-driven repo checks: resolve the interpreter at configure time.
 #
@@ -687,7 +697,9 @@ if(NOT EMSCRIPTEN)
     configure_openglad_sdl_target(og_interface)
     # og_interface contains src/interface/render/; enforce render stays read-only
     # on synced entity state (the drawcycle-class guard).
-    add_dependencies(og_interface check_render_no_sim_writes og_git_hash_gen)
+    # The fade call sites straddle src/interface/ui/ and src/platform/sdl/, so
+    # the allowlist guard hangs off both components.
+    add_dependencies(og_interface check_render_no_sim_writes check_fadeblack_sites og_git_hash_gen)
     target_include_directories(og_interface PRIVATE ${CMAKE_BINARY_DIR})
     target_link_libraries(og_interface PUBLIC
         og_core
@@ -719,7 +731,7 @@ if(NOT EMSCRIPTEN)
     if(NOT EMSCRIPTEN)
         target_link_libraries(og_platform_sdl PRIVATE og_ext_ixwebsocket)
     endif()
-    add_dependencies(og_platform_sdl check_vendor_leaks)
+    add_dependencies(og_platform_sdl check_vendor_leaks check_fadeblack_sites)
 
     add_library(og_platform_emscripten_transport STATIC
         ${SRC_DIR}/platform/emscripten/net_transport_emscripten_ws.cpp

--- a/cmake/OpenGladTests.cmake
+++ b/cmake/OpenGladTests.cmake
@@ -196,6 +196,7 @@ set(ALL_INTEGRATION_TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/integration/test_cloud_ui.cpp
     ${CMAKE_SOURCE_DIR}/tests/integration/test_uxshots_probe.cpp
     ${CMAKE_SOURCE_DIR}/tests/integration/test_seat_chip.cpp
+    ${CMAKE_SOURCE_DIR}/tests/integration/test_fade_ownership.cpp
 )
 
 function(og_add_test_group NAME)
@@ -530,6 +531,7 @@ og_add_test_group(og_test_basecamp FILES
     test_company_list.cpp
     test_uxshots_probe.cpp
     test_seat_chip.cpp
+    test_fade_ownership.cpp
 )
 
 og_add_test_group(og_test_input FILES

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -989,7 +989,7 @@ Menu functions block in event loops. Tests use a separate thread to drive naviga
 ```cpp
 static int injector_thread(void* data) {
     wait_for_interactable("button_id", 5000);  // Wait for button to exist
-    SDL_Delay(1500);                            // Wait for fadeblack animation
+    SDL_Delay(1500);                            // Entry settle (fades are instant under TESTING)
     interact("button_id");                      // Click by ID
     return 0;
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -610,12 +610,16 @@ play the server and the single client are both in-process (`InProcessTransport`)
 
 ### Lobby → gameplay → lobby flow
 
-Base Camp coordinates a networked start. Its seat rail is a four-card view of
-the authoritative lobby roster, with paging for larger lobbies and a **+** at
-the rail's left end for adding a local seat. An owned card opens its machine-local control profile and
-next-level team assignment; a foreign card is read-only. The interface keeps
-stable seat tokens behind the dense display ordinals, so removing a middle
-seat cannot retarget a command to one of its siblings.
+Base Camp coordinates a networked start. Its seat rail is a four-slot view of
+**this machine's** seats — never the whole lobby. A slot holding one of them
+opens that seat's machine-local control profile and next-level team
+assignment; a slot with no seat in it is an **ADD PLAYER** button that runs the
+add path (dimmed to **LOBBY FULL** at the sixteen-seat ceiling, and absent
+past what the device can seat). Other machines' seats are counted on the
+header line and listed in VIEW LEVEL's seat report, which is why the rail
+needs no pager. The interface keeps stable seat tokens behind the dense
+display ordinals, so removing a middle seat cannot retarget a command to one
+of its siblings.
 
 `IPickerLobbyClient`
 (`src/interface/ui/picker_lobby_client.cpp`,

--- a/docs/basecamp-zones-design.md
+++ b/docs/basecamp-zones-design.md
@@ -46,7 +46,9 @@ became unreachable; the freed value is documented as free.
   the wall x and static_asserted against the button geometry). The
   networked session status composes to the live budget — a narrow band
   takes a whole shorter spelling ("3 PLAYERS/2 PCS", then "3P/2M", then the
-  room code goes) rather than a mid-word cut. Players lead the census
+  room code goes) rather than a mid-word cut, and a count of one takes the
+  singular ("1 PLAYER / 1 MACHINE", "1 PLAYER/1 PC") — always the shorter
+  spelling, so it never costs a rung its band. Players lead the census
   because the seat rail shows only this machine's seats.
 
 ## The widget contract

--- a/docs/basecamp-zones-design.md
+++ b/docs/basecamp-zones-design.md
@@ -45,8 +45,9 @@ became unreachable; the freed value is documented as free.
   one hides it (`kBaseCampLineBChars*` in `picker_common.h`, derived from
   the wall x and static_asserted against the button geometry). The
   networked session status composes to the live budget — a narrow band
-  takes compact spellings ("2M / 3P", the joiner's "HOST: " label
-  dropped) rather than a mid-word cut.
+  takes a whole shorter spelling ("3 PLAYERS/2 PCS", then "3P/2M", then the
+  room code goes) rather than a mid-word cut. Players lead the census
+  because the seat rail shows only this machine's seats.
 
 ## The widget contract
 

--- a/docs/camp-controls-design.md
+++ b/docs/camp-controls-design.md
@@ -193,8 +193,11 @@ code in the same commit (`wasm_helpers.js`, `wasm-networking.spec.js`,
 zone spares, so no established Base Camp ordinal moved; the ceiling
 (`kCreateMenuButtonCount`, `MAX_BUTTONS`, `SessionState::kMaxButtons`) goes
 72 → 73. The per-frame rewire runs BACK ↔ DIFFICULTY ↔ SCENARIO and drops
-seat card one onto DIFFICULTY (it is the door under that card's face; the
-empty slot used to force a doubled SCENARIO link). The difficulty screen's
+seat slot one onto DIFFICULTY (the door under that slot's face; the empty slot
+used to force a doubled SCENARIO link). The rail's later widening to four
+70px slots moved slot one's face left over BACK, but the strip's four doors
+still take the rail's four slots one apiece — re-pointing slot one at BACK
+would leave the strip a door short of a keyboard route down from the rail. The difficulty screen's
 `remote_start` scope becomes `TeamBuildScope` like every other Base Camp
 child, so a host GO launches a joiner parked inside it.
 

--- a/docs/company-basecamp-design.md
+++ b/docs/company-basecamp-design.md
@@ -85,21 +85,22 @@ level, and experience fields.
 - Tap the deploy box to deploy or bench a character.
 - Tap the team box to cycle the character's combat team.
 - Tap the name or row body to train that character.
-- Use **+** at the left end of the seat rail to add a local seat. A machine
-  may contribute four active seats and a network lobby may contain sixteen.
-  Four cards are shown at a time; **<** and **>** page the rail when it grows
-  past the visible window. Slots with no seat in them yet are drawn as empty
-  recesses, showing where the next player will land. They appear only while
-  another seat can actually be claimed, so a device that seats one player
-  shows one card and nothing else.
-- Open an owned seat card to edit that player. The top row contains
+- The seat rail is **this machine's** four seats and nothing else. A slot with
+  no seat in it is a button reading **ADD PLAYER**; tap it to claim that seat.
+  A machine may contribute four active seats and a network lobby may contain
+  sixteen. When the lobby is at its sixteen-seat ceiling the remaining slots
+  dim and read **LOBBY FULL**.
+- The rail shrinks to what the device can seat. A phone with no gamepad shows
+  one card and nothing beside it; each gamepad attached to it adds one slot,
+  up to four. An offer the hardware cannot accept is worse than no offer.
+- Open a seat card to edit that player. The top row contains
   **4-DIRECTION**/**8-DIRECTION**, **REMAP**, and **RESET**. The bottom row
   contains **TEAM** and **REMOVE PLAYER**. In a network lobby the last action
-  becomes **SPECTATE** when it removes the machine's final active seat. Use
-  **+** to return from spectator mode.
-- Player numbers are lobby-wide. A local card says **YOU**; a remote card uses
-  a short company abbreviation. Remote cards are read-only and identify the
-  company that controls them.
+  becomes **SPECTATE** when it removes the machine's final active seat. Tap
+  any **ADD PLAYER** slot to return from spectator mode.
+- Player numbers are lobby-wide, so a card can read **P5** on a machine that
+  owns one seat. Other machines' seats are never in the rail: the header line
+  counts them and **VIEW LEVEL** lists them by name and team.
 - Multiple seats may deliberately choose the same team for co-op or team
   matchups. Seats on different teams oppose one another.
 - The full seat and team overview lives in **VIEW LEVEL**, on the Scenario
@@ -108,10 +109,6 @@ level, and experience fields.
 - Network guests may inspect foreign rows but cannot mutate them.
 
 ![Owned seat settings](media/team-selection/seat-settings.png)
-
-| Seats 1–4 | Seats 5–7 |
-|---|---|
-| ![Base Camp seat page one](media/team-selection/basecamp-seats-page-1.png) | ![Base Camp seat page two](media/team-selection/basecamp-seats-page-2.png) |
 
 Adding or removing seats and choosing their teams changes the current session.
 Those choices survive leaving Base Camp and returning through **CONTINUE**, but
@@ -248,8 +245,8 @@ Ready state belongs to a machine, not a character. Roster or relevant lobby
 changes clear readiness. A client with an active seat but an empty roster may
 ready without supplying a hero. A machine with no active seat remains
 connected as a spectator, has no **READY** action, and does not consume player
-capacity or a gameplay binding; **+** can reactivate its dormant stable seat
-token. Start validation checks participating machines and returns a specific
+capacity or a gameplay binding; any **ADD PLAYER** slot reactivates its dormant
+stable seat token. Start validation checks participating machines and returns a specific
 denial when the roster cannot satisfy the requested local views.
 
 ### 4.4 Ownership and controls
@@ -261,7 +258,9 @@ Changing a seat assignment never recolors a character. With cross-control
 disabled, input may claim only eligible characters owned by that player or
 machine.
 
-The visible `P#` is a dense lobby-wide display ordinal and may change when a
+The seat rail shows only the seats this machine owns, in local-slot order, so
+slot **k** of the rail is always local controller profile **k**. The visible
+`P#` on that card is a dense lobby-wide display ordinal and may change when a
 seat or machine leaves. Team-change and remove commands therefore target a
 separate stable, server-issued seat token. Removing a middle seat re-densifies
 the display ordinals without changing its siblings' tokens. The server also
@@ -335,39 +334,54 @@ network rows hide that action and use the wider ownership hit area instead.
 
 ### 9.12 Network status
 
-The second header line shows host/join role, room, and machine/player census.
-A degraded-link alert takes the same line and its warning color.
+The second header line shows host/join role, room, and the census — **players
+first**, then machines, because the seat rail shows only this machine's seats
+and the size of the lobby has nowhere else to live. It reads
+`HOSTING GLAD-7Q2F: 3 PLAYERS / 2 MACHINES` (or `IN <room>: ...` for a guest).
+A narrower band takes a whole shorter spelling rather than a byte cut:
+`3 PLAYERS/2 PCS`, then `3P/2M`, then the room code goes. The joiner's line
+no longer names the host company — every one of the host's roster rows already
+does, and none of them carries the census. A degraded-link alert takes the
+same line and its warning color.
 
-### 9.14 Eight-row page
+### 9.14 Eight-row page and the seat rail
 
 Eight roster rows fit above the independent player-seat rail while leaving the
-column header clear. The rail reads left to right: **+**, then a four-slot
-window between **<** and **>**. The scenario summary is a direct click target.
+column header clear. The scenario summary is a direct click target.
 
-The row is laid out every frame from the controls that are actually on it, and
-it always opens on BACK's left edge. Real cards pack left into the slots and
-the slots that follow are drawn as empty recesses — ghosts — as long as
-another seat can be claimed. A row that fills all four slots, and any row
-whose pager arrows are up, justifies between the panel's two rails: the slack
-is split evenly among the gutters, the leftmost ones absorbing the odd pixel.
-A shorter row packs left at the same seven-pixel gutter instead of stretching,
-because two controls spread across the whole panel read as a mistake. The card
-face never changes width; it is a nine-character label budget that the seat
-names and the team chip both depend on.
+The rail is four slots on a **fixed** grid: 70-pixel faces at x = 8, 86, 164
+and 242, an 8-pixel gutter between them, opening on BACK's left edge and
+closing on the panel's right rail with no remainder (4x70 + 3x8 = 304 = 312 -
+8). Slot **k** is at 8 + 78k whether or not its neighbours are on screen, so a
+card can never slide sideways under a finger already on its way down to it.
+The face never changes width; it is an eleven-character label budget that the
+seat names, **ADD PLAYER**, **LOBBY FULL** and the team chip all depend on.
+The chip owns the face's last nine pixels, and the label's trailing pad is what
+keeps the centred ink clear of it.
 
-Three shapes are worth naming. Four seats and both arrows is the widest one,
-and its arithmetic is what the seven-pixel gutter was chosen for: 262 pixels
-of face across 8..312 leaves 42 for six gutters. One seat on a desktop draws
-one card and three ghosts, justified. A single-seat device — a phone with
-nothing attached — hides **+**, offers no ghosts, and puts its lone card flush
-on the left rail rather than floating in from the edge.
+What varies is how many slots are live, and that is a property of the DEVICE,
+never of the lobby: four on a desktop, one on a phone with nothing attached,
+one more per gamepad. A slot past the device cap is absent. A slot inside it
+with no seat in it is a real button reading **ADD PLAYER** whose activation is
+the add path itself — the same debounce, the same capacity gates, the same
+gamepad auto-claim. When the lobby is at its sixteen-seat ceiling that button
+dims and reads **LOBBY FULL** instead: the seat is still this machine's to
+offer, and the reason it cannot be taken is somewhere else.
 
-The rail once opened with a **SEATS** label that led to the team overview.
-That was a second, worse-placed door to a screen the Scenario menu already
-owned, and it cost the cards their breathing room — the four faces sat a
-single pixel apart. Issue #236 spent the label's width on the gutters and
-gave its ordinal to the **+**; issue #243 stopped the leftover width from
-collecting in the holes those hidden controls left behind.
+The rail once windowed the whole lobby. It opened with a **SEATS** label that
+led to the team overview — a second, worse-placed door to a screen the
+Scenario menu already owned — and it cost the cards their breathing room, the
+four faces sitting a single pixel apart. Issue #236 spent the label's width on
+the gutters and gave its ordinal to a **+** at the left end; issue #243
+stopped the leftover width from collecting in the holes hidden controls left
+behind, drawing empty recesses (ghosts) where a seat could still land. Both
+were fixes to a premise that was wrong: remote seats were in the rail, which
+forced a pager, which forced a moving grid, which forced the **+** to live
+somewhere the cards were not. Restricting the rail to this machine's seats
+retires the **+**, both pagers and the ghosts at once — the ghost became the
+button it was always miming, and remote seats moved to the two places that
+already described them, the header line's census and **VIEW LEVEL**'s seat
+report.
 
 ### 9.19 Company List geometry
 

--- a/docs/company-basecamp-design.md
+++ b/docs/company-basecamp-design.md
@@ -339,7 +339,10 @@ first**, then machines, because the seat rail shows only this machine's seats
 and the size of the lobby has nowhere else to live. It reads
 `HOSTING GLAD-7Q2F: 3 PLAYERS / 2 MACHINES` (or `IN <room>: ...` for a guest).
 A narrower band takes a whole shorter spelling rather than a byte cut:
-`3 PLAYERS/2 PCS`, then `3P/2M`, then the room code goes. The joiner's line
+`3 PLAYERS/2 PCS`, then `3P/2M`, then the room code goes. One is one: a lobby
+of one reads `1 PLAYER`, `1 MACHINE`, `1 PC` — the singular is always the
+shorter spelling, so it can never cost a rung the band it used to fit. The
+joiner's line
 no longer names the host company — every one of the host's roster rows already
 does, and none of them carries the census. A degraded-link alert takes the
 same line and its warning color.
@@ -356,8 +359,25 @@ closing on the panel's right rail with no remainder (4x70 + 3x8 = 304 = 312 -
 card can never slide sideways under a finger already on its way down to it.
 The face never changes width; it is an eleven-character label budget that the
 seat names, **ADD PLAYER**, **LOBBY FULL** and the team chip all depend on.
-The chip owns the face's last nine pixels, and the label's trailing pad is what
-keeps the centred ink clear of it.
+The chip owns the face's last ten pixels — eight for the chip and one of face
+either side of it, so it is framed on the right exactly as it is above and
+below — and a seat label's two trailing pads are what centre its ink over the
+zone the chip leaves rather than over the whole face. A bare slot has no chip
+to dodge, so **ADD PLAYER** and **LOBBY FULL** centre on the face itself.
+
+The rail's band — everything between the roster panel's bottom bevel and the
+command strip — is painted black before the buttons draw. The title backdrop
+runs behind this screen, and the 8-pixel gutters framed a fragment of its grey
+blade so neatly that it read as a stray glyph between two cards. One ground
+under the whole row also makes a networked frame and a local one identical
+here. The band is 17 pixels for a 10-pixel card: 3 above and 4 below, because
+an odd budget cannot split evenly and the heavier gap belongs under the rail,
+where the command strip's own bevel already separates.
+
+A dimmed slot is still a whole card. The disabled face shade collides with the
+button shadow shade, so a dimmed face steps its right and bottom bevels one
+shade darker; without that, **LOBBY FULL** rendered as a card with a flat
+right edge.
 
 What varies is how many slots are live, and that is a property of the DEVICE,
 never of the lobby: four on a desktop, one on a phone with nothing attached,

--- a/docs/company-basecamp-design.md
+++ b/docs/company-basecamp-design.md
@@ -88,7 +88,10 @@ level, and experience fields.
 - Use **+** at the left end of the seat rail to add a local seat. A machine
   may contribute four active seats and a network lobby may contain sixteen.
   Four cards are shown at a time; **<** and **>** page the rail when it grows
-  past the visible window.
+  past the visible window. Slots with no seat in them yet are drawn as empty
+  recesses, showing where the next player will land. They appear only while
+  another seat can actually be claimed, so a device that seats one player
+  shows one card and nothing else.
 - Open an owned seat card to edit that player. The top row contains
   **4-DIRECTION**/**8-DIRECTION**, **REMAP**, and **RESET**. The bottom row
   contains **TEAM** and **REMOVE PLAYER**. In a network lobby the last action
@@ -338,16 +341,33 @@ A degraded-link alert takes the same line and its warning color.
 ### 9.14 Eight-row page
 
 Eight roster rows fit above the independent player-seat rail while leaving the
-column header clear. The rail reads left to right: **+**, then a four-card
-window between **<** and **>**. Every neighbour on the row is seven pixels
-apart, the **+** starts on BACK's left edge, and the **>** closes on the
-panel's right rail. The scenario summary is a direct click target.
+column header clear. The rail reads left to right: **+**, then a four-slot
+window between **<** and **>**. The scenario summary is a direct click target.
+
+The row is laid out every frame from the controls that are actually on it, and
+it always opens on BACK's left edge. Real cards pack left into the slots and
+the slots that follow are drawn as empty recesses — ghosts — as long as
+another seat can be claimed. A row that fills all four slots, and any row
+whose pager arrows are up, justifies between the panel's two rails: the slack
+is split evenly among the gutters, the leftmost ones absorbing the odd pixel.
+A shorter row packs left at the same seven-pixel gutter instead of stretching,
+because two controls spread across the whole panel read as a mistake. The card
+face never changes width; it is a nine-character label budget that the seat
+names and the team chip both depend on.
+
+Three shapes are worth naming. Four seats and both arrows is the widest one,
+and its arithmetic is what the seven-pixel gutter was chosen for: 262 pixels
+of face across 8..312 leaves 42 for six gutters. One seat on a desktop draws
+one card and three ghosts, justified. A single-seat device — a phone with
+nothing attached — hides **+**, offers no ghosts, and puts its lone card flush
+on the left rail rather than floating in from the edge.
 
 The rail once opened with a **SEATS** label that led to the team overview.
 That was a second, worse-placed door to a screen the Scenario menu already
 owned, and it cost the cards their breathing room — the four faces sat a
 single pixel apart. Issue #236 spent the label's width on the gutters and
-gave its ordinal to the **+**.
+gave its ordinal to the **+**; issue #243 stopped the leftover width from
+collecting in the holes those hidden controls left behind.
 
 ### 9.19 Company List geometry
 

--- a/docs/menu-engine.md
+++ b/docs/menu-engine.md
@@ -132,7 +132,12 @@ back. `run_menu_screen` derives the decision; no screen declares a fade:
     `run_nested_menu_door()` is the one bracket both share: it fades the menu
     out, notes `Fade` so the nested entry fades in, and on the way back fades
     the door out and leaves a black note that the parent loop turns into a
-    fade-in on its next present.
+    fade-in on its next present. Half of the way in belongs to the body: it
+    has to spend that `Fade` note on a fade-in of its own first composed
+    frame. CLOUD SAVES gets that from the runner; the level editor runs its
+    own loop, so it calls `begin_legacy_menu_entry_fade()` and presents its
+    first frame with `fadeblack(1)`. A body that discards the note leaves the
+    door at one fade in against two back — the asymmetry #237 is about.
   - **NETWORKING** — a Base Camp strip door, but Base Camp *exits* before its
     legacy screen runs, so the rule would fade both legs. `configure_networking`
     notes `Instant` on the way in and on a non-hookup return, keeping the door

--- a/docs/menu-engine.md
+++ b/docs/menu-engine.md
@@ -113,53 +113,101 @@ Fades follow one rule (#237): a transition fades exactly when it crosses the
 main-menu boundary, and it fades **symmetrically** — the way in and the way
 back. `run_menu_screen` derives the decision; no screen declares a fade:
 
-- `MenuScreenKind::Screen` entered at menu-stack depth 1 fades: the previous
-  surface fades out (skipped when a teardown already noted the surface
-  black), the cold first frame is composed, and `fadeblack(1)` presents it.
-  Every main-menu door enters this way — GAME SETTINGS, HELP, the LOAD list,
-  BEGIN NEW GAME's name entry, CONTINUE's Base Camp — and so does the main
-  menu itself behind each BACK. That symmetry is the rule's whole point: a
-  door that faded only on the way back was the bug (#237).
+- `MenuScreenKind::Screen` entered at menu-stack depth 1 fades: whatever is
+  still on the window fades out (a no-op when the previous screen already
+  faded itself out — see ownership below), the cold first frame is composed,
+  `fadeblack(1)` presents it, and the screen fades its own last frame out
+  again at its exit. Every main-menu door enters this way — GAME SETTINGS,
+  HELP, the LOAD list, BEGIN NEW GAME's name entry, CONTINUE's Base Camp —
+  and so does the main menu itself behind each BACK. That symmetry is the
+  rule's whole point: a door that faded only on the way back was the bug
+  (#237).
 - A nested `run_menu_screen` call (any subscreen door under an open screen)
   never fades; its cold frame is composed and presented directly. Base Camp's
   strip and roster doors, settings' own subscreens, and the company list's
   BACKUPS view are all instant, both ways.
 - Two doors sit on neither side of that line and take a one-shot
-  `note_menu_entry_fade()` override (swallowed by every entry like the black
-  note, so an unused one cannot leak forward):
+  `note_menu_entry_fade()` override (swallowed by every entry, so an unused
+  one cannot leak forward):
   - **Nested main-menu doors** — CLOUD SAVES and the LEVEL EDITOR run inside
     the still-open main menu, at a depth the rule reads as "subscreen".
-    `run_nested_menu_door()` is the one bracket both share: it fades the menu
-    out, notes `Fade` so the nested entry fades in, and on the way back fades
-    the door out and leaves a black note that the parent loop turns into a
-    fade-in on its next present. Half of the way in belongs to the body: it
-    has to spend that `Fade` note on a fade-in of its own first composed
-    frame. CLOUD SAVES gets that from the runner; the level editor runs its
-    own loop, so it calls `begin_legacy_menu_entry_fade()` and presents its
-    first frame with `fadeblack(1)`. A body that discards the note leaves the
-    door at one fade in against two back — the asymmetry #237 is about.
+    `run_nested_menu_door()` notes `Fade`, so the nested entry fades the
+    still-open menu out and its own first frame in; the nested screen's exit
+    fades it out again, and the parent loop's next present finds a black
+    window and fades back in. CLOUD SAVES gets all of that from the runner;
+    the level editor runs its own loop, so it holds a `LegacyMenuFade` and
+    calls `end()` before its post-loop teardown touches the buffer.
   - **NETWORKING** — a Base Camp strip door, but Base Camp *exits* before its
-    legacy screen runs, so the rule would fade both legs. `configure_networking`
-    notes `Instant` on the way in and on a non-hookup return, keeping the door
-    as snappy as its HIRE/TRAIN/DIFFICULTY siblings. A successful hookup notes
-    nothing: that one leaves the lobby-config context and Base Camp's entry
-    fades it.
-- `MenuScreenKind::Overlay` (the pause family) never fades at any depth.
-- Legacy full-screen entries outside the runner — NETWORKING, campaign
-  select, the results panel — apply the same rule by hand through
-  `begin_legacy_menu_entry_fade()`, which honors the same override.
+    legacy screen runs, so the rule would fade both legs. The click intercept
+    notes `Instant` before Base Camp exits (its exit scope skips the fade-out
+    on a pending `Instant`), `configure_networking` notes it again on the way
+    in and on a non-hookup return, keeping the door as snappy as its
+    HIRE/TRAIN/DIFFICULTY siblings. A successful hookup notes nothing: that
+    one leaves the lobby-config context and Base Camp's entry fades it.
+- `MenuScreenKind::Overlay` (the pause family) never fades at any depth, not
+  even when its loop's present finds a black window.
+- Legacy full-screen presenters outside the runner — campaign select, the
+  results panel, the level editor, the campaign intro scroller, NETWORKING —
+  apply the same rule by hand through `og::ui::LegacyMenuFade`, which honors
+  the same override.
 
-The teardowns that already fade the presented surface to black (the two
-gameplay exits, the intro's last page, the new-game cut) call
-`note_menu_faded_to_black()`; the next fading entry skips its own fade-out
-instead of playing black-to-black (#200). Every entry consumes the note,
-fading or not, so a stale note cannot leak one screen forward. Purely
-technical fades that mask loads and canvas resets (glad_init, the gameplay
-teardowns) are not entry transitions and stay where they are.
+### Ownership: whoever fades in fades out
+
+A fade-out belongs to the outgoing screen and runs **at that screen's own
+exit, while its last presented frame is still the render buffer** —
+`run_menu_screen` holds an RAII scope whose destructor fades out on every
+return path, and a legacy presenter's `LegacyMenuFade` does the same (its
+`end()` runs the fade early where later teardown would touch the buffer or
+switch the active canvas). The fade-out is never deferred to the incoming
+screen. That deferral is what the two shipped hard cuts (naming a new company,
+dismissing the campaign intro) and the HELP regression before them had in
+common: between the outgoing screen's last present and its deferred fade-out
+sat door-site code — setup, `clear()`s, mounts — and one clear was enough to
+turn the fade into black-to-black. `fadeblack(0)` reads the **buffer**, not
+the window, so nothing may write the buffer between a screen's last present
+and its fade-out; with the fade at the exit, nothing can.
+
+The video layer is the single source of truth for "the window is black"
+(`screen::window_is_black()`: set by a completed `fadeblack(0)`, cleared by
+every present through `Screen::swap`, true from window creation). A
+`fadeblack(0)` on a black window is a no-op that never reaches `FadeBetween`,
+so a teardown that already faded out (the two gameplay exits, the intro's
+last page, the results panel) never plays a second, black-to-black fade, and
+no screen has to be told about it. Purely technical fades that mask loads and
+canvas resets (`glad_init`, the gameplay teardowns) are not entry transitions
+and stay where they are; idempotency makes them harmless when the last screen
+already faded.
+
+Two invariants make the class structurally impossible rather than merely
+fixed. Under TESTING the video layer checks them at the fade itself and
+records a violation (`og::video_testing::g_fade_violations`, traced as
+`("video", "FADE VIOLATION: ...")`); `integration_main`'s listener fails the
+running test on every violation, so every flow test in the tree is an oracle:
+
+- `fadeblack(1)` requires a black window — **"fade-in without a fade-out"**;
+- `fadeblack(0)` requires the render buffer to equal the frame the window last
+  showed (a per-surface snapshot taken at every present) — **"fade-out from a
+  frame that was never presented"**, which catches both a clear and a stale
+  redraw between the last present and the fade.
+
+The third guard is static: every `fadeblack(` call site under `src/` is listed
+with its reason in `scripts/fadeblack_sites.txt`, and
+`scripts/check_fadeblack_sites.sh` (a build dependency of `og_interface` and
+`og_platform_sdl`) fails the build on an unlisted call, so a new ad-hoc fade
+has to be classified before it compiles.
+
+The demo compositor (`demo.cpp`) presents through its own `SDL_RenderPresent`
+and never fades; it is documented here rather than hooked.
 
 Fades are instant under TESTING (`FadeBetween` blits once and traces instead
 of animating), so injector `SDL_Delay(750)` waits are generic settles, not
-fade timing.
+fade timing. Two TESTING hooks keep the campaign-intro leg inside every BEGIN
+NEW GAME flow: the un-driven campaign browser accepts the current campaign one
+presented frame in (`campaign_picker_testing_set_auto_accept`, re-armed at
+every test start; a test that drives the browser disarms it — every
+`campaign_picker_testing_input_reset()` does), and the un-driven text scroller
+dismisses itself after its first frame unless a test forces the real view
+(`help_testing_set_force_scroll_text`).
 
 The runtime also supports:
 

--- a/docs/menu-engine.md
+++ b/docs/menu-engine.md
@@ -116,10 +116,17 @@ the decision; no screen declares a fade:
 - `MenuScreenKind::Screen` entered at menu-stack depth 1 fades: the previous
   surface fades out (skipped when a teardown already noted the surface
   black), the cold first frame is composed, and `fadeblack(1)` presents it.
-  The main menu, Base Camp, name entry, the LOAD list, and the main menu's
-  SETTINGS/HELP doors all enter this way.
+  The main menu, Base Camp, and name entry (the BEGIN NEW GAME flow's first
+  step) enter this way.
 - A nested `run_menu_screen` call (any subscreen door under an open screen)
   never fades; its cold frame is composed and presented directly.
+- A depth-1 sibling that is really a door on the open menu — SETTINGS, HELP,
+  the LOAD list, NETWORKING, and the way back from each — is a *peer
+  transition*, not a context switch: the dispatch site calls
+  `note_menu_peer_transition()` (a one-shot, swallowed by every entry like
+  the black note) and the entry stays instant. Only an outcome that leaves
+  the cluster (a company opened, a network hookup) fades, at the next
+  context switch's own entry.
 - `MenuScreenKind::Overlay` (the pause family) never fades at any depth.
 - Legacy full-screen entries outside the runner — NETWORKING, campaign
   select, the results panel — apply the same rule by hand through

--- a/docs/menu-engine.md
+++ b/docs/menu-engine.md
@@ -37,7 +37,11 @@ A `MenuScreenSpec` supplies:
 
 Rows are materialized into the existing `button`/`vbutton` surfaces. Hidden
 rows disappear from both pointer and keyboard navigation. Disabled rows remain
-visible but have no action.
+visible but have no action, and draw with a dimmed face. That dim shade
+collides with the palette entry the button shadow uses, so a dimmed row also
+steps its right and bottom bevels one shade darker (`vbutton::dimmed`);
+without it a disabled row loses two of its four bevels and reads as a
+half-drawn card.
 
 Dynamic company and backup lists use fixed row tables windowed by `PageModel`.
 Stable row IDs and button ordinals are therefore preserved between pages.

--- a/docs/menu-engine.md
+++ b/docs/menu-engine.md
@@ -140,12 +140,22 @@ back. `run_menu_screen` derives the decision; no screen declares a fade:
   - **NETWORKING** — a Base Camp strip door, but Base Camp *exits* before its
     legacy screen runs, so the rule would fade both legs. The click intercept
     notes `Instant` before Base Camp exits (its exit scope skips the fade-out
-    on a pending `Instant`), `configure_networking` notes it again on the way
+    on a pending `Instant` and traces `exit fade skipped: Instant note
+    pending` — the networking flow pins hold that trace to exactly one
+    occurrence, this door), `configure_networking` notes it again on the way
     in and on a non-hookup return, keeping the door as snappy as its
-    HIRE/TRAIN/DIFFICULTY siblings. A successful hookup notes nothing: that
-    one leaves the lobby-config context and Base Camp's entry fades it.
-- `MenuScreenKind::Overlay` (the pause family) never fades at any depth, not
-  even when its loop's present finds a black window.
+    HIRE/TRAIN/DIFFICULTY siblings. An `Instant` note suppresses only that
+    entry's fade-in: Base Camp re-entered under it still owns its exit
+    fade, so BACK to the main menu fades like every boundary crossing
+    (only a fresh `Instant` pending at that exit skips it). A successful hookup leaves the
+    lobby-config context, so that exit is the legacy screen's own: it calls
+    `LegacyMenuFade::fade_out_at_exit()` and fades its last frame out
+    (instant-in, fade-out-to-Base-Camp), and Base Camp's fading re-entry
+    finds the black window it expects.
+- `MenuScreenKind::Overlay` (the pause family) never fades at any depth, and
+  neither does any other non-fading entry whose loop finds a black window: the
+  loop's fade-in is gated on the entry's own fade scope, so only a screen
+  whose exit will fade out again ever fades in.
 - Legacy full-screen presenters outside the runner — campaign select, the
   results panel, the level editor, the campaign intro scroller, NETWORKING —
   apply the same rule by hand through `og::ui::LegacyMenuFade`, which honors
@@ -178,26 +188,56 @@ canvas resets (`glad_init`, the gameplay teardowns) are not entry transitions
 and stay where they are; idempotency makes them harmless when the last screen
 already faded.
 
-Two invariants make the class structurally impossible rather than merely
-fixed. Under TESTING the video layer checks them at the fade itself and
-records a violation (`og::video_testing::g_fade_violations`, traced as
-`("video", "FADE VIOLATION: ...")`); `integration_main`'s listener fails the
-running test on every violation, so every flow test in the tree is an oracle:
+Three TESTING invariants back the rule. Each records a violation
+(`og::video_testing::g_fade_violations`, traced as `("video", "FADE VIOLATION:
+...")`), and `integration_main`'s listener fails the running test on every one,
+so every flow test in the tree is an oracle. Exactly these three things fire:
 
-- `fadeblack(1)` requires a black window — **"fade-in without a fade-out"**;
-- `fadeblack(0)` requires the render buffer to equal the frame the window last
-  showed (a per-surface snapshot taken at every present) — **"fade-out from a
-  frame that was never presented"**, which catches both a clear and a stale
-  redraw between the last present and the fade.
+- `fadeblack(1)` on a window that is not black — **"fade-in without a
+  fade-out"** (the video layer, at the fade);
+- `fadeblack(0)` when the render buffer differs from what the window last
+  showed — **"fade-out from a frame that was never presented"** (the video
+  layer, at the fade). "Showed" is the rect each present *declared*:
+  `Screen::swap` snapshots only its `x,y,w,h` (a full-frame present snapshots
+  everything), so a clear, a stale redraw, or a draw outside every present's
+  rect all count. The nearest present path happens to upload the whole
+  surface; the SAI/Eagle path refreshes only the rect of its scaled scratch —
+  the declared rect is the honest lower bound and callers are held to it;
+- a fading **entry** — `run_menu_screen` at depth 1, or an active
+  `LegacyMenuFade` — that finds the window not black — **"entry found an
+  unfaded window: the previous surface exited without its fade-out (<screen
+  name>)"** (the runner, before its entry fade-out). The entry still fades
+  out, because production must never hard-cut; under TESTING the missing exit
+  fade is the failure. A nested main-menu door under a `Fade` note is the one
+  entry exempt by definition: its parent has not exited, and fading the
+  still-open parent out is the door's own job.
 
-The third guard is static: every `fadeblack(` call site under `src/` is listed
-with its reason in `scripts/fadeblack_sites.txt`, and
+Nothing else is checked. A missing fade-in, or a fade at a door the depth rule
+says is instant, shows up only in the per-leg count pins.
+
+The entry invariant is what makes the deferred fade-out impossible to
+reintroduce silently: an entry's own `fadeblack(0)` is a no-op on the black
+window a correct exit leaves, so a screen that forgets its exit fade would
+otherwise be faded out by the *next* entry — invisibly. Every producer is
+therefore ownership-correct rather than exempted: the intro fades the loading
+dialog out (and the intro-skipped web start fades it out where the skip
+happens), the networking screen fades itself out on hookup, the results panel
+fades the mission's tail (its last frame with the ending popup dismissed) out
+before its own entry, and the test boundary leaves the window **black** —
+what an exit fade leaves and what a process starts with — so a direct-call
+test that presents a frame of its own owes that frame's fade-out like any
+other screen.
+
+The fourth guard is static: every function under `src/` that calls
+`fadeblack(` is listed in `scripts/fadeblack_sites.txt` as
+`<path>::<function>=<count>` with its reason, and
 `scripts/check_fadeblack_sites.sh` (a build dependency of `og_interface` and
-`og_platform_sdl`) fails the build on an unlisted call, so a new ad-hoc fade
-has to be classified before it compiles. Sites are keyed by path plus enclosing
-function rather than by line number, so editing around a fade never rots the
-list — and an allowlisted key that no longer resolves fails the build too, so a
-renamed or deleted fade site gets reclassified instead of lingering.
+`og_platform_sdl`) fails the build on an unlisted function, on a listed
+function whose call count changed, and on a listed function that no longer
+fades. The count is the point: a door-site fade planted beside an existing
+teardown fade in `go_menu` or `glad_init` is exactly the shape the rule
+forbids, and a per-function count is what makes it fail to build. Keys carry
+no line numbers, so editing around a fade never rots the list.
 
 The demo compositor (`demo.cpp`) presents through its own `SDL_RenderPresent`
 and never fades; it is documented here rather than hooked.
@@ -208,7 +248,8 @@ fade timing. Two TESTING hooks keep the campaign-intro leg inside every BEGIN
 NEW GAME flow: the un-driven campaign browser accepts the current campaign one
 presented frame in (`campaign_picker_testing_set_auto_accept`, re-armed at
 every test start; a test that drives the browser disarms it — every
-`campaign_picker_testing_input_reset()` does), and the un-driven text scroller
+`campaign_picker_testing_input_reset()` does — and with nothing listed it
+returns empty at once rather than blocking), and the un-driven text scroller
 dismisses itself after its first frame unless a test forces the real view
 (`help_testing_set_force_scroll_text`).
 

--- a/docs/menu-engine.md
+++ b/docs/menu-engine.md
@@ -194,7 +194,10 @@ The third guard is static: every `fadeblack(` call site under `src/` is listed
 with its reason in `scripts/fadeblack_sites.txt`, and
 `scripts/check_fadeblack_sites.sh` (a build dependency of `og_interface` and
 `og_platform_sdl`) fails the build on an unlisted call, so a new ad-hoc fade
-has to be classified before it compiles.
+has to be classified before it compiles. Sites are keyed by path plus enclosing
+function rather than by line number, so editing around a fade never rots the
+list — and an allowlisted key that no longer resolves fails the build too, so a
+renamed or deleted fade site gets reclassified instead of lingering.
 
 The demo compositor (`demo.cpp`) presents through its own `SDL_RenderPresent`
 and never fades; it is documented here rather than hooked.

--- a/docs/menu-engine.md
+++ b/docs/menu-engine.md
@@ -77,7 +77,8 @@ Entry performs these steps:
 2. Initialize live buttons and clear keyboard state.
 3. Apply art bindings.
 4. Compute row gates and navigation.
-5. Run the screen's entry transition.
+5. Compose and present the cold first frame — faded in when the entry is a
+   context switch (see "Drawing and transitions").
 
 Each frame then:
 
@@ -108,10 +109,36 @@ compiled variants must keep every surviving raw index and link valid.
 
 ## Drawing and transitions
 
-The runtime supports:
+Fades follow one rule (#237): a screen fades exactly when it is entered as a
+context switch — from outside the open menu stack. `run_menu_screen` derives
+the decision; no screen declares a fade:
 
-- the main menu's initial draw between fade-out and fade-in;
-- Base Camp's fade around its cold first frame;
+- `MenuScreenKind::Screen` entered at menu-stack depth 1 fades: the previous
+  surface fades out (skipped when a teardown already noted the surface
+  black), the cold first frame is composed, and `fadeblack(1)` presents it.
+  The main menu, Base Camp, name entry, the LOAD list, and the main menu's
+  SETTINGS/HELP doors all enter this way.
+- A nested `run_menu_screen` call (any subscreen door under an open screen)
+  never fades; its cold frame is composed and presented directly.
+- `MenuScreenKind::Overlay` (the pause family) never fades at any depth.
+- Legacy full-screen entries outside the runner — NETWORKING, campaign
+  select, the results panel — apply the same rule by hand through
+  `begin_legacy_menu_entry_fade()`.
+
+The teardowns that already fade the presented surface to black (the two
+gameplay exits, the intro's last page, the new-game cut) call
+`note_menu_faded_to_black()`; the next fading entry skips its own fade-out
+instead of playing black-to-black (#200). Every entry consumes the note,
+fading or not, so a stale note cannot leak one screen forward. Purely
+technical fades that mask loads and canvas resets (glad_init, the gameplay
+teardowns) are not entry transitions and stay where they are.
+
+Fades are instant under TESTING (`FadeBetween` blits once and traces instead
+of animating), so injector `SDL_Delay(750)` waits are generic settles, not
+fade timing.
+
+The runtime also supports:
+
 - background drawing below buttons;
 - content drawing above buttons;
 - screens without a backdrop;

--- a/docs/menu-engine.md
+++ b/docs/menu-engine.md
@@ -246,6 +246,46 @@ no line numbers, so editing around a fade never rots the list.
 The demo compositor (`demo.cpp`) presents through its own `SDL_RenderPresent`
 and never fades; it is documented here rather than hooked.
 
+### Pointer handoff: a surface owns its pointer state
+
+The fade rule's sibling, born from the editor-exit phantom click (File →
+Exit in the LEVEL EDITOR, hover BEGIN NEW GAME during the fade back — it
+activated itself): a surface **acknowledges the presses it saw, and hands
+back a clean pointer when it returns. No screen may consume a click minted
+on another surface.**
+
+The mechanism being contained is the collapsed-tap pending queue in
+`input.cpp`: a release whose press no `query_mouse()` observed mints a
+pending click — deliberately, because a web tap can land press+release
+inside one pump. The queue carries **no coordinates**; a consumer pairs a
+pending click with the LIVE pointer. A surface that pumps its own events
+and reads the pointer through `query_mouse_no_poll()` therefore mints one
+phantom per click unless it acknowledges its presses, and whatever it
+leaks is spent by the next screen's `leftmouse()` at wherever the pointer
+has moved to — the 500 ms fade is merely the delay that lets it travel.
+
+Obligations:
+
+- A self-pumping surface calls `acknowledge_mouse_presses()` once per
+  frame, after its pump — `query_mouse()`'s observed-press bookkeeping
+  without the poll (a second poll would steal the surface's own events).
+  The level editor, the results panel, and the editor's text prompt do
+  this; surfaces that call `query_mouse()` every frame (HELP is the
+  model) are already correct.
+- `run_menu_screen` re-baselines the pointer
+  (`reset_mouse_click_tracking()`) beside `clear_keyboard()` at entry,
+  and again before its loop-exit return — every engine screen starts
+  from and returns a clean pointer.
+- `run_nested_menu_door` re-baselines after its body returns, so a
+  legacy body hands the still-open parent a clean pointer even if it
+  leaked, and an impatient click during the door's exit fade is dropped
+  with it. A click during the PARENT's own fade-in is a genuine click at
+  the pointer's position and stays honored — that is what the
+  collapsed-tap queue is for.
+- Level-triggered pickers (campaign select, the level picker) hold fire
+  at entry until the door click's button has been seen up once, so a
+  held button cannot click through onto a row on frame one.
+
 Fades are instant under TESTING (`FadeBetween` blits once and traces instead
 of animating), so injector `SDL_Delay(750)` waits are generic settles, not
 fade timing. Two TESTING hooks keep the campaign-intro leg inside every BEGIN

--- a/docs/menu-engine.md
+++ b/docs/menu-engine.md
@@ -109,28 +109,40 @@ compiled variants must keep every surviving raw index and link valid.
 
 ## Drawing and transitions
 
-Fades follow one rule (#237): a screen fades exactly when it is entered as a
-context switch — from outside the open menu stack. `run_menu_screen` derives
-the decision; no screen declares a fade:
+Fades follow one rule (#237): a transition fades exactly when it crosses the
+main-menu boundary, and it fades **symmetrically** — the way in and the way
+back. `run_menu_screen` derives the decision; no screen declares a fade:
 
 - `MenuScreenKind::Screen` entered at menu-stack depth 1 fades: the previous
   surface fades out (skipped when a teardown already noted the surface
   black), the cold first frame is composed, and `fadeblack(1)` presents it.
-  The main menu, Base Camp, and name entry (the BEGIN NEW GAME flow's first
-  step) enter this way.
+  Every main-menu door enters this way — GAME SETTINGS, HELP, the LOAD list,
+  BEGIN NEW GAME's name entry, CONTINUE's Base Camp — and so does the main
+  menu itself behind each BACK. That symmetry is the rule's whole point: a
+  door that faded only on the way back was the bug (#237).
 - A nested `run_menu_screen` call (any subscreen door under an open screen)
-  never fades; its cold frame is composed and presented directly.
-- A depth-1 sibling that is really a door on the open menu — SETTINGS, HELP,
-  the LOAD list, NETWORKING, and the way back from each — is a *peer
-  transition*, not a context switch: the dispatch site calls
-  `note_menu_peer_transition()` (a one-shot, swallowed by every entry like
-  the black note) and the entry stays instant. Only an outcome that leaves
-  the cluster (a company opened, a network hookup) fades, at the next
-  context switch's own entry.
+  never fades; its cold frame is composed and presented directly. Base Camp's
+  strip and roster doors, settings' own subscreens, and the company list's
+  BACKUPS view are all instant, both ways.
+- Two doors sit on neither side of that line and take a one-shot
+  `note_menu_entry_fade()` override (swallowed by every entry like the black
+  note, so an unused one cannot leak forward):
+  - **Nested main-menu doors** — CLOUD SAVES and the LEVEL EDITOR run inside
+    the still-open main menu, at a depth the rule reads as "subscreen".
+    `run_nested_menu_door()` is the one bracket both share: it fades the menu
+    out, notes `Fade` so the nested entry fades in, and on the way back fades
+    the door out and leaves a black note that the parent loop turns into a
+    fade-in on its next present.
+  - **NETWORKING** — a Base Camp strip door, but Base Camp *exits* before its
+    legacy screen runs, so the rule would fade both legs. `configure_networking`
+    notes `Instant` on the way in and on a non-hookup return, keeping the door
+    as snappy as its HIRE/TRAIN/DIFFICULTY siblings. A successful hookup notes
+    nothing: that one leaves the lobby-config context and Base Camp's entry
+    fades it.
 - `MenuScreenKind::Overlay` (the pause family) never fades at any depth.
 - Legacy full-screen entries outside the runner — NETWORKING, campaign
   select, the results panel — apply the same rule by hand through
-  `begin_legacy_menu_entry_fade()`.
+  `begin_legacy_menu_entry_fade()`, which honors the same override.
 
 The teardowns that already fade the presented surface to black (the two
 gameplay exits, the intro's last page, the new-game cut) call

--- a/docs/mp-game-modes.md
+++ b/docs/mp-game-modes.md
@@ -93,16 +93,20 @@ the control from it returns to **ALL**.
 VIEW LEVEL previews the result: entries the setting will remove are flagged
 in the scenario report.
 
-Assign player teams with the seat rail in Base Camp. Use **+** at its left end
-to add a local seat, then open an owned **P#** card and choose **TEAM** in its
-editor.
-The rail shows four cards at a time and **<**/**>** page through larger network
-lobbies. Put several seats on one team for co-op, or spread them across teams
-for a versus or mixed-team match. Remote cards are read-only.
+Assign player teams with the seat rail in Base Camp. The rail is this
+machine's four seats: tap a slot reading **ADD PLAYER** to claim one, then
+open its **P#** card and choose **TEAM** in the editor. Put several seats on
+one team for co-op, or spread them across teams for a versus or mixed-team
+match. Other machines' seats are not in the rail — the header line counts them
+and **VIEW LEVEL** lists them with their teams.
+
+A slot dims to **LOBBY FULL** when the lobby is at its sixteen-player ceiling,
+and a device that seats fewer than four players shows fewer slots.
 
 The same editor selects 4- or 8-direction movement, remaps that local player's
 keys, resets that player's controls, and removes the seat. Removing a machine's
-last network seat leaves it connected as a spectator; **+** brings it back.
+last network seat leaves it connected as a spectator; any **ADD PLAYER** slot
+brings it back.
 Seat membership and match team choices belong to the current session, not the
 company file. A fighter's color remains its combat allegiance, so changing a
 player-seat assignment does not recolor the company roster. The assignments

--- a/docs/pause-menu-design.md
+++ b/docs/pause-menu-design.md
@@ -140,10 +140,11 @@ seat settings, minus TEAM):
 
 `"P1 YOU "` → `"P1 {SHORT} "` for local seats, where SHORT is the mapping
 short name (≤5 chars: `WASD`, `ARROW`, `IJKL`, `TFGH`, `JOY1`, or the derived
-movement cluster for customs). Budget: the 57px card face is exactly 9 chars
-and the trailing space is load-bearing (team chip clearance): `"P2 ARROW "` =
-9. Foreign seats keep `"P3 {ABBR} "`. The shared seat identity strings are
-unchanged.
+movement cluster for customs). Budget: the seat card face is exactly 11 chars
+(70px / 6) and the trailing space is load-bearing (team chip clearance):
+`"P2 ARROW "` = 9, well inside it. The rail holds only this machine's seats,
+so no card carries a foreign company abbreviation any more. The shared seat
+identity strings are unchanged.
 
 ## 3. Named mappings
 
@@ -248,7 +249,7 @@ inserts, zero parity-golden movement, zero protocol bump):
    every frame; it was just unrouted.
 5. Team choice: the team of view 0 in allied/co-op saves (the common case);
    the new seat's controls come from the rotated profile pool exactly as a
-   Base Camp `[+]` would.
+   Base Camp **ADD PLAYER** slot would.
 6. The local lobby seat count is synced at level end so the added player
    survives the return to Base Camp.
 

--- a/docs/pause-menu-design.md
+++ b/docs/pause-menu-design.md
@@ -138,11 +138,13 @@ seat settings, minus TEAM):
 
 ### 2.3 Base Camp seat cards
 
-`"P1 YOU "` → `"P1 {SHORT} "` for local seats, where SHORT is the mapping
+`"P1 YOU "` → `"P1 {SHORT}  "` for local seats, where SHORT is the mapping
 short name (≤5 chars: `WASD`, `ARROW`, `IJKL`, `TFGH`, `JOY1`, or the derived
 movement cluster for customs). Budget: the seat card face is exactly 11 chars
-(70px / 6) and the trailing space is load-bearing (team chip clearance):
-`"P2 ARROW "` = 9, well inside it. The rail holds only this machine's seats,
+(70px / 6) and BOTH trailing spaces are load-bearing — they centre the visible
+ink over the zone the team chip leaves rather than over the whole face:
+`"P2 ARROW  "` = 10, and the widest shape, `"P16 ARROW  "`, is exactly 11. The
+rail holds only this machine's seats,
 so no card carries a foreign company abbreviation any more. The shared seat
 identity strings are unchanged.
 

--- a/include/openglad/gameplay/lobby_server.h
+++ b/include/openglad/gameplay/lobby_server.h
@@ -137,7 +137,7 @@ private:
         // Removing the final seat leaves the peer connected as a true
         // spectator: it is absent from LobbyState, readiness, capacity, and
         // gameplay bindings. Retain only its stable command token privately so
-        // a later [+] can reactivate the same seat identity.
+        // a later ADD PLAYER can reactivate the same seat identity.
         LobbySeatId dormant_seat_id = kInvalidLobbySeatId;
         // Recipient-specific Join acknowledgement. This is deliberately peer
         // state rather than canonical LobbyState so another client's broadcast

--- a/include/openglad/interface/button.h
+++ b/include/openglad/interface/button.h
@@ -116,6 +116,13 @@ class vbutton
 		std::unique_ptr<pixieN> mypixie;
 		int hotkey;
 		unsigned char color;
+		// Drawn as an inert row: the face dims to GREY, which lands on the
+		// SAME palette shade as BUTTON_RIGHT/BUTTON_BOTTOM. Left alone, a
+		// dimmed button's right and bottom bevels dissolve into its face and
+		// it reads as a half-drawn card with a flat right edge. When this is
+		// set, vdisplay steps those two edges one shade darker so all four
+		// bevels survive at the dim shade.
+		bool dimmed = false;
 		bool hidden;
         bool no_draw;  // Does not draw but still accepts clicks
 };

--- a/include/openglad/interface/input.h
+++ b/include/openglad/interface/input.h
@@ -693,11 +693,30 @@ inline MouseState& query_mouse_no_poll() { return mouse_state; }
 // A press that begins after this call remains a normal fresh click.
 void reset_mouse_click_tracking();
 
+// Pointer-handoff bookkeeping for surfaces that run their OWN event pump and
+// read the pointer through query_mouse_no_poll() (the level editor, the
+// results panel, the editor's text prompt). Such a surface never runs
+// query_mouse()'s "press observed" acknowledgement, so every click made on
+// it would mint a collapsed-tap pending click — a click with no coordinates
+// that the NEXT surface's detector would spend at wherever the pointer is by
+// then (the editor-exit phantom-activation bug). Call once per frame, after
+// the pump: exactly query_mouse()'s observed-press bookkeeping WITHOUT the
+// poll — polling here would steal the surface's own events.
+void acknowledge_mouse_presses();
+
 // Collapsed touch-tap clicks (press+release inside one event pump, invisible
 // to sampled up->down edge detection). Click detectors OR these into their
 // edge results; each call consumes one pending click.
 bool take_pending_left_click();
 bool take_pending_right_click();
+
+#ifdef TESTING
+namespace og::input {
+// Test-only read of the collapsed-tap queue depth: the pointer-handoff
+// invariant is "zero pending clicks survive a surface boundary".
+int testing_pending_left_clicks();
+} // namespace og::input
+#endif
 
 unsigned char convert_to_ascii(int scancode);
 

--- a/include/openglad/interface/input.h
+++ b/include/openglad/interface/input.h
@@ -674,6 +674,9 @@ void clear_transient_input_state();
 void wait_for_key(int somekey);
 inline short query_key_press_event() { return input_key_press_event_ref(); }
 inline void clear_key_press_event() { input_key_press_event_ref() = 0; }
+// Monotonic count of key presses seen (never cleared): compare two readings
+// to ask "was a key pressed BETWEEN them" without disturbing the latch.
+unsigned query_key_press_serial();
 inline short query_text_input_event() { return input_text_input_event_ref(); }
 inline void clear_text_input_event() { input_text_input_event_ref() = 0; input_raw_text_input_ref().clear(); }
 void init_input();

--- a/include/openglad/interface/render/video.h
+++ b/include/openglad/interface/render/video.h
@@ -417,9 +417,14 @@ public:
     // fade-out with no present since. The single source of truth.
     virtual bool window_is_black() = 0;
 #ifdef TESTING
-    // Test boundary reset: the window counts as showing every canvas as it
-    // stands (not black). See Screen::testing_reset_window_state.
+    // Test boundary reset: the window is black and every canvas counts as
+    // presented as it stands. See Screen::testing_reset_window_state.
     virtual void testing_reset_window_state() = 0;
+    // Records a fade-ownership violation the video layer cannot see at the
+    // fade itself (an ENTRY that found an unfaded window — the outgoing
+    // screen skipped its exit fade-out). Same sink as the two fade-site
+    // invariants: traced, logged, and failed by the integration listener.
+    virtual void testing_report_fade_violation(const char* what) = 0;
 #endif
 
     virtual std::array<unsigned char, 768>& ourpalette_ref() = 0;

--- a/include/openglad/interface/render/video.h
+++ b/include/openglad/interface/render/video.h
@@ -406,7 +406,21 @@ public:
 
     virtual void fade_between24(void* surface, const Uint8* from, const Uint8* to, int amount) = 0;
     virtual int fade_between(void* old_surface, void* new_surface, void* dest_surface) = 0;
+    // Fade ownership (docs/menu-engine.md, "Drawing and transitions"):
+    // fadeblack(false) blends the ACTIVE render buffer to black and is a
+    // no-op (returns 0, no FadeBetween) while the window already shows
+    // black; fadeblack(true) blends the composed buffer in from black.
+    // Whoever fades a screen in fades it out, at its own exit, while its
+    // last presented frame is still the buffer.
     virtual int fadeblack(bool fade_in) = 0;
+    // True while the window shows black: never presented, or a completed
+    // fade-out with no present since. The single source of truth.
+    virtual bool window_is_black() = 0;
+#ifdef TESTING
+    // Test boundary reset: the window counts as showing every canvas as it
+    // stands (not black). See Screen::testing_reset_window_state.
+    virtual void testing_reset_window_state() = 0;
+#endif
 
     virtual std::array<unsigned char, 768>& ourpalette_ref() = 0;
     virtual std::array<unsigned char, 768>& redpalette_ref() = 0;

--- a/include/openglad/interface/screen.h
+++ b/include/openglad/interface/screen.h
@@ -300,6 +300,7 @@ public:
     bool window_is_black() override;
 #ifdef TESTING
     void testing_reset_window_state() override;
+    void testing_report_fade_violation(const char* what) override;
 #endif
     std::array<unsigned char, 768>& ourpalette_ref() override { return ourpalette; }
     std::array<unsigned char, 768>& redpalette_ref() override { return redpalette; }

--- a/include/openglad/interface/screen.h
+++ b/include/openglad/interface/screen.h
@@ -297,6 +297,10 @@ public:
     void fade_between24(void* surface, const Uint8* from, const Uint8* to, int amount) override;
     int fade_between(void* old_surface, void* new_surface, void* dest_surface) override;
     int fadeblack(bool fade_in) override;
+    bool window_is_black() override;
+#ifdef TESTING
+    void testing_reset_window_state() override;
+#endif
     std::array<unsigned char, 768>& ourpalette_ref() override { return ourpalette; }
     std::array<unsigned char, 768>& redpalette_ref() override { return redpalette; }
     std::array<unsigned char, 768>& bluepalette_ref() override { return bluepalette; }

--- a/include/openglad/interface/session_state.h
+++ b/include/openglad/interface/session_state.h
@@ -45,6 +45,9 @@ struct SessionState {
     int raw_key_ = 0;
     std::string raw_text_input_;
     short key_press_event_ = 0;
+    // Counts every key press; a fade aborts on a CHANGE during the fade
+    // (an edge), while key_press_event_ stays the latch everyone else reads.
+    unsigned key_press_serial_ = 0;
     // used to signal text input
     short text_input_event_ = 0;
     // for scrolling up and down text popups

--- a/include/openglad/interface/ui/menu_screen_spec.h
+++ b/include/openglad/interface/ui/menu_screen_spec.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+class screen;
+
 namespace og::ui {
 
 // Rows that do not apply to the target platform are dropped at
@@ -239,16 +241,31 @@ std::vector<const MenuButtonSpec*> materialized_spec_rows_for(
 // spec.exit_value (or propagates a remote-start MENU_EXIT).
 Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state = nullptr);
 
-// #237 depth-rule transition state. A fade-out semantically belongs to the
-// OUTGOING surface but is executed by the INCOMING screen; when a teardown
-// (the two gameplay exits, the intro's last page, the new-game cut) already
-// left the presented surface black, it notes that here and the next fading
-// entry skips its own fade-out instead of playing black-to-black (#200).
-// Every run_menu_screen entry (and begin_legacy_menu_entry_fade) consumes
-// the note even when it does not fade — the swallow-even-if-unused property
-// that keeps a stale note from leaking one screen forward.
-void note_menu_faded_to_black();
-bool consume_menu_faded_to_black();
+// #237 fade ownership (docs/menu-engine.md, "Drawing and transitions").
+//
+// THE RULE: whoever fades a screen IN fades it OUT, at its own exit, while
+// its last presented frame is still the render buffer. A fade-out is never
+// deferred to the incoming screen — that deferral left arbitrary door-site
+// code (setup, clears, mounts) between the outgoing screen's last present and
+// its fade-out, and every such site was a fresh chance to blacken the buffer
+// and turn the fade into a hard cut (the HELP, new-company and campaign-intro
+// regressions). run_menu_screen brackets a fading entry with an RAII scope
+// whose destructor fades out on EVERY return path; legacy presenters use
+// LegacyMenuFade (below) the same way.
+//
+// THE STATE: the video layer is the single source of truth for "the window
+// is black" (screen::window_is_black(); set by a completed fadeblack(0),
+// cleared by every present). fadeblack(0) on a black window is a no-op, so a
+// teardown or door that already faded out never plays a second, black-to-
+// black fade, and no screen has to be told about it — the "faded to black"
+// note this replaced is gone.
+//
+// THE INVARIANTS (TESTING, checked by the video layer at the fade itself and
+// turned into a test failure by integration_main's listener):
+//   * fadeblack(1) requires a black window — "fade-in without a fade-out";
+//   * fadeblack(0) requires the render buffer to equal the frame the window
+//     last showed — "fade-out from a frame that was never presented" (a
+//     clear or a stale redraw between the last present and the fade).
 
 // One-shot override for the NEXT menu entry, the escape hatch on both sides
 // of the depth rule. Instant suppresses the fade a depth-0/depth-1 entry
@@ -256,9 +273,13 @@ bool consume_menu_faded_to_black();
 // screen runs at depth 0, so the rule would fade it like a main-menu door);
 // Fade forces one on an entry the rule leaves instant (the main menu's own
 // nested doors — see run_nested_menu_door). Consumed by every entry —
-// including nested and Overlay entries and begin_legacy_menu_entry_fade —
-// with the same swallow-even-if-unused property as the black note, so a note
-// nobody used cannot leak one screen forward.
+// including nested and Overlay entries and LegacyMenuFade — with the
+// swallow-even-if-unused property, so a note nobody used cannot leak one
+// screen forward. An Instant note that is still pending when a fading screen
+// EXITS classifies the door being opened as instant: the exit skips its
+// fade-out and leaves the note for that door's entry (NETWORKING again —
+// Base Camp exits before the legacy screen runs, and the door is instant
+// both ways).
 enum class MenuEntryFade : std::uint8_t {
     Fade,
     Instant,
@@ -268,23 +289,15 @@ void note_menu_entry_fade(MenuEntryFade fade);
 // The bracket both nested main-menu doors share (CLOUD SAVES from the main
 // menu's own spec-row dispatch, LEVEL EDITOR from ButtonAction::DoLevelEdit):
 // their screens run INSIDE the still-open main menu, so no depth the rule can
-// read distinguishes them from a Base Camp subscreen. Going in it fades the
-// main menu out and notes Fade so the nested entry fades back in; coming back
-// it fades the door out and leaves a black note that the parent loop turns
-// into a fade-in on its next present. One implementation of the rule for both
-// doors — but the way in is only half here, so two preconditions bind BODY:
-//   * It must spend the Fade note on a fade-in of its own first composed
-//     frame, or the door plays 1 fade in against 2 back. A run_menu_screen
-//     body does that in the runner; a legacy body (the level editor) does it
-//     by hand — begin_legacy_menu_entry_fade() and present the first frame
-//     with fadeblack(1) when it returns true.
-//   * It must return with the canvas holding its last presented frame still
-//     ACTIVE, because the return fadeblack(0) below blends whatever surface
-//     is bound to the active canvas. The editor satisfies this by pinning the
-//     world canvas classic (shared 320x200 storage with the UI canvas) and
-//     restoring UI before returning; note that reading last_presented_canvas()
-//     here instead would be WRONG for it — the pin is already released by
-//     then, so World may name a freshly allocated, never-drawn surface.
+// read distinguishes them from a Base Camp subscreen. It notes Fade so the
+// nested entry fades — out of the still-open menu's frame, and back in on its
+// own first composed frame — and the body's own exit (the runner's scope, or
+// the editor's LegacyMenuFade) fades the door out; the parent loop's next
+// present finds a black window and fades back in. Precondition on a legacy
+// BODY: its exit fade must run while the canvas holding its last presented
+// frame is still ACTIVE (the editor calls LegacyMenuFade::end() before
+// releasing its classic world-canvas pin; reading last_presented_canvas()
+// after that release would name a freshly allocated, never-drawn surface).
 Sint32 run_nested_menu_door(Sint32 (*body)());
 
 // Current menu-stack depth (0 = no engine screen open). run_menu_screen
@@ -292,18 +305,37 @@ Sint32 run_nested_menu_door(Sint32 (*body)());
 // MenuScreenKind::Screen is the main-menu-boundary crossing that fades.
 int menu_screen_depth();
 
-// The hand-applied depth rule for legacy full-screen entries that never call
-// run_menu_screen (NETWORKING, campaign select, the results panel). At a
-// context switch (no engine screen open) it fades the presented surface to
-// black — skipped when a teardown already left it black — and returns true:
-// the caller must present its FIRST composed frame with fadeblack(1) instead
-// of buffer_to_screen. Nested under an open menu screen (Base Camp's SET
-// CAMPAIGN) it fades nothing and returns false. A noted MenuEntryFade
-// overrides both directions.
-bool begin_legacy_menu_entry_fade();
+// The ownership rule for legacy full-screen presenters that never call
+// run_menu_screen (campaign select, the results panel, the level editor, the
+// campaign intro scroller, NETWORKING). The constructor decides whether this
+// entry fades — a context switch (no engine screen open) or a Fade note,
+// never an Instant note — and fades the presented surface out at once (a
+// no-op if the window is already black). present_first() presents the first
+// composed frame: fadeblack(1) when this entry fades, a plain full-frame
+// present otherwise (safe as the loop's every-frame present). end() fades
+// the screen's last presented frame out; the destructor is its backstop on
+// every return path. Call end() explicitly where the last frame must be
+// faded BEFORE later teardown touches the buffer or the active canvas.
+class LegacyMenuFade {
+public:
+    LegacyMenuFade();
+    ~LegacyMenuFade();
+    LegacyMenuFade(const LegacyMenuFade&) = delete;
+    LegacyMenuFade& operator=(const LegacyMenuFade&) = delete;
+
+    bool active() const { return active_; }
+    bool fade_in_pending() const { return active_ && fade_in_pending_; }
+    void present_first(screen& scr);
+    void end();
+
+private:
+    bool active_ = false;
+    bool fade_in_pending_ = false;
+    bool ended_ = false;
+};
 
 #ifdef TESTING
-// Reset the transition state (depth 0, no black note) between tests.
+// Reset the transition state (depth 0, no pending override) between tests.
 void menu_transition_testing_reset();
 #endif
 

--- a/include/openglad/interface/ui/menu_screen_spec.h
+++ b/include/openglad/interface/ui/menu_screen_spec.h
@@ -138,11 +138,15 @@ enum class RemoteStartExit : std::uint8_t {
 // is a true modal drawn over a live scene (the pause family) and never
 // fades. Whether a Screen actually fades is DERIVED per entry by
 // run_menu_screen — never declared per screen: it fades exactly when the
-// entry is a context switch (menu-stack depth 1, nothing else open) and
-// never when nested under an already-open menu screen. Note: fades are
-// instant under TESTING (FadeBetween skips the animation), so the injector
-// SDL_Delay(750) waits around menu entries are generic settles, not fade
-// timing — several guard transitions that never faded at all.
+// entry crosses the main-menu boundary (menu-stack depth 1, nothing else
+// open) and never when nested under an already-open menu screen. The two
+// doors the depth rule cannot see either way — the main menu's own nested
+// screens (CLOUD SAVES, LEVEL EDITOR) and the Base Camp strip door whose
+// legacy screen runs at depth 0 (NETWORKING) — override the derivation with
+// note_menu_entry_fade() below. Note: fades are instant under TESTING
+// (FadeBetween skips the animation), so the injector SDL_Delay(750) waits
+// around menu entries are generic settles, not fade timing — several guard
+// transitions that never faded at all.
 enum class MenuScreenKind : std::uint8_t {
     Screen,
     Overlay,
@@ -246,17 +250,34 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state = nullptr)
 void note_menu_faded_to_black();
 bool consume_menu_faded_to_black();
 
-// A lateral move inside the open menu cluster (the main menu's SETTINGS /
-// HELP / LOAD / NETWORKING doors, and the way back from them): the next
-// depth-1 entry is not a context switch and must not fade. One-shot, and
-// consumed by every entry — including nested and Overlay entries and
-// begin_legacy_menu_entry_fade — with the same swallow-even-if-unused
-// property as the black note.
-void note_menu_peer_transition();
+// One-shot override for the NEXT menu entry, the escape hatch on both sides
+// of the depth rule. Instant suppresses the fade a depth-0/depth-1 entry
+// would otherwise play (NETWORKING: a Base Camp strip door whose legacy
+// screen runs at depth 0, so the rule would fade it like a main-menu door);
+// Fade forces one on an entry the rule leaves instant (the main menu's own
+// nested doors — see run_nested_menu_door). Consumed by every entry —
+// including nested and Overlay entries and begin_legacy_menu_entry_fade —
+// with the same swallow-even-if-unused property as the black note, so a note
+// nobody used cannot leak one screen forward.
+enum class MenuEntryFade : std::uint8_t {
+    Fade,
+    Instant,
+};
+void note_menu_entry_fade(MenuEntryFade fade);
+
+// The bracket both nested main-menu doors share (CLOUD SAVES from the main
+// menu's own spec-row dispatch, LEVEL EDITOR from ButtonAction::DoLevelEdit):
+// their screens run INSIDE the still-open main menu, so no depth the rule can
+// read distinguishes them from a Base Camp subscreen. Going in it fades the
+// main menu out and notes Fade so the nested entry fades back in; coming back
+// it fades the door out and leaves a black note that the parent loop turns
+// into a fade-in on its next present. Symmetric by construction — the one
+// implementation of the rule for both doors.
+Sint32 run_nested_menu_door(Sint32 (*body)());
 
 // Current menu-stack depth (0 = no engine screen open). run_menu_screen
 // increments it around every entry; the depth-1 entry of a
-// MenuScreenKind::Screen is the context switch that fades.
+// MenuScreenKind::Screen is the main-menu-boundary crossing that fades.
 int menu_screen_depth();
 
 // The hand-applied depth rule for legacy full-screen entries that never call
@@ -265,7 +286,8 @@ int menu_screen_depth();
 // black — skipped when a teardown already left it black — and returns true:
 // the caller must present its FIRST composed frame with fadeblack(1) instead
 // of buffer_to_screen. Nested under an open menu screen (Base Camp's SET
-// CAMPAIGN) it fades nothing and returns false.
+// CAMPAIGN) it fades nothing and returns false. A noted MenuEntryFade
+// overrides both directions.
 bool begin_legacy_menu_entry_fade();
 
 #ifdef TESTING

--- a/include/openglad/interface/ui/menu_screen_spec.h
+++ b/include/openglad/interface/ui/menu_screen_spec.h
@@ -478,14 +478,16 @@ struct BaseCampScreenState {
     // owned, the replicated wire copy when foreign.
     std::vector<BaseCampDisplaySlot> slots;
     PageModel page{};
-    // The live lobby's globally indexed player seats, sorted by player_index,
-    // plus a four-card page window for the Base Camp assignment rail. Unlike
-    // character TEAM colors above, these assignments are transient per-level
-    // player/view ownership and never rewrite a company roster.
+    // The live lobby's globally indexed player seats, sorted by player_index.
+    // Unlike character TEAM colors above, these assignments are transient
+    // per-level player/view ownership and never rewrite a company roster.
+    // `local_seat_indices` is THIS machine's seats in local-slot order — the
+    // seat rail's four slots read it directly and never page (remote seats
+    // are counted on the header line and listed in VIEW LEVEL's SEATS
+    // report), so there is no seat page window here.
     std::vector<og::sim::LobbyPlayer> seats;
     std::vector<std::uint8_t> local_seat_indices;
-    PageModel seat_page{};
-    // Accepted + activations are debounced like deploy taps: touch click
+    // Accepted ADD PLAYER activations are debounced like deploy taps: touch click
     // collapsing can otherwise create two local seats from one visible tap.
     // Denials never stamp, so retry-after-capacity remains immediate.
     std::int64_t last_seat_add_ms = -1;

--- a/include/openglad/interface/ui/menu_screen_spec.h
+++ b/include/openglad/interface/ui/menu_screen_spec.h
@@ -246,6 +246,14 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state = nullptr)
 void note_menu_faded_to_black();
 bool consume_menu_faded_to_black();
 
+// A lateral move inside the open menu cluster (the main menu's SETTINGS /
+// HELP / LOAD / NETWORKING doors, and the way back from them): the next
+// depth-1 entry is not a context switch and must not fade. One-shot, and
+// consumed by every entry — including nested and Overlay entries and
+// begin_legacy_menu_entry_fade — with the same swallow-even-if-unused
+// property as the black note.
+void note_menu_peer_transition();
+
 // Current menu-stack depth (0 = no engine screen open). run_menu_screen
 // increments it around every entry; the depth-1 entry of a
 // MenuScreenKind::Screen is the context switch that fades.

--- a/include/openglad/interface/ui/menu_screen_spec.h
+++ b/include/openglad/interface/ui/menu_screen_spec.h
@@ -280,6 +280,19 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state = nullptr)
 // Nothing else is checked: in particular a missing fade-in, or a fade at a
 // door the depth rule says should be instant, is caught only by the per-leg
 // count pins.
+//
+// The POINTER HANDOFF contract is the fade rule's sibling (docs/
+// menu-engine.md, "Pointer handoff"): a surface owns its pointer state. It
+// acknowledges the presses it saw — query_mouse() per frame, or
+// acknowledge_mouse_presses() after a self-run pump — and hands back a
+// clean pointer when it returns; no screen may consume a click minted on
+// another surface. The collapsed-tap pending queue carries no coordinates,
+// so a leaked click lands wherever the pointer sits when the next screen
+// drains it (the editor-exit phantom click). run_menu_screen re-baselines
+// (reset_mouse_click_tracking) at entry and before its loop-exit return;
+// run_nested_menu_door re-baselines after its body returns. A click during
+// the PARENT's own fade-in is a genuine click at the pointer's position and
+// stays honored — that is what the collapsed-tap queue is for.
 
 // One-shot override for the NEXT menu entry, the escape hatch on both sides
 // of the depth rule. Instant suppresses the fade a depth-0/depth-1 entry

--- a/include/openglad/interface/ui/menu_screen_spec.h
+++ b/include/openglad/interface/ui/menu_screen_spec.h
@@ -133,12 +133,19 @@ enum class RemoteStartExit : std::uint8_t {
     BreakWithSelection,
 };
 
-// Per-screen entry transition timing (injector SDL_Delay(750) cadence
-// depends on this being preserved exactly).
-enum class EnterTransition : std::uint8_t {
-    None,
-    FadeAroundEntry,
-    FadeWithInitialDraw,
+// Which transition family a screen belongs to (#237, docs/menu-engine.md
+// "Drawing and transitions"). Screen is a full-window menu surface; Overlay
+// is a true modal drawn over a live scene (the pause family) and never
+// fades. Whether a Screen actually fades is DERIVED per entry by
+// run_menu_screen — never declared per screen: it fades exactly when the
+// entry is a context switch (menu-stack depth 1, nothing else open) and
+// never when nested under an already-open menu screen. Note: fades are
+// instant under TESTING (FadeBetween skips the animation), so the injector
+// SDL_Delay(750) waits around menu entries are generic settles, not fade
+// timing — several guard transitions that never faded at all.
+enum class MenuScreenKind : std::uint8_t {
+    Screen,
+    Overlay,
 };
 
 // Reserved for a future dynamic row-template consumer.
@@ -159,7 +166,7 @@ struct MenuScreenSpec {
     // PickerInterceptScope value the screen runs under; 0 = inherit the
     // ambient scope (subscreens never change it).
     int intercept_scope = 0;
-    EnterTransition enter = EnterTransition::None;
+    MenuScreenKind kind = MenuScreenKind::Screen;
     int default_highlight = 0;
     bool right_click_enabled = false;
     // Subscreens whose BACK carries MENU_REDRAW (VIEW TEAM, MATCHUP and the
@@ -228,13 +235,35 @@ std::vector<const MenuButtonSpec*> materialized_spec_rows_for(
 // spec.exit_value (or propagates a remote-start MENU_EXIT).
 Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state = nullptr);
 
-// Post-game teardown hand-off (#200): the code that ends a mission already
-// fades the presented canvas to black, so the next screen's
-// EnterTransition::FadeAroundEntry must skip its own fade-out instead of
-// fading the stale menu image out a second time. One-shot; the fade-in still
-// runs. consume_* is the runner's own read-and-clear.
-void suppress_next_menu_entry_fade_out();
-bool consume_suppressed_menu_entry_fade_out();
+// #237 depth-rule transition state. A fade-out semantically belongs to the
+// OUTGOING surface but is executed by the INCOMING screen; when a teardown
+// (the two gameplay exits, the intro's last page, the new-game cut) already
+// left the presented surface black, it notes that here and the next fading
+// entry skips its own fade-out instead of playing black-to-black (#200).
+// Every run_menu_screen entry (and begin_legacy_menu_entry_fade) consumes
+// the note even when it does not fade — the swallow-even-if-unused property
+// that keeps a stale note from leaking one screen forward.
+void note_menu_faded_to_black();
+bool consume_menu_faded_to_black();
+
+// Current menu-stack depth (0 = no engine screen open). run_menu_screen
+// increments it around every entry; the depth-1 entry of a
+// MenuScreenKind::Screen is the context switch that fades.
+int menu_screen_depth();
+
+// The hand-applied depth rule for legacy full-screen entries that never call
+// run_menu_screen (NETWORKING, campaign select, the results panel). At a
+// context switch (no engine screen open) it fades the presented surface to
+// black — skipped when a teardown already left it black — and returns true:
+// the caller must present its FIRST composed frame with fadeblack(1) instead
+// of buffer_to_screen. Nested under an open menu screen (Base Camp's SET
+// CAMPAIGN) it fades nothing and returns false.
+bool begin_legacy_menu_entry_fade();
+
+#ifdef TESTING
+// Reset the transition state (depth 0, no black note) between tests.
+void menu_transition_testing_reset();
+#endif
 
 // Registry of picker-screen ownership. Runtime screens carry their spec;
 // legacy screens carry their blocking entry point. NETWORKING is owned by

--- a/include/openglad/interface/ui/menu_screen_spec.h
+++ b/include/openglad/interface/ui/menu_screen_spec.h
@@ -260,12 +260,26 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state = nullptr)
 // black fade, and no screen has to be told about it — the "faded to black"
 // note this replaced is gone.
 //
-// THE INVARIANTS (TESTING, checked by the video layer at the fade itself and
-// turned into a test failure by integration_main's listener):
-//   * fadeblack(1) requires a black window — "fade-in without a fade-out";
-//   * fadeblack(0) requires the render buffer to equal the frame the window
-//     last showed — "fade-out from a frame that was never presented" (a
-//     clear or a stale redraw between the last present and the fade).
+// THE INVARIANTS (TESTING; each one traces ("video", "FADE VIOLATION: ..."),
+// counts in og::video_testing::g_fade_violations, and fails the running test
+// through integration_main's listener). Exactly three things fire:
+//   * fadeblack(1) on a window that is not black — "fade-in without a
+//     fade-out" (checked by the video layer at the fade);
+//   * fadeblack(0) when the render buffer differs from what the window last
+//     showed — "fade-out from a frame that was never presented" (checked by
+//     the video layer at the fade; "showed" is the rect each present
+//     declared, so a clear, a stale redraw, or a draw outside every present's
+//     rect all count);
+//   * a fading ENTRY (run_menu_screen at depth 1, or an active
+//     LegacyMenuFade) that finds the window not black — "entry found an
+//     unfaded window: the previous surface exited without its fade-out"
+//     (checked by the runner before its entry fade-out, which still runs so
+//     production never hard-cuts). The one entry exempt by definition is a
+//     nested main-menu door under a Fade note: its parent has not exited,
+//     and fading the still-open parent out is that door's own job.
+// Nothing else is checked: in particular a missing fade-in, or a fade at a
+// door the depth rule says should be instant, is caught only by the per-leg
+// count pins.
 
 // One-shot override for the NEXT menu entry, the escape hatch on both sides
 // of the depth rule. Instant suppresses the fade a depth-0/depth-1 entry
@@ -279,7 +293,10 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state = nullptr)
 // EXITS classifies the door being opened as instant: the exit skips its
 // fade-out and leaves the note for that door's entry (NETWORKING again —
 // Base Camp exits before the legacy screen runs, and the door is instant
-// both ways).
+// both ways). Instant suppresses ONLY that entry's fade-in: a screen entered
+// under it still OWNS its exit fade (Base Camp back from NETWORKING fades
+// out on its way to the main menu like any boundary surface) unless a fresh
+// Instant note is pending at that exit.
 enum class MenuEntryFade : std::uint8_t {
     Fade,
     Instant,
@@ -310,15 +327,24 @@ int menu_screen_depth();
 // campaign intro scroller, NETWORKING). The constructor decides whether this
 // entry fades — a context switch (no engine screen open) or a Fade note,
 // never an Instant note — and fades the presented surface out at once (a
-// no-op if the window is already black). present_first() presents the first
+// no-op if the window is already black; an unfaded window is the entry
+// invariant's violation under TESTING). present_first() presents the first
 // composed frame: fadeblack(1) when this entry fades, a plain full-frame
 // present otherwise (safe as the loop's every-frame present). end() fades
 // the screen's last presented frame out; the destructor is its backstop on
 // every return path. Call end() explicitly where the last frame must be
 // faded BEFORE later teardown touches the buffer or the active canvas.
+//
+// fade_out_at_exit(): a screen that entered INSTANTLY but leaves its context
+// still owns its exit. NETWORKING is the case: an instant Base Camp strip
+// door on the way in and on BACK, but a successful hookup leaves the
+// lobby-config context for Base Camp's fading re-entry, and that re-entry
+// must find a black window. The screen calls this on that exit path, and
+// end() then fades its last frame out exactly as an active scope would.
+// The screen name is for the violation message only.
 class LegacyMenuFade {
 public:
-    LegacyMenuFade();
+    explicit LegacyMenuFade(const char* screen_name = "legacy screen");
     ~LegacyMenuFade();
     LegacyMenuFade(const LegacyMenuFade&) = delete;
     LegacyMenuFade& operator=(const LegacyMenuFade&) = delete;
@@ -326,11 +352,13 @@ public:
     bool active() const { return active_; }
     bool fade_in_pending() const { return active_ && fade_in_pending_; }
     void present_first(screen& scr);
+    void fade_out_at_exit();
     void end();
 
 private:
     bool active_ = false;
     bool fade_in_pending_ = false;
+    bool exit_fade_owed_ = false;
     bool ended_ = false;
 };
 

--- a/include/openglad/interface/ui/menu_screen_spec.h
+++ b/include/openglad/interface/ui/menu_screen_spec.h
@@ -271,8 +271,20 @@ void note_menu_entry_fade(MenuEntryFade fade);
 // read distinguishes them from a Base Camp subscreen. Going in it fades the
 // main menu out and notes Fade so the nested entry fades back in; coming back
 // it fades the door out and leaves a black note that the parent loop turns
-// into a fade-in on its next present. Symmetric by construction — the one
-// implementation of the rule for both doors.
+// into a fade-in on its next present. One implementation of the rule for both
+// doors — but the way in is only half here, so two preconditions bind BODY:
+//   * It must spend the Fade note on a fade-in of its own first composed
+//     frame, or the door plays 1 fade in against 2 back. A run_menu_screen
+//     body does that in the runner; a legacy body (the level editor) does it
+//     by hand — begin_legacy_menu_entry_fade() and present the first frame
+//     with fadeblack(1) when it returns true.
+//   * It must return with the canvas holding its last presented frame still
+//     ACTIVE, because the return fadeblack(0) below blends whatever surface
+//     is bound to the active canvas. The editor satisfies this by pinning the
+//     world canvas classic (shared 320x200 storage with the UI canvas) and
+//     restoring UI before returning; note that reading last_presented_canvas()
+//     here instead would be WRONG for it — the pin is already released by
+//     then, so World may name a freshly allocated, never-drawn surface.
 Sint32 run_nested_menu_door(Sint32 (*body)());
 
 // Current menu-stack depth (0 = no engine screen open). run_menu_screen

--- a/include/openglad/interface/ui/picker_common.h
+++ b/include/openglad/interface/ui/picker_common.h
@@ -647,8 +647,10 @@ inline constexpr int kBaseCampLineBCharsHireHidden =
 // PLAYERS lead: the seat rail shows this machine's seats only, so the size
 // of the lobby has no other home on the screen. A narrower band takes a
 // whole shorter spelling rather than a byte cut — "<p> PLAYERS/<n> PCS",
-// then "<p>P/<n>M", then the room code goes. Room codes display-clip at 12
-// chars (relay codes are "GLAD-XXXX").
+// then "<p>P/<n>M", then the room code goes. A count of one takes the
+// singular ("1 PLAYER", "1 MACHINE", "1 PC") — always the shorter spelling,
+// so it can never push a rung off a band the plural fit. Room codes
+// display-clip at 12 chars (relay codes are "GLAD-XXXX").
 std::string format_base_camp_session_status(
     bool is_host,
     std::string_view room_code,

--- a/include/openglad/interface/ui/picker_common.h
+++ b/include/openglad/interface/ui/picker_common.h
@@ -908,12 +908,13 @@ struct SeatRailLayout {
 };
 
 // The rail's per-frame geometry. Elements run left to right: [+] when
-// visible, '<' when the pagers are up, slot_count() slots, then '>'. A full
-// four-slot row — or any paged row, where the arrows already own both ends —
-// JUSTIFIES between the two rails: the slack is split evenly among the
-// gutters and the leftmost ones take the odd pixels. Anything shorter
-// left-packs from x=8 at the uniform 7px gutter, because a two-control row
-// stretched across the whole panel reads as broken rather than as design.
+// visible, '<' when the pagers are up, slot_count() slots, then '>'. The '>'
+// ANCHORS the right rail whenever the pagers are up. A full four-slot row
+// JUSTIFIES the remaining run between the margins: the slack is split evenly
+// among its gutters and the leftmost ones take the odd pixels. A shorter row
+// left-packs from x=8 at the uniform 7px gutter — stretching two or three
+// controls across the whole panel reads as broken rather than as design, and
+// on a paged rail the anchored '>' holds the right margin regardless.
 SeatRailLayout base_camp_seat_rail_layout(bool add_visible,
                                           bool pagers_visible,
                                           int visible_cards, int ghost_count);

--- a/include/openglad/interface/ui/picker_common.h
+++ b/include/openglad/interface/ui/picker_common.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <openglad/core/constants.h>
+#include <openglad/gameplay/input_state.h>
 #include <openglad/gameplay/lobby_state.h>
 #include <openglad/resources/company.h>
 #include <openglad/resources/save_data.h>
@@ -841,6 +842,81 @@ struct ScenarioRosterRow {
     int level = 1;
     int count = 1;
 };
+
+// --- Base Camp player-seat rail geometry (#243) ---
+//
+// The rail is one row of controls across the roster panel's full width:
+// [+] | < | four seat SLOTS | >. A slot with no seat in it yet is a GHOST —
+// an empty recess showing where the next player lands — so the row keeps
+// both of the panel's margins instead of trailing off mid-panel. The card
+// face is a label contract (kBaseCampSeatCardLabelBudget = 57/6 characters)
+// and never changes width; all the slack goes into the gutters.
+inline constexpr int kSeatRailX0 = 8;           // the panel's left rail (BACK's x)
+inline constexpr int kSeatRailRightX = 312;     // exclusive: the panel's right rail
+inline constexpr int kSeatRailGap = 7;          // the packed (under-full) gutter
+inline constexpr int kSeatRailAddWidth = 14;    // the [+] face
+inline constexpr int kSeatRailPagerWidth = 10;  // the '<' and '>' faces
+inline constexpr int kSeatRailCardWidth = 57;
+inline constexpr int kSeatRailSlots = 4;        // seat cards per page
+// og::sim::kMaxGlobalPlayers, restated so this pure header need not pull the
+// transport contract into every picker TU. menu_screen_specs.cpp
+// static_asserts that the two still agree.
+inline constexpr int kSeatRailGlobalSeatCap = 16;
+
+// The one question behind both the [+] gate and the ghost promise: can
+// another seat be claimed right now? Kept as data so the rail's chrome and
+// the button's row state can never disagree about the answer.
+struct SeatClaimability {
+    bool multiplayer_enabled = true;  // false in a DISABLE_MULTIPLAYER build
+    int local_count = 0;              // seats this machine already owns
+    int local_seat_cap = MAX_PLAYERS; // og::input::local_seat_cap()
+    int global_count = 0;             // seats across the whole lobby
+    int global_cap = kSeatRailGlobalSeatCap;
+};
+
+// Seats this machine may still claim: the smaller headroom of the two caps,
+// never negative, and zero when the build has no multiplayer at all.
+int seats_still_claimable(const SeatClaimability& claim);
+
+struct SeatRailGhostInputs {
+    SeatClaimability claim{};
+    int visible_cards = 0;   // real cards on the page being drawn
+    bool on_last_page = true;
+};
+
+// Ghost slots to draw after the real cards. Zero unless a seat is genuinely
+// claimable this instant — an empty recess the player cannot fill would be a
+// promise the rail cannot keep — and, while the rail is paged, only on the
+// last page, where the next seat would actually appear.
+int base_camp_seat_rail_ghost_count(const SeatRailGhostInputs& in);
+
+struct SeatRailLayout {
+    bool add_visible = false;
+    bool pagers_visible = false;
+    int card_w = kSeatRailCardWidth;
+    int add_x = kSeatRailX0;
+    int prev_x = kSeatRailX0;
+    int next_x = kSeatRailX0;
+    // slot_x[0 .. shown_cards) hold real cards and the next ghost_count are
+    // ghosts. Any slot past those is parked at the rail's origin: its button
+    // row is hidden, and draw_buttons/leftmouse both skip hidden rows.
+    std::array<int, kSeatRailSlots> slot_x{};
+    int shown_cards = 0;
+    int ghost_count = 0;
+
+    [[nodiscard]] int slot_count() const { return shown_cards + ghost_count; }
+};
+
+// The rail's per-frame geometry. Elements run left to right: [+] when
+// visible, '<' when the pagers are up, slot_count() slots, then '>'. A full
+// four-slot row — or any paged row, where the arrows already own both ends —
+// JUSTIFIES between the two rails: the slack is split evenly among the
+// gutters and the leftmost ones take the odd pixels. Anything shorter
+// left-packs from x=8 at the uniform 7px gutter, because a two-control row
+// stretched across the whole panel reads as broken rather than as design.
+SeatRailLayout base_camp_seat_rail_layout(bool add_visible,
+                                          bool pagers_visible,
+                                          int visible_cards, int ghost_count);
 
 // --- Player seats (#218 seat block) ---
 

--- a/include/openglad/interface/ui/picker_common.h
+++ b/include/openglad/interface/ui/picker_common.h
@@ -616,14 +616,6 @@ struct BaseCampSessionCensus {
 BaseCampSessionCensus count_base_camp_session_census(
     const std::vector<og::sim::LobbyPlayer>& players);
 
-// The host machine's human identity for the joiner's "HOST:" display:
-// its company name, falling back to that seat's display name when the company
-// is empty. Neither string participates in identity or grouping. Clipped to
-// the 16-char COMPANY column budget. Empty until a host seat exists in the
-// replicated state.
-std::string base_camp_host_display_name(
-    const std::vector<og::sim::LobbyPlayer>& players);
-
 // --- §9.12 header line-B character budgets ---
 //
 // The band's ink starts at x=10 and its readability strip pads 2px on each
@@ -650,14 +642,13 @@ inline constexpr int kBaseCampLineBCharsHireHidden =
 
 // §9.12 header line B, networked HEALTHY shape — the G5 session status
 // (role + room code + census), SHAPED to fit `max_chars`:
-//   host:   "HOSTING <ROOM> - <n> MACH / <p> PLYR"  (no room: the census
-//           alone after HOSTING)
-//   joiner: "IN <ROOM> - HOST: <name16>"  (no room: "JOINED - HOST: ...";
-//           host not yet known: the room half alone)
-// A narrow band takes compact spellings rather than a byte cut: the census
-// abbreviates to "<n>M / <p>P", the joiner drops "HOST: " (the company is
-// what names the lobby), and a company that still over-runs loses whole
-// words. Room codes display-clip at 12 chars (relay codes are "GLAD-XXXX").
+//   host:   "HOSTING <ROOM>: <p> PLAYERS / <n> MACHINES"
+//   joiner: "IN <ROOM>: <p> PLAYERS / <n> MACHINES"  (no room: "JOINED: ...")
+// PLAYERS lead: the seat rail shows this machine's seats only, so the size
+// of the lobby has no other home on the screen. A narrower band takes a
+// whole shorter spelling rather than a byte cut — "<p> PLAYERS/<n> PCS",
+// then "<p>P/<n>M", then the room code goes. Room codes display-clip at 12
+// chars (relay codes are "GLAD-XXXX").
 std::string format_base_camp_session_status(
     bool is_host,
     std::string_view room_code,
@@ -843,29 +834,36 @@ struct ScenarioRosterRow {
     int count = 1;
 };
 
-// --- Base Camp player-seat rail geometry (#243) ---
+// --- Base Camp player-seat rail geometry (#243, redesigned) ---
 //
-// The rail is one row of controls across the roster panel's full width:
-// [+] | < | four seat SLOTS | >. A slot with no seat in it yet is a GHOST —
-// an empty recess showing where the next player lands — so the row keeps
-// both of the panel's margins instead of trailing off mid-panel. The card
-// face is a label contract (kBaseCampSeatCardLabelBudget = 57/6 characters)
-// and never changes width; all the slack goes into the gutters.
-inline constexpr int kSeatRailX0 = 8;           // the panel's left rail (BACK's x)
-inline constexpr int kSeatRailRightX = 312;     // exclusive: the panel's right rail
-inline constexpr int kSeatRailGap = 7;          // the packed (under-full) gutter
-inline constexpr int kSeatRailAddWidth = 14;    // the [+] face
-inline constexpr int kSeatRailPagerWidth = 10;  // the '<' and '>' faces
-inline constexpr int kSeatRailCardWidth = 57;
-inline constexpr int kSeatRailSlots = 4;        // seat cards per page
+// The rail is THIS MACHINE'S four seat slots and nothing else. Remote seats
+// are counted on the header line and listed in VIEW LEVEL's SEATS report;
+// they never take a slot here, so the rail needs no pager and no [+] at its
+// left end. A slot holding one of this machine's seats draws a card; a slot
+// past them is a real ADD PLAYER button (or a dimmed LOBBY FULL one) whose
+// activation is the add path itself.
+//
+// The grid is FIXED, so a slot never moves when its neighbour appears: four
+// 70px faces at x = 8 / 86 / 164 / 242, gutter 8, closing exactly on the
+// panel's right rail (4*70 + 3*8 = 304 = 312 - 8). The face is a label
+// contract (kBaseCampSeatCardLabelBudget = 70/6 characters).
+inline constexpr int kSeatRailX0 = 8;        // the panel's left rail (BACK's x)
+inline constexpr int kSeatRailRightX = 312;  // exclusive: the panel's right rail
+inline constexpr int kSeatRailGap = 8;
+inline constexpr int kSeatRailCardWidth = 70;
+inline constexpr int kSeatRailSlots = 4;     // this machine's seat ceiling
+static_assert(kSeatRailSlots * kSeatRailCardWidth +
+                      (kSeatRailSlots - 1) * kSeatRailGap ==
+                  kSeatRailRightX - kSeatRailX0,
+              "the four slots close on both of the panel's margins");
 // og::sim::kMaxGlobalPlayers, restated so this pure header need not pull the
 // transport contract into every picker TU. menu_screen_specs.cpp
 // static_asserts that the two still agree.
 inline constexpr int kSeatRailGlobalSeatCap = 16;
 
-// The one question behind both the [+] gate and the ghost promise: can
-// another seat be claimed right now? Kept as data so the rail's chrome and
-// the button's row state can never disagree about the answer.
+// The one question behind every bare slot: can another seat be claimed right
+// now? Kept as data so the rail's chrome and the button's row state can never
+// disagree about the answer.
 struct SeatClaimability {
     bool multiplayer_enabled = true;  // false in a DISABLE_MULTIPLAYER build
     int local_count = 0;              // seats this machine already owns
@@ -878,46 +876,42 @@ struct SeatClaimability {
 // never negative, and zero when the build has no multiplayer at all.
 int seats_still_claimable(const SeatClaimability& claim);
 
-struct SeatRailGhostInputs {
-    SeatClaimability claim{};
-    int visible_cards = 0;   // real cards on the page being drawn
-    bool on_last_page = true;
-};
+// Slots the rail shows at all. What limits the rail is the DEVICE, never the
+// lobby: a phone with no pad shows exactly one slot (#249 — an offer the
+// hardware cannot accept is worse than no offer), a phone with two pads
+// three, a desktop four. A build with no multiplayer has one seat and no
+// door to a second.
+int base_camp_seat_rail_slot_cap(const SeatClaimability& claim);
 
-// Ghost slots to draw after the real cards. Zero unless a seat is genuinely
-// claimable this instant — an empty recess the player cannot fill would be a
-// promise the rail cannot keep — and, while the rail is paged, only on the
-// last page, where the next seat would actually appear.
-int base_camp_seat_rail_ghost_count(const SeatRailGhostInputs& in);
+// Bare slots after this machine's own seats: every remaining slot inside the
+// device cap. A slot the lobby cannot currently fill still appears — dimmed,
+// saying LOBBY FULL — because "there is a seat here and it is spoken for"
+// is the honest answer; only hardware removes the slot entirely.
+int base_camp_seat_rail_placeholder_count(const SeatClaimability& claim);
 
 struct SeatRailLayout {
-    bool add_visible = false;
-    bool pagers_visible = false;
     int card_w = kSeatRailCardWidth;
-    int add_x = kSeatRailX0;
-    int prev_x = kSeatRailX0;
-    int next_x = kSeatRailX0;
-    // slot_x[0 .. shown_cards) hold real cards and the next ghost_count are
-    // ghosts. Any slot past those is parked at the rail's origin: its button
-    // row is hidden, and draw_buttons/leftmouse both skip hidden rows.
+    // The fixed four-slot grid. slot_x[0 .. shown_cards) hold this machine's
+    // seats and the next placeholder_count are ADD PLAYER / LOBBY FULL
+    // buttons; any slot past those is hidden (draw_buttons and leftmouse both
+    // skip hidden rows) but keeps its grid x so nothing shifts when it
+    // returns.
     std::array<int, kSeatRailSlots> slot_x{};
     int shown_cards = 0;
-    int ghost_count = 0;
+    int placeholder_count = 0;
 
-    [[nodiscard]] int slot_count() const { return shown_cards + ghost_count; }
+    [[nodiscard]] int slot_count() const
+    {
+        return shown_cards + placeholder_count;
+    }
 };
 
-// The rail's per-frame geometry. Elements run left to right: [+] when
-// visible, '<' when the pagers are up, slot_count() slots, then '>'. The '>'
-// ANCHORS the right rail whenever the pagers are up. A full four-slot row
-// JUSTIFIES the remaining run between the margins: the slack is split evenly
-// among its gutters and the leftmost ones take the odd pixels. A shorter row
-// left-packs from x=8 at the uniform 7px gutter — stretching two or three
-// controls across the whole panel reads as broken rather than as design, and
-// on a paged rail the anchored '>' holds the right margin regardless.
-SeatRailLayout base_camp_seat_rail_layout(bool add_visible,
-                                          bool pagers_visible,
-                                          int visible_cards, int ghost_count);
+// The rail's per-frame geometry: the fixed grid plus how many of its slots
+// are live this frame. Nothing justifies and nothing packs — a slot's x is a
+// property of the slot, not of how many neighbours it has, so a card cannot
+// slide sideways when a player joins or leaves.
+SeatRailLayout base_camp_seat_rail_layout(int visible_cards,
+                                          int placeholder_count);
 
 // --- Player seats (#218 seat block) ---
 

--- a/include/openglad/interface/ui/picker_lobby_client.h
+++ b/include/openglad/interface/ui/picker_lobby_client.h
@@ -276,6 +276,14 @@ using PickerSaveSlotEditableCallback = bool (*)(int);
 inline PickerSaveSlotEditableCallback g_picker_save_slot_editable_callback =
     nullptr;
 
+// Null in every shipping build: menu screens are single-threaded there.
+// Test injector threads install a pump so their save/config mutations run
+// between menu frames instead of racing the main thread's poll (issue #257 —
+// completed_levels is node-based, so one concurrent insert dangles the
+// digest walk's iterator).
+using PickerMainThreadPump = void (*)();
+inline PickerMainThreadPump g_picker_main_thread_pump = nullptr;
+
 } // namespace og::ui
 
 void picker_lobby_initialize_from_save();

--- a/include/openglad/interface/ui/picker_ui_state.h
+++ b/include/openglad/interface/ui/picker_ui_state.h
@@ -144,3 +144,11 @@ struct PickerState {
     int menu_click_x = -1;
     int menu_click_y = -1;
 };
+
+// Load the four quadrant pixies of the picker's tiled title backdrop into the
+// session's PickerState. picker_main runs this once when it builds the shared
+// menu state; anything that composes a picker screen WITHOUT going through
+// picker_main — the UX-shot probe's direct create_team_menu fixtures — must
+// run it too, or its capture shows the screen's chrome floating on black
+// instead of the frame a player sees.
+void picker_load_menu_backdrops();

--- a/include/openglad/platform/sai2x.h
+++ b/include/openglad/platform/sai2x.h
@@ -122,10 +122,15 @@ class Screen
 		// cleared it since its last present). False for a surface that was
 		// never presented. `detail` (optional) receives where it differs —
 		// the bounding box of the changed pixels, or "never presented".
+		// "Showed" means the rect each present DECLARED: a partial-rect
+		// swap() records only that rect, so a draw outside it stays
+		// unpresented until a present covers it.
 		bool testing_render_matches_presented(std::string* detail = nullptr) const;
-		// Test boundary: every canvas counts as presented as it stands and
-		// the window is not black, so a direct-call test never inherits the
-		// previous test's window.
+		// Test boundary: the window is BLACK — the state a screen that faded
+		// itself out at its exit leaves, and the state a process starts in —
+		// and every canvas counts as presented as it stands, so a direct-call
+		// test never inherits the previous test's window and its first
+		// fading entry finds exactly what the ownership rule promises.
 		void testing_reset_window_state();
 #endif
 		// Repoints render/render_tex at the chosen canvas. Precondition:
@@ -290,7 +295,11 @@ class Screen
 			SDL_Surface* pixels = nullptr;
 		};
 		std::vector<PresentedSnapshot> presented_snapshots_;
-		void testing_snapshot_presented(SDL_Surface* surface);
+		// Records the rect a present declared (clipped to the surface). A
+		// surface's first snapshot starts black outside that rect: those
+		// pixels were never shown.
+		void testing_snapshot_presented(SDL_Surface* surface, int x, int y,
+		                                int w, int h);
 		void testing_forget_presented(SDL_Surface* surface);
 #endif
 		// Parsed zoom/smoothing state. Legacy is the byte-identical shared

--- a/include/openglad/platform/sai2x.h
+++ b/include/openglad/platform/sai2x.h
@@ -5,6 +5,7 @@
 #include <openglad/core/scale_mode.h> // zoom/smoothing canvas settings
 #include <memory>
 #include <span>
+#include <string>
 #include <vector>
 
 enum class RenderEngine
@@ -106,6 +107,27 @@ class Screen
 		int ui_h() const { return kUiCanvasH; }
 		CanvasTarget active_canvas() const { return active_; }
 		CanvasTarget last_presented_canvas() const { return last_presented_; }
+		// --- Window state (fade ownership, docs/menu-engine.md) ---------
+		// True while the physical window shows black: from creation (a
+		// window that has never presented shows nothing) and after a
+		// completed fade-out, until the next present. swap() — the single
+		// present site — clears it; sdl_video::fadeblack(false) sets it and
+		// is a no-op while it holds, so a screen that already faded out can
+		// never be faded out a second time, black-to-black.
+		bool window_is_black() const { return window_is_black_; }
+		void set_window_black(bool black) { window_is_black_ = black; }
+#ifdef TESTING
+		// The fade-out precondition: the active render surface holds
+		// exactly the pixels the window last showed of it (nothing drew or
+		// cleared it since its last present). False for a surface that was
+		// never presented. `detail` (optional) receives where it differs —
+		// the bounding box of the changed pixels, or "never presented".
+		bool testing_render_matches_presented(std::string* detail = nullptr) const;
+		// Test boundary: every canvas counts as presented as it stands and
+		// the window is not black, so a direct-call test never inherits the
+		// previous test's window.
+		void testing_reset_window_state();
+#endif
 		// Repoints render/render_tex at the chosen canvas. Precondition:
 		// never call during a floor-layer redirect (floor_layer_begin/end
 		// bracket their redirect within one viewport draw).
@@ -257,6 +279,20 @@ class Screen
 
 		CanvasTarget active_ = CanvasTarget::UI;
 		CanvasTarget last_presented_ = CanvasTarget::UI;
+		bool window_is_black_ = true;
+#ifdef TESTING
+		// Per canvas surface, a copy of its pixels as of its last present
+		// (keyed by the surface, so the shared classic pair — one surface
+		// under two canvas names — has one snapshot). Production builds
+		// carry none of this.
+		struct PresentedSnapshot {
+			SDL_Surface* surface = nullptr;
+			SDL_Surface* pixels = nullptr;
+		};
+		std::vector<PresentedSnapshot> presented_snapshots_;
+		void testing_snapshot_presented(SDL_Surface* surface);
+		void testing_forget_presented(SDL_Surface* surface);
+#endif
 		// Parsed zoom/smoothing state. Legacy is the byte-identical shared
 		// 320x200 canvas with smoothing off.
 		og::WorldScaleSetting world_scale_{};

--- a/include/openglad/platform/video_sdl.h
+++ b/include/openglad/platform/video_sdl.h
@@ -23,9 +23,29 @@
 #include <SDL3/SDL.h>
 
 #include <array>
+#include <atomic>
 #include <span>
+#include <string>
 #include <string_view>
 #include <vector>
+
+#ifdef TESTING
+namespace og::video_testing
+{
+// Fade-ownership invariants, checked by sdl_video::fadeblack at the fade
+// itself: a fade-in requires a black window ("fade-in without a fade-out"),
+// and a fade-out requires the render buffer to equal the frame the window
+// last showed ("fade-out from a frame that was never presented" — a clear or
+// a stale redraw between the last present and the fade). A violation traces
+// ("video", "FADE VIOLATION: ..."), logs, and lands here. trace_clear() never
+// touches this: the integration listener resets it at test start and fails
+// the test at its end for each message recorded, so every flow test in the
+// tree is an oracle for the class.
+extern std::atomic<int> g_fade_violations;
+std::vector<std::string> fade_violation_messages();
+void reset_fade_violations();
+} // namespace og::video_testing
+#endif
 
 namespace og::platform
 {
@@ -236,6 +256,10 @@ public:
     void fade_between24(void* surface, const Uint8* from, const Uint8* to, int amount) override;
     int fade_between(void* old_surface, void* new_surface, void* dest_surface) override;
     int fadeblack(bool fade_in) override;
+    bool window_is_black() override;
+#ifdef TESTING
+    void testing_reset_window_state() override;
+#endif
 
     std::array<unsigned char, 768>& ourpalette_ref() override { return ourpalette; }
     std::array<unsigned char, 768>& redpalette_ref() override { return redpalette; }

--- a/include/openglad/platform/video_sdl.h
+++ b/include/openglad/platform/video_sdl.h
@@ -32,18 +32,24 @@
 #ifdef TESTING
 namespace og::video_testing
 {
-// Fade-ownership invariants, checked by sdl_video::fadeblack at the fade
-// itself: a fade-in requires a black window ("fade-in without a fade-out"),
-// and a fade-out requires the render buffer to equal the frame the window
-// last showed ("fade-out from a frame that was never presented" — a clear or
-// a stale redraw between the last present and the fade). A violation traces
-// ("video", "FADE VIOLATION: ..."), logs, and lands here. trace_clear() never
-// touches this: the integration listener resets it at test start and fails
-// the test at its end for each message recorded, so every flow test in the
-// tree is an oracle for the class.
+// Fade-ownership invariants. Two are checked by sdl_video::fadeblack at the
+// fade itself: a fade-in requires a black window ("fade-in without a
+// fade-out"), and a fade-out requires the render buffer to equal the frame
+// the window last showed ("fade-out from a frame that was never presented" —
+// a clear or a stale redraw between the last present and the fade, or a draw
+// no present's rect ever covered). The third is reported by the menu runner
+// at a fading ENTRY that found the window not black ("entry found an unfaded
+// window: the previous surface exited without its fade-out") — the entry
+// still fades out, so production never hard-cuts, but under TESTING the
+// missing exit fade is a failure. A violation traces ("video", "FADE
+// VIOLATION: ..."), logs, and lands here. trace_clear() never touches this:
+// the integration listener resets it at test start and fails the test at its
+// end for each message recorded, so every flow test in the tree is an oracle
+// for the class.
 extern std::atomic<int> g_fade_violations;
 std::vector<std::string> fade_violation_messages();
 void reset_fade_violations();
+void report_fade_violation(const char* what);
 } // namespace og::video_testing
 #endif
 
@@ -259,6 +265,7 @@ public:
     bool window_is_black() override;
 #ifdef TESTING
     void testing_reset_window_state() override;
+    void testing_report_fade_violation(const char* what) override;
 #endif
 
     std::array<unsigned char, 768>& ourpalette_ref() override { return ourpalette; }

--- a/scripts/check_fadeblack_sites.sh
+++ b/scripts/check_fadeblack_sites.sh
@@ -10,24 +10,19 @@
 # into black.
 #
 # So the set of places allowed to call fadeblack() is small, deliberate, and
-# checked in: scripts/fadeblack_sites.txt, one site per line with the reason it
-# is allowed to fade. A new call fails the build until somebody classifies it.
+# checked in: scripts/fadeblack_sites.txt, one function per line with HOW MANY
+# fades it makes and the reason. A new call fails the build until somebody
+# classifies it — including a call added next to an existing, classified fade
+# in the same function (the count changes), which is exactly where a door-site
+# fade tends to get planted.
 #
-# Sites are keyed by path + enclosing function, never by line number, so that
-# edits elsewhere in a file do not rot the list.
+# Sites are keyed by path + enclosing function + count, never by line number,
+# so that edits elsewhere in a file do not rot the list.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC_DIR="${ROOT}/src"
 ALLOWLIST="${ROOT}/scripts/fadeblack_sites.txt"
-
-# The two definition sites: screen::fadeblack (the pure delegate) and
-# sdl_video::fadeblack (the implementation, plus the FadeBetween prose around
-# it). Everything else in src/ is a caller and must be classified.
-EXCLUDED_FILES=(
-    "src/interface/screen.cpp"
-    "src/platform/sdl/video_sdl.cpp"
-)
 
 if [[ ! -d "${SRC_DIR}" ]]; then
     echo "ERROR: cannot find ${SRC_DIR}" >&2
@@ -38,11 +33,13 @@ if [[ ! -f "${ALLOWLIST}" ]]; then
     exit 2
 fi
 
-# Keys a call site to "<path>::<enclosing function>". Comments and string
-# literals are stripped first, so commented-out and merely-mentioned fades do
-# not count. A function definition is an identifier followed by a balanced
-# parameter list followed by `{` (rather than `;`), which distinguishes it from
-# a declaration and from a multi-line call.
+# Prints "<path>::<enclosing function>" once per fadeblack() call. Comments
+# and string literals are stripped first, so commented-out and merely-mentioned
+# fades do not count; the definition line of a function itself named fadeblack
+# (screen::fadeblack, sdl_video::fadeblack) is a definition, not a call. A
+# function definition is an identifier followed by a balanced parameter list
+# followed by `{` (rather than `;`), which distinguishes it from a declaration
+# and from a multi-line call.
 read -r -d '' SITE_KEY_AWK <<'AWK' || true
 {
     raw[NR] = $0
@@ -72,10 +69,14 @@ END {
         name = definition_name(i)
         if (name != "")
             current = name
-        if (code[i] ~ /(^|[^A-Za-z0-9_])fadeblack[ \t]*\(/) {
+        if (name ~ /(^|::)fadeblack$/)
+            continue
+        line = code[i]
+        while (match(line, /(^|[^A-Za-z0-9_])fadeblack[ \t]*\(/)) {
             if (current == "")
                 current = "<file scope>"
             print rel "::" current
+            line = substr(line, RSTART + RLENGTH)
         }
     }
 }
@@ -148,39 +149,64 @@ status=0
 FOUND_KEYS_FILE="$(mktemp)"
 trap 'rm -f "${FOUND_KEYS_FILE}"' EXIT
 
+# One line per call, then "<path>::<function>=<count>" per function.
 {
     while IFS= read -r file; do
         rel="${file#"${ROOT}"/}"
-        skip=0
-        for excluded in "${EXCLUDED_FILES[@]}"; do
-            [[ "${rel}" == "${excluded}" ]] && skip=1
-        done
-        [[ "${skip}" -eq 1 ]] && continue
         awk -v rel="${rel}" "${SITE_KEY_AWK}" "${file}"
     done < <(grep -rlE '(^|[^A-Za-z0-9_])fadeblack[[:space:]]*\(' "${SRC_DIR}" | sort)
-} | sort -u > "${FOUND_KEYS_FILE}"
+} | sort | uniq -c | awk '{ print $2 "=" $1 }' | sort > "${FOUND_KEYS_FILE}"
 
 ALLOWED_KEYS_FILE="$(mktemp)"
 trap 'rm -f "${FOUND_KEYS_FILE}" "${ALLOWED_KEYS_FILE}"' EXIT
 sed -E 's/#.*//; s/[[:space:]]+$//; s/^[[:space:]]+//' "${ALLOWLIST}" \
     | { grep -v '^$' || true; } | sort -u > "${ALLOWED_KEYS_FILE}"
 
-UNLISTED="$(comm -23 "${FOUND_KEYS_FILE}" "${ALLOWED_KEYS_FILE}")"
-STALE="$(comm -13 "${FOUND_KEYS_FILE}" "${ALLOWED_KEYS_FILE}")"
+# A key is "<path>::<function>=<count>". Three ways to disagree: a function
+# that fades but is not listed, a listed function whose fade count changed,
+# and a listed function that no longer fades (or no longer exists).
+FOUND_ONLY="$(comm -23 "${FOUND_KEYS_FILE}" "${ALLOWED_KEYS_FILE}")"
+ALLOWED_ONLY="$(comm -13 "${FOUND_KEYS_FILE}" "${ALLOWED_KEYS_FILE}")"
+
+UNLISTED=""
+MISMATCH=""
+STALE=""
+# Keys never contain "=" except before the count, so field 1 is the function.
+listed_count() { awk -F= -v fn="$1" '$1 == fn { print $2 }' "${ALLOWED_KEYS_FILE}"; }
+found_count()  { awk -F= -v fn="$1" '$1 == fn { print $2 }' "${FOUND_KEYS_FILE}"; }
+while IFS= read -r key; do
+    [[ -z "${key}" ]] && continue
+    fn="${key%=*}"
+    listed="$(listed_count "${fn}")"
+    if [[ -n "${listed}" ]]; then
+        MISMATCH+="  ${fn}: found ${key#*=} fadeblack() call(s), allowlist says ${listed}"$'\n'
+    else
+        UNLISTED+="  ${key}"$'\n'
+    fi
+done <<< "${FOUND_ONLY}"
+while IFS= read -r key; do
+    [[ -z "${key}" ]] && continue
+    fn="${key%=*}"
+    if [[ -z "$(found_count "${fn}")" ]]; then
+        STALE+="  ${key}"$'\n'
+    fi
+done <<< "${ALLOWED_ONLY}"
 
 if [[ -n "${UNLISTED}" ]]; then
     echo "ERROR: unclassified fadeblack() call site(s):" >&2
-    while IFS= read -r key; do
-        echo "  ${key}" >&2
-    done <<< "${UNLISTED}"
+    printf '%s' "${UNLISTED}" >&2
+    status=1
+fi
+
+if [[ -n "${MISMATCH}" ]]; then
+    echo "ERROR: fadeblack() call count changed in classified function(s):" >&2
+    printf '%s' "${MISMATCH}" >&2
     status=1
 fi
 
 if [[ -n "${STALE}" ]]; then
     echo "ERROR: allowlisted fadeblack() call site(s) that no longer exist:" >&2
-    while IFS= read -r key; do
-        echo "  ${key}" >&2
-    done <<< "${STALE}"
+    printf '%s' "${STALE}" >&2
     status=1
 fi
 
@@ -200,9 +226,12 @@ key with the reason to:
 
   ${ALLOWLIST}
 
-Keys are "<path>::<enclosing function>" — the same key the errors above print.
+Keys are "<path>::<enclosing function>=<count>" — the count is how many
+fadeblack() calls that function makes, so a fade added beside an existing one
+has to be classified too. The errors above print the exact key.
 EOF
     exit 2
 fi
 
-echo "OK: $(wc -l < "${FOUND_KEYS_FILE}") classified fadeblack() call site(s)."
+TOTAL_CALLS="$(awk -F= '{ s += $2 } END { print s + 0 }' "${FOUND_KEYS_FILE}")"
+echo "OK: ${TOTAL_CALLS} classified fadeblack() call(s) in $(wc -l < "${FOUND_KEYS_FILE}") function(s)."

--- a/scripts/check_fadeblack_sites.sh
+++ b/scripts/check_fadeblack_sites.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Guard the fade-ownership rule (#237): every fade is classified.
+#
+# `fadeblack()` is the only way the window goes to (or comes back from) black,
+# and the ownership rule says a screen fades its OWN last frame out at its own
+# exit, while that frame is still the render buffer. Ad-hoc fade calls sprinkled
+# at door sites are exactly how the "hard cut to black, then fade-in" class of
+# bug kept coming back: a clear() or a stale redraw lands between the outgoing
+# screen's last present and somebody else's fade-out, and the fade blends black
+# into black.
+#
+# So the set of places allowed to call fadeblack() is small, deliberate, and
+# checked in: scripts/fadeblack_sites.txt, one site per line with the reason it
+# is allowed to fade. A new call fails the build until somebody classifies it.
+#
+# Sites are keyed by path + enclosing function, never by line number, so that
+# edits elsewhere in a file do not rot the list.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="${ROOT}/src"
+ALLOWLIST="${ROOT}/scripts/fadeblack_sites.txt"
+
+# The two definition sites: screen::fadeblack (the pure delegate) and
+# sdl_video::fadeblack (the implementation, plus the FadeBetween prose around
+# it). Everything else in src/ is a caller and must be classified.
+EXCLUDED_FILES=(
+    "src/interface/screen.cpp"
+    "src/platform/sdl/video_sdl.cpp"
+)
+
+if [[ ! -d "${SRC_DIR}" ]]; then
+    echo "ERROR: cannot find ${SRC_DIR}" >&2
+    exit 2
+fi
+if [[ ! -f "${ALLOWLIST}" ]]; then
+    echo "ERROR: cannot find ${ALLOWLIST}" >&2
+    exit 2
+fi
+
+# Keys a call site to "<path>::<enclosing function>". Comments and string
+# literals are stripped first, so commented-out and merely-mentioned fades do
+# not count. A function definition is an identifier followed by a balanced
+# parameter list followed by `{` (rather than `;`), which distinguishes it from
+# a declaration and from a multi-line call.
+read -r -d '' SITE_KEY_AWK <<'AWK' || true
+{
+    raw[NR] = $0
+    line = $0
+    if (in_block) {
+        idx = index(line, "*/")
+        if (idx == 0) { code[NR] = ""; next }
+        line = substr(line, idx + 2)
+        in_block = 0
+    }
+    gsub(/"(\\.|[^"\\])*"/, "\"\"", line)
+    gsub(/'(\\.|[^'\\])*'/, "''", line)
+    gsub(/\/\*([^*]|\*+[^*\/])*\*+\//, " ", line)
+    line_comment = index(line, "//")
+    block_open = index(line, "/*")
+    if (line_comment > 0 && (block_open == 0 || line_comment < block_open))
+        line = substr(line, 1, line_comment - 1)
+    else if (block_open > 0) {
+        line = substr(line, 1, block_open - 1)
+        in_block = 1
+    }
+    code[NR] = line
+}
+END {
+    n = NR
+    for (i = 1; i <= n; i++) {
+        name = definition_name(i)
+        if (name != "")
+            current = name
+        if (code[i] ~ /(^|[^A-Za-z0-9_])fadeblack[ \t]*\(/) {
+            if (current == "")
+                current = "<file scope>"
+            print rel "::" current
+        }
+    }
+}
+
+# Returns the function name defined at line i, or "" if line i does not open a
+# function definition.
+function definition_name(i,   t, depth, j, prefix, rest, name, ch, k, seen) {
+    t = code[i]
+    if (t ~ /^[ \t]*$/) return ""
+    if (raw[i] ~ /^[ \t]*#/) return ""
+    sub(/^[ \t]*\}?[ \t]*/, "", t)
+    # A definition starts with a return type, a class name or a `~`; anything
+    # else (`&& live->mouse_on()) {`, `, foo(x)`) is a continuation line.
+    if (t !~ /^[A-Za-z_~]/) return ""
+    if (t ~ /^(if|for|while|switch|return|else|do|catch|case|default|new|delete|sizeof|throw)([^A-Za-z0-9_]|$)/)
+        return ""
+    if (index(t, "(") == 0) return ""
+
+    prefix = substr(t, 1, index(t, "(") - 1)
+    sub(/[ \t]+$/, "", prefix)
+    if (match(prefix, /(~?[A-Za-z_][A-Za-z0-9_]*)(::~?[A-Za-z_][A-Za-z0-9_]*)*$/) == 0)
+        return ""
+    name = substr(prefix, RSTART, RLENGTH)
+    if (name ~ /^(operator)$/) return ""
+
+    # Walk forward from the parameter list until it balances, then look at what
+    # follows: `{` means definition, `;` means declaration or call statement.
+    depth = 0
+    rest = ""
+    for (j = i; j <= NR && j <= i + 12; j++) {
+        seen = (j == i) ? substr(code[j], index(code[j], "(")) : code[j]
+        for (k = 1; k <= length(seen); k++) {
+            ch = substr(seen, k, 1)
+            if (ch == "(") depth++
+            else if (ch == ")") {
+                depth--
+                if (depth == 0) { rest = substr(seen, k + 1); break }
+            }
+        }
+        if (depth == 0) break
+    }
+    if (depth != 0) return ""
+    # A `)` right after the parameter list means the call was nested inside an
+    # enclosing expression, so this was never a definition.
+    if (rest ~ /^[ \t]*\)/) return ""
+
+    # `rest` is the tail of the closing line; keep reading until `{` or `;`.
+    for (; j <= NR && j <= i + 12; ) {
+        gsub(/[ \t]+/, "", rest)
+        if (rest != "") {
+            # An initializer list `: member(x)` still leads to a definition.
+            sub(/^:[^;{]*/, "", rest)
+            if (index(rest, ";") > 0 && (index(rest, "{") == 0 || index(rest, ";") < index(rest, "{")))
+                return ""
+            if (index(rest, "{") > 0) return name
+            if (rest != "") {
+                # const / noexcept / override / trailing return type: keep going.
+                if (rest !~ /^[A-Za-z_>&*-]/) return ""
+            }
+        }
+        j++
+        if (j > NR) return ""
+        rest = code[j]
+    }
+    return ""
+}
+AWK
+
+status=0
+FOUND_KEYS_FILE="$(mktemp)"
+trap 'rm -f "${FOUND_KEYS_FILE}"' EXIT
+
+{
+    while IFS= read -r file; do
+        rel="${file#"${ROOT}"/}"
+        skip=0
+        for excluded in "${EXCLUDED_FILES[@]}"; do
+            [[ "${rel}" == "${excluded}" ]] && skip=1
+        done
+        [[ "${skip}" -eq 1 ]] && continue
+        awk -v rel="${rel}" "${SITE_KEY_AWK}" "${file}"
+    done < <(grep -rlE '(^|[^A-Za-z0-9_])fadeblack[[:space:]]*\(' "${SRC_DIR}" | sort)
+} | sort -u > "${FOUND_KEYS_FILE}"
+
+ALLOWED_KEYS_FILE="$(mktemp)"
+trap 'rm -f "${FOUND_KEYS_FILE}" "${ALLOWED_KEYS_FILE}"' EXIT
+sed -E 's/#.*//; s/[[:space:]]+$//; s/^[[:space:]]+//' "${ALLOWLIST}" \
+    | { grep -v '^$' || true; } | sort -u > "${ALLOWED_KEYS_FILE}"
+
+UNLISTED="$(comm -23 "${FOUND_KEYS_FILE}" "${ALLOWED_KEYS_FILE}")"
+STALE="$(comm -13 "${FOUND_KEYS_FILE}" "${ALLOWED_KEYS_FILE}")"
+
+if [[ -n "${UNLISTED}" ]]; then
+    echo "ERROR: unclassified fadeblack() call site(s):" >&2
+    while IFS= read -r key; do
+        echo "  ${key}" >&2
+    done <<< "${UNLISTED}"
+    status=1
+fi
+
+if [[ -n "${STALE}" ]]; then
+    echo "ERROR: allowlisted fadeblack() call site(s) that no longer exist:" >&2
+    while IFS= read -r key; do
+        echo "  ${key}" >&2
+    done <<< "${STALE}"
+    status=1
+fi
+
+if [[ "${status}" -ne 0 ]]; then
+    cat >&2 <<EOF
+
+Fade ownership (#237): a screen fades its own last frame out at its own exit,
+while that frame is still the render buffer. Ad-hoc fades at door sites are how
+"hard cut to black, then fade in" keeps coming back — a clear() or a stale
+redraw lands between the last present and the fade-out, and the fade blends
+black into black.
+
+Before adding a fade, check whether the runner already owns it:
+og::ui::ScreenFadeScope (run_menu_screen) and og::ui::LegacyMenuFade bracket
+every menu screen already. If the site genuinely needs its own fade, add its
+key with the reason to:
+
+  ${ALLOWLIST}
+
+Keys are "<path>::<enclosing function>" — the same key the errors above print.
+EOF
+    exit 2
+fi
+
+echo "OK: $(wc -l < "${FOUND_KEYS_FILE}") classified fadeblack() call site(s)."

--- a/scripts/fadeblack_sites.txt
+++ b/scripts/fadeblack_sites.txt
@@ -1,0 +1,34 @@
+# Every place in src/ allowed to call fadeblack(), one per line, with the
+# reason it owns a fade. Checked by scripts/check_fadeblack_sites.sh, which is
+# a build dependency of og_interface and og_platform_sdl — an unclassified fade
+# fails the build.
+#
+# A key is "<path>::<enclosing function>", never a line number, so unrelated
+# edits do not rot this list. One key covers every fade in that function.
+#
+# The two definition sites (screen::fadeblack in src/interface/screen.cpp and
+# sdl_video::fadeblack in src/platform/sdl/video_sdl.cpp) are excluded by the
+# script itself.
+#
+# The ownership rule (#237): whoever fades in fades out, at its own exit, while
+# its last frame is still the render buffer. Menu screens get that for free
+# from ScreenFadeScope / LegacyMenuFade, so a new entry here should be rare and
+# is either the fade engine itself or a boundary the runner does not cover
+# (process start, the gameplay/menu boundary).
+
+# --- the fade engine: the runner's own entry and exit brackets ---
+src/interface/ui/menu_screen_runner.cpp::~ScreenFadeScope         # exit-owned fade-out; every return path out of run_menu_screen
+src/interface/ui/menu_screen_runner.cpp::run_menu_screen          # entry fade-out, cold first-frame fade-in, loop fade-in after a nested door
+src/interface/ui/menu_screen_runner.cpp::LegacyMenuFade::LegacyMenuFade  # entry fade-out for screens outside the runner (campaign select, results, editor)
+src/interface/ui/menu_screen_runner.cpp::LegacyMenuFade::present_first   # the paired fade-in, presenting the legacy screen's first composed frame
+src/interface/ui/menu_screen_runner.cpp::LegacyMenuFade::end            # the paired exit fade-out (also runs from the destructor)
+
+# --- process start: the intro sequence owns its own pages ---
+src/interface/ui/intro.cpp::intro_main   # fade the cold-start window out before the first intro page composes
+src/interface/ui/intro.cpp::show         # per-page fade-in and fade-out; both returns honour the -1 key abort
+src/interface/ui/intro.cpp::cleanup      # fades an aborted page out so the main menu's entry only ever fades in
+
+# --- the gameplay/menu boundary: outside every menu runner ---
+src/platform/sdl/glad_gameplay.cpp::glad_init          # technical teardown: fade the picker out, then fade the first composed gameplay frame in
+src/interface/ui/picker_team_build.cpp::go_menu        # native return-from-game; fades whichever canvas gameplay last presented
+src/interface/ui/picker.cpp::picker_reinit_after_game  # the same return-from-game fade on the Emscripten state-machine path

--- a/scripts/fadeblack_sites.txt
+++ b/scripts/fadeblack_sites.txt
@@ -1,14 +1,14 @@
-# Every place in src/ allowed to call fadeblack(), one per line, with the
-# reason it owns a fade. Checked by scripts/check_fadeblack_sites.sh, which is
-# a build dependency of og_interface and og_platform_sdl — an unclassified fade
-# fails the build.
+# Every function in src/ allowed to call fadeblack(), one per line, with how
+# many fades it makes and the reason it owns them. Checked by
+# scripts/check_fadeblack_sites.sh, which is a build dependency of
+# og_interface and og_platform_sdl — an unclassified fade fails the build, and
+# so does a fade added beside an existing one (the count changes).
 #
-# A key is "<path>::<enclosing function>", never a line number, so unrelated
-# edits do not rot this list. One key covers every fade in that function.
-#
-# The two definition sites (screen::fadeblack in src/interface/screen.cpp and
-# sdl_video::fadeblack in src/platform/sdl/video_sdl.cpp) are excluded by the
-# script itself.
+# A key is "<path>::<enclosing function>=<count>", never a line number, so
+# unrelated edits do not rot this list. The count is the number of fadeblack()
+# calls in that function: a door-site fade planted next to a classified
+# teardown fade is exactly the shape the ownership rule forbids, and a
+# per-function count is what makes it fail to build.
 #
 # The ownership rule (#237): whoever fades in fades out, at its own exit, while
 # its last frame is still the render buffer. Menu screens get that for free
@@ -16,19 +16,26 @@
 # is either the fade engine itself or a boundary the runner does not cover
 # (process start, the gameplay/menu boundary).
 
+# --- the definition: screen::fadeblack delegates to the video layer ---
+# (sdl_video::fadeblack, the implementation, calls FadeBetween and makes no
+# fadeblack() call of its own, so it has no key.)
+src/interface/screen.cpp::screen::fadeblack=1   # the delegate to video_impl_->fadeblack
+
 # --- the fade engine: the runner's own entry and exit brackets ---
-src/interface/ui/menu_screen_runner.cpp::~ScreenFadeScope         # exit-owned fade-out; every return path out of run_menu_screen
-src/interface/ui/menu_screen_runner.cpp::run_menu_screen          # entry fade-out, cold first-frame fade-in, loop fade-in after a nested door
-src/interface/ui/menu_screen_runner.cpp::LegacyMenuFade::LegacyMenuFade  # entry fade-out for screens outside the runner (campaign select, results, editor)
-src/interface/ui/menu_screen_runner.cpp::LegacyMenuFade::present_first   # the paired fade-in, presenting the legacy screen's first composed frame
-src/interface/ui/menu_screen_runner.cpp::LegacyMenuFade::end            # the paired exit fade-out (also runs from the destructor)
+src/interface/ui/menu_screen_runner.cpp::~ScreenFadeScope=1              # exit-owned fade-out; every return path out of run_menu_screen
+src/interface/ui/menu_screen_runner.cpp::run_menu_screen=3               # entry fade-out, cold first-frame fade-in, loop fade-in after a nested door
+src/interface/ui/menu_screen_runner.cpp::LegacyMenuFade::LegacyMenuFade=1  # entry fade-out for screens outside the runner (campaign select, results, editor)
+src/interface/ui/menu_screen_runner.cpp::LegacyMenuFade::present_first=1   # the paired fade-in, presenting the legacy screen's first composed frame
+src/interface/ui/menu_screen_runner.cpp::LegacyMenuFade::end=1             # the paired exit fade-out (also runs from the destructor, and for fade_out_at_exit)
 
 # --- process start: the intro sequence owns its own pages ---
-src/interface/ui/intro.cpp::intro_main   # fade the cold-start window out before the first intro page composes
-src/interface/ui/intro.cpp::show         # per-page fade-in and fade-out; both returns honour the -1 key abort
-src/interface/ui/intro.cpp::cleanup      # fades an aborted page out so the main menu's entry only ever fades in
+src/interface/ui/intro.cpp::intro_main=1   # fade the cold-start loading dialog out before the first intro page composes
+src/interface/ui/intro.cpp::show=2         # per-page fade-in and fade-out; both returns honour the -1 key abort
+src/interface/ui/intro.cpp::cleanup=1      # fades an aborted page out so the main menu's entry only ever fades in
+src/platform/sdl/glad.cpp::bootstrap_runtime=1  # the intro-skipped web start: the loading dialog exits here, so it fades out here
 
 # --- the gameplay/menu boundary: outside every menu runner ---
-src/platform/sdl/glad_gameplay.cpp::glad_init          # technical teardown: fade the picker out, then fade the first composed gameplay frame in
-src/interface/ui/picker_team_build.cpp::go_menu        # native return-from-game; fades whichever canvas gameplay last presented
-src/interface/ui/picker.cpp::picker_reinit_after_game  # the same return-from-game fade on the Emscripten state-machine path
+src/platform/sdl/glad_gameplay.cpp::glad_init=2          # technical teardown: fade the picker out (a no-op after Base Camp's exit fade), then fade the first composed gameplay frame in
+src/interface/ui/picker_team_build.cpp::go_menu=1        # native return-from-game; fades whichever canvas gameplay last presented
+src/interface/ui/picker.cpp::picker_reinit_after_game=1  # the same return-from-game fade on the Emscripten state-machine path
+src/interface/ui/results_screen.cpp::results_screen=1    # the mission's tail (last frame + dismissed ending popup) exits here: fade it out before the results panel's entry

--- a/src/interface/input/input.cpp
+++ b/src/interface/input/input.cpp
@@ -1748,6 +1748,27 @@ void reset_mouse_click_tracking()
     hw().picker_was_right_down = mouse_state.right;
 }
 
+void acknowledge_mouse_presses()
+{
+    // The pointer-handoff rule (docs/menu-engine.md, "Pointer handoff"): a
+    // surface acknowledges the presses it saw. This is query_mouse()'s
+    // observed-press bookkeeping without the poll — the callers run their
+    // own pumps, and a second poll here would steal their events. A press
+    // and release that land inside ONE pump still mint a collapsed tap,
+    // exactly as they do for a query_mouse() surface.
+    g_mouse_left_unqueried_press = false;
+    g_mouse_right_unqueried_press = false;
+}
+
+#ifdef TESTING
+namespace og::input {
+int testing_pending_left_clicks()
+{
+    return g_pending_left_clicks;
+}
+} // namespace og::input
+#endif
+
 bool take_pending_left_click()
 {
     if (g_pending_left_clicks > 0)

--- a/src/interface/input/input.cpp
+++ b/src/interface/input/input.cpp
@@ -77,6 +77,11 @@ short& input_key_press_event_ref()
     return og::runtime::current_session->key_press_event_;
 }
 
+unsigned query_key_press_serial()
+{
+    return og::runtime::current_session->key_press_serial_;
+}
+
 short& input_text_input_event_ref()
 {
     return og::runtime::current_session->text_input_event_;
@@ -604,6 +609,7 @@ void handle_mouse_event(const void* native_event)
     case og::input_native::EventType::MouseWheel:
         og::runtime::current_session->scroll_amount_ = static_cast<short>(5*event.wheel_y);
         og::runtime::current_session->key_press_event_ = 1;
+        ++og::runtime::current_session->key_press_serial_;
         break;
 
 #ifndef USE_TOUCH_INPUT
@@ -891,6 +897,7 @@ void handle_mouse_event(const void* native_event)
             
             
             og::runtime::current_session->key_press_event_ = 1;
+        ++og::runtime::current_session->key_press_serial_;
             mouse_state.left = 1;
             mouse_state.x = x;
             mouse_state.y = y;
@@ -918,14 +925,17 @@ void handle_joy_event(const void* native_event)
         if (event.joy_axis_value > JOY_DEAD_ZONE ||
             event.joy_axis_value < -JOY_DEAD_ZONE)
             og::runtime::current_session->key_press_event_ = 1;
+        ++og::runtime::current_session->key_press_serial_;
         break;
     case og::input_native::EventType::JoyButtonDown:
         og::runtime::current_session->key_press_event_ = 1;
+        ++og::runtime::current_session->key_press_serial_;
         break;
     case og::input_native::EventType::JoyHatMotion:
         // A hat returning to center is a release, not a press.
         if (event.joy_hat_value != 0)
             og::runtime::current_session->key_press_event_ = 1;
+        ++og::runtime::current_session->key_press_serial_;
         break;
     default:
         break;

--- a/src/interface/input/input_state.cpp
+++ b/src/interface/input/input_state.cpp
@@ -345,8 +345,8 @@ bool compact_player_controls_after_removal(int removed_player_index, int active_
         return false;
 
     // Control profiles are a four-entry pool. Compact the surviving seats,
-    // then rotate the freed profile to the first inactive slot so a later [+]
-    // reuses that distinct mapping. Resetting the tail by its array index
+    // then rotate the freed profile to the first inactive slot so a later ADD
+    // PLAYER reuses that distinct mapping. Resetting the tail by its array index
     // cloned P4's THGF defaults after P1 was removed from a four-seat game.
     sync_runtime_keys_to_active_mode(removed_player_index);
     std::array<std::array<int, NUM_KEYS>, 2> removed_keys{};

--- a/src/interface/screen.cpp
+++ b/src/interface/screen.cpp
@@ -992,6 +992,20 @@ int screen::fadeblack(bool fade_in)
     return video_impl_->fadeblack(fade_in);
 }
 
+bool screen::window_is_black()
+{
+    // A headless session has no window; nothing is ever shown.
+    return video_impl_ == nullptr || video_impl_->window_is_black();
+}
+
+#ifdef TESTING
+void screen::testing_reset_window_state()
+{
+    if (video_impl_ != nullptr)
+        video_impl_->testing_reset_window_state();
+}
+#endif
+
 // ************************************************************
 //  SCREEN -- graphics routines
 //

--- a/src/interface/screen.cpp
+++ b/src/interface/screen.cpp
@@ -1004,6 +1004,12 @@ void screen::testing_reset_window_state()
     if (video_impl_ != nullptr)
         video_impl_->testing_reset_window_state();
 }
+
+void screen::testing_report_fade_violation(const char* what)
+{
+    if (video_impl_ != nullptr)
+        video_impl_->testing_report_fade_violation(what);
+}
 #endif
 
 // ************************************************************

--- a/src/interface/ui/button.cpp
+++ b/src/interface/ui/button.cpp
@@ -29,6 +29,7 @@
 #include <openglad/resources/gloader.h>
 #include <openglad/resources/gparser.h>
 #include <openglad/resources/io_common.h>
+#include <openglad/interface/ui/menu_screen_spec.h>
 #include <openglad/interface/ui/picker_ui_state.h>
 #include <openglad/interface/session_state.h>
 #include <algorithm>
@@ -735,7 +736,9 @@ bool picker_try_intercept_button_action(Sint32 whatfunc, Sint32 call_arg, Sint32
     case ButtonAction::ToggleLobbyReady:
         return teams_toggle_ready();
     case ButtonAction::DoLevelEdit:
-        return level_editor();
+        // #237: the LEVEL EDITOR is a main-menu door whose loop runs NESTED
+        // inside the open main menu, exactly like CLOUD SAVES — same bracket.
+        return og::ui::run_nested_menu_door(&level_editor);
     case ButtonAction::YesOrNo:
         return yes_or_no(arg);
     case ButtonAction::MainOptions:

--- a/src/interface/ui/button.cpp
+++ b/src/interface/ui/button.cpp
@@ -230,6 +230,12 @@ void vbutton::vdisplay(Sint32 status)
     if (!status) // do normal
     {
         vdisplay();
+        // The released face is presented like the pressed one above: an
+        // activation that EXITS its screen never reaches the loop's next
+        // present, and the exit fade reads the buffer — which must hold a
+        // frame the window has shown (#237 ownership; the video layer flags
+        // a released face the window never saw as a stale redraw).
+        og::runtime::current_session->myscreen_->buffer_to_screen(xloc,yloc,xend-xloc,yend-yloc);
         return;
     }
     
@@ -336,7 +342,7 @@ Sint32 vbutton::leftclick(Sint32 whichbutton)
         {
             og::runtime::current_session->myscreen_->soundp->play_sound(SOUND_BOW);
             vdisplay(1);
-            vdisplay();
+            vdisplay(0); // pressed, then released — both presented
             if (myfunc)
             {
                 // Coordinate-free activation: never leave a stale pointer
@@ -359,7 +365,7 @@ Sint32 vbutton::leftclick(Sint32 whichbutton)
         {
             og::runtime::current_session->myscreen_->soundp->play_sound(SOUND_BOW);
             vdisplay(1);
-            vdisplay();
+            vdisplay(0); // pressed, then released — both presented
             if (myfunc)
             {
                 // Pointer activation: stamp the UI-canvas position that hit

--- a/src/interface/ui/button.cpp
+++ b/src/interface/ui/button.cpp
@@ -212,11 +212,19 @@ void vbutton::vdisplay()
     }
     else
     {
+        // A dimmed (inert) face sits on the same palette shade as the normal
+        // shadow edges, so those two step one shade darker to keep the bevel
+        // readable — the lit edges are already well clear of it. The shade
+        // ramp 11..15 is contiguous, so "one darker" is exactly one index.
+        const unsigned char shadow_right = static_cast<unsigned char>(
+            dimmed ? BUTTON_RIGHT - 1 : BUTTON_RIGHT);
+        const unsigned char shadow_bottom = static_cast<unsigned char>(
+            dimmed ? BUTTON_BOTTOM - 1 : BUTTON_BOTTOM);
         og::runtime::current_session->myscreen_->draw_box(xloc,yloc,xend-1,yend-1,color,1,1); // front
         og::runtime::current_session->myscreen_->draw_box(xloc,yloc,xend-2,yloc,BUTTON_TOP,1,1); // top edge
         og::runtime::current_session->myscreen_->draw_box(xloc,yloc+1,xloc,yend-2,BUTTON_LEFT,1,1); // left
-        og::runtime::current_session->myscreen_->draw_box(xend-1,yloc+1,xend-1,yend-2,BUTTON_RIGHT,1,1); // right
-        og::runtime::current_session->myscreen_->draw_box(xloc+1,yend-1,xend-1,yend-1,BUTTON_BOTTOM,1,1); // bottom
+        og::runtime::current_session->myscreen_->draw_box(xend-1,yloc+1,xend-1,yend-2,shadow_right,1,1); // right
+        og::runtime::current_session->myscreen_->draw_box(xloc+1,yend-1,xend-1,yend-1,shadow_bottom,1,1); // bottom
         if (label.size())
             mytext.write_xy( static_cast<short>( static_cast<size_t>((xloc+xend)/2) - ((label.size()* (mytext.letters->w+1) - 1)/2)) ,
                               static_cast<short>(yloc + (height-(mytext.letters->h))/2), label.c_str(), static_cast<unsigned char>(DARK_BLUE), 1);

--- a/src/interface/ui/campaign_picker.cpp
+++ b/src/interface/ui/campaign_picker.cpp
@@ -328,11 +328,16 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
     // it while World is active; keep the campaign icon, text and controls on
     // the nearest UI present path instead of filtering the whole browser with
     // the editor map's SAI/Eagle setting.
-    ScopedUiCanvas canvas_target(*og::runtime::current_session->myscreen_);
-    // #237 depth rule, applied by hand (legacy blocking browser): a
-    // top-level entry (the new-game flow, the editor) is a context switch
-    // and fades; SET CAMPAIGN from an open Base Camp is nested and does not.
+    // #237 depth rule, applied by hand (legacy blocking browser): the
+    // new-game flow's entry (depth 0) is a context switch and fades; SET
+    // CAMPAIGN from an open Base Camp is nested and does not. The in-game
+    // editor's browser is likewise nested inside the main menu's screen, so
+    // only the standalone editor (openscen) reaches the fade here. The
+    // fade-out must run BEFORE the UI-canvas switch below: it fades whatever
+    // canvas is actually presented (openscen presents the World canvas), not
+    // the stale UI surface.
     bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
+    ScopedUiCanvas canvas_target(*og::runtime::current_session->myscreen_);
     std::string old_campaign_id = get_mounted_campaign();
     CampaignEntry* result = nullptr;
     CampaignResult ret_value;

--- a/src/interface/ui/campaign_picker.cpp
+++ b/src/interface/ui/campaign_picker.cpp
@@ -329,12 +329,12 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
     // the nearest UI present path instead of filtering the whole browser with
     // the editor map's SAI/Eagle setting.
     // #237 depth rule, applied by hand (legacy blocking browser): the
-    // new-game flow's entry (depth 0) is a context switch and fades; SET
-    // CAMPAIGN from an open Base Camp is nested and does not. The in-game
-    // editor's browser is likewise nested inside the main menu's screen, so
-    // only the standalone editor (openscen) reaches the fade here. The
+    // new-game flow's entry (depth 0, via SdlPickerClient::show_campaign_select
+    // — the live consumer of the fade here) is a context switch and fades. SET
+    // CAMPAIGN from an open Base Camp is nested and does not, and neither is
+    // the in-game editor's browser (nested inside the main menu's screen). The
     // fade-out must run BEFORE the UI-canvas switch below: it fades whatever
-    // canvas is actually presented (openscen presents the World canvas), not
+    // canvas is actually presented (the editor presents the World canvas), not
     // the stale UI surface.
     bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
     ScopedUiCanvas canvas_target(*og::runtime::current_session->myscreen_);

--- a/src/interface/ui/campaign_picker.cpp
+++ b/src/interface/ui/campaign_picker.cpp
@@ -27,6 +27,7 @@
 #include <openglad/interface/render/text.h>
 #include <openglad/gameplay/guy.h>
 #include <openglad/interface/screen.h>
+#include <openglad/core/test_trace.h>
 #include <openglad/interface/button.h>
 #include <openglad/interface/native_input.h>
 #include <openglad/core/text_wrap.h>
@@ -59,6 +60,7 @@ bool handle_menu_nav(button* buttons, int& highlighted_button, Sint32& retvalue,
 bool campaign_picker_testing_take_abort();
 void campaign_picker_testing_mark_entered();
 void campaign_picker_testing_mark_action();
+bool campaign_picker_testing_auto_accept();
 #endif
 
 namespace
@@ -328,15 +330,17 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
     // it while World is active; keep the campaign icon, text and controls on
     // the nearest UI present path instead of filtering the whole browser with
     // the editor map's SAI/Eagle setting.
-    // #237 depth rule, applied by hand (legacy blocking browser): the
+    // #237 ownership rule, applied by hand (legacy blocking browser): the
     // new-game flow's entry (depth 0, via SdlPickerClient::show_campaign_select
-    // — the live consumer of the fade here) is a context switch and fades. SET
-    // CAMPAIGN from an open Base Camp is nested and does not, and neither is
-    // the in-game editor's browser (nested inside the main menu's screen). The
-    // fade-out must run BEFORE the UI-canvas switch below: it fades whatever
-    // canvas is actually presented (the editor presents the World canvas), not
-    // the stale UI surface.
-    bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
+    // — the live consumer of the fade here) is a context switch and fades —
+    // out of the previous screen now, in on the first composed frame, and out
+    // again at entry_fade.end() after the loop. SET CAMPAIGN from an open Base
+    // Camp is nested and does not, and neither is the in-game editor's browser
+    // (nested inside the main menu's screen). The entry fade-out must run
+    // BEFORE the UI-canvas switch below: it fades whatever canvas is actually
+    // presented (the editor presents the World canvas), not the stale UI
+    // surface.
+    og::ui::LegacyMenuFade entry_fade;
     ScopedUiCanvas canvas_target(*og::runtime::current_session->myscreen_);
     std::string old_campaign_id = get_mounted_campaign();
     CampaignEntry* result = nullptr;
@@ -519,6 +523,7 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
     bool done = false;
     int last_highlighted = highlighted_button;
 #ifdef TESTING
+    bool first_frame_presented = false;
     campaign_picker_testing_mark_entered();
 #endif
     while (!done)
@@ -526,6 +531,20 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
 #ifdef TESTING
         if (campaign_picker_testing_take_abort())
             break;
+        // The un-driven browser (every BEGIN NEW GAME flow that never
+        // touches it) accepts the current campaign once its first frame is
+        // on the window — the real screen, its real fades, no injector
+        // clicks. Tests that drive the browser disarm this first.
+        if (first_frame_presented && campaign_picker_testing_auto_accept())
+        {
+            result = ensure_entry(cursor);
+            if (result != nullptr)
+            {
+                TRACE("campaign_picker", "auto-accept %s", result->id.c_str());
+                done = true;
+                break;
+            }
+        }
 #endif
         // Reset the timer count to zero ...
         reset_timer();
@@ -775,15 +794,20 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
             entries[static_cast<std::size_t>(cursor)]->draw(army_power);
 
         draw_highlight(buttons[highlighted_button]);
-        if (entry_fade_in_pending) {
-            // fadeblack presents the composed buffer itself (#237).
-            entry_fade_in_pending = false;
-            og::runtime::current_session->myscreen_->fadeblack(1);
-        } else {
-            og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
-        }
+        // The first frame fades in when this entry fades; every later one
+        // presents plainly (#237).
+        entry_fade.present_first(*og::runtime::current_session->myscreen_);
+#ifdef TESTING
+        if (!first_frame_presented)
+            TRACE("campaign_picker", "first frame presented");
+        first_frame_presented = true;
+#endif
         og::input_native::sleep_ms(10);
     }
+    // The browser's last presented frame fades out HERE — before the key
+    // release wait, the remount and the canvas restore below can touch the
+    // buffer or the active canvas (#237 ownership).
+    entry_fade.end();
 
     wait_for_key_release(KEYSTATE_q, "quit");
 

--- a/src/interface/ui/campaign_picker.cpp
+++ b/src/interface/ui/campaign_picker.cpp
@@ -340,7 +340,7 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
     // BEFORE the UI-canvas switch below: it fades whatever canvas is actually
     // presented (the editor presents the World canvas), not the stale UI
     // surface.
-    og::ui::LegacyMenuFade entry_fade;
+    og::ui::LegacyMenuFade entry_fade("campaign select");
     ScopedUiCanvas canvas_target(*og::runtime::current_session->myscreen_);
     std::string old_campaign_id = get_mounted_campaign();
     CampaignEntry* result = nullptr;
@@ -544,6 +544,11 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
                 done = true;
                 break;
             }
+            // Nothing listed (unmounted or broken assets): an un-driven
+            // browser must return empty, not block until the test times out.
+            TRACE("campaign_picker", "auto-accept: no campaigns listed");
+            done = true;
+            break;
         }
 #endif
         // Reset the timer count to zero ...

--- a/src/interface/ui/campaign_picker.cpp
+++ b/src/interface/ui/campaign_picker.cpp
@@ -520,6 +520,14 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
 	};
 	sync_visibility();
 
+    // Pointer handoff (docs/menu-engine.md): this browser opens off a click
+    // on another surface, and its rows are LEVEL-triggered (do_click below
+    // fires while the button is down). Start from a fresh baseline and hold
+    // fire until the door click's button has been seen up once, so it cannot
+    // click through onto a row on frame one.
+    reset_mouse_click_tracking();
+    bool saw_left_release = !query_mouse_no_poll().left;
+
     bool done = false;
     int last_highlighted = highlighted_button;
 #ifdef TESTING
@@ -581,7 +589,9 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
         int mx = static_cast<int>(mymouse.x);
         int my = static_cast<int>(mymouse.y);
 
-        bool do_click = mymouse.left;
+        if (!mymouse.left)
+            saw_left_release = true;
+        bool do_click = mymouse.left && saw_left_release;
 		bool do_prev = !buttons[prev_index].hidden && ((do_click && prev.x <= mx && mx <= prev.x + prev.w
                && prev.y <= my && my <= prev.y + prev.h) || (retvalue == OG_OK && highlighted_button == prev_index));
         bool do_next = !buttons[next_index].hidden && ((do_click && next.x <= mx && mx <= next.x + next.w

--- a/src/interface/ui/campaign_picker.cpp
+++ b/src/interface/ui/campaign_picker.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <openglad/interface/ui/campaign_picker.h>
+#include <openglad/interface/ui/menu_screen_spec.h>
 #include <openglad/interface/ui/picker_common.h>
 #include <openglad/interface/ui/picker_lobby_client.h>
 #include <openglad/resources/campaign_metadata.h>
@@ -328,6 +329,10 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
     // the nearest UI present path instead of filtering the whole browser with
     // the editor map's SAI/Eagle setting.
     ScopedUiCanvas canvas_target(*og::runtime::current_session->myscreen_);
+    // #237 depth rule, applied by hand (legacy blocking browser): a
+    // top-level entry (the new-game flow, the editor) is a context switch
+    // and fades; SET CAMPAIGN from an open Base Camp is nested and does not.
+    bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
     std::string old_campaign_id = get_mounted_campaign();
     CampaignEntry* result = nullptr;
     CampaignResult ret_value;
@@ -765,7 +770,13 @@ CampaignResult pick_campaign(SaveData* save_data, bool enable_delete)
             entries[static_cast<std::size_t>(cursor)]->draw(army_power);
 
         draw_highlight(buttons[highlighted_button]);
-        og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
+        if (entry_fade_in_pending) {
+            // fadeblack presents the composed buffer itself (#237).
+            entry_fade_in_pending = false;
+            og::runtime::current_session->myscreen_->fadeblack(1);
+        } else {
+            og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
+        }
         og::input_native::sleep_ms(10);
     }
 

--- a/src/interface/ui/help.cpp
+++ b/src/interface/ui/help.cpp
@@ -491,7 +491,7 @@ short read_campaign_intro(screen *s)
 	// select (which faded itself out) and Base Camp — it fades its first
 	// frame in over black and fades itself out on dismissal, while its last
 	// frame is still the buffer. Base Camp then finds a black window.
-	og::ui::LegacyMenuFade entry_fade;
+	og::ui::LegacyMenuFade entry_fade("campaign intro");
 	return scroll_campaign_description(s, s->save_data.current_campaign,
 	                                   &entry_fade);
 }

--- a/src/interface/ui/help.cpp
+++ b/src/interface/ui/help.cpp
@@ -909,15 +909,12 @@ Sint32 show_general_help()
 	HelpScreenState state;
 	help_switch_tab(state, HelpTab::Controls, true);
 
-	og::runtime::current_session->myscreen_->clearbuffer();
 	// A wheel notch queued before entry must not page the first frame.
 	(void)get_and_reset_scroll_amount();
 
 	g_help_screen_state = &state;
 	(void)og::ui::run_menu_screen(og::ui::help_menu_screen_spec(), &state);
 	g_help_screen_state = nullptr;
-
-	og::runtime::current_session->myscreen_->clearbuffer();
 
 	// Drain a still-held Escape: the re-entered main menu's QUIT row carries
 	// KEYSTATE_ESCAPE and would consume the same press.

--- a/src/interface/ui/help.cpp
+++ b/src/interface/ui/help.cpp
@@ -36,6 +36,7 @@
 #include <openglad/interface/ui/scroll_view_layout.h>
 #include <openglad/resources/og_file.h>
 #include <openglad/interface/screen.h>
+#include <openglad/core/test_trace.h>
 #include <openglad/interface/game_context.h>
 #include <openglad/interface/ui/menu_screen_spec.h>
 #include "picker_sdl_defs.h"
@@ -130,10 +131,12 @@ bool help_testing_force_scroll_text()
 // GetLine(int index) should return a std::string for the given line index.
 // Note: this code has been redone to work in 'scanlines,'
 //       so that the text scrolls by pixels rather than lines.
+// entry_fade (optional): the campaign intro's context-switch fade — its
+// first frame fades in through the scope instead of the partial-rect present.
 template <typename GetLine>
 static short scroll_text_view(screen* scr, int num_lines, int box_width,
     const char* title, Sint32 buf_x, Sint32 buf_y, Sint32 buf_w, Sint32 buf_h,
-    GetLine get_line)
+    GetLine get_line, og::ui::LegacyMenuFade* entry_fade = nullptr)
 {
 	ScopedUiCanvas canvas_target(*scr);
 	// Flow the source lines to the frame's character budget before display
@@ -396,9 +399,24 @@ static short scroll_text_view(screen* scr, int num_lines, int box_width,
 			int cont_x = HELPTEXT_LEFT + chrome_w/2 - cont_len*3;
 			mytext.write_xy(cont_x, HELPTEXT_TOP+98,
 			                CONTINUE_ACTION_STRING " TO CONTINUE", static_cast<unsigned char>(RED), 1);
-			scr->buffer_to_screen(frame.blit_x, frame.blit_y,
-			                      frame.blit_w, frame.blit_h);
+			if (entry_fade != nullptr && entry_fade->fade_in_pending())
+				entry_fade->present_first(*scr);
+			else
+				scr->buffer_to_screen(frame.blit_x, frame.blit_y,
+				                      frame.blit_w, frame.blit_h);
 			changed = 0;
+#ifdef TESTING
+			TRACE("help", "scroller presented");
+			// The un-driven scroller (the campaign intro inside every BEGIN
+			// NEW GAME flow) dismisses itself once its first frame is on the
+			// window, so the leg runs for real — fades included — without
+			// an injector keypress. A test that drives the view forces it.
+			if (!help_testing_force_scroll_text())
+			{
+				TRACE("help", "scroller auto-dismissed");
+				break;
+			}
+#endif
 		}
 
 		if (query_input_continue())
@@ -442,7 +460,8 @@ short read_scenario(screen *s)
 // read_campaign_intro and the campaign browser's MORE control (which passes
 // the highlighted — not necessarily current — campaign id).
 static short scroll_campaign_description(screen *s,
-	const std::string& campaign_id)
+	const std::string& campaign_id,
+	og::ui::LegacyMenuFade* entry_fade = nullptr)
 {
 	CampaignData data(campaign_id);
 	if (!data.load())
@@ -452,7 +471,7 @@ static short scroll_campaign_description(screen *s,
 	return scroll_text_view(s,
 		static_cast<int>(data.description.size()), 240,
 		data.title.c_str(), HELPTEXT_LEFT-4, HELPTEXT_TOP-4-8, 244, 119,
-		[&](int idx) { return data.getDescriptionLine(idx); });
+		[&](int idx) { return data.getDescriptionLine(idx); }, entry_fade);
 }
 
 short show_campaign_description(screen *scr, const std::string& campaign_id)
@@ -468,7 +487,13 @@ short show_campaign_description(screen *scr, const std::string& campaign_id)
 
 short read_campaign_intro(screen *s)
 {
-	return scroll_campaign_description(s, s->save_data.current_campaign);
+	// #237 ownership: the intro is the context switch between campaign
+	// select (which faded itself out) and Base Camp — it fades its first
+	// frame in over black and fades itself out on dismissal, while its last
+	// frame is still the buffer. Base Camp then finds a black window.
+	og::ui::LegacyMenuFade entry_fade;
+	return scroll_campaign_description(s, s->save_data.current_campaign,
+	                                   &entry_fade);
 }
 
 

--- a/src/interface/ui/intro.cpp
+++ b/src/interface/ui/intro.cpp
@@ -372,5 +372,9 @@ int show(int howlong)
 
 	set_web_intro_tap_ready(false);
 	if (og::runtime::current_session->myscreen_->fadeblack(FADE_TO) == -1) return -1;
+	// A tap during this page's closing fade mints its pending click AFTER
+	// the loop's drain above — spend it here so the intro keeps its own
+	// promise: no click made on the intro leaks into whatever follows.
+	while (take_pending_left_click()) {}
 	return 1;
 }

--- a/src/interface/ui/intro.cpp
+++ b/src/interface/ui/intro.cpp
@@ -302,13 +302,12 @@ int cleanup()
 	int red,green,blue; //buffers: PORT: changed to ints
 	query_palette_reg(static_cast<unsigned char>(0), &red, &green, &blue); // Resets palette to read mode
 	release_timer();
-	og::runtime::current_session->myscreen_->clear();
-	og::runtime::current_session->myscreen_->refresh();
-	// #237: every intro exit (last page's fade-to-black or a key abort)
-	// leaves the presented surface black here, so the main menu's depth-1
-	// entry must skip its own fade-out — the cold-start black-to-black
-	// 500ms fade (#200's shape) dies with this note.
-	og::ui::note_menu_faded_to_black();
+	// #237 ownership: the intro fades its last page out itself. After a
+	// completed last page this is a no-op (the window is already black); a
+	// key abort mid-page fades that page out instead of hard-cutting. Either
+	// way the window is black, so the main menu's entry fades in only — the
+	// cold-start black-to-black 500ms fade (#200's shape) cannot come back.
+	og::runtime::current_session->myscreen_->fadeblack(FADE_TO);
 
 		for (i = 0; i<256; i++)
 		{

--- a/src/interface/ui/intro.cpp
+++ b/src/interface/ui/intro.cpp
@@ -26,6 +26,7 @@
 #include <openglad/core/util.h>
 #include <openglad/core/test_trace.h>
 #include <openglad/interface/input.h>
+#include <openglad/interface/ui/menu_screen_spec.h>
 #include <array>
 #include <cstring>
 #ifdef __EMSCRIPTEN__
@@ -303,6 +304,11 @@ int cleanup()
 	release_timer();
 	og::runtime::current_session->myscreen_->clear();
 	og::runtime::current_session->myscreen_->refresh();
+	// #237: every intro exit (last page's fade-to-black or a key abort)
+	// leaves the presented surface black here, so the main menu's depth-1
+	// entry must skip its own fade-out — the cold-start black-to-black
+	// 500ms fade (#200's shape) dies with this note.
+	og::ui::note_menu_faded_to_black();
 
 		for (i = 0; i<256; i++)
 		{

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -3701,6 +3701,42 @@ Sint32 level_editor()
 	std::uint32_t last_ticks = og::input_native::ticks_ms();
 	std::uint32_t start_ticks = last_ticks;
 
+	// One composer for the editor's frame, called once COLD below and then by
+	// the loop's redraw branch. LevelEditorData::draw prepares one
+	// smart-smoothed scenery + crisp UI transaction; present only after every
+	// layer (including the controller cursor) is complete, because the
+	// gameplay overlay is single-use. The first call fades in (#237): the
+	// editor's canvas is pinned classic (a shared surface), so it fades the
+	// real first frame, not a stale UI image. Later calls present plainly.
+	// `data` is function-static, so it is named directly rather than
+	// captured (a lambda cannot capture non-automatic storage).
+	const auto compose_and_present = [&mymouse, &entry_fade]() {
+	    eds().redraw = 0;
+	    data.draw(og::runtime::current_session->myscreen_);
+
+	    #ifdef USE_CONTROLLER_INPUT
+	    {
+	        ScopedGameplayUiCanvas editor_ui(
+	            *og::runtime::current_session->myscreen_);
+	        og::runtime::current_session->myscreen_->fastbox(mymouse.x-1, mymouse.y-1, 4, 4, PURE_WHITE);
+	        og::runtime::current_session->myscreen_->fastbox(mymouse.x, mymouse.y, 2, 2, PURE_BLACK);
+	    }
+	    #else
+	    (void)mymouse;
+	    #endif
+	    entry_fade.present_first(*og::runtime::current_session->myscreen_);
+	};
+
+	// #237 ownership: whoever fades IN composes first. The loop below polls
+	// input before it ever reaches its redraw branch, and a button face
+	// presents itself when it is pressed — so on a stretched first iteration
+	// a click already in the queue puts a frame on screen BETWEEN the door's
+	// fade-out and this fade-in, which the video layer reports as a fade-in
+	// without a fade-out. Compose and present the cold frame here, ahead of
+	// the first poll; from then on the loop only refreshes a screen the fade
+	// already owns.
+	compose_and_present();
+
 	//
 	// This is the main program loop
 	//
@@ -4170,26 +4206,7 @@ Sint32 level_editor()
 		
 		// Redraw screen
 		if (eds().redraw)
-		{
-            eds().redraw = 0;
-			data.draw(og::runtime::current_session->myscreen_);
-			
-			#ifdef USE_CONTROLLER_INPUT
-			{
-				ScopedGameplayUiCanvas editor_ui(
-					*og::runtime::current_session->myscreen_);
-				og::runtime::current_session->myscreen_->fastbox(mymouse.x-1, mymouse.y-1, 4, 4, PURE_WHITE);
-				og::runtime::current_session->myscreen_->fastbox(mymouse.x, mymouse.y, 2, 2, PURE_BLACK);
-			}
-			#endif
-			// LevelEditorData::draw prepares one smart-smoothed scenery + crisp
-			// UI transaction. Present only after every layer (including the
-			// controller cursor) is complete: the gameplay overlay is single-use.
-			// The first frame fades in (#237): the editor's canvas is pinned
-			// classic (shared surface), so this fades the real first frame,
-			// not a stale UI image. Every later frame presents plainly.
-			entry_fade.present_first(*og::runtime::current_session->myscreen_);
-		}
+			compose_and_present();
 
         og::input_native::sleep_ms(10);
 

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -3542,7 +3542,7 @@ Sint32 level_editor()
     // the surface that menu is on), fades the editor's first composed frame
     // in at the loop's first present, and fades the editor out at
     // entry_fade.end() after the loop.
-    og::ui::LegacyMenuFade entry_fade;
+    og::ui::LegacyMenuFade entry_fade("level editor");
 
     static LevelEditorData data;
     // Refresh radar pointers in case the session's viewscreen was rebuilt

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -43,6 +43,7 @@
 #include <openglad/interface/ui/campaign_picker.h>
 #include <openglad/resources/gparser.h>
 #include <openglad/interface/ui/level_editor_state.h>
+#include <openglad/interface/ui/menu_screen_spec.h>
 #include <openglad/interface/session_state.h>
 #include <algorithm>
 #include <array>
@@ -3533,6 +3534,15 @@ EventType handle_basic_editor_event(const void* native_event)
 
 Sint32 level_editor()
 {
+    // #237: the editor is a full-screen entry outside the runner, so it owes
+    // the transition notes the same swallow every entry owes them. Its door
+    // (run_nested_menu_door, ButtonAction::DoLevelEdit) already faded the
+    // menu out and left both notes; consuming them here keeps the Fade note
+    // from reaching the editor's own SET CAMPAIGN browser, which would fade
+    // a subscreen the rule wants instant. The editor's loop draws through
+    // refresh(), not the fade path, so the returned fade-in is discarded.
+    (void)og::ui::begin_legacy_menu_entry_fade();
+
     static LevelEditorData data;
     // Refresh radar pointers in case the session's viewscreen was rebuilt
     // since this static was first constructed (avoids a dangling viewscreen*).

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -3539,9 +3539,11 @@ Sint32 level_editor()
     // (run_nested_menu_door, ButtonAction::DoLevelEdit) already faded the
     // menu out and left both notes; consuming them here keeps the Fade note
     // from reaching the editor's own SET CAMPAIGN browser, which would fade
-    // a subscreen the rule wants instant. The editor's loop draws through
-    // refresh(), not the fade path, so the returned fade-in is discarded.
-    (void)og::ui::begin_legacy_menu_entry_fade();
+    // a subscreen the rule wants instant. The pending fade-in is honored at
+    // the loop's first present (below): the door owes the same two fades in
+    // as it spends on the way back, so the editor's first composed frame
+    // fades in instead of cutting.
+    bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
 
     static LevelEditorData data;
     // Refresh radar pointers in case the session's viewscreen was rebuilt
@@ -4184,7 +4186,15 @@ Sint32 level_editor()
 			// LevelEditorData::draw prepares one smart-smoothed scenery + crisp
 			// UI transaction. Present only after every layer (including the
 			// controller cursor) is complete: the gameplay overlay is single-use.
-			og::runtime::current_session->myscreen_->refresh();
+			if (entry_fade_in_pending) {
+				// fadeblack presents the composed buffer itself (#237). The
+				// editor's canvas is pinned classic (shared surface), so this
+				// fades the real first frame, not a stale UI image.
+				entry_fade_in_pending = false;
+				og::runtime::current_session->myscreen_->fadeblack(1);
+			} else {
+				og::runtime::current_session->myscreen_->refresh();
+			}
 		}
         
         og::input_native::sleep_ms(10);

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -3534,16 +3534,15 @@ EventType handle_basic_editor_event(const void* native_event)
 
 Sint32 level_editor()
 {
-    // #237: the editor is a full-screen entry outside the runner, so it owes
-    // the transition notes the same swallow every entry owes them. Its door
-    // (run_nested_menu_door, ButtonAction::DoLevelEdit) already faded the
-    // menu out and left both notes; consuming them here keeps the Fade note
-    // from reaching the editor's own SET CAMPAIGN browser, which would fade
-    // a subscreen the rule wants instant. The pending fade-in is honored at
-    // the loop's first present (below): the door owes the same two fades in
-    // as it spends on the way back, so the editor's first composed frame
-    // fades in instead of cutting.
-    bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
+    // #237 ownership: the editor is a full-screen entry outside the runner.
+    // Its door (run_nested_menu_door, ButtonAction::DoLevelEdit) noted Fade;
+    // this scope consumes the note — so it cannot reach the editor's own SET
+    // CAMPAIGN browser, a subscreen the rule wants instant — fades the still-
+    // open main menu out NOW (before the canvas pin below switches away from
+    // the surface that menu is on), fades the editor's first composed frame
+    // in at the loop's first present, and fades the editor out at
+    // entry_fade.end() after the loop.
+    og::ui::LegacyMenuFade entry_fade;
 
     static LevelEditorData data;
     // Refresh radar pointers in case the session's viewscreen was rebuilt
@@ -4186,24 +4185,24 @@ Sint32 level_editor()
 			// LevelEditorData::draw prepares one smart-smoothed scenery + crisp
 			// UI transaction. Present only after every layer (including the
 			// controller cursor) is complete: the gameplay overlay is single-use.
-			if (entry_fade_in_pending) {
-				// fadeblack presents the composed buffer itself (#237). The
-				// editor's canvas is pinned classic (shared surface), so this
-				// fades the real first frame, not a stale UI image.
-				entry_fade_in_pending = false;
-				og::runtime::current_session->myscreen_->fadeblack(1);
-			} else {
-				og::runtime::current_session->myscreen_->refresh();
-			}
+			// The first frame fades in (#237): the editor's canvas is pinned
+			// classic (shared surface), so this fades the real first frame,
+			// not a stale UI image. Every later frame presents plainly.
+			entry_fade.present_first(*og::runtime::current_session->myscreen_);
 		}
-        
+
         og::input_native::sleep_ms(10);
-        
+
 	    last_ticks = start_ticks;
 	    start_ticks = og::input_native::ticks_ms();
 
 	}
-	
+
+	// The editor's last presented frame fades out HERE (#237 ownership):
+	// the pinned classic canvas that holds it is still active, and the
+	// reset draw + clear below have not touched the buffer yet.
+	entry_fade.end();
+
 	// Reset the screen position so it doesn't ruin the main menu
     data.level->set_draw_pos(0, 0);
     // Update the screen's position

--- a/src/interface/ui/level_editor.cpp
+++ b/src/interface/ui/level_editor.cpp
@@ -3972,6 +3972,14 @@ Sint32 level_editor()
             }
         }
 
+		// Pointer handoff (docs/menu-engine.md): the editor pumps its own
+		// events and reads the pointer via query_mouse_no_poll(), so it must
+		// acknowledge the presses it saw once per frame — or every click made
+		// here mints a coordinate-less collapsed-tap pending click that the
+		// next surface (the main menu after File -> Exit) would spend at
+		// wherever the pointer has moved to (the phantom-activation bug).
+		acknowledge_mouse_presses();
+
 		short scroll_delta = get_and_reset_scroll_amount();
 		#if defined(USE_TOUCH_INPUT)
 		// Only scroll the tile selector when touching it and you've already moved a bit

--- a/src/interface/ui/level_editor_ui.cpp
+++ b/src/interface/ui/level_editor_ui.cpp
@@ -183,6 +183,10 @@ bool prompt_for_string_block(const std::string& message, std::list<std::string>&
 	while (!done)
 	{
         get_input_events(POLL);
+        // Pointer handoff: this prompt pumps its own events and reads the
+        // pointer level directly — acknowledge its presses so its clicks
+        // cannot mint collapsed-tap pending clicks for a later surface.
+        acknowledge_mouse_presses();
 #ifdef TESTING
         if (s_prompt_block_click_pending.exchange(
                 false, std::memory_order_acquire))

--- a/src/interface/ui/level_picker.cpp
+++ b/src/interface/ui/level_picker.cpp
@@ -502,6 +502,12 @@ int pick_level(screen *screenp, int default_level, bool enable_delete)
 
 	};
     
+    // Pointer handoff (docs/menu-engine.md): level-triggered rows — hold
+    // fire until the door click's button has been seen up once, so it
+    // cannot click through onto a row on frame one.
+    reset_mouse_click_tracking();
+    bool saw_left_release = !query_mouse_no_poll().left;
+
     bool done = false;
 #ifdef TESTING
     s_level_picker_entered_count.fetch_add(1, std::memory_order_release);
@@ -535,7 +541,9 @@ int pick_level(screen *screenp, int default_level, bool enable_delete)
 	        int mx = static_cast<int>(mymouse.x);
 	        int my = static_cast<int>(mymouse.y);
         
-        bool do_click = mymouse.left;
+        if (!mymouse.left)
+            saw_left_release = true;
+        bool do_click = mymouse.left && saw_left_release;
 #ifdef TESTING
         if (s_level_picker_click_pending.exchange(
                 false, std::memory_order_acquire))

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -451,7 +451,16 @@ Sint32 run_nested_menu_door(Sint32 (*body)())
     // own exit fades it out again, and the parent loop's next present finds a
     // black window and fades back in (run_menu_screen's loop present).
     note_menu_entry_fade(MenuEntryFade::Fade);
-    return body();
+    const Sint32 result = body();
+    // Pointer handoff (menu_screen_spec.h): the door hands the still-open
+    // parent a clean pointer. A legacy body's leaked collapsed-tap pending
+    // clicks (and an impatient click during the body's exit fade) are
+    // dropped here — the parent's next leftmouse() must never spend a click
+    // minted on the door's surface at wherever the pointer has moved to
+    // (the editor-exit phantom-activation bug). A click during the PARENT's
+    // own fade-in lands after this line and stays honored.
+    reset_mouse_click_tracking();
+    return result;
 }
 
 #ifdef TESTING
@@ -577,6 +586,11 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
     int highlighted_button = spec.default_highlight;
     og::runtime::current_session->localbuttons_ = init_buttons(buttons, num_buttons);
     clear_keyboard();
+    // Pointer handoff (menu_screen_spec.h): every engine screen starts from
+    // a fresh pointer baseline — a click completed on the previous surface
+    // is dropped, a button still held becomes the edge baseline, and a
+    // press that begins after this line is a normal fresh click.
+    reset_mouse_click_tracking();
     apply_art_bindings(spec_rows, num_buttons);
 
     RowState states[MAX_BUTTONS] = {};
@@ -805,6 +819,9 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
         og::input_native::sleep_ms(10);
     }
 
+    // Pointer handoff, the exit half: a nested engine screen hands its
+    // parent a clean pointer without the parent having to know a child ran.
+    reset_mouse_click_tracking();
     return spec.exit_value;
 }
 

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -278,6 +278,7 @@ constexpr MenuBuildVariant kCompiledBuildVariant =
 struct MenuTransitionState {
     int depth = 0;
     bool faded_to_black = false;
+    bool peer_transition = false;
 };
 MenuTransitionState g_menu_transition;
 
@@ -317,6 +318,22 @@ bool consume_menu_faded_to_black()
     return faded;
 }
 
+void note_menu_peer_transition()
+{
+    g_menu_transition.peer_transition = true;
+}
+
+namespace {
+
+bool consume_menu_peer_transition()
+{
+    const bool peer = g_menu_transition.peer_transition;
+    g_menu_transition.peer_transition = false;
+    return peer;
+}
+
+} // namespace
+
 int menu_screen_depth()
 {
     return g_menu_transition.depth;
@@ -324,9 +341,10 @@ int menu_screen_depth()
 
 bool begin_legacy_menu_entry_fade()
 {
-    // Swallow-even-if-unused: a nested entry clears a stale note too.
+    // Swallow-even-if-unused: a nested entry clears stale notes too.
     const bool already_black = consume_menu_faded_to_black();
-    if (g_menu_transition.depth != 0)
+    const bool peer = consume_menu_peer_transition();
+    if (g_menu_transition.depth != 0 || peer)
         return false;
     if (!already_black)
         og::runtime::current_session->myscreen_->fadeblack(0);
@@ -394,11 +412,14 @@ void materialize_menu_buttons(const MenuScreenSpec& spec,
 Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
 {
     // #237 depth rule: a Screen fades exactly when this entry is a context
-    // switch — nothing else on the menu stack (depth 1). Nested subscreen
-    // entries and Overlay screens (the pause family) never fade.
+    // switch — nothing else on the menu stack (depth 1) and not a noted
+    // lateral move between menu-cluster peers (SETTINGS/HELP/LOAD/
+    // NETWORKING and the way back). Nested subscreen entries and Overlay
+    // screens (the pause family) never fade.
     const MenuDepthScope depth_scope;
+    const bool peer_entry = consume_menu_peer_transition();
     const bool should_fade = spec.kind == MenuScreenKind::Screen
-        && g_menu_transition.depth == 1;
+        && g_menu_transition.depth == 1 && !peer_entry;
     // Consumed unconditionally: the black note is a hand-off from whatever
     // ran last, so whichever screen opens next must clear it even when it
     // does not fade around its entry.

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -272,8 +272,23 @@ constexpr MenuBuildVariant kCompiledBuildVariant =
     MenuBuildVariant::Native;
 #endif
 
-// One-shot: set by the post-game teardown, consumed by the next screen.
-bool g_suppress_entry_fade_out = false;
+// #237 depth-rule transition state (session-scoped): the menu-stack depth
+// run_menu_screen brackets around every entry, and the one-shot "presented
+// surface is already black" note the teardowns set.
+struct MenuTransitionState {
+    int depth = 0;
+    bool faded_to_black = false;
+};
+MenuTransitionState g_menu_transition;
+
+// RAII depth bracket: every run_menu_screen entry — including the early
+// remote-start returns — restores the depth it found.
+struct MenuDepthScope {
+    MenuDepthScope() { ++g_menu_transition.depth; }
+    ~MenuDepthScope() { --g_menu_transition.depth; }
+    MenuDepthScope(const MenuDepthScope&) = delete;
+    MenuDepthScope& operator=(const MenuDepthScope&) = delete;
+};
 
 bool spec_row_survives_build(const MenuButtonSpec& row, MenuBuildVariant variant)
 {
@@ -290,17 +305,40 @@ bool spec_row_survives_build(const MenuButtonSpec& row, MenuBuildVariant variant
 
 } // namespace
 
-void suppress_next_menu_entry_fade_out()
+void note_menu_faded_to_black()
 {
-    g_suppress_entry_fade_out = true;
+    g_menu_transition.faded_to_black = true;
 }
 
-bool consume_suppressed_menu_entry_fade_out()
+bool consume_menu_faded_to_black()
 {
-    const bool suppressed = g_suppress_entry_fade_out;
-    g_suppress_entry_fade_out = false;
-    return suppressed;
+    const bool faded = g_menu_transition.faded_to_black;
+    g_menu_transition.faded_to_black = false;
+    return faded;
 }
+
+int menu_screen_depth()
+{
+    return g_menu_transition.depth;
+}
+
+bool begin_legacy_menu_entry_fade()
+{
+    // Swallow-even-if-unused: a nested entry clears a stale note too.
+    const bool already_black = consume_menu_faded_to_black();
+    if (g_menu_transition.depth != 0)
+        return false;
+    if (!already_black)
+        og::runtime::current_session->myscreen_->fadeblack(0);
+    return true;
+}
+
+#ifdef TESTING
+void menu_transition_testing_reset()
+{
+    g_menu_transition = {};
+}
+#endif
 
 #ifdef TESTING
 void picker_testing_draw_menu_highlight(const MenuScreenSpec& spec,
@@ -355,10 +393,16 @@ void materialize_menu_buttons(const MenuScreenSpec& spec,
 
 Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
 {
-    // Consumed unconditionally: the flag is a hand-off from the screen that
+    // #237 depth rule: a Screen fades exactly when this entry is a context
+    // switch — nothing else on the menu stack (depth 1). Nested subscreen
+    // entries and Overlay screens (the pause family) never fade.
+    const MenuDepthScope depth_scope;
+    const bool should_fade = spec.kind == MenuScreenKind::Screen
+        && g_menu_transition.depth == 1;
+    // Consumed unconditionally: the black note is a hand-off from whatever
     // ran last, so whichever screen opens next must clear it even when it
     // does not fade around its entry.
-    const bool skip_entry_fade_out = consume_suppressed_menu_entry_fade_out();
+    const bool already_black = consume_menu_faded_to_black();
     // Sequence the D3 accessors: buttons() fills the vector count() reads.
     button* buttons = spec.buttons_accessor();
     const int num_buttons = spec.count_accessor();
@@ -395,41 +439,26 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
         apply_nav_program(spec, buttons, num_buttons, highlighted_button);
     }
 
-    if (spec.enter == EnterTransition::FadeAroundEntry) {
-        // The legacy team-build entry, verbatim: fade the previous screen
-        // out, compose the cold first frame, and fade it in (fadeblack
-        // presents the buffer itself; the first highlighted frame follows in
-        // the loop, after the level-reload guard). Content must be present in
-        // this compose: Base Camp's roster ink is a content hook while its
-        // deploy X is a button, and splitting them across the fade makes the
-        // control pop in as the first full frame replaces the partial one.
-        screen* scr = og::runtime::current_session->myscreen_;
-        // ...unless the post-game teardown already faded to black (#200): the
-        // fade-out would run over the stale menu image the UI canvas still
-        // holds and play the same transition a second time.
-        if (!skip_entry_fade_out)
-            scr->fadeblack(0);
-        if (spec.backdrop)
-            draw_backdrop();
-        if (spec.draw_background != nullptr)
-            spec.draw_background(screen_state);
-        draw_buttons(buttons, num_buttons);
-        if (spec.draw_content != nullptr)
-            spec.draw_content(screen_state);
-        scr->fadeblack(1);
-    }
-
-    if (spec.enter == EnterTransition::FadeWithInitialDraw) {
-        // The legacy mainmenu entry, verbatim: settle one timer tick, fade
-        // the previous menu out, compose the first frame in the buffer, and
-        // fade it in (fadeblack presents the buffer itself — no
-        // buffer_to_screen here). Injector SDL_Delay(750) cadence depends on
-        // this exact sequence.
-        reset_timer();
-        while (query_timer() < 1)
-            ;
-        screen* scr = og::runtime::current_session->myscreen_;
-        scr->fadeblack(0);
+    // Cold first frame, every screen: labels bound, full compose, highlight.
+    // Content must be present in this compose: Base Camp's roster ink is a
+    // content hook while its deploy X is a button, and splitting them across
+    // the fade makes the control pop in as the first full frame replaces the
+    // partial one. (Fades are instant under TESTING — FadeBetween skips the
+    // animation — so no injector cadence depends on this sequence.)
+    {
+        screen* const scr = og::runtime::current_session->myscreen_;
+        if (should_fade) {
+            // The legacy mainmenu entry cadence: settle one timer tick, then
+            // fade the previous screen out — unless a teardown already left
+            // the presented surface black (#200): that fade-out would run
+            // over the stale menu image the UI canvas still holds and play
+            // the same transition a second time.
+            reset_timer();
+            while (query_timer() < 1)
+                ;
+            if (!already_black)
+                scr->fadeblack(0);
+        }
         {
             const MenuLabelContext context = build_label_context(spec);
             apply_label_bindings(spec_rows, buttons, num_buttons, context);
@@ -442,9 +471,15 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
         if (spec.draw_content != nullptr)
             spec.draw_content(screen_state);
         draw_menu_highlight(spec, buttons, highlighted_button);
-        // Zardus: PORT: fade from black
-        scr->fadeblack(1);
-        grab_mouse();
+        if (should_fade) {
+            // Zardus: PORT: fade from black
+            // fadeblack presents the composed buffer itself.
+            scr->fadeblack(1);
+            grab_mouse();
+        } else {
+            // Without a fade nothing presents the cold frame.
+            scr->buffer_to_screen(0, 0, 320, 200);
+        }
     }
 
     int frame = 0;

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -35,6 +35,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -278,7 +279,8 @@ constexpr MenuBuildVariant kCompiledBuildVariant =
 struct MenuTransitionState {
     int depth = 0;
     bool faded_to_black = false;
-    bool peer_transition = false;
+    // Tri-state: no note / Fade / Instant (see note_menu_entry_fade).
+    std::optional<MenuEntryFade> entry_fade{};
 };
 MenuTransitionState g_menu_transition;
 
@@ -318,18 +320,18 @@ bool consume_menu_faded_to_black()
     return faded;
 }
 
-void note_menu_peer_transition()
+void note_menu_entry_fade(MenuEntryFade fade)
 {
-    g_menu_transition.peer_transition = true;
+    g_menu_transition.entry_fade = fade;
 }
 
 namespace {
 
-bool consume_menu_peer_transition()
+std::optional<MenuEntryFade> consume_menu_entry_fade()
 {
-    const bool peer = g_menu_transition.peer_transition;
-    g_menu_transition.peer_transition = false;
-    return peer;
+    const std::optional<MenuEntryFade> fade = g_menu_transition.entry_fade;
+    g_menu_transition.entry_fade.reset();
+    return fade;
 }
 
 } // namespace
@@ -343,12 +345,40 @@ bool begin_legacy_menu_entry_fade()
 {
     // Swallow-even-if-unused: a nested entry clears stale notes too.
     const bool already_black = consume_menu_faded_to_black();
-    const bool peer = consume_menu_peer_transition();
-    if (g_menu_transition.depth != 0 || peer)
+    const std::optional<MenuEntryFade> override_fade = consume_menu_entry_fade();
+    if (override_fade == MenuEntryFade::Instant)
+        return false;
+    if (g_menu_transition.depth != 0 && override_fade != MenuEntryFade::Fade)
         return false;
     if (!already_black)
         og::runtime::current_session->myscreen_->fadeblack(0);
     return true;
+}
+
+Sint32 run_nested_menu_door(Sint32 (*body)())
+{
+    screen* const scr = og::runtime::current_session->myscreen_;
+    // Way in. The main menu stays open underneath, so this fade-out belongs
+    // to the door site; the black note lets the nested entry skip a second
+    // one (#200) and the Fade note makes it fade in despite its depth.
+    if (!consume_menu_faded_to_black())
+        scr->fadeblack(0);
+    note_menu_faded_to_black();
+    note_menu_entry_fade(MenuEntryFade::Fade);
+
+    const Sint32 result = body();
+
+    // A legacy door body (the level editor runs its own loop, not the
+    // runner's) consumes neither note. Swallow both here so nothing leaks
+    // onto the next unrelated entry.
+    (void)consume_menu_entry_fade();
+    (void)consume_menu_faded_to_black();
+
+    // Way back, symmetric: fade the door out and hand the still-open parent
+    // loop a black note — its next present turns that into the fade-in.
+    scr->fadeblack(0);
+    note_menu_faded_to_black();
+    return result;
 }
 
 #ifdef TESTING
@@ -411,15 +441,19 @@ void materialize_menu_buttons(const MenuScreenSpec& spec,
 
 Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
 {
-    // #237 depth rule: a Screen fades exactly when this entry is a context
-    // switch — nothing else on the menu stack (depth 1) and not a noted
-    // lateral move between menu-cluster peers (SETTINGS/HELP/LOAD/
-    // NETWORKING and the way back). Nested subscreen entries and Overlay
-    // screens (the pause family) never fade.
+    // #237 depth rule: a Screen fades exactly when this entry crosses the
+    // main-menu boundary — nothing else on the menu stack (depth 1). Every
+    // main-menu door fades symmetrically, the way in and the way back;
+    // everything deeper (Base Camp's strip and roster doors, settings' own
+    // subscreens, the company list's BACKUPS view) is instant both ways, and
+    // Overlay screens (the pause family) never fade. A noted MenuEntryFade
+    // overrides the derivation in either direction for the doors the depth
+    // alone cannot classify.
     const MenuDepthScope depth_scope;
-    const bool peer_entry = consume_menu_peer_transition();
+    const std::optional<MenuEntryFade> override_fade = consume_menu_entry_fade();
     const bool should_fade = spec.kind == MenuScreenKind::Screen
-        && g_menu_transition.depth == 1 && !peer_entry;
+        && override_fade != MenuEntryFade::Instant
+        && (g_menu_transition.depth == 1 || override_fade == MenuEntryFade::Fade);
     // Consumed unconditionally: the black note is a hand-off from whatever
     // ran last, so whichever screen opens next must clear it even when it
     // does not fade around its entry.
@@ -653,7 +687,14 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
         if (spec.draw_content != nullptr)
             spec.draw_content(screen_state);
         draw_menu_highlight(spec, buttons, highlighted_button);
-        og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
+        // A nested door's return hands this loop a black note (the door
+        // faded its own last frame out on the way back — run_nested_menu_door).
+        // Present THAT frame with fadeblack(1) so the parent screen fades
+        // back in; every other frame presents plainly.
+        if (consume_menu_faded_to_black())
+            og::runtime::current_session->myscreen_->fadeblack(1);
+        else
+            og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
         // The ONE asyncify yield per iteration (emscripten contract).
         og::input_native::sleep_ms(10);
     }

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -32,6 +32,7 @@
 
 #include "picker_sdl_defs.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <mutex>
@@ -94,9 +95,16 @@ void draw_menu_highlight(const MenuScreenSpec& spec,
         highlighted_button >= kBaseCampInteriorRingFirstIndex &&
         highlighted_button <= kBaseCampInteriorRingLastIndex)
     {
+        // The chip clearance belongs to the slots that HAVE a chip. A bare
+        // slot's ADD PLAYER / LOBBY FULL face is ten pad-less glyphs whose
+        // last one ends at x+64 — cutting the ring back to x+60 there would
+        // strike through the label instead of clearing a chip that isn't
+        // drawn. Ask the frame shape the chip pass reads.
         if (highlighted_button >= kBaseCampSeatCardBase &&
             highlighted_button <
-                kBaseCampSeatCardBase + kBaseCampSeatCardsPerPage)
+                kBaseCampSeatCardBase + kBaseCampSeatCardsPerPage &&
+            base_camp_rail_slot_has_chip(highlighted_button -
+                                         kBaseCampSeatCardBase))
         {
             // The numbered chip occupies the final nine pixels of a seat
             // card. Keep the pulsing ring around the label face so the
@@ -473,6 +481,23 @@ std::vector<const MenuButtonSpec*> materialized_spec_rows(
 {
     return materialized_spec_rows_for(spec, kCompiledBuildVariant);
 }
+
+#ifdef TESTING
+// The production gate pass, for tests that drive a spec's draw hooks without
+// the loop around them: the Disabled dim (live->color = GREY) and the inert
+// myfun/myfunc are what this writes, and a test that painted them by hand
+// would prove nothing about the engine.
+void picker_testing_apply_row_states(const MenuScreenSpec& spec,
+                                     button* buttons, int num_buttons)
+{
+    const SpecRowView spec_rows = materialized_spec_rows(spec);
+    const MenuLabelContext context = build_label_context(spec);
+    RowState states[MAX_BUTTONS] = {};
+    apply_row_states(spec_rows, buttons,
+                     std::min(num_buttons, static_cast<int>(MAX_BUTTONS)),
+                     context, states);
+}
+#endif
 
 void materialize_menu_buttons_for(const MenuScreenSpec& spec,
                                   MenuBuildVariant variant,

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -450,6 +450,11 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
     int frame = 0;
     Sint32 retvalue = 0;
     while (!(retvalue & MENU_EXIT)) {
+        // Frame-top main-thread work handoff (null outside tests): runs
+        // before the poll so an injector's save write is complete before
+        // anything on this frame reads it.
+        if (g_picker_main_thread_pump != nullptr)
+            g_picker_main_thread_pump();
         if (spec.polls_lobby)
             picker_lobby_poll();
 

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -86,8 +86,8 @@ void draw_menu_highlight(const MenuScreenSpec& spec,
                          int highlighted_button)
 {
     // The compact Base Camp seat rail packs a numbered team chip into each
-    // card's last nine pixels, and the move-up column hugs the roster
-    // panel's inner face. Their focus ring must stay inside the selected
+    // card's right end, and the move-up column hugs the roster panel's inner
+    // face. Their focus ring must stay inside the selected
     // control so it cannot paint over the chip or the panel bevel. Bounded
     // to the rail/move-up band (33..48): the appended gameplay-zone rows
     // past it take the normal exterior focus ring.
@@ -97,20 +97,20 @@ void draw_menu_highlight(const MenuScreenSpec& spec,
     {
         // The chip clearance belongs to the slots that HAVE a chip. A bare
         // slot's ADD PLAYER / LOBBY FULL face is ten pad-less glyphs whose
-        // last one ends at x+64 — cutting the ring back to x+60 there would
-        // strike through the label instead of clearing a chip that isn't
-        // drawn. Ask the frame shape the chip pass reads.
+        // last one ends at x+64 — cutting the ring back over the chip zone
+        // there would strike through the label instead of clearing a chip
+        // that isn't drawn. Ask the count the chip pass paints.
         if (highlighted_button >= kBaseCampSeatCardBase &&
             highlighted_button <
                 kBaseCampSeatCardBase + kBaseCampSeatCardsPerPage &&
             base_camp_rail_slot_has_chip(highlighted_button -
                                          kBaseCampSeatCardBase))
         {
-            // The numbered chip occupies the final nine pixels of a seat
-            // card. Keep the pulsing ring around the label face so the
-            // highlight never erases the chip's border or glyph.
+            // Keep the pulsing ring around the label face so the highlight
+            // never erases the chip's border or glyph. The clearance is
+            // derived from the card geometry, not typed here.
             button label_face = buttons[highlighted_button];
-            label_face.sizex -= 10;
+            label_face.sizex -= og::ui::base_camp_seat_chip_ring_clearance();
             draw_highlight_interior(label_face);
         }
         else
@@ -181,12 +181,18 @@ void apply_row_states(const SpecRowView& rows, button* buttons,
             if (live != nullptr) {
                 live->myfunc = 0;
                 live->color = GREY;  // draw dimmed
+                // GREY lands on the same palette shade as the shadow edges,
+                // so the face would swallow the right and bottom bevels and
+                // the row would read as a half-drawn card. The flag steps
+                // those two edges one shade darker for the dim face.
+                live->dimmed = true;
             }
         } else {
             const Sint32 fun = button_action_id(row.action);
             buttons[i].myfun = fun;
             if (live != nullptr) {
                 live->myfunc = fun;
+                live->dimmed = false;
                 if (row.color == nullptr)
                     live->color = BUTTON_FACING;
             }

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -274,11 +274,11 @@ constexpr MenuBuildVariant kCompiledBuildVariant =
 #endif
 
 // #237 depth-rule transition state (session-scoped): the menu-stack depth
-// run_menu_screen brackets around every entry, and the one-shot "presented
-// surface is already black" note the teardowns set.
+// run_menu_screen brackets around every entry, and the one-shot entry-fade
+// override. Whether the window is black is NOT here — the video layer owns
+// that (screen::window_is_black()).
 struct MenuTransitionState {
     int depth = 0;
-    bool faded_to_black = false;
     // Tri-state: no note / Fade / Instant (see note_menu_entry_fade).
     std::optional<MenuEntryFade> entry_fade{};
 };
@@ -291,6 +291,28 @@ struct MenuDepthScope {
     ~MenuDepthScope() { --g_menu_transition.depth; }
     MenuDepthScope(const MenuDepthScope&) = delete;
     MenuDepthScope& operator=(const MenuDepthScope&) = delete;
+};
+
+// Exit-owned fade-out (#237 ownership rule): a fading entry fades its own
+// last frame out on EVERY return path — the remote-start returns, a
+// MENU_REDRAW exit, a MENU_EXIT, a frame_tick veto — while that frame is
+// still the render buffer (every exit leaves the loop above the bottom-of-
+// loop compose/present block, so nothing draws after the last present). An
+// Instant note still pending here means the door being opened is instant
+// (NETWORKING): skip, and leave the note for that door's entry to consume.
+struct ScreenFadeScope {
+    bool active;
+    explicit ScreenFadeScope(bool fades) : active(fades) {}
+    ~ScreenFadeScope()
+    {
+        if (!active)
+            return;
+        if (g_menu_transition.entry_fade == MenuEntryFade::Instant)
+            return;
+        og::runtime::current_session->myscreen_->fadeblack(0);
+    }
+    ScreenFadeScope(const ScreenFadeScope&) = delete;
+    ScreenFadeScope& operator=(const ScreenFadeScope&) = delete;
 };
 
 bool spec_row_survives_build(const MenuButtonSpec& row, MenuBuildVariant variant)
@@ -307,18 +329,6 @@ bool spec_row_survives_build(const MenuButtonSpec& row, MenuBuildVariant variant
 }
 
 } // namespace
-
-void note_menu_faded_to_black()
-{
-    g_menu_transition.faded_to_black = true;
-}
-
-bool consume_menu_faded_to_black()
-{
-    const bool faded = g_menu_transition.faded_to_black;
-    g_menu_transition.faded_to_black = false;
-    return faded;
-}
 
 void note_menu_entry_fade(MenuEntryFade fade)
 {
@@ -341,51 +351,52 @@ int menu_screen_depth()
     return g_menu_transition.depth;
 }
 
-bool begin_legacy_menu_entry_fade()
+LegacyMenuFade::LegacyMenuFade()
 {
-    // Swallow-even-if-unused: a nested entry clears stale notes too.
-    const bool already_black = consume_menu_faded_to_black();
+    // Swallow-even-if-unused: a nested entry clears a stale note too.
     const std::optional<MenuEntryFade> override_fade = consume_menu_entry_fade();
     if (override_fade == MenuEntryFade::Instant)
-        return false;
+        return;
     if (g_menu_transition.depth != 0 && override_fade != MenuEntryFade::Fade)
-        return false;
-    if (!already_black)
-        og::runtime::current_session->myscreen_->fadeblack(0);
-    return true;
+        return;
+    active_ = true;
+    fade_in_pending_ = true;
+    // Idempotent: a window a previous exit already faded to black stays as
+    // it is, and the fade-in below still owes its first frame.
+    og::runtime::current_session->myscreen_->fadeblack(0);
+}
+
+LegacyMenuFade::~LegacyMenuFade()
+{
+    end();
+}
+
+void LegacyMenuFade::present_first(screen& scr)
+{
+    if (active_ && fade_in_pending_) {
+        fade_in_pending_ = false;
+        // fadeblack presents the composed buffer itself.
+        scr.fadeblack(1);
+        return;
+    }
+    scr.buffer_to_screen(0, 0, scr.canvas_w(), scr.canvas_h());
+}
+
+void LegacyMenuFade::end()
+{
+    if (!active_ || ended_)
+        return;
+    ended_ = true;
+    og::runtime::current_session->myscreen_->fadeblack(0);
 }
 
 Sint32 run_nested_menu_door(Sint32 (*body)())
 {
-    screen* const scr = og::runtime::current_session->myscreen_;
-    // Way in. The main menu stays open underneath, so this fade-out belongs
-    // to the door site; the black note lets the nested entry skip a second
-    // one (#200) and the Fade note makes it fade in despite its depth.
-    if (!consume_menu_faded_to_black())
-        scr->fadeblack(0);
-    note_menu_faded_to_black();
+    // The nested entry fades the still-open parent out and itself in; its
+    // own exit fades it out again, and the parent loop's next present finds a
+    // black window and fades back in (run_menu_screen's loop present).
     note_menu_entry_fade(MenuEntryFade::Fade);
-
-    const Sint32 result = body();
-
-    // A legacy door body (the level editor runs its own loop, not the
-    // runner's) consumes neither note. Swallow both here so nothing leaks
-    // onto the next unrelated entry.
-    (void)consume_menu_entry_fade();
-    (void)consume_menu_faded_to_black();
-
-    // Way back, symmetric: fade the door out and hand the still-open parent
-    // loop a black note — its next present turns that into the fade-in.
-    // Precondition (documented on the declaration): the body returns with the
-    // canvas that holds its last frame still active, since fadeblack blends
-    // the active canvas's render surface. The teardown idiom's
-    // set_active_canvas(last_presented_canvas()) is deliberately NOT used
-    // here: the editor body releases its classic world-canvas pin on the way
-    // out, so by now World can name a freshly allocated, never-drawn surface
-    // while the editor's actual last frame lives on the (shared) UI canvas.
-    scr->fadeblack(0);
-    note_menu_faded_to_black();
-    return result;
+    return body();
 }
 
 #ifdef TESTING
@@ -461,10 +472,9 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
     const bool should_fade = spec.kind == MenuScreenKind::Screen
         && override_fade != MenuEntryFade::Instant
         && (g_menu_transition.depth == 1 || override_fade == MenuEntryFade::Fade);
-    // Consumed unconditionally: the black note is a hand-off from whatever
-    // ran last, so whichever screen opens next must clear it even when it
-    // does not fade around its entry.
-    const bool already_black = consume_menu_faded_to_black();
+    // Whoever fades in fades out: declared here, before any return path, so
+    // a fading entry's last presented frame fades out on every exit.
+    const ScreenFadeScope fade_scope(should_fade);
     // Sequence the D3 accessors: buttons() fills the vector count() reads.
     button* buttons = spec.buttons_accessor();
     const int num_buttons = spec.count_accessor();
@@ -514,21 +524,16 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
     if (should_fade) {
         screen* const scr = og::runtime::current_session->myscreen_;
         // The legacy mainmenu entry cadence: settle one timer tick, then
-        // fade the previous screen out — unless a teardown already left
-        // the presented surface black (#200): that fade-out would run
-        // over the stale menu image the UI canvas still holds and play
-        // the same transition a second time.
-        //
-        // fadeblack(0) blends FROM the render buffer, not from the window: a
-        // door body must not draw into it before run_menu_screen, or this
-        // fade-out runs black-to-black and the door hard-cuts (the entry's own
-        // background is composed below, after the fade). Under TESTING the
-        // trace is one line either way, so no pin can see that mistake.
+        // fade whatever is still on the window out. Normally a no-op: the
+        // previous screen's exit already faded out (the ownership rule), and
+        // fadeblack(0) skips a black window. It stays for the entries that
+        // follow a plain present — gameplay's first menu after a hard exit,
+        // a legacy screen that never faded — and under TESTING the video
+        // layer flags it if the buffer no longer matches the window.
         reset_timer();
         while (query_timer() < 1)
             ;
-        if (!already_black)
-            scr->fadeblack(0);
+        scr->fadeblack(0);
         {
             const MenuLabelContext context = build_label_context(spec);
             apply_label_bindings(spec_rows, buttons, num_buttons, context);
@@ -700,11 +705,13 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
         if (spec.draw_content != nullptr)
             spec.draw_content(screen_state);
         draw_menu_highlight(spec, buttons, highlighted_button);
-        // A nested door's return hands this loop a black note (the door
-        // faded its own last frame out on the way back — run_nested_menu_door).
-        // Present THAT frame with fadeblack(1) so the parent screen fades
-        // back in; every other frame presents plainly.
-        if (consume_menu_faded_to_black())
+        // A nested door (run_nested_menu_door) faded its own last frame out
+        // on the way back, so this loop's next present finds a black window:
+        // present THAT frame with fadeblack(1) so the parent screen fades
+        // back in. Every other frame presents plainly, and an Overlay never
+        // fades at all.
+        if (spec.kind != MenuScreenKind::Overlay
+            && og::runtime::current_session->myscreen_->window_is_black())
             og::runtime::current_session->myscreen_->fadeblack(1);
         else
             og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -307,13 +307,46 @@ struct ScreenFadeScope {
     {
         if (!active)
             return;
-        if (g_menu_transition.entry_fade == MenuEntryFade::Instant)
+        if (g_menu_transition.entry_fade == MenuEntryFade::Instant) {
+            // Traced so a flow pin can hold that this happens on exactly
+            // the door it is meant for (NETWORKING) and nowhere else.
+            TRACE("video", "exit fade skipped: Instant note pending");
             return;
+        }
         og::runtime::current_session->myscreen_->fadeblack(0);
     }
     ScreenFadeScope(const ScreenFadeScope&) = delete;
     ScreenFadeScope& operator=(const ScreenFadeScope&) = delete;
 };
+
+// The entry invariant (#237, docs/menu-engine.md): a fading entry expects a
+// BLACK window — the outgoing screen faded itself out at its exit. Finding
+// it unfaded means that screen skipped its exit fade-out, and the entry's
+// own fade-out below is now doing the outgoing screen's job: the deferred
+// fade the ownership rule exists to forbid. Under TESTING that is a
+// violation (the listener fails the test); the entry still fades out either
+// way, because production must never hard-cut. A nested main-menu door
+// (a Fade note: CLOUD SAVES, the LEVEL EDITOR) is the one entry whose
+// outgoing screen has NOT exited — the parent is still open beneath it — so
+// its fade-out of the parent's frame is the door's by contract, not a
+// violation.
+void check_entry_found_black_window(std::optional<MenuEntryFade> override_fade,
+                                    const char* screen_name)
+{
+#ifdef TESTING
+    screen* const scr = og::runtime::current_session->myscreen_;
+    if (scr->window_is_black() || override_fade == MenuEntryFade::Fade)
+        return;
+    const std::string what =
+        std::string("entry found an unfaded window: the previous surface "
+                    "exited without its fade-out (") +
+        (screen_name != nullptr ? screen_name : "") + ")";
+    scr->testing_report_fade_violation(what.c_str());
+#else
+    (void)override_fade;
+    (void)screen_name;
+#endif
+}
 
 bool spec_row_survives_build(const MenuButtonSpec& row, MenuBuildVariant variant)
 {
@@ -351,7 +384,7 @@ int menu_screen_depth()
     return g_menu_transition.depth;
 }
 
-LegacyMenuFade::LegacyMenuFade()
+LegacyMenuFade::LegacyMenuFade(const char* screen_name)
 {
     // Swallow-even-if-unused: a nested entry clears a stale note too.
     const std::optional<MenuEntryFade> override_fade = consume_menu_entry_fade();
@@ -361,14 +394,22 @@ LegacyMenuFade::LegacyMenuFade()
         return;
     active_ = true;
     fade_in_pending_ = true;
-    // Idempotent: a window a previous exit already faded to black stays as
-    // it is, and the fade-in below still owes its first frame.
+    exit_fade_owed_ = true;
+    // Normally a no-op: the previous screen's exit already faded out and
+    // fadeblack(0) skips a black window. An unfaded window here is the
+    // entry invariant's violation (still faded, never hard-cut).
+    check_entry_found_black_window(override_fade, screen_name);
     og::runtime::current_session->myscreen_->fadeblack(0);
 }
 
 LegacyMenuFade::~LegacyMenuFade()
 {
     end();
+}
+
+void LegacyMenuFade::fade_out_at_exit()
+{
+    exit_fade_owed_ = true;
 }
 
 void LegacyMenuFade::present_first(screen& scr)
@@ -384,7 +425,7 @@ void LegacyMenuFade::present_first(screen& scr)
 
 void LegacyMenuFade::end()
 {
-    if (!active_ || ended_)
+    if (!exit_fade_owed_ || ended_)
         return;
     ended_ = true;
     og::runtime::current_session->myscreen_->fadeblack(0);
@@ -469,12 +510,21 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
     // alone cannot classify.
     const MenuDepthScope depth_scope;
     const std::optional<MenuEntryFade> override_fade = consume_menu_entry_fade();
-    const bool should_fade = spec.kind == MenuScreenKind::Screen
-        && override_fade != MenuEntryFade::Instant
+    // Two decisions, deliberately separate. owns_transition: this screen is
+    // a boundary surface (a depth-1 Screen, or a nested main-menu door) and
+    // OWES its last frame's fade-out at exit no matter how it was entered.
+    // should_fade: it also fades IN now — unless an Instant note says the
+    // previous surface is still on the window by design (Base Camp returning
+    // from the NETWORKING door). A screen entered instantly still fades out
+    // on its way to the main menu; only a pending Instant note at exit (the
+    // NETWORKING door itself) skips that.
+    const bool owns_transition = spec.kind == MenuScreenKind::Screen
         && (g_menu_transition.depth == 1 || override_fade == MenuEntryFade::Fade);
-    // Whoever fades in fades out: declared here, before any return path, so
-    // a fading entry's last presented frame fades out on every exit.
-    const ScreenFadeScope fade_scope(should_fade);
+    const bool should_fade = owns_transition
+        && override_fade != MenuEntryFade::Instant;
+    // Whoever owns the transition fades out: declared here, before any
+    // return path, so the last presented frame fades out on every exit.
+    const ScreenFadeScope fade_scope(owns_transition);
     // Sequence the D3 accessors: buttons() fills the vector count() reads.
     button* buttons = spec.buttons_accessor();
     const int num_buttons = spec.count_accessor();
@@ -526,13 +576,15 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
         // The legacy mainmenu entry cadence: settle one timer tick, then
         // fade whatever is still on the window out. Normally a no-op: the
         // previous screen's exit already faded out (the ownership rule), and
-        // fadeblack(0) skips a black window. It stays for the entries that
-        // follow a plain present — gameplay's first menu after a hard exit,
-        // a legacy screen that never faded — and under TESTING the video
-        // layer flags it if the buffer no longer matches the window.
+        // fadeblack(0) skips a black window. An unfaded window here means
+        // that screen skipped its exit fade — the entry invariant's
+        // violation under TESTING (and the video layer separately flags a
+        // buffer that no longer matches the window). The fade-out still
+        // runs: production never hard-cuts.
         reset_timer();
         while (query_timer() < 1)
             ;
+        check_entry_found_black_window(override_fade, spec.name);
         scr->fadeblack(0);
         {
             const MenuLabelContext context = build_label_context(spec);
@@ -708,9 +760,12 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
         // A nested door (run_nested_menu_door) faded its own last frame out
         // on the way back, so this loop's next present finds a black window:
         // present THAT frame with fadeblack(1) so the parent screen fades
-        // back in. Every other frame presents plainly, and an Overlay never
-        // fades at all.
-        if (spec.kind != MenuScreenKind::Overlay
+        // back in. Only a FADING entry does this — its exit scope owns the
+        // matching fade-out. A non-fading entry over a black window (an
+        // instant door, an Overlay) presents plainly: "instant" means
+        // exactly that, and a fade-in nobody fades out again is the shape
+        // this rule forbids.
+        if (fade_scope.active
             && og::runtime::current_session->myscreen_->window_is_black())
             og::runtime::current_session->myscreen_->fadeblack(1);
         else

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -460,26 +460,28 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
         apply_nav_program(spec, buttons, num_buttons, highlighted_button);
     }
 
-    // Cold first frame, every screen: labels bound, full compose, highlight.
-    // Content must be present in this compose: Base Camp's roster ink is a
-    // content hook while its deploy X is a button, and splitting them across
-    // the fade makes the control pop in as the first full frame replaces the
-    // partial one. (Fades are instant under TESTING — FadeBetween skips the
-    // animation — so no injector cadence depends on this sequence.)
-    {
+    // Cold first frame, FADING entries only: the fade brackets need a fully
+    // composed frame (labels bound, content, highlight — Base Camp's roster
+    // ink is a content hook while its deploy X is a button, and splitting
+    // them across the fade makes the control pop in as the first full frame
+    // replaces the partial one). Non-fading entries paint nothing here: the
+    // loop's first iteration composes and presents AFTER the frame_tick veto
+    // check, so a screen whose first tick ends it (a dead host's pause, a
+    // vanished seat) never flashes a frame — the pre-#237 behavior. (Fades
+    // are instant under TESTING — FadeBetween skips the animation — so no
+    // injector cadence depends on this sequence.)
+    if (should_fade) {
         screen* const scr = og::runtime::current_session->myscreen_;
-        if (should_fade) {
-            // The legacy mainmenu entry cadence: settle one timer tick, then
-            // fade the previous screen out — unless a teardown already left
-            // the presented surface black (#200): that fade-out would run
-            // over the stale menu image the UI canvas still holds and play
-            // the same transition a second time.
-            reset_timer();
-            while (query_timer() < 1)
-                ;
-            if (!already_black)
-                scr->fadeblack(0);
-        }
+        // The legacy mainmenu entry cadence: settle one timer tick, then
+        // fade the previous screen out — unless a teardown already left
+        // the presented surface black (#200): that fade-out would run
+        // over the stale menu image the UI canvas still holds and play
+        // the same transition a second time.
+        reset_timer();
+        while (query_timer() < 1)
+            ;
+        if (!already_black)
+            scr->fadeblack(0);
         {
             const MenuLabelContext context = build_label_context(spec);
             apply_label_bindings(spec_rows, buttons, num_buttons, context);
@@ -492,15 +494,10 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
         if (spec.draw_content != nullptr)
             spec.draw_content(screen_state);
         draw_menu_highlight(spec, buttons, highlighted_button);
-        if (should_fade) {
-            // Zardus: PORT: fade from black
-            // fadeblack presents the composed buffer itself.
-            scr->fadeblack(1);
-            grab_mouse();
-        } else {
-            // Without a fade nothing presents the cold frame.
-            scr->buffer_to_screen(0, 0, 320, 200);
-        }
+        // Zardus: PORT: fade from black
+        // fadeblack presents the composed buffer itself.
+        scr->fadeblack(1);
+        grab_mouse();
     }
 
     int frame = 0;

--- a/src/interface/ui/menu_screen_runner.cpp
+++ b/src/interface/ui/menu_screen_runner.cpp
@@ -376,6 +376,13 @@ Sint32 run_nested_menu_door(Sint32 (*body)())
 
     // Way back, symmetric: fade the door out and hand the still-open parent
     // loop a black note — its next present turns that into the fade-in.
+    // Precondition (documented on the declaration): the body returns with the
+    // canvas that holds its last frame still active, since fadeblack blends
+    // the active canvas's render surface. The teardown idiom's
+    // set_active_canvas(last_presented_canvas()) is deliberately NOT used
+    // here: the editor body releases its classic world-canvas pin on the way
+    // out, so by now World can name a freshly allocated, never-drawn surface
+    // while the editor's actual last frame lives on the (shared) UI canvas.
     scr->fadeblack(0);
     note_menu_faded_to_black();
     return result;
@@ -511,6 +518,12 @@ Sint32 run_menu_screen(const MenuScreenSpec& spec, void* screen_state)
         // the presented surface black (#200): that fade-out would run
         // over the stale menu image the UI canvas still holds and play
         // the same transition a second time.
+        //
+        // fadeblack(0) blends FROM the render buffer, not from the window: a
+        // door body must not draw into it before run_menu_screen, or this
+        // fade-out runs black-to-black and the door hard-cuts (the entry's own
+        // background is composed below, after the fade). Under TESTING the
+        // trace is one line either way, so no pin can see that mistake.
         reset_timer();
         while (query_timer() < 1)
             ;

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -1548,6 +1548,11 @@ void zone_submenu_rewire(button* buttons, int count, int& /*highlighted*/)
                      !row.affordable))
                 {
                     live->color = GREY;
+                    // One rule for every dim face: GREY collides with the
+                    // shadow shade, so a dimmed row steps its right/bottom
+                    // bevels darker and stays a whole card. The gate pass
+                    // clears the flag on every non-dim row each frame.
+                    live->dimmed = true;
                 } else if (row.is_level() && level_rows_actionable) {
                     live->color = og::ui::kReadyGoFaceGo;
                 }
@@ -2411,9 +2416,11 @@ constexpr int kBaseCampSeatCardPitch =
 // left, running to the card's right edge. Pointer clicks inside the zone
 // cycle the seat's team; the rest of the card (and every coordinate-free
 // activation) opens the seat editor. DERIVED from the face so a width change
-// carries the chip with it: the chip owns the last nine pixels, which is
-// also the half-cell the label's trailing pad buys back.
-constexpr int kBaseCampSeatChipOffsetX = kBaseCampSeatCardWidth - 9;
+// carries the chip with it: the chip owns the last TEN pixels, which leaves
+// it a 1px margin of face on the right exactly like the 1px it keeps top and
+// bottom — at nine it butted the right bevel and read as nipped. Ten is also
+// the full cell the label's two trailing pads buy back.
+constexpr int kBaseCampSeatChipOffsetX = kBaseCampSeatCardWidth - 10;
 constexpr int kBaseCampSeatChipZoneOffsetX = kBaseCampSeatChipOffsetX - 2;
 constexpr int kBaseCampSeatCardX0 = kBaseCampSeatRailX0;
 constexpr std::array<int, kBaseCampSeatCardsPerPage> kBaseCampSeatCardX{
@@ -2424,8 +2431,26 @@ static_assert(kBaseCampSeatCardX[kBaseCampSeatCardsPerPage - 1] +
                       kBaseCampSeatCardWidth ==
                   kBaseCampPanelRightX,
               "the seat rail closes on the panel's right rail");
+// The rail's own band: everything between the roster panel's bottom bevel
+// (y=160) and the command strip (y=178), which draw_background paints black
+// so the cards sit on one ground. 17px for a 10px card is a 3px gap above and
+// 4px below — ACCEPTED, not drift: an odd budget cannot split evenly, and the
+// alternatives both cost more than the pixel is worth (shrinking the panel to
+// 159 shortens the roster's face; growing the card to 11 breaks the button
+// grid's row height). The heavier gap sits under the rail, where the command
+// strip's own bevel already reads as a separator.
+constexpr int kBaseCampSeatRailBandY = 161;
+constexpr int kBaseCampSeatRailBandHeight = 17;
 constexpr int kBaseCampSeatRailY = 164;
 constexpr int kBaseCampSeatRailHeight = 10;
+static_assert(kBaseCampSeatRailY - kBaseCampSeatRailBandY == 3,
+              "3px of band above the rail");
+static_assert(kBaseCampSeatRailBandY + kBaseCampSeatRailBandHeight -
+                      (kBaseCampSeatRailY + kBaseCampSeatRailHeight) == 4,
+              "4px of band below the rail");
+static_assert(kBaseCampSeatRailBandY + kBaseCampSeatRailBandHeight ==
+                  kBaseCampStripY,
+              "the band closes where the command strip opens");
 // The two labels a bare slot wears. Both are 10 characters — one under the
 // 11-char face budget, which is what the 70px width bought.
 constexpr const char* kBaseCampAddPlayerLabel = "ADD PLAYER";
@@ -2575,6 +2600,19 @@ BaseCampRailSeats base_camp_rail_seats(const BaseCampScreenState* state)
         ++out.count;
     }
     return out;
+}
+
+// How many rail slots carry a numbered team chip this frame. ONE answer for
+// the two consumers that must agree — the chip draw pass and the focus ring's
+// chip clearance — because they read different sources: the frame shape is
+// what the buttons on screen were laid out from, while the seat list is what
+// the state can name RIGHT NOW, and a roster refresh between the rewire and
+// the draw moves only the second. A chip may only ever index a seat that
+// exists, and the ring may only ever dodge a chip that is drawn.
+int base_camp_rail_chip_cards(const BaseCampScreenState* state)
+{
+    return std::min(g_base_camp_rail_frame_shape.shown_cards,
+                    base_camp_rail_seats(state).count);
 }
 
 // The claim the RAIL answers to. Identical to the lobby's, except that
@@ -2968,21 +3006,34 @@ std::string base_camp_seat_label(const BaseCampScreenState& state,
         owner = local_slot >= 0 ? std::string("SPEC")
                                 : company_abbreviation(seat.company);
     }
-    // The trailing visual pad shifts the visible centered ink one half-cell
-    // left, keeping the 8px numbered team chip clear on the 70px face.
-    // The pad is part of the 11-char face budget, and so is a two-digit P#:
-    // a global P16 seat keeps its mapping name one character shorter.
+    // TWO trailing visual pads shift the visible centered ink a full cell
+    // left, which centers it over the chip-free zone (the face minus the last
+    // ten pixels, which the chip owns) instead of over the whole face. One pad
+    // only bought a half cell and left the ink 2px right of that zone's
+    // middle, so a card's label and a bare slot's ADD PLAYER — centered on
+    // the same row with no chip to dodge — read as two different conventions.
+    // The pads are part of the 11-char face budget, and so is a two-digit P#:
+    // "P16 " + a 5-char mapping short name + 2 pads is exactly 11, so a global
+    // P16 seat still names its controller in full.
     const std::string prefix =
         std::format("P{} ", static_cast<int>(seat.player_index) + 1);
+    constexpr std::size_t kTrailingPads = 2;
+    static_assert(std::string_view("P16 ").size() +
+                          static_cast<std::size_t>(
+                              og::input::kMappingShortNameMaxLength) +
+                          kTrailingPads <=
+                      static_cast<std::size_t>(kBaseCampSeatCardLabelBudget),
+                  "the widest seat card — a two-digit P# and a full-length "
+                  "mapping short name — still fits its face with both pads");
     const std::size_t room =
-        prefix.size() + 1 < static_cast<std::size_t>(
-                                kBaseCampSeatCardLabelBudget)
+        prefix.size() + kTrailingPads <
+                static_cast<std::size_t>(kBaseCampSeatCardLabelBudget)
         ? static_cast<std::size_t>(kBaseCampSeatCardLabelBudget) -
-              prefix.size() - 1
+              prefix.size() - kTrailingPads
         : 0u;
     if (owner.size() > room)
         owner.resize(room);
-    return prefix + owner + " ";
+    return prefix + owner + std::string(kTrailingPads, ' ');
 }
 
 std::vector<short> base_camp_selectable_seat_teams(const SaveData& save)
@@ -4494,6 +4545,20 @@ void base_camp_draw_background(void* screen_state)
     // instead of touching bevels.
     game->draw_button(8, 28, 311, 160, 2, 1);
 
+    // The seat rail's ground, painted here (pre-buttons) so the cards land on
+    // it instead of under it. The rail band is the one place on this screen
+    // where raw backdrop shows between opaque chrome — the title art's grey
+    // blade runs straight through x=15..133, and the 8px gutters framed it so
+    // neatly that it read as a stray glyph wedged between two cards. This is
+    // the lines A/B readability-strip idiom taken opaque: the goal is not just
+    // legible ink but ONE ground under the whole row, so a networked frame and
+    // a local one are pixel-identical in the band whatever the backdrop is
+    // doing behind them. Spans the panel's own outside-to-outside line (8..311)
+    // and the full 17px between the panel's bottom bevel and the command strip.
+    game->fastbox(kBaseCampSeatRailX0, kBaseCampSeatRailBandY,
+                  kBaseCampPanelRightX - kBaseCampSeatRailX0,
+                  kBaseCampSeatRailBandHeight, PURE_BLACK);
+
     // NO readability strips inside the panel (the one-screen rule): the
     // black strip idiom exists to lift text off the title-screen BACKDROP,
     // and the panel's own opaque face already does that. Charcoal bars and
@@ -4769,12 +4834,11 @@ void base_camp_draw_content(void* screen_state)
         // draw_buttons like every other row — there is no chrome left for
         // this pass to paint. Only the chips are ours.
         //
-        // Positions come from the frame's laid-out shape; the COUNT must
-        // clamp to the seats st holds right now — the roster can refresh
-        // between the rewire and this draw, and a chip may only ever index
-        // a seat that exists.
+        // Positions come from the frame's laid-out shape; the COUNT comes
+        // from base_camp_rail_chip_cards, the one answer the focus ring's
+        // clearance reads too.
         const BaseCampRailSeats chip_seats = base_camp_rail_seats(st);
-        const int chip_cards = std::min(rail.shown_cards, chip_seats.count);
+        const int chip_cards = base_camp_rail_chip_cards(st);
         for (int card = 0; card < chip_cards; ++card) {
             const og::sim::LobbyPlayer& seat =
                 *chip_seats.seat[static_cast<std::size_t>(card)];
@@ -6964,7 +7028,18 @@ const MenuScreenSpec& company_list_menu_screen_spec()
 
 bool base_camp_rail_slot_has_chip(int slot)
 {
-    return slot >= 0 && slot < g_base_camp_rail_frame_shape.shown_cards;
+    // The SAME count the chip pass paints. Asking the frame shape alone let
+    // the ring clear a chip on a slot whose seat had left the roster since
+    // the rewire — cutting the ring back over a label with nothing beside it.
+    return slot >= 0 && slot < base_camp_rail_chip_cards(g_base_camp_state);
+}
+
+int base_camp_seat_chip_ring_clearance()
+{
+    // The chip owns [chip_offset, card_w). The ring's right column is drawn
+    // AT x + sizex (the +1 convention), so the cut has to be one wider than
+    // the chip's own run for that column to land on the face pixel before it.
+    return kBaseCampSeatCardWidth - kBaseCampSeatChipOffsetX + 1;
 }
 
 void install_base_camp_state_for_screen(BaseCampScreenState* state)

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -2381,17 +2381,31 @@ constexpr int kBaseCampFamilySwatchHeight = 8;
 // each) plus four cards (57 each) is 262px of face, leaving 42px for the six
 // gutters between them — 7px between every neighbour, where the cards used
 // to sit 1px apart with the '+' pinned to the far right.
-constexpr int kBaseCampSeatRailX0 = 8;
+//
+// #243: those numbers are the EVERYTHING-VISIBLE shape and nothing more.
+// The static table below still carries them (they are what the rail looks
+// like with four seats and both arrows up), but the live geometry is
+// recomputed every frame by og::ui::base_camp_seat_rail_layout, which packs
+// or justifies the controls that are actually on screen. The widths are the
+// shared inputs to that function.
+constexpr int kBaseCampSeatRailX0 = og::ui::kSeatRailX0;
 static_assert(kBaseCampSeatRailX0 == kBaseCampStripBackX,
               "the rail's + opens on BACK's left edge");
-constexpr int kBaseCampSeatRailGap = 7;
-constexpr int kBaseCampAddSeatWidth = 14;
+static_assert(og::ui::kSeatRailRightX == kBaseCampPanelRightX,
+              "the rail justifies to the panel's right rail");
+static_assert(og::ui::kSeatRailSlots == kBaseCampSeatCardsPerPage,
+              "one slot per seat card on a page");
+static_assert(og::ui::kSeatRailGlobalSeatCap ==
+                  static_cast<int>(og::sim::kMaxGlobalPlayers),
+              "the rail's ghost slots count against the real lobby ceiling");
+constexpr int kBaseCampSeatRailGap = og::ui::kSeatRailGap;
+constexpr int kBaseCampAddSeatWidth = og::ui::kSeatRailAddWidth;
 constexpr int kBaseCampAddSeatX = kBaseCampSeatRailX0;
-constexpr int kBaseCampSeatPagerWidth = 10;
+constexpr int kBaseCampSeatPagerWidth = og::ui::kSeatRailPagerWidth;
 constexpr int kBaseCampSeatPagePrevX =
     kBaseCampAddSeatX + kBaseCampAddSeatWidth + kBaseCampSeatRailGap;
 // One seat-card table: the button specs and the chip overlay both index it.
-constexpr int kBaseCampSeatCardWidth = 57;
+constexpr int kBaseCampSeatCardWidth = og::ui::kSeatRailCardWidth;
 constexpr int kBaseCampSeatCardPitch =
     kBaseCampSeatCardWidth + kBaseCampSeatRailGap;
 // The 8x8 numbered team chip drawn on each card's right end, and the #202
@@ -2507,34 +2521,47 @@ unsigned char base_camp_ready_face_color(const MenuLabelContext& /*context*/)
     return kReadyGoFaceUnready;
 }
 
-RowState base_camp_add_seat_row_state(
-    const MenuLabelContext& /*context*/)
+// The live seat-claim facts, read once per consumer. A connected spectator
+// owns no published seat, so activating one consumes the same global
+// capacity as every other + request.
+og::ui::SeatClaimability base_camp_seat_claimability()
 {
+    og::ui::SeatClaimability claim;
 #ifdef DISABLE_MULTIPLAYER
-    return RowState::Hidden;
-#else
-    const std::size_t local_count = picker_lobby_local_seat_count();
-    const int seat_cap = og::input::local_seat_cap();
-    if (local_count >= static_cast<std::size_t>(seat_cap))
+    claim.multiplayer_enabled = false;
+#endif
+    claim.local_count = static_cast<int>(picker_lobby_local_seat_count());
+    claim.local_seat_cap = og::input::local_seat_cap();
+    claim.global_count = static_cast<int>(picker_lobby_players().size());
+    return claim;
+}
+
+// The [+] gate, over facts the caller already gathered so the rail's
+// per-frame layout can ask the same question the row state answers (#243)
+// instead of keeping a second copy of the rule — or paying twice to read it.
+RowState base_camp_add_seat_state(const og::ui::SeatClaimability& claim)
+{
+    if (og::ui::seats_still_claimable(claim) > 0)
+        return RowState::Visible;
+    if (!claim.multiplayer_enabled)
+        return RowState::Hidden;
+    if (claim.local_count >= claim.local_seat_cap &&
+        claim.local_seat_cap < MAX_PLAYERS)
     {
         // A device-capped rail HIDES the button (matching the pause menu's
         // + ADD PLAYER row): on a phone a dimmed [+] reads as tappable and
         // explains nothing, while an absent one that appears when a pad is
         // plugged in explains itself. The ordinary build-limit cap keeps the
         // dimmed button.
-        return seat_cap < MAX_PLAYERS ? RowState::Hidden
-                                      : RowState::Disabled;
+        return RowState::Hidden;
     }
+    return RowState::Disabled;
+}
 
-    // A connected spectator owns no published seat. Activating one therefore
-    // consumes the same global capacity as every other + request.
-    const std::size_t global_count = picker_lobby_players().size();
-    if (global_count >= og::sim::kMaxGlobalPlayers)
-    {
-        return RowState::Disabled;
-    }
-    return RowState::Visible;
-#endif
+RowState base_camp_add_seat_row_state(
+    const MenuLabelContext& /*context*/)
+{
+    return base_camp_add_seat_state(base_camp_seat_claimability());
 }
 
 // Static nav encodes the full-page shape (8 visible rows, pagers hidden,
@@ -3568,6 +3595,36 @@ constexpr MenuScreenSpec make_seat_settings_spec(
     return spec;
 }
 
+// #243: the seat rail's live geometry, recomputed from the same inputs by
+// everything that needs it — the rewire that positions the seven ordinals,
+// the content pass that draws the ghost slots and the team chips, and the
+// pointer predicate that decides whether a click landed on a chip. All three
+// run inside one frame over unchanged lobby state, so recomputing is exact
+// and nothing has to cache a frame-scoped copy.
+og::ui::SeatRailLayout base_camp_seat_rail_shape(
+    const og::ui::BaseCampScreenState* st)
+{
+    const int visible_cards = st != nullptr
+        ? std::max(0, st->seat_page.end_index() - st->seat_page.first_index())
+        : 0;
+    const bool pagers = st != nullptr && st->seat_page.multi_page();
+    const bool last_page =
+        st == nullptr || st->seat_page.end_index() >= st->seat_page.item_count;
+    // The [+] gate is RE-EVALUATED rather than read off buttons[].hidden:
+    // apply_row_states has already run in production, but several tests drive
+    // the rewire alone, and a rail that trusted the static `false` would lay
+    // out the desktop shape on a phone.
+    const og::ui::SeatClaimability claim = base_camp_seat_claimability();
+    const bool add_visible =
+        base_camp_add_seat_state(claim) != RowState::Hidden;
+    const int ghosts = og::ui::base_camp_seat_rail_ghost_count(
+        {.claim = claim,
+         .visible_cards = visible_cards,
+         .on_last_page = last_page});
+    return og::ui::base_camp_seat_rail_layout(add_visible, pagers,
+                                              visible_cards, ghosts);
+}
+
 // Per-frame visibility + labels + nav over the live roster state (pattern
 // b): page-window the rows, stamp the deploy glyphs on BOTH label surfaces,
 // host-gate GO, close the strip/pager links, and seed the empty-roster
@@ -3654,10 +3711,9 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
         ? kCreateMenuGoIndex
         : (ready_visible ? kCreateMenuReadyIndex : -1);
     const SaveData& save = og::runtime::current_session->myscreen_->save_data;
-#ifdef DISABLE_MULTIPLAYER
-    buttons[kBaseCampAddSeatIndex].hidden = true;
-#endif
-    const bool add_visible = !buttons[kBaseCampAddSeatIndex].hidden;
+    const og::ui::SeatRailLayout rail_layout = base_camp_seat_rail_shape(st);
+    const bool add_visible = rail_layout.add_visible;
+    buttons[kBaseCampAddSeatIndex].hidden = !add_visible;
     // #236: the rail's retired right-end ordinal stays parked with the zone
     // spares — hidden, zero-size, no nav — so nothing can route into it.
     buttons[kBaseCampSeatRailSpareIndex].hidden = true;
@@ -3684,6 +3740,27 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
             live->label = card_button.label;
         }
     }
+    // #243: the rail's x's are a per-frame computation, not table constants.
+    // Every one of the seven ordinals is rewritten unconditionally — the
+    // button array is materialized once at screen entry, so a branch that
+    // skipped a write would leave a stale position from an earlier shape —
+    // and pushed to the live vbutton, which is what actually draws and
+    // hit-tests. Only x and width move; the rail keeps one baseline.
+    buttons[kBaseCampAddSeatIndex].x = rail_layout.add_x;
+    buttons[kBaseCampAddSeatIndex].sizex = kBaseCampAddSeatWidth;
+    buttons[kBaseCampSeatPagePrevIndex].x = rail_layout.prev_x;
+    buttons[kBaseCampSeatPagePrevIndex].sizex = kBaseCampSeatPagerWidth;
+    buttons[kBaseCampSeatPageNextIndex].x = rail_layout.next_x;
+    buttons[kBaseCampSeatPageNextIndex].sizex = kBaseCampSeatPagerWidth;
+    sync_live_rect(kBaseCampAddSeatIndex);
+    sync_live_rect(kBaseCampSeatPagePrevIndex);
+    for (int card = 0; card < kBaseCampSeatCardsPerPage; ++card) {
+        button& face = buttons[kBaseCampSeatCardBase + card];
+        face.x = rail_layout.slot_x[static_cast<std::size_t>(card)];
+        face.sizex = rail_layout.card_w;
+        sync_live_rect(kBaseCampSeatCardBase + card);
+    }
+    sync_live_rect(kBaseCampSeatPageNextIndex);
     std::vector<int> rail;
     if (add_visible)
         rail.push_back(kBaseCampAddSeatIndex);
@@ -4614,16 +4691,27 @@ void base_camp_draw_content(void* screen_state)
     // draw. They use the same four gameplay-team ramps as character chips,
     // while the P# label identifies the player/view rather than a fighter.
     if (st != nullptr) {
+        const og::ui::SeatRailLayout rail = base_camp_seat_rail_shape(st);
+        // #243: a slot with no seat in it yet is drawn as an empty recess.
+        // It keeps the rail on both of the panel's margins and shows where
+        // the next player will land — chrome, not a control: the ordinals
+        // are frozen, so a ghost is never navigable, highlightable or
+        // clickable, and it appears only while a seat is actually claimable.
+        for (int slot = rail.shown_cards; slot < rail.slot_count(); ++slot) {
+            game->draw_button_inverted(
+                rail.slot_x[static_cast<std::size_t>(slot)],
+                kBaseCampSeatRailY, static_cast<Uint32>(rail.card_w),
+                static_cast<Uint32>(kBaseCampSeatRailHeight));
+        }
         const int seat_first = st->seat_page.first_index();
-        const int seat_end = st->seat_page.end_index();
-        for (int card = 0; card < seat_end - seat_first; ++card) {
+        for (int card = 0; card < rail.shown_cards; ++card) {
             const og::sim::LobbyPlayer& seat =
                 st->seats[static_cast<std::size_t>(seat_first + card)];
             const int team = std::clamp(
                 static_cast<int>(seat.team), 0,
                 static_cast<int>(SCORE_TEAM_COUNT) - 1);
             const int chip_x =
-                kBaseCampSeatCardX[static_cast<std::size_t>(card)] +
+                rail.slot_x[static_cast<std::size_t>(card)] +
                 kBaseCampSeatChipOffsetX;
             game->fastbox(chip_x, kBaseCampSeatRailY + 1, 8, 8, PURE_BLACK);
             game->fastbox(
@@ -5090,8 +5178,8 @@ Sint32 base_camp_on_spec_row(int row, void* screen_state)
         // region. Non-editable seats never reach here (the ownership and
         // spectator gates above popped already).
         {
-            const int card_x =
-                kBaseCampSeatCardX[static_cast<std::size_t>(card)];
+            const int card_x = base_camp_seat_rail_shape(st)
+                                   .slot_x[static_cast<std::size_t>(card)];
             const int click_x = pks().menu_click_x;
             if (click_x >= card_x + kBaseCampSeatChipZoneOffsetX &&
                 click_x < card_x + kBaseCampSeatCardWidth)

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -5557,7 +5557,8 @@ const MenuScreenSpec& team_build_menu_screen_spec()
         // The loop-top host-GO check that launches a joiner parked here.
         .remote_start = RemoteStartScope::TeamBuildScope,
         .remote_start_exit = RemoteStartExit::ReturnMenuExit,
-        .enter = EnterTransition::FadeAroundEntry,
+        // Base Camp is a run_picker top-level entry (depth 1), so the #237
+        // derivation fades it; opened nested it would not.
         // §9.11 (G4): roster-first on row 0's BODY — entering the base camp
         // highlights the first row and Enter trains (the curses roster
         // grammar); the deploy toggle sits one Left away. Empty roster:
@@ -5594,8 +5595,9 @@ constexpr MenuScreenSpec make_main_menu_spec(const MenuButtonSpec* rows,
     // into team build, whose loop-top check launches the game.
     spec.remote_start = RemoteStartScope::MainScope;
     spec.remote_start_exit = RemoteStartExit::BreakWithSelection;
-    // Legacy entry: fade the previous menu out, first draw, fade in.
-    spec.enter = EnterTransition::FadeWithInitialDraw;
+    // A run_picker top-level entry: the #237 derivation fades it (the
+    // fade-out is skipped over the intro's noted black — no more cold-start
+    // black-to-black fade).
     spec.default_highlight = 1;  // continue_game
     // Historical note, kept from PLAYER SETTINGS:
     // "Right-clicking the selected count still enters the long-standing
@@ -6827,11 +6829,11 @@ const MenuScreenSpec& help_menu_screen_spec()
         // Nav closure over the hidden pagers (BACK's right-link), reading
         // the open screen's PageModel.
         .nav = {.kind = NavProgramKind::Rewire, .rewire = &help_engine_rewire},
-        // The legacy help loop entered with no fade and ran no remote-start
-        // check (a joiner parked here launches when the main menu re-enters
-        // — the FX-subscreen precedent). Keep both: DELIBERATELY not
-        // FadeAroundEntry (issue #200 is reworking that path).
-        .enter = EnterTransition::None,
+        // The legacy help loop ran no remote-start check (a joiner parked
+        // here launches when the main menu re-enters — the FX-subscreen
+        // precedent). Fading is the #237 derivation's call: the main menu's
+        // HELP door is a context switch (depth 1) and fades; Base Camp's is
+        // nested and does not.
         .default_highlight = kHelpMenuBackIndex,
         // BACK carries MENU_REDRAW and ends the screen there.
         .exit_on_redraw = true,
@@ -6855,9 +6857,8 @@ const MenuScreenSpec& name_entry_menu_screen_spec()
         .row_count = static_cast<int>(std::size(kNameEntryRows)),
         .buttons_accessor = &picker_name_entry_buttons,
         .count_accessor = &picker_name_entry_button_count,
-        // Fade the main menu out, draw the name screen cold, fade in (the
-        // team-build entry idiom).
-        .enter = EnterTransition::FadeAroundEntry,
+        // Entered after the main menu returns (a depth-1 context switch), so
+        // the #237 derivation fades the main menu out around the cold draw.
         // Initial highlight: ACCEPT (§2.2).
         .default_highlight = kNameEntryAcceptIndex,
         // A joiner can still receive the host's launch while this modal is
@@ -6906,9 +6907,8 @@ const MenuScreenSpec& company_list_menu_screen_spec()
         // reports "not opened" and the re-entered main menu launches.
         .remote_start = RemoteStartScope::MainScope,
         .remote_start_exit = RemoteStartExit::ReturnMenuExit,
-        // Fade the main menu out, draw the list cold, fade in (the name-entry
-        // entry idiom).
-        .enter = EnterTransition::FadeAroundEntry,
+        // The LOAD door enters after the main menu returns (depth 1), so the
+        // #237 derivation fades it.
         // The retired load loop opened on BACK; keep that keyboard starting
         // point and its BACK -> row 0 -> ... -> BACK vertical cycle.
         .default_highlight = kCompanyListBackIndex,
@@ -7046,8 +7046,8 @@ const MenuScreenSpec& company_backups_menu_screen_spec()
         // "not opened" and the re-entered outer screens unwind in turn.
         .remote_start = RemoteStartScope::MainScope,
         .remote_start_exit = RemoteStartExit::ReturnMenuExit,
-        // Fade the Company List out, draw the sub-view cold, fade in.
-        .enter = EnterTransition::FadeAroundEntry,
+        // Opened nested under the Company List, so the #237 derivation does
+        // not fade it (subscreens opened from an open menu never fade).
         // Initial highlight: row 0 — the newest snapshot.
         .default_highlight = 0,
         .polls_lobby = true,
@@ -7238,8 +7238,8 @@ int picker_mainmenu_options_index()
 }
 
 // The main menu, engine-hosted (the legacy loop in picker_main_menu.cpp is
-// gone). The fade-out/first-draw/fade-in entry is the spec's
-// FadeWithInitialDraw transition; every caller (present_menu /
+// gone). Its fade-out/first-draw/fade-in entry comes from the #237
+// derivation (a depth-1 Screen); every caller (present_menu /
 // picker_mainmenu_loop) acts on pks().selected_menu_item and ignores the
 // return value, exactly as it ignored the legacy loop's retvalue.
 Sint32 mainmenu(Sint32 arg1)

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -2379,37 +2379,29 @@ constexpr int kBaseCampFamilySwatchGap = 1;
 constexpr int kBaseCampFamilySwatchRampWidth = 8;
 constexpr int kBaseCampFamilySwatchWidth = kBaseCampFamilySwatchRampWidth + 2;
 constexpr int kBaseCampFamilySwatchHeight = 8;
-// The player-seat rail (#236), one row of controls across the panel's full
-// width: [+] | < | card 0..3 | >. The SEATS label that used to open the rail
-// is gone — it duplicated the SCENARIO submenu's team-overview door — and
-// the '+' took its place at the left edge so the cards can breathe.
-// Arithmetic across x=8..311 (304px): the '+' (14) plus two pager faces (10
-// each) plus four cards (57 each) is 262px of face, leaving 42px for the six
-// gutters between them — 7px between every neighbour, where the cards used
-// to sit 1px apart with the '+' pinned to the far right.
+// The player-seat rail: THIS MACHINE'S four seat slots, and nothing else on
+// the row. Remote seats are counted on the header line and listed in VIEW
+// LEVEL's SEATS report — they never took a slot the local player could act
+// on, and windowing them here cost the rail a [+] at its left end and two
+// pager arrows in the middle of it. All three are retired (their ordinals
+// park); a slot with no seat in it is now a real ADD PLAYER button.
 //
-// #243: those numbers are the EVERYTHING-VISIBLE shape and nothing more.
-// The static table below still carries them (they are what the rail looks
-// like with four seats and both arrows up), but the live geometry is
-// recomputed every frame by og::ui::base_camp_seat_rail_layout, which packs
-// or justifies the controls that are actually on screen. The widths are the
-// shared inputs to that function.
+// Arithmetic across x=8..311 (304px): four 70px faces and three 8px gutters
+// are 304 exactly, so the row opens on BACK's left edge and closes on the
+// panel's right rail with no remainder to distribute. The grid is FIXED —
+// slot k sits at 8 + 78k whether or not its neighbours are on screen — so a
+// card never slides sideways when a player joins or leaves.
 constexpr int kBaseCampSeatRailX0 = og::ui::kSeatRailX0;
 static_assert(kBaseCampSeatRailX0 == kBaseCampStripBackX,
-              "the rail's + opens on BACK's left edge");
+              "the rail's first slot opens on BACK's left edge");
 static_assert(og::ui::kSeatRailRightX == kBaseCampPanelRightX,
-              "the rail justifies to the panel's right rail");
+              "the rail closes on the panel's right rail");
 static_assert(og::ui::kSeatRailSlots == kBaseCampSeatCardsPerPage,
-              "one slot per seat card on a page");
+              "one slot per local seat");
 static_assert(og::ui::kSeatRailGlobalSeatCap ==
                   static_cast<int>(og::sim::kMaxGlobalPlayers),
-              "the rail's ghost slots count against the real lobby ceiling");
+              "a bare slot's LOBBY FULL face counts the real lobby ceiling");
 constexpr int kBaseCampSeatRailGap = og::ui::kSeatRailGap;
-constexpr int kBaseCampAddSeatWidth = og::ui::kSeatRailAddWidth;
-constexpr int kBaseCampAddSeatX = kBaseCampSeatRailX0;
-constexpr int kBaseCampSeatPagerWidth = og::ui::kSeatRailPagerWidth;
-constexpr int kBaseCampSeatPagePrevX =
-    kBaseCampAddSeatX + kBaseCampAddSeatWidth + kBaseCampSeatRailGap;
 // One seat-card table: the button specs and the chip overlay both index it.
 constexpr int kBaseCampSeatCardWidth = og::ui::kSeatRailCardWidth;
 constexpr int kBaseCampSeatCardPitch =
@@ -2418,23 +2410,32 @@ constexpr int kBaseCampSeatCardPitch =
 // pointer zone that cycles it in place: the chip plus 2px of grace on its
 // left, running to the card's right edge. Pointer clicks inside the zone
 // cycle the seat's team; the rest of the card (and every coordinate-free
-// activation) opens the seat editor.
-constexpr int kBaseCampSeatChipOffsetX = 48;
+// activation) opens the seat editor. DERIVED from the face so a width change
+// carries the chip with it: the chip owns the last nine pixels, which is
+// also the half-cell the label's trailing pad buys back.
+constexpr int kBaseCampSeatChipOffsetX = kBaseCampSeatCardWidth - 9;
 constexpr int kBaseCampSeatChipZoneOffsetX = kBaseCampSeatChipOffsetX - 2;
-constexpr int kBaseCampSeatCardX0 =
-    kBaseCampSeatPagePrevX + kBaseCampSeatPagerWidth + kBaseCampSeatRailGap;
+constexpr int kBaseCampSeatCardX0 = kBaseCampSeatRailX0;
 constexpr std::array<int, kBaseCampSeatCardsPerPage> kBaseCampSeatCardX{
     kBaseCampSeatCardX0, kBaseCampSeatCardX0 + kBaseCampSeatCardPitch,
     kBaseCampSeatCardX0 + 2 * kBaseCampSeatCardPitch,
     kBaseCampSeatCardX0 + 3 * kBaseCampSeatCardPitch};
-constexpr int kBaseCampSeatPageNextX =
-    kBaseCampSeatCardX[kBaseCampSeatCardsPerPage - 1] +
-    kBaseCampSeatCardWidth + kBaseCampSeatRailGap;
-static_assert(kBaseCampSeatPageNextX + kBaseCampSeatPagerWidth ==
+static_assert(kBaseCampSeatCardX[kBaseCampSeatCardsPerPage - 1] +
+                      kBaseCampSeatCardWidth ==
                   kBaseCampPanelRightX,
               "the seat rail closes on the panel's right rail");
 constexpr int kBaseCampSeatRailY = 164;
 constexpr int kBaseCampSeatRailHeight = 10;
+// The two labels a bare slot wears. Both are 10 characters — one under the
+// 11-char face budget, which is what the 70px width bought.
+constexpr const char* kBaseCampAddPlayerLabel = "ADD PLAYER";
+constexpr const char* kBaseCampLobbyFullLabel = "LOBBY FULL";
+static_assert(std::string_view(kBaseCampAddPlayerLabel).size() <=
+                  static_cast<std::size_t>(kBaseCampSeatCardLabelBudget),
+              "a bare slot's label fits its face");
+static_assert(std::string_view(kBaseCampLobbyFullLabel).size() <=
+                  static_cast<std::size_t>(kBaseCampSeatCardLabelBudget),
+              "a full lobby's label fits its face");
 // §9.5.4 + graft (a): non-identity fields on benched rows dim to palette
 // shade 21 — GREY(23)'s glyph ramp overlaps WHITE(24) by all but one step,
 // so 23-vs-24 dimming was nearly invisible. §9.23 uses it for benched
@@ -2529,7 +2530,7 @@ unsigned char base_camp_ready_face_color(const MenuLabelContext& /*context*/)
 
 // The live seat-claim facts, read once per consumer. A connected spectator
 // owns no published seat, so activating one consumes the same global
-// capacity as every other + request.
+// capacity as every other ADD PLAYER request.
 og::ui::SeatClaimability base_camp_seat_claimability()
 {
     og::ui::SeatClaimability claim;
@@ -2542,31 +2543,110 @@ og::ui::SeatClaimability base_camp_seat_claimability()
     return claim;
 }
 
-// The [+] gate, over facts the caller already gathered so the rail's
-// per-frame layout can ask the same question the row state answers (#243)
-// instead of keeping a second copy of the rule — or paying twice to read it.
-RowState base_camp_add_seat_state(const og::ui::SeatClaimability& claim)
+// The rail's seats: this machine's own, in local-slot order, capped at the
+// four slots. The inverse of base_camp_seat_local_slot — slot k is the seat
+// whose player_index is local_seat_indices[k]. A local index the roster does
+// not (yet) carry stops the list rather than leaving a hole: the rail never
+// shows a card it cannot name, and the slots after it fall back to ADD
+// PLAYER, which is what the lobby is about to say anyway.
+struct BaseCampRailSeats {
+    std::array<const og::sim::LobbyPlayer*, kBaseCampSeatCardsPerPage> seat{};
+    int count = 0;
+};
+
+BaseCampRailSeats base_camp_rail_seats(const BaseCampScreenState* state)
 {
-    if (og::ui::seats_still_claimable(claim) > 0)
-        return RowState::Visible;
-    if (!claim.multiplayer_enabled) return RowState::Hidden;
-    if (claim.local_count >= claim.local_seat_cap &&
-        claim.local_seat_cap < MAX_PLAYERS)
-    {
-        // A device-capped rail HIDES the button (matching the pause menu's
-        // + ADD PLAYER row): on a phone a dimmed [+] reads as tappable and
-        // explains nothing, while an absent one that appears when a pad is
-        // plugged in explains itself. The ordinary build-limit cap keeps the
-        // dimmed button.
-        return RowState::Hidden;
+    BaseCampRailSeats out;
+    if (state == nullptr)
+        return out;
+    for (int slot = 0; slot < kBaseCampSeatCardsPerPage; ++slot) {
+        if (slot >= static_cast<int>(state->local_seat_indices.size()))
+            break;
+        const std::uint8_t player_index =
+            state->local_seat_indices[static_cast<std::size_t>(slot)];
+        const auto found = std::find_if(
+            state->seats.begin(), state->seats.end(),
+            [player_index](const og::sim::LobbyPlayer& player) {
+                return player.player_index == player_index;
+            });
+        if (found == state->seats.end())
+            break;
+        out.seat[static_cast<std::size_t>(slot)] = &*found;
+        ++out.count;
     }
-    return RowState::Disabled;
+    return out;
 }
 
-RowState base_camp_add_seat_row_state(
-    const MenuLabelContext& /*context*/)
+// The claim the RAIL answers to. Identical to the lobby's, except that
+// local_count is the seats the rail can actually name: the lobby and the
+// screen's collected roster can disagree for one frame after a join, and a
+// slot that said "card" while the rewire had nothing to write in it would
+// draw a blank face.
+og::ui::SeatClaimability base_camp_rail_claimability()
 {
-    return base_camp_add_seat_state(base_camp_seat_claimability());
+    og::ui::SeatClaimability claim = base_camp_seat_claimability();
+    claim.local_count = base_camp_rail_seats(g_base_camp_state).count;
+    return claim;
+}
+
+// What slot k of the rail IS this frame. One function, four thunks (the
+// pause menu's pause_player_row_state<K> precedent) so the row state, the
+// label, the layout and the click dispatch can never hold four opinions
+// about the same slot.
+enum class BaseCampSlotKind {
+    Card,        // one of this machine's seats
+    Hidden,      // past what the device can seat (#249)
+    LobbyFull,   // a real slot the lobby has no room to fill
+    AddPlayer,   // a real slot, and the door to claiming it
+};
+
+BaseCampSlotKind base_camp_seat_slot_kind(const og::ui::SeatClaimability& claim,
+                                          int slot)
+{
+    // Order is the rule: a seat this machine already holds always draws its
+    // card, whatever the caps now say (a pad unplugged under a live seat
+    // must not erase the player sitting in it).
+    if (slot < claim.local_count)
+        return BaseCampSlotKind::Card;
+    if (slot >= og::ui::base_camp_seat_rail_slot_cap(claim))
+    {
+        // A device-capped rail HIDES the slot (matching the pause menu's
+        // + ADD PLAYER row): on a phone a dimmed offer reads as tappable and
+        // explains nothing, while a slot that appears when a pad is plugged
+        // in explains itself.
+        return BaseCampSlotKind::Hidden;
+    }
+    if (og::ui::seats_still_claimable(claim) <= 0)
+        return BaseCampSlotKind::LobbyFull;
+    return BaseCampSlotKind::AddPlayer;
+}
+
+RowState base_camp_slot_row_state(BaseCampSlotKind kind)
+{
+    switch (kind) {
+    case BaseCampSlotKind::Hidden:
+        return RowState::Hidden;
+    case BaseCampSlotKind::LobbyFull:
+        return RowState::Disabled;
+    case BaseCampSlotKind::Card:
+    case BaseCampSlotKind::AddPlayer:
+        break;
+    }
+    return RowState::Visible;
+}
+
+template <int Slot>
+RowState base_camp_seat_slot_state(const MenuLabelContext& /*context*/)
+{
+    return base_camp_slot_row_state(
+        base_camp_seat_slot_kind(base_camp_rail_claimability(), Slot));
+}
+
+// A bare slot's face. Cards get theirs from base_camp_seat_label.
+const char* base_camp_slot_placeholder_label(BaseCampSlotKind kind)
+{
+    return kind == BaseCampSlotKind::LobbyFull ? kBaseCampLobbyFullLabel
+                                               : kBaseCampAddPlayerLabel;
 }
 
 // Static nav encodes the full-page shape (8 visible rows, pagers hidden,
@@ -2717,59 +2797,58 @@ constexpr MenuButtonSpec kBaseCampRows[] = {
      .label_binding = {.formatter = &base_camp_ready_label},
      .color = &base_camp_ready_face_color,
      .hidden = true},
-    // Per-level player-seat assignments, left to right: [+] | < | four
-    // cards | >. The four-card window is independent of the character-roster
-    // pager above; the rewire fills authoritative P# labels, ownership,
-    // visibility, and navigation every frame.
-    {.id = "add_seat", .label = "+",
-     .x = kBaseCampAddSeatX, .y = kBaseCampSeatRailY,
-     .w = kBaseCampAddSeatWidth, .h = kBaseCampSeatRailHeight,
+    // The retired [+] and '<' (ordinals 33/34). Ordinals are append-only, so
+    // they park exactly like a zone spare — zero-size rect, empty label,
+    // hidden, no nav — and the 73-button table never shifted.
+    {.id = "seat_rail_spare_0", .label = "",
+     .x = 0, .y = 0, .w = 0, .h = 0,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampAddSeatIndex,
-     .nav = {.down = kCreateMenuBackIndex,
-             .right = kBaseCampSeatPagePrevIndex},
-     .state_override = &base_camp_add_seat_row_state},
-    {.id = "seat_page_prev", .label = "<",
-     .x = kBaseCampSeatPagePrevX, .y = kBaseCampSeatRailY,
-     .w = kBaseCampSeatPagerWidth, .h = kBaseCampSeatRailHeight,
-     .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatPagePrevIndex,
-     .nav = {.down = kCreateMenuBackIndex,
-             .left = kBaseCampAddSeatIndex,
-             .right = kBaseCampSeatCardBase},
      .hidden = true},
-    {.id = "seat_card_0", .label = "",
+    {.id = "seat_rail_spare_1", .label = "",
+     .x = 0, .y = 0, .w = 0, .h = 0,
+     .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatPagePrevIndex,
+     .hidden = true},
+    // This machine's four seat slots, on a fixed grid across the panel. Slot
+    // k IS local controller profile k, so a card and its editor always name
+    // one profile. A slot with no seat in it wears the static ADD PLAYER
+    // label and activates the add path on the same ordinal — the placeholder
+    // is the button, not a second button behind it. The rewire fills
+    // authoritative P# labels, ownership and navigation every frame.
+    {.id = "seat_card_0", .label = kBaseCampAddPlayerLabel,
      .x = kBaseCampSeatCardX[0], .y = kBaseCampSeatRailY,
      .w = kBaseCampSeatCardWidth, .h = kBaseCampSeatRailHeight,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatCardBase,
-     .nav = {.left = kBaseCampSeatPagePrevIndex,
-             .right = kBaseCampSeatCardBase + 1}},
-    {.id = "seat_card_1", .label = "",
+     .nav = {.down = kCreateMenuDifficultyIndex,
+             .right = kBaseCampSeatCardBase + 1},
+     .state_override = &base_camp_seat_slot_state<0>},
+    {.id = "seat_card_1", .label = kBaseCampAddPlayerLabel,
      .x = kBaseCampSeatCardX[1], .y = kBaseCampSeatRailY,
      .w = kBaseCampSeatCardWidth, .h = kBaseCampSeatRailHeight,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatCardBase + 1,
-     .nav = {.left = kBaseCampSeatCardBase,
-             .right = kBaseCampSeatCardBase + 2}},
-    {.id = "seat_card_2", .label = "",
+     .nav = {.down = kCreateMenuScenarioIndex,
+             .left = kBaseCampSeatCardBase,
+             .right = kBaseCampSeatCardBase + 2},
+     .state_override = &base_camp_seat_slot_state<1>},
+    {.id = "seat_card_2", .label = kBaseCampAddPlayerLabel,
      .x = kBaseCampSeatCardX[2], .y = kBaseCampSeatRailY,
      .w = kBaseCampSeatCardWidth, .h = kBaseCampSeatRailHeight,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatCardBase + 2,
-     .nav = {.left = kBaseCampSeatCardBase + 1,
-             .right = kBaseCampSeatCardBase + 3}},
-    {.id = "seat_card_3", .label = "",
+     .nav = {.down = kCreateMenuNetworkingIndex,
+             .left = kBaseCampSeatCardBase + 1,
+             .right = kBaseCampSeatCardBase + 3},
+     .state_override = &base_camp_seat_slot_state<2>},
+    {.id = "seat_card_3", .label = kBaseCampAddPlayerLabel,
      .x = kBaseCampSeatCardX[3], .y = kBaseCampSeatRailY,
      .w = kBaseCampSeatCardWidth, .h = kBaseCampSeatRailHeight,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatCardBase + 3,
-     .nav = {.left = kBaseCampSeatCardBase + 2,
-             .right = kBaseCampSeatPageNextIndex}},
-    {.id = "seat_page_next", .label = ">",
-     .x = kBaseCampSeatPageNextX, .y = kBaseCampSeatRailY,
-     .w = kBaseCampSeatPagerWidth, .h = kBaseCampSeatRailHeight,
-     .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatPageNextIndex,
      .nav = {.down = kCreateMenuGoIndex,
-             .left = kBaseCampSeatCardBase + 3},
+             .left = kBaseCampSeatCardBase + 2},
+     .state_override = &base_camp_seat_slot_state<3>},
+    // The retired '>' (ordinal 39) and the ordinal the '+' vacated in #236.
+    {.id = "seat_rail_spare_2", .label = "",
+     .x = 0, .y = 0, .w = 0, .h = 0,
+     .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatPageNextIndex,
      .hidden = true},
-    // The ordinal the '+' vacated when it moved to the rail's left end
-    // (#236). Parked exactly like a zone spare — zero-size rect, empty
-    // label, hidden, no nav — so the 73-button table never shifted.
     {.id = "seat_rail_spare", .label = "",
      .x = 0, .y = 0, .w = 0, .h = 0,
      .action = ButtonAction::MenuSpecRow, .arg = kBaseCampSeatRailSpareIndex,
@@ -2890,8 +2969,8 @@ std::string base_camp_seat_label(const BaseCampScreenState& state,
                                 : company_abbreviation(seat.company);
     }
     // The trailing visual pad shifts the visible centered ink one half-cell
-    // left, keeping the 8px numbered team chip clear on the compact 57px face.
-    // The pad is part of the 9-char face budget, and so is a two-digit P#:
+    // left, keeping the 8px numbered team chip clear on the 70px face.
+    // The pad is part of the 11-char face budget, and so is a two-digit P#:
     // a global P16 seat keeps its mapping name one character shorter.
     const std::string prefix =
         std::format("P{} ", static_cast<int>(seat.player_index) + 1);
@@ -3600,36 +3679,25 @@ constexpr MenuScreenSpec make_seat_settings_spec(
     return spec;
 }
 
-// #243: the seat rail's live geometry. Computed ONCE per frame by the rewire
-// (which positions the seven ordinals from it) and cached in
+// The seat rail's live geometry. Computed ONCE per frame by the rewire
+// (which positions the slots from it) and cached in
 // g_base_camp_rail_frame_shape for the other two consumers — the content
-// pass (ghost slots, team chips) and the chip click predicate. They must
-// read the CACHE, not recompute: base_camp_frame_tick refreshes the seat
-// page between the rewire and the draw, so a recompute against the newer
-// state can disagree with the button rects already laid out this frame
-// (ghosts painting over real cards on a page flip).
+// pass (team chips) and the chip click predicate. They must read the CACHE,
+// not recompute: base_camp_frame_tick refreshes the seats between the rewire
+// and the draw, so a recompute against the newer state can disagree with the
+// button rects already laid out this frame.
 og::ui::SeatRailLayout base_camp_seat_rail_shape(
     const og::ui::BaseCampScreenState* st)
 {
-    const int visible_cards = st != nullptr
-        ? std::max(0, st->seat_page.end_index() - st->seat_page.first_index())
-        : 0;
-    const bool pagers = st != nullptr && st->seat_page.multi_page();
-    const bool last_page =
-        st == nullptr || st->seat_page.end_index() >= st->seat_page.item_count;
-    // The [+] gate is RE-EVALUATED rather than read off buttons[].hidden:
+    // The caps are RE-EVALUATED rather than read off buttons[].hidden:
     // apply_row_states has already run in production, but several tests drive
-    // the rewire alone, and a rail that trusted the static `false` would lay
-    // out the desktop shape on a phone.
-    const og::ui::SeatClaimability claim = base_camp_seat_claimability();
-    const bool add_visible =
-        base_camp_add_seat_state(claim) != RowState::Hidden;
-    const int ghosts = og::ui::base_camp_seat_rail_ghost_count(
-        {.claim = claim,
-         .visible_cards = visible_cards,
-         .on_last_page = last_page});
-    return og::ui::base_camp_seat_rail_layout(add_visible, pagers,
-                                              visible_cards, ghosts);
+    // the rewire alone, and a rail that trusted the static shape would lay
+    // out the desktop row on a phone.
+    og::ui::SeatClaimability claim = base_camp_seat_claimability();
+    claim.local_count = base_camp_rail_seats(st).count;
+    const int placeholders =
+        og::ui::base_camp_seat_rail_placeholder_count(claim);
+    return og::ui::base_camp_seat_rail_layout(claim.local_count, placeholders);
 }
 
 // Per-frame visibility + labels + nav over the live roster state (pattern
@@ -3699,11 +3767,7 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
         if (live != nullptr)
             live->color = face;
     };
-    const int seat_first = st != nullptr ? st->seat_page.first_index() : 0;
-    const int seat_end = st != nullptr ? st->seat_page.end_index() : 0;
-    const int seat_visible = std::max(0, seat_end - seat_first);
-    const bool seat_pagers =
-        st != nullptr && st->seat_page.multi_page();
+    const BaseCampRailSeats rail_seats = base_camp_rail_seats(st);
     const bool networked = picker_lobby_is_networked();
     const bool host_visible = picker_lobby_host_controls_visible();
     // §2.6: the GO/READY pair shares one rect with mutually exclusive gates
@@ -3720,75 +3784,70 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
     const SaveData& save = og::runtime::current_session->myscreen_->save_data;
     const og::ui::SeatRailLayout rail_layout = base_camp_seat_rail_shape(st);
     g_base_camp_rail_frame_shape = rail_layout;
-    const bool add_visible = rail_layout.add_visible;
-    buttons[kBaseCampAddSeatIndex].hidden = !add_visible;
-    // #236: the rail's retired right-end ordinal stays parked with the zone
-    // spares — hidden, zero-size, no nav — so nothing can route into it.
-    buttons[kBaseCampSeatRailSpareIndex].hidden = true;
-    buttons[kBaseCampSeatRailSpareIndex].nav = {};
+    // The retired [+], '<' and '>' stay parked with the zone spares —
+    // hidden, zero-size, no nav — so nothing can route into them.
+    for (const int spare : kBaseCampSeatRailSpares) {
+        buttons[spare].hidden = true;
+        buttons[spare].nav = {};
+    }
 
-    // Player-seat rail: P# is the current dense authoritative lobby position
-    // and may change when seats leave; YOU is derived from exact current local
-    // ownership, while remote cards carry a compact company prefix. Both pager
-    // arrows appear together only when more than four seats exist.
-    buttons[kBaseCampSeatPagePrevIndex].hidden = !seat_pagers;
-    buttons[kBaseCampSeatPageNextIndex].hidden = !seat_pagers;
-    for (int card = 0; card < kBaseCampSeatCardsPerPage; ++card) {
-        button& card_button = buttons[kBaseCampSeatCardBase + card];
-        card_button.hidden = card >= seat_visible;
-        if (card_button.hidden)
-            continue;
-        const og::sim::LobbyPlayer& seat =
-            st->seats[static_cast<std::size_t>(seat_first + card)];
-        card_button.label = base_camp_seat_label(*st, seat);
+    // Player-seat rail: THIS MACHINE'S seats, slot k == local controller
+    // profile k. A slot past them is a real ADD PLAYER button (LOBBY FULL and
+    // dimmed when the lobby has no room), and a slot past what the device can
+    // seat is hidden outright (#249). Labels go to BOTH surfaces — the
+    // descriptor row backs later redraws, the live vbutton is what draws.
+    og::ui::SeatClaimability slot_claim = base_camp_seat_claimability();
+    slot_claim.local_count = rail_seats.count;
+    const int seat_visible = rail_layout.slot_count();
+    for (int slot = 0; slot < kBaseCampSeatCardsPerPage; ++slot) {
+        button& slot_button = buttons[kBaseCampSeatCardBase + slot];
+        const BaseCampSlotKind kind =
+            base_camp_seat_slot_kind(slot_claim, slot);
+        slot_button.hidden = slot >= seat_visible ||
+            kind == BaseCampSlotKind::Hidden;
+        if (kind == BaseCampSlotKind::Card &&
+            rail_seats.seat[static_cast<std::size_t>(slot)] != nullptr)
+        {
+            slot_button.label = base_camp_seat_label(
+                *st, *rail_seats.seat[static_cast<std::size_t>(slot)]);
+        }
+        else
+        {
+            slot_button.label = base_camp_slot_placeholder_label(kind);
+        }
         if (vbutton* const live =
                 og::runtime::current_session
-                    ->allbuttons_[static_cast<std::size_t>(kBaseCampSeatCardBase + card)])
+                    ->allbuttons_[static_cast<std::size_t>(
+                        kBaseCampSeatCardBase + slot)])
         {
-            live->label = card_button.label;
+            live->label = slot_button.label;
         }
     }
-    // #243: the rail's x's are a per-frame computation, not table constants.
-    // Every one of the seven ordinals is rewritten unconditionally — the
-    // button array is materialized once at screen entry, so a branch that
-    // skipped a write would leave a stale position from an earlier shape —
-    // and pushed to the live vbutton, which is what actually draws and
-    // hit-tests. Only x and width move; the rail keeps one baseline.
-    buttons[kBaseCampAddSeatIndex].x = rail_layout.add_x;
-    buttons[kBaseCampAddSeatIndex].sizex = kBaseCampAddSeatWidth;
-    buttons[kBaseCampSeatPagePrevIndex].x = rail_layout.prev_x;
-    buttons[kBaseCampSeatPagePrevIndex].sizex = kBaseCampSeatPagerWidth;
-    buttons[kBaseCampSeatPageNextIndex].x = rail_layout.next_x;
-    buttons[kBaseCampSeatPageNextIndex].sizex = kBaseCampSeatPagerWidth;
-    sync_live_rect(kBaseCampAddSeatIndex);
-    sync_live_rect(kBaseCampSeatPagePrevIndex);
-    for (int card = 0; card < kBaseCampSeatCardsPerPage; ++card) {
-        button& face = buttons[kBaseCampSeatCardBase + card];
-        face.x = rail_layout.slot_x[static_cast<std::size_t>(card)];
+    // The rail's x's are a per-frame computation, not table constants. Every
+    // slot is rewritten unconditionally — the button array is materialized
+    // once at screen entry, so a branch that skipped a write would leave a
+    // stale position from an earlier shape — and pushed to the live vbutton,
+    // which is what actually draws and hit-tests. Only x and width move; the
+    // rail keeps one baseline.
+    for (int slot = 0; slot < kBaseCampSeatCardsPerPage; ++slot) {
+        button& face = buttons[kBaseCampSeatCardBase + slot];
+        face.x = rail_layout.slot_x[static_cast<std::size_t>(slot)];
         face.sizex = rail_layout.card_w;
-        sync_live_rect(kBaseCampSeatCardBase + card);
+        sync_live_rect(kBaseCampSeatCardBase + slot);
     }
-    sync_live_rect(kBaseCampSeatPageNextIndex);
     std::vector<int> rail;
-    if (add_visible)
-        rail.push_back(kBaseCampAddSeatIndex);
-    if (seat_pagers)
-        rail.push_back(kBaseCampSeatPagePrevIndex);
-    for (int card = 0; card < seat_visible; ++card)
-        rail.push_back(kBaseCampSeatCardBase + card);
-    if (seat_pagers)
-        rail.push_back(kBaseCampSeatPageNextIndex);
-    // Every vertical link into the rail lands on its leftmost visible
-    // control, and the strip's right end climbs to its rightmost. That is
-    // the '+' and the '>' in a normal build; a no-multiplayer build hides
-    // the '+', so the ends walk inward to the first live control. With no
-    // rail at all, links from above skip it to BACK.
+    for (int slot = 0; slot < kBaseCampSeatCardsPerPage; ++slot) {
+        if (!buttons[kBaseCampSeatCardBase + slot].hidden)
+            rail.push_back(kBaseCampSeatCardBase + slot);
+    }
+    // Every vertical link into the rail lands on its leftmost visible slot,
+    // and the strip's right end climbs to its rightmost. On a phone that is
+    // the same single slot; with no rail at all (a build with neither seats
+    // nor a door to one), links from above skip it to BACK.
     const int rail_first = rail.empty() ? -1 : rail.front();
     const int rail_last = rail.empty() ? -1 : rail.back();
     const int rail_entry =
         rail_first >= 0 ? rail_first : kCreateMenuBackIndex;
-    const int seat_card_anchor =
-        seat_visible > 0 ? kBaseCampSeatCardBase : rail_entry;
     for (std::size_t index = 0; index < rail.size(); ++index) {
         button& control = buttons[rail[index]];
         control.nav.left = index > 0 ? rail[index - 1] : -1;
@@ -4158,9 +4217,11 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
     const int dep_down_exit = band_below_roster_top >= 0
         ? band_below_roster_top
         : rail_entry;
+    // The roster's body column drops onto the rail's leftmost live slot —
+    // which IS the rail's entry now that no [+] or pager sits left of it.
     const int body_down_exit = band_below_roster_top >= 0
         ? band_below_roster_top
-        : seat_card_anchor;
+        : rail_entry;
 
     // Roster nav (the classic chains, walked over the presence arrays so a
     // capability-hidden column never strands a link).
@@ -4313,39 +4374,38 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
         ? bands_below.back().bottom
         : (last_body >= 0 ? kBaseCampRowBodyBase + last_body
                           : (last_dep >= 0 ? last_dep : spine_last));
-    // The rail's left end — the '+' and the '<' — sits over BACK.
-    buttons[kBaseCampAddSeatIndex].nav.up = rail_up_left;
-    buttons[kBaseCampAddSeatIndex].nav.down = kCreateMenuBackIndex;
-    buttons[kBaseCampSeatPagePrevIndex].nav.up = rail_up_left;
-    buttons[kBaseCampSeatPagePrevIndex].nav.down = kCreateMenuBackIndex;
-    // Each card drops onto the strip door under its face. The re-gridded
-    // strip put DIFFICULTY under card one, so the doubled SCENARIO link the
-    // empty slot forced is gone.
+    // Each slot drops onto its strip door, the column relationship the rail
+    // has always had. (The four faces widened over BACK..GO, but re-pointing
+    // slot one at BACK would leave the whole strip one door short of a
+    // keyboard route down from the rail.) The rail's LEFT end climbs into
+    // the roster's left column and the rest into its body column — the split
+    // the retired '+' used to make at exactly this x.
     constexpr std::array<int, kBaseCampSeatCardsPerPage> card_down{
         kCreateMenuDifficultyIndex,
         kCreateMenuScenarioIndex,
         kCreateMenuNetworkingIndex,
         kCreateMenuGoIndex};
-    for (int card = 0; card < seat_visible; ++card) {
-        button& card_button = buttons[kBaseCampSeatCardBase + card];
-        card_button.nav.up = rail_up_right;
-        if (card == kBaseCampSeatCardsPerPage - 1) {
-            // Card four historically lands on the GO/READY slot. A connected
+    for (int slot = 0; slot < kBaseCampSeatCardsPerPage; ++slot) {
+        button& slot_button = buttons[kBaseCampSeatCardBase + slot];
+        if (slot_button.hidden)
+            continue;
+        slot_button.nav.up =
+            slot == 0 ? rail_up_left : rail_up_right;
+        if (slot == kBaseCampSeatCardsPerPage - 1) {
+            // Slot four historically lands on the GO/READY slot. A connected
             // zero-seat guest has neither half of that slot, so keep the old
             // strip-column relationship but fall back one door to NETWORK
             // instead of leaving keyboard focus pointed at a hidden row.
-            card_button.nav.down =
+            slot_button.nav.down =
                 strip_end >= 0 ? strip_end : kCreateMenuNetworkingIndex;
         } else {
-            card_button.nav.down =
-                card_down[static_cast<std::size_t>(card)];
+            slot_button.nav.down =
+                card_down[static_cast<std::size_t>(slot)];
         }
     }
-    buttons[kBaseCampSeatPageNextIndex].nav.up = rail_up_right;
-    buttons[kBaseCampSeatPageNextIndex].nav.down =
-        strip_end >= 0 ? strip_end : kCreateMenuNetworkingIndex;
-    const auto visible_card_or_rail = [seat_visible, rail_entry](int card) {
-        return card >= 0 && card < seat_visible
+    const auto visible_card_or_rail = [buttons, rail_entry](int card) {
+        return card >= 0 && card < kBaseCampSeatCardsPerPage &&
+                !buttons[kBaseCampSeatCardBase + card].hidden
             ? kBaseCampSeatCardBase + card
             : rail_entry;
     };
@@ -4699,31 +4759,22 @@ void base_camp_draw_content(void* screen_state)
     // draw. They use the same four gameplay-team ramps as character chips,
     // while the P# label identifies the player/view rather than a fighter.
     if (st != nullptr) {
-        // The rewire's cached frame shape — never recomputed here (the seat
-        // page may have refreshed since; the buttons on screen have not).
+        // The rewire's cached frame shape — never recomputed here (the
+        // roster may have refreshed since; the buttons on screen have not).
         const og::ui::SeatRailLayout& rail = g_base_camp_rail_frame_shape;
-        // #243: a slot with no seat in it yet is drawn as an empty recess.
-        // It keeps the rail on both of the panel's margins and shows where
-        // the next player will land — chrome, not a control: the ordinals
-        // are frozen, so a ghost is never navigable, highlightable or
-        // clickable, and it appears only while a seat is actually claimable.
-        for (int slot = rail.shown_cards; slot < rail.slot_count(); ++slot) {
-            game->draw_button_inverted(
-                rail.slot_x[static_cast<std::size_t>(slot)],
-                kBaseCampSeatRailY, static_cast<Uint32>(rail.card_w),
-                static_cast<Uint32>(kBaseCampSeatRailHeight));
-        }
-        const int seat_first = st->seat_page.first_index();
+        // A slot with no seat in it is a real ADD PLAYER button now, drawn by
+        // draw_buttons like every other row — there is no chrome left for
+        // this pass to paint. Only the chips are ours.
+        //
         // Positions come from the frame's laid-out shape; the COUNT must
-        // clamp to the seats st holds right now — the page can refresh
+        // clamp to the seats st holds right now — the roster can refresh
         // between the rewire and this draw, and a chip may only ever index
         // a seat that exists.
-        const int chip_cards = std::min(
-            rail.shown_cards,
-            std::max(0, st->seat_page.end_index() - seat_first));
+        const BaseCampRailSeats chip_seats = base_camp_rail_seats(st);
+        const int chip_cards = std::min(rail.shown_cards, chip_seats.count);
         for (int card = 0; card < chip_cards; ++card) {
             const og::sim::LobbyPlayer& seat =
-                st->seats[static_cast<std::size_t>(seat_first + card)];
+                *chip_seats.seat[static_cast<std::size_t>(card)];
             const int team = std::clamp(
                 static_cast<int>(seat.team), 0,
                 static_cast<int>(SCORE_TEAM_COUNT) - 1);
@@ -5068,137 +5119,103 @@ Sint32 base_camp_on_spec_row(int row, void* screen_state)
         return MENU_OK;
     }
 
-    if (row == kBaseCampSeatPagePrevIndex ||
-        row == kBaseCampSeatPageNextIndex)
-    {
-        if (st->seat_page.step(
-                row == kBaseCampSeatPagePrevIndex ? -1 : 1))
-        {
-            TRACE("basecamp", "seat_page %s",
-                  st->seat_page.indicator().c_str());
-        }
-        return MENU_OK;
-    }
-
-#ifndef DISABLE_MULTIPLAYER
-    if (row == kBaseCampAddSeatIndex) {
-        const std::int64_t now_ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::steady_clock::now().time_since_epoch())
-                .count();
-        constexpr std::int64_t kSeatAddDebounceMs = 250;
-        if (st->last_seat_add_ms >= 0 &&
-            now_ms - st->last_seat_add_ms < kSeatAddDebounceMs)
-        {
-            TRACE("basecamp", "seat_add_debounced");
-            return MENU_OK;
-        }
-        const std::size_t local_count =
-            picker_lobby_local_seat_count();
-        const int seat_cap = og::input::local_seat_cap();
-        if (local_count >= static_cast<std::size_t>(seat_cap)) {
-            // A phone runs out of seats below the build limit, and the way
-            // out is hardware, not a smaller number to argue with.
-            popup_dialog("SEATS",
-                         seat_cap < MAX_PLAYERS
-                             ? "ATTACH A GAMEPAD TO ADD SEATS"
-                             : "LOCAL LIMIT IS 4");
-            return MENU_OK;
-        }
-        if (picker_lobby_players().size() >=
-                og::sim::kMaxGlobalPlayers)
-        {
-            popup_dialog("SEATS", "LOBBY FULL");
-            return MENU_OK;
-        }
-        if (!picker_lobby_add_local_seat()) {
-            popup_dialog("SEATS", "ADD DENIED");
-            return MENU_OK;
-        }
-        st->last_seat_add_ms = now_ms;
-        // The new seat reads profile-pool slot N, which can duplicate a
-        // mapping an existing seat already cycled onto (the mid-game ADD
-        // PLAYER shares this rule): land it on the first unchosen one.
-        {
-            const int seat_count =
-                static_cast<int>(picker_lobby_local_seat_count());
-            bool controls_changed = og::ui::ensure_unique_seat_mapping(
-                cfg, seat_count - 1, seat_count);
-            // On a single-seat device the pad IS why this door opened: a
-            // keyboard mapping would leave the seat with no input at all.
-            if (og::input::is_single_seat_device() &&
-                og::ui::claim_free_joystick_for_seat(cfg, seat_count - 1,
-                                                     seat_count))
-            {
-                controls_changed = true;
-            }
-            if (controls_changed)
-            {
-                persist_player_controls();
-            }
-        }
-        base_camp_refresh_rows(*st);
-        if (!st->local_seat_indices.empty()) {
-            const std::uint8_t added_player =
-                st->local_seat_indices.back();
-            const auto added = std::find_if(
-                st->seats.begin(), st->seats.end(),
-                [added_player](const og::sim::LobbyPlayer& player) {
-                    return player.player_index == added_player;
-                });
-            if (added != st->seats.end()) {
-                const int position = static_cast<int>(
-                    std::distance(st->seats.begin(), added));
-                st->seat_page.page =
-                    position / kBaseCampSeatCardsPerPage;
-            }
-        }
-        TRACE("basecamp", "seat_add local_count=%zu",
-              picker_lobby_local_seat_count());
-        return MENU_OK;
-    }
-#endif
-
     if (row >= kBaseCampSeatCardBase &&
         row < kBaseCampSeatCardBase + kBaseCampSeatCardsPerPage)
     {
-        const int card = row - kBaseCampSeatCardBase;
-        const int seat_index = st->seat_page.first_index() + card;
-        if (seat_index < 0 ||
-            seat_index >= static_cast<int>(st->seats.size()))
-        {
+        const int slot = row - kBaseCampSeatCardBase;
+        const BaseCampRailSeats rail_seats = base_camp_rail_seats(st);
+        const og::sim::LobbyPlayer* const held =
+            slot < rail_seats.count
+            ? rail_seats.seat[static_cast<std::size_t>(slot)]
+            : nullptr;
+
+        if (held == nullptr) {
+            // A BARE SLOT IS THE ADD DOOR. This is the [+]'s whole body,
+            // moved here unchanged — one implementation of the rule, gates
+            // included. picker_lobby_add_local_seat is a build-limit
+            // backstop only; the device cap is enforced HERE, by the door.
+#ifndef DISABLE_MULTIPLAYER
+            const std::int64_t now_ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now().time_since_epoch())
+                    .count();
+            constexpr std::int64_t kSeatAddDebounceMs = 250;
+            if (st->last_seat_add_ms >= 0 &&
+                now_ms - st->last_seat_add_ms < kSeatAddDebounceMs)
+            {
+                TRACE("basecamp", "seat_add_debounced");
+                return MENU_OK;
+            }
+            const std::size_t local_count =
+                picker_lobby_local_seat_count();
+            const int seat_cap = og::input::local_seat_cap();
+            if (local_count >= static_cast<std::size_t>(seat_cap)) {
+                // A phone runs out of seats below the build limit, and the
+                // way out is hardware, not a smaller number to argue with.
+                popup_dialog("SEATS",
+                             seat_cap < MAX_PLAYERS
+                                 ? "ATTACH A GAMEPAD TO ADD SEATS"
+                                 : "LOCAL LIMIT IS 4");
+                return MENU_OK;
+            }
+            if (picker_lobby_players().size() >=
+                    og::sim::kMaxGlobalPlayers)
+            {
+                popup_dialog("SEATS", "LOBBY FULL");
+                return MENU_OK;
+            }
+            if (!picker_lobby_add_local_seat()) {
+                popup_dialog("SEATS", "ADD DENIED");
+                return MENU_OK;
+            }
+            st->last_seat_add_ms = now_ms;
+            // The new seat reads profile-pool slot N, which can duplicate a
+            // mapping an existing seat already cycled onto (the mid-game ADD
+            // PLAYER shares this rule): land it on the first unchosen one.
+            {
+                const int seat_count =
+                    static_cast<int>(picker_lobby_local_seat_count());
+                bool controls_changed = og::ui::ensure_unique_seat_mapping(
+                    cfg, seat_count - 1, seat_count);
+                // On a single-seat device the pad IS why this door opened: a
+                // keyboard mapping would leave the seat with no input at all.
+                if (og::input::is_single_seat_device() &&
+                    og::ui::claim_free_joystick_for_seat(cfg, seat_count - 1,
+                                                         seat_count))
+                {
+                    controls_changed = true;
+                }
+                if (controls_changed)
+                {
+                    persist_player_controls();
+                }
+            }
+            base_camp_refresh_rows(*st);
+            TRACE("basecamp", "seat_add local_count=%zu",
+                  picker_lobby_local_seat_count());
+#endif
             return MENU_OK;
         }
 
-        const og::sim::LobbyPlayer& seat =
-            st->seats[static_cast<std::size_t>(seat_index)];
-        const int local_slot =
-            base_camp_seat_local_slot(*st, seat.player_index);
-        if (local_slot < 0) {
-            const std::string owner = std::format(
-                "P{}  {}",
-                static_cast<int>(seat.player_index) + 1,
-                seat.company.empty() ? "ANOTHER COMPANY" : seat.company);
-            popup_dialog("CONTROLLED BY", owner.c_str());
-            return MENU_OK;
-        }
-
-        if (picker_lobby_local_seat_count() == 0) {
-            popup_dialog("SPECTATOR", "PRESS + TO ADD A PLAYER");
-            return MENU_OK;
-        }
+        // SLOT k IS LOCAL CONTROLLER PROFILE k. base_camp_rail_seats built
+        // this entry out of local_seat_indices[slot], so the editor's
+        // profile is the slot index itself — no second lookup, and no way
+        // for the card and the editor to name different profiles (the
+        // menu_system.md §3.1 hazard, where displayed P1 once drove
+        // profile 3).
+        const og::sim::LobbyPlayer& seat = *held;
+        const int local_slot = slot;
 
         // #202: a pointer click on the card's team-square region cycles the
         // seat's team in place through the seat editor's exact mutation
         // path. Keyboard FIRE / hotkey dispatches stamp menu_click_x = -1
         // and fall through to the editor, as do clicks on the P#/name
-        // region. Non-editable seats never reach here (the ownership and
-        // spectator gates above popped already).
+        // region.
         {
             // The rewire's cached frame shape: the click must be judged
             // against the rects the player saw, not a fresher recompute.
             const int card_x = g_base_camp_rail_frame_shape
-                                   .slot_x[static_cast<std::size_t>(card)];
+                                   .slot_x[static_cast<std::size_t>(slot)];
             const int click_x = pks().menu_click_x;
             if (click_x >= card_x + kBaseCampSeatChipZoneOffsetX &&
                 click_x < card_x + kBaseCampSeatCardWidth)
@@ -6994,12 +7011,6 @@ void base_camp_refresh_rows(BaseCampScreenState& state)
         for (const og::sim::LobbyPlayer& seat : state.seats)
             state.local_seat_indices.push_back(seat.player_index);
     }
-    const int seat_page_before = state.seat_page.page;
-    state.seat_page = PageModel::make(
-        static_cast<int>(state.seats.size()),
-        kBaseCampSeatCardsPerPage);
-    state.seat_page.page = std::clamp(
-        seat_page_before, 0, state.seat_page.page_count() - 1);
 }
 
 void install_company_list_state_for_screen(CompanyListScreenState* state)

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -2224,6 +2224,9 @@ static_assert(std::size(kHelpMenuRows) == kHelpMenuNextIndex + 1,
 // The company-list seam pattern: the per-frame rewire reads this file-static
 // pointer; run_menu_screen's screen_state points at the SAME object.
 BaseCampScreenState* g_base_camp_state = nullptr;
+// The frame's rail geometry, written by base_camp_rewire (see
+// base_camp_seat_rail_shape) and read by the draw and click consumers.
+og::ui::SeatRailLayout g_base_camp_rail_frame_shape;
 
 // Round-6 vertical rhythm: the panel's inner face is y=30..158. Header ink
 // is y=33..38; rows at y=45+14r leave six clear pixels after the header and
@@ -2543,8 +2546,7 @@ RowState base_camp_add_seat_state(const og::ui::SeatClaimability& claim)
 {
     if (og::ui::seats_still_claimable(claim) > 0)
         return RowState::Visible;
-    if (!claim.multiplayer_enabled)
-        return RowState::Hidden;
+    if (!claim.multiplayer_enabled) return RowState::Hidden;
     if (claim.local_count >= claim.local_seat_cap &&
         claim.local_seat_cap < MAX_PLAYERS)
     {
@@ -3595,12 +3597,14 @@ constexpr MenuScreenSpec make_seat_settings_spec(
     return spec;
 }
 
-// #243: the seat rail's live geometry, recomputed from the same inputs by
-// everything that needs it — the rewire that positions the seven ordinals,
-// the content pass that draws the ghost slots and the team chips, and the
-// pointer predicate that decides whether a click landed on a chip. All three
-// run inside one frame over unchanged lobby state, so recomputing is exact
-// and nothing has to cache a frame-scoped copy.
+// #243: the seat rail's live geometry. Computed ONCE per frame by the rewire
+// (which positions the seven ordinals from it) and cached in
+// g_base_camp_rail_frame_shape for the other two consumers — the content
+// pass (ghost slots, team chips) and the chip click predicate. They must
+// read the CACHE, not recompute: base_camp_frame_tick refreshes the seat
+// page between the rewire and the draw, so a recompute against the newer
+// state can disagree with the button rects already laid out this frame
+// (ghosts painting over real cards on a page flip).
 og::ui::SeatRailLayout base_camp_seat_rail_shape(
     const og::ui::BaseCampScreenState* st)
 {
@@ -3712,6 +3716,7 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
         : (ready_visible ? kCreateMenuReadyIndex : -1);
     const SaveData& save = og::runtime::current_session->myscreen_->save_data;
     const og::ui::SeatRailLayout rail_layout = base_camp_seat_rail_shape(st);
+    g_base_camp_rail_frame_shape = rail_layout;
     const bool add_visible = rail_layout.add_visible;
     buttons[kBaseCampAddSeatIndex].hidden = !add_visible;
     // #236: the rail's retired right-end ordinal stays parked with the zone
@@ -4691,7 +4696,9 @@ void base_camp_draw_content(void* screen_state)
     // draw. They use the same four gameplay-team ramps as character chips,
     // while the P# label identifies the player/view rather than a fighter.
     if (st != nullptr) {
-        const og::ui::SeatRailLayout rail = base_camp_seat_rail_shape(st);
+        // The rewire's cached frame shape — never recomputed here (the seat
+        // page may have refreshed since; the buttons on screen have not).
+        const og::ui::SeatRailLayout& rail = g_base_camp_rail_frame_shape;
         // #243: a slot with no seat in it yet is drawn as an empty recess.
         // It keeps the rail on both of the panel's margins and shows where
         // the next player will land — chrome, not a control: the ordinals
@@ -4704,7 +4711,14 @@ void base_camp_draw_content(void* screen_state)
                 static_cast<Uint32>(kBaseCampSeatRailHeight));
         }
         const int seat_first = st->seat_page.first_index();
-        for (int card = 0; card < rail.shown_cards; ++card) {
+        // Positions come from the frame's laid-out shape; the COUNT must
+        // clamp to the seats st holds right now — the page can refresh
+        // between the rewire and this draw, and a chip may only ever index
+        // a seat that exists.
+        const int chip_cards = std::min(
+            rail.shown_cards,
+            std::max(0, st->seat_page.end_index() - seat_first));
+        for (int card = 0; card < chip_cards; ++card) {
             const og::sim::LobbyPlayer& seat =
                 st->seats[static_cast<std::size_t>(seat_first + card)];
             const int team = std::clamp(
@@ -5178,7 +5192,9 @@ Sint32 base_camp_on_spec_row(int row, void* screen_state)
         // region. Non-editable seats never reach here (the ownership and
         // spectator gates above popped already).
         {
-            const int card_x = base_camp_seat_rail_shape(st)
+            // The rewire's cached frame shape: the click must be judged
+            // against the rects the player saw, not a fresher recompute.
+            const int card_x = g_base_camp_rail_frame_shape
                                    .slot_x[static_cast<std::size_t>(card)];
             const int click_x = pks().menu_click_x;
             if (click_x >= card_x + kBaseCampSeatChipZoneOffsetX &&
@@ -6832,8 +6848,8 @@ const MenuScreenSpec& help_menu_screen_spec()
         // The legacy help loop ran no remote-start check (a joiner parked
         // here launches when the main menu re-enters — the FX-subscreen
         // precedent). Fading is the #237 derivation's call: the main menu's
-        // HELP door is a context switch (depth 1) and fades; Base Camp's is
-        // nested and does not.
+        // HELP door dispatches with a peer note (a lateral menu move) and
+        // Base Camp's is nested — neither entry fades.
         .default_highlight = kHelpMenuBackIndex,
         // BACK carries MENU_REDRAW and ends the screen there.
         .exit_on_redraw = true,
@@ -6907,8 +6923,9 @@ const MenuScreenSpec& company_list_menu_screen_spec()
         // reports "not opened" and the re-entered main menu launches.
         .remote_start = RemoteStartScope::MainScope,
         .remote_start_exit = RemoteStartExit::ReturnMenuExit,
-        // The LOAD door enters after the main menu returns (depth 1), so the
-        // #237 derivation fades it.
+        // The LOAD door enters after the main menu returns (depth 1) but
+        // dispatches with a peer note — a lateral menu move, no fade. Only
+        // an OPENED company leaves the cluster (Base Camp's entry fades).
         // The retired load loop opened on BACK; keep that keyboard starting
         // point and its BACK -> row 0 -> ... -> BACK vertical cycle.
         .default_highlight = kCompanyListBackIndex,
@@ -6924,6 +6941,10 @@ const MenuScreenSpec& company_list_menu_screen_spec()
 void install_base_camp_state_for_screen(BaseCampScreenState* state)
 {
     g_base_camp_state = state;
+    // Prime the frame shape for the new state: the rewire refreshes it every
+    // frame, but the draw hooks are also driven directly (tests, the first
+    // compose) and must never read a shape left over from another state.
+    g_base_camp_rail_frame_shape = base_camp_seat_rail_shape(state);
 }
 
 void base_camp_refresh_rows(BaseCampScreenState& state)

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -3842,12 +3842,12 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
     }
     // Every vertical link into the rail lands on its leftmost visible slot,
     // and the strip's right end climbs to its rightmost. On a phone that is
-    // the same single slot; with no rail at all (a build with neither seats
-    // nor a door to one), links from above skip it to BACK.
-    const int rail_first = rail.empty() ? -1 : rail.front();
-    const int rail_last = rail.empty() ? -1 : rail.back();
-    const int rail_entry =
-        rail_first >= 0 ? rail_first : kCreateMenuBackIndex;
+    // the same single slot — and there is always at least that one:
+    // base_camp_seat_rail_slot_cap clamps to 1, so slot 0 is either this
+    // machine's first seat or the ADD PLAYER door into it, never hidden. The
+    // rail cannot be empty, so no link into it needs a fallback.
+    const int rail_first = rail.front();
+    const int rail_last = rail.back();
     for (std::size_t index = 0; index < rail.size(); ++index) {
         button& control = buttons[rail[index]];
         control.nav.left = index > 0 ? rail[index - 1] : -1;
@@ -4187,7 +4187,7 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
         else if (band_below_roster_top >= 0)
             down_exit = band_below_roster_top;
         else
-            down_exit = rail_entry;
+            down_exit = rail_first;
         buttons[bands_above[i].top].nav.up = up_exit;
         buttons[bands_above[i].bottom].nav.down = down_exit;
     }
@@ -4203,7 +4203,7 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
             up_exit = kCreateMenuHireIndex;
         const int down_exit = i + 1 < bands_below.size()
             ? bands_below[i + 1].top
-            : rail_entry;
+            : rail_first;
         buttons[bands_below[i].top].nav.up = up_exit;
         buttons[bands_below[i].bottom].nav.down = down_exit;
     }
@@ -4216,12 +4216,12 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
         : (can_hire ? kCreateMenuHireIndex : -1);
     const int dep_down_exit = band_below_roster_top >= 0
         ? band_below_roster_top
-        : rail_entry;
+        : rail_first;
     // The roster's body column drops onto the rail's leftmost live slot —
     // which IS the rail's entry now that no [+] or pager sits left of it.
     const int body_down_exit = band_below_roster_top >= 0
         ? band_below_roster_top
-        : rail_entry;
+        : rail_first;
 
     // Roster nav (the classic chains, walked over the presence arrays so a
     // capability-hidden column never strands a link).
@@ -4320,7 +4320,7 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
         ? kBaseCampRowBodyBase + first_body
         : (roster_top >= 0
                ? roster_top
-               : (spine_first >= 0 ? spine_first : rail_entry));
+               : (spine_first >= 0 ? spine_first : rail_first));
     buttons[kBaseCampPagePrevIndex].nav = {
         .up = -1,
         .down = pager_down,
@@ -4335,7 +4335,7 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
     // HIRE bridges the header band into the gameplay spine.
     buttons[kCreateMenuHireIndex].nav = {
         .up = -1,
-        .down = spine_first >= 0 ? spine_first : rail_entry,
+        .down = spine_first >= 0 ? spine_first : rail_first,
         .left = networked ? -1 : kBaseCampScenarioLineIndex,
         .right = pagers ? kBaseCampPagePrevIndex : -1};
 
@@ -4403,11 +4403,11 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
                 card_down[static_cast<std::size_t>(slot)];
         }
     }
-    const auto visible_card_or_rail = [buttons, rail_entry](int card) {
+    const auto visible_card_or_rail = [buttons, rail_first](int card) {
         return card >= 0 && card < kBaseCampSeatCardsPerPage &&
                 !buttons[kBaseCampSeatCardBase + card].hidden
             ? kBaseCampSeatCardBase + card
-            : rail_entry;
+            : rail_first;
     };
     buttons[kCreateMenuBackIndex].nav = {
         .up = rail_first, .down = -1, .left = -1,
@@ -4469,7 +4469,7 @@ void base_camp_rewire(button* buttons, int count, int& highlighted_button)
         && buttons[highlighted_button].hidden)
     {
         highlighted_button =
-            can_hire ? kCreateMenuHireIndex : rail_entry;
+            can_hire ? kCreateMenuHireIndex : rail_first;
     }
 
     for (int i = 0; i < count; ++i)
@@ -4548,9 +4548,12 @@ void base_camp_draw_content(void* screen_state)
     strip_text(244, 3, format_base_camp_gold_label(save), YELLOW);
 
     // Line B: solo scenario/deploy header, or the §9.12 (G5) networked
-    // session status — role + room code + machine/player census ("HOSTING
-    // GLAD-XXXX - 2 MACH / 3 PLYR" / "IN GLAD-XXXX - HOST: <company>") —
-    // with the degraded-link alert (join connecting/failed/lost, host
+    // session status — role + room code + player/machine census, players
+    // first ("HOSTING GLAD-XXXX: 3 PLAYERS / 2 MACHINES", falling through
+    // "3 PLAYERS/2 PCS" and "3P/2M" as the band narrows; a joiner reads
+    // "IN GLAD-XXXX: ..." and no longer names the host's company, which
+    // every one of its roster rows already carries) — with the
+    // degraded-link alert (join connecting/failed/lost, host
     // relay drop) keeping slot AND color precedence until the link heals.
     // This is the base-camp home of the lobby clients' status lines — the
     // pre-reshape team-build screen drew them at the same spot. The READY
@@ -6957,6 +6960,11 @@ const MenuScreenSpec& company_list_menu_screen_spec()
         .exit_value = MENU_REDRAW,
     };
     return spec;
+}
+
+bool base_camp_rail_slot_has_chip(int slot)
+{
+    return slot >= 0 && slot < g_base_camp_rail_frame_shape.shown_cards;
 }
 
 void install_base_camp_state_for_screen(BaseCampScreenState* state)

--- a/src/interface/ui/menu_screen_specs.cpp
+++ b/src/interface/ui/menu_screen_specs.cpp
@@ -1103,7 +1103,10 @@ Sint32 main_menu_on_spec_row(int row, void* /*screen_state*/)
 {
     if (row == kMainMenuCloudSpecArg)
     {
-        (void)run_cloud_save_screen();
+        // #237: CLOUD SAVES is a main-menu door whose screen runs NESTED in
+        // this loop (depth 2), so the depth rule can never see it — the
+        // shared nested-door bracket owns both halves of its fade.
+        (void)run_nested_menu_door(&run_cloud_save_screen);
         return MENU_REDRAW;
     }
     return 0;
@@ -6847,9 +6850,10 @@ const MenuScreenSpec& help_menu_screen_spec()
         .nav = {.kind = NavProgramKind::Rewire, .rewire = &help_engine_rewire},
         // The legacy help loop ran no remote-start check (a joiner parked
         // here launches when the main menu re-enters — the FX-subscreen
-        // precedent). Fading is the #237 derivation's call: the main menu's
-        // HELP door dispatches with a peer note (a lateral menu move) and
-        // Base Camp's is nested — neither entry fades.
+        // precedent). Fading is the #237 derivation's call, not a spec
+        // field: HELP is a main-menu door, so its entry and the main menu's
+        // re-entry behind BACK both fade. (There is no HELP row on Base
+        // Camp — ShowHelp appears only in the two main-menu tables.)
         .default_highlight = kHelpMenuBackIndex,
         // BACK carries MENU_REDRAW and ends the screen there.
         .exit_on_redraw = true,
@@ -6923,9 +6927,9 @@ const MenuScreenSpec& company_list_menu_screen_spec()
         // reports "not opened" and the re-entered main menu launches.
         .remote_start = RemoteStartScope::MainScope,
         .remote_start_exit = RemoteStartExit::ReturnMenuExit,
-        // The LOAD door enters after the main menu returns (depth 1) but
-        // dispatches with a peer note — a lateral menu move, no fade. Only
-        // an OPENED company leaves the cluster (Base Camp's entry fades).
+        // The LOAD door enters after the main menu returns (depth 1), so the
+        // #237 depth rule fades it — and fades the main menu again behind
+        // BACK. An OPENED company lands on Base Camp, whose entry fades too.
         // The retired load loop opened on BACK; keep that keyboard starting
         // point and its BACK -> row 0 -> ... -> BACK vertical cycle.
         .default_highlight = kCompanyListBackIndex,

--- a/src/interface/ui/pause_menu.cpp
+++ b/src/interface/ui/pause_menu.cpp
@@ -977,7 +977,10 @@ constexpr MenuScreenSpec make_pause_menu_spec()
     spec.nav = {.kind = NavProgramKind::Rewire, .rewire = &pause_menu_rewire};
     spec.remote_start = RemoteStartScope::None;
     spec.default_highlight = kPauseMenuResumeIndex;
-    spec.enter = EnterTransition::None;
+    // A true modal over the live (darkened) world: Overlay never fades,
+    // even at depth 1 — the only screens carrying this kind are the pause
+    // family (#237).
+    spec.kind = MenuScreenKind::Overlay;
     spec.backdrop = false;
     spec.polls_lobby = false;
     spec.draw_background = &pause_menu_draw_background;
@@ -1000,7 +1003,8 @@ constexpr MenuScreenSpec make_pause_player_spec()
                 .rewire = &pause_player_rewire};
     spec.remote_start = RemoteStartScope::None;
     spec.default_highlight = kPausePlayerInputIndex;
-    spec.enter = EnterTransition::None;
+    // Pause family: a mid-mission modal card, never faded (#237).
+    spec.kind = MenuScreenKind::Overlay;
     spec.exit_on_redraw = true;
     spec.backdrop = false;
     spec.polls_lobby = false;

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -746,8 +746,8 @@ public:
         // (and the re-entry behind it) as a main-menu-boundary crossing and
         // fade both. Note Instant on each leg to keep the door as snappy as
         // its HIRE/TRAIN/DIFFICULTY siblings. Only a successful hookup
-        // leaves the lobby-config context, and Base Camp's own entry fades
-        // that one.
+        // leaves the lobby-config context: the legacy screen fades its own
+        // last frame out on that exit and Base Camp's entry fades in.
         og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Instant);
         const bool hooked_up = configure_networking_body();
         if (!hooked_up)
@@ -777,12 +777,16 @@ public:
         // MenuEngine.networking_stays_legacy_v2_decision). The wrapper's
         // Instant note classifies this door as a Base Camp strip door, and
         // this scope is the note's consumer (the swallow-even-if-unused
-        // discipline): it is inactive here, so it fades nothing on entry or
-        // exit and the loop below presents plainly. If the wrapper's note is
-        // ever removed, this fades the menu out and in and out again —
-        // visible, not broken.
-        og::ui::LegacyMenuFade entry_fade;
-        (void)entry_fade;
+        // discipline): it is inactive here, so it fades nothing on entry,
+        // the loop below presents plainly, and BACK leaves the frame for
+        // Base Camp's instant re-entry. A successful hookup is different:
+        // it leaves the lobby-config context, Base Camp re-enters FADING,
+        // and that entry must find a black window — so this screen fades
+        // its own last frame out on the hookup exits (fade_out_at_exit),
+        // instant-in / fade-out-to-Base-Camp. If the wrapper's note is ever
+        // removed, this fades the menu out and in and out again — visible,
+        // not broken.
+        og::ui::LegacyMenuFade entry_fade("networking");
 
         auto visible_room_count = [&]() -> int {
             if (!networking_settings_.use_room_code ||
@@ -915,6 +919,7 @@ public:
                 if (submit_network_host())
                 {
                     cancel_relay_room_list_request();
+                    entry_fade.fade_out_at_exit();
                     return true;
                 }
                 reinitialize_buttons();
@@ -924,6 +929,7 @@ public:
                     submit_network_join())
                 {
                     cancel_relay_room_list_request();
+                    entry_fade.fade_out_at_exit();
                     return true;
                 }
                 reinitialize_buttons();
@@ -941,6 +947,7 @@ public:
                     if (submit_network_join())
                     {
                         cancel_relay_room_list_request();
+                        entry_fade.fade_out_at_exit();
                         return true;
                     }
                 }

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -730,6 +730,18 @@ public:
 
     bool configure_networking() override
     {
+        // #237: the NETWORKING door is a lateral menu move (instant), and so
+        // is BACK; only a successful hookup's exit to Base Camp is a context
+        // switch, and Base Camp's own entry fades it.
+        og::ui::note_menu_peer_transition();
+        const bool hooked_up = configure_networking_body();
+        if (!hooked_up)
+            og::ui::note_menu_peer_transition();
+        return hooked_up;
+    }
+
+    bool configure_networking_body()
+    {
 #ifdef __EMSCRIPTEN__
         constexpr std::string_view kRoomCodePlaceholder =
             "(tap to enter room code)";
@@ -747,8 +759,8 @@ public:
         pks().networking_clicked_room_slot = -1;
         begin_relay_room_list_view();
         // #237 depth rule, applied by hand (this screen stays legacy —
-        // MenuEngine.networking_stays_legacy_v2_decision): fade the main
-        // menu out now, fade the first composed frame in below.
+        // MenuEngine.networking_stays_legacy_v2_decision). The wrapper's
+        // peer note makes this consume-and-skip: no fade on the door.
         bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
 
         auto visible_room_count = [&]() -> int {
@@ -1118,12 +1130,20 @@ public:
 
     void show_options() override
     {
+        // #237: SETTINGS is a lateral move inside the menu cluster — neither
+        // its entry nor the main menu's re-entry is a context switch.
+        og::ui::note_menu_peer_transition();
         main_options();
+        og::ui::note_menu_peer_transition();
     }
 
     void show_help() override
     {
+        // #237: HELP's instant entry is a deliberate decision (the old
+        // spec pinned it); the way back stays instant too.
+        og::ui::note_menu_peer_transition();
         show_general_help();
+        og::ui::note_menu_peer_transition();
     }
 
     void run_game() override
@@ -1155,7 +1175,13 @@ public:
         // (a company opened: active slot + save + mount switched) proceeds
         // to team build; false (BACK / list emptied) re-presents the main
         // menu, whose entry refresh re-derives the CONTINUE/LOAD gate.
-        return og::ui::run_company_list_screen();
+        // #237: the door and the BACK path are lateral menu moves; only an
+        // OPENED company is a context switch (Base Camp's entry fades).
+        og::ui::note_menu_peer_transition();
+        const bool opened = og::ui::run_company_list_screen();
+        if (!opened)
+            og::ui::note_menu_peer_transition();
+        return opened;
     }
 
     og::ui::PickerScreen screen_after_game() const override

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -760,8 +760,12 @@ public:
         begin_relay_room_list_view();
         // #237 depth rule, applied by hand (this screen stays legacy —
         // MenuEngine.networking_stays_legacy_v2_decision). The wrapper's
-        // peer note makes this consume-and-skip: no fade on the door.
-        bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
+        // peer note classifies this door as instant, and this call is the
+        // note's consumer (the swallow-even-if-unused discipline): it always
+        // returns false here, and the loop below presents plainly. If the
+        // wrapper's note is ever removed, this fades the menu out and the
+        // first presented frame cuts in a beat later — visible, not broken.
+        (void)og::ui::begin_legacy_menu_entry_fade();
 
         auto visible_room_count = [&]() -> int {
             if (!networking_settings_.use_room_code ||
@@ -1025,14 +1029,8 @@ public:
             }
 
             draw_highlight(buttons[highlighted_button]);
-            if (entry_fade_in_pending) {
-                // fadeblack presents the composed buffer itself (#237).
-                entry_fade_in_pending = false;
-                og::runtime::current_session->myscreen_->fadeblack(1);
-            } else {
-                og::runtime::current_session->myscreen_->buffer_to_screen(
-                    0, 0, 320, 200);
-            }
+            og::runtime::current_session->myscreen_->buffer_to_screen(
+                0, 0, 320, 200);
             og::input_native::sleep_ms(10);
         }
 
@@ -1153,6 +1151,11 @@ public:
 
     bool load_game() override
     {
+        // #237: same door as show_company_list — a lateral menu move. Only
+        // scripted test clients reach this legacy transition; the return
+        // side keeps run_picker's legacy mapping and fades per the next
+        // screen's own rule.
+        og::ui::note_menu_peer_transition();
         // §2.3: the slot menu is retired — loading IS the Company List.
         // (Reached only via run_picker's legacy LoadGame transition; the
         // main-menu LOAD door routes through show_company_list directly.)

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -230,7 +230,12 @@ static void picker_initialize_shared_menu_state()
     pks().backdrops[3]->setxy(160, 100);
 
     og::runtime::current_session->myscreen_->viewob[0]->resize(PREF_VIEW_FULL);
-    og::runtime::current_session->myscreen_->clearbuffer();
+    // No clear here (#237 ownership): whatever the window shows when the
+    // picker starts (the loading dialog when the intro was skipped, the
+    // previous test's frame) is what the main menu's entry fade-out reads,
+    // and main_menu_draw_background clears before it paints. A clear between
+    // that last present and the fade is the hard-cut class the video layer
+    // flags under TESTING.
 
     pks().main_title_logo_data = read_pixie_file("title.png"); // marbled gladiator title
     pks().main_title_logo_pix = make_picker_pixie(pks().main_title_logo_data);
@@ -349,6 +354,11 @@ bool picker_try_intercept_button_action(Sint32 whatfunc, Sint32 call_arg, Sint32
         if (action == ButtonAction::Networking) {
             pks().selected_menu_item = og::ui::find_picker_menu_item(
                 og::ui::PickerMenuId::TeamBuild, og::ui::PickerMenuCommand::Networking);
+            // #237: NETWORKING is an instant Base Camp strip door, but Base
+            // Camp EXITS to open it. Noted before that exit so Base Camp's
+            // exit scope skips its fade-out (the note then rides through to
+            // the legacy screen's entry — configure_networking re-notes it).
+            og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Instant);
             retvalue = MENU_EXIT;
             return true;
         }
@@ -763,15 +773,16 @@ public:
         clear_keyboard();
         pks().networking_clicked_room_slot = -1;
         begin_relay_room_list_view();
-        // #237 depth rule, applied by hand (this screen stays legacy —
+        // #237 ownership rule, applied by hand (this screen stays legacy —
         // MenuEngine.networking_stays_legacy_v2_decision). The wrapper's
         // Instant note classifies this door as a Base Camp strip door, and
-        // this call is the note's consumer (the swallow-even-if-unused
-        // discipline): it always returns false here, and the loop below
-        // presents plainly. If the wrapper's note is ever removed, this
-        // fades the menu out and the first presented frame cuts in a beat
-        // later — visible, not broken.
-        (void)og::ui::begin_legacy_menu_entry_fade();
+        // this scope is the note's consumer (the swallow-even-if-unused
+        // discipline): it is inactive here, so it fades nothing on entry or
+        // exit and the loop below presents plainly. If the wrapper's note is
+        // ever removed, this fades the menu out and in and out again —
+        // visible, not broken.
+        og::ui::LegacyMenuFade entry_fade;
+        (void)entry_fade;
 
         auto visible_room_count = [&]() -> int {
             if (!networking_settings_.use_room_code ||
@@ -1091,12 +1102,13 @@ public:
 
     std::string show_campaign_select() override
     {
-#ifdef TESTING
-        // Keep legacy menu-injector tests stable: they script Begin New Game ->
-        // Hire menu directly and do not interact with the campaign picker UI.
-        // (This also keeps the blocking intro below out of every test flow.)
-        return og::runtime::current_session->myscreen_->save_data.current_campaign;
-#endif
+        // Under TESTING this leg runs for real too (it used to short-circuit
+        // to current_campaign, which hid the intro's fade regression from
+        // every flow test): the browser auto-accepts the current campaign one
+        // presented frame in unless a test disarms it
+        // (campaign_picker_testing_set_auto_accept), and the intro scroller
+        // dismisses itself after its first frame unless a test forces the
+        // real view (help_testing_set_force_scroll_text).
         screen* game = og::runtime::current_session->myscreen_;
         CampaignResult result = pick_campaign(&game->save_data);
         if (result.id.empty())
@@ -1119,16 +1131,15 @@ public:
 
         // The CHOSEN campaign's intro, now that the selection committed
         // (issue #186 — it used to show the default campaign's intro before
-        // the picker ever ran). #237: the cut to the intro is a context
-        // switch — fade the select screen out instead of hard-cutting. No
-        // black note: the scroller draws right after, and Base Camp's own
-        // entry fade-out owns the scroller's last frame.
+        // the picker ever ran). #237 ownership: campaign select faded its
+        // own last frame out; the intro fades in over that black and fades
+        // itself out on dismissal (read_campaign_intro's LegacyMenuFade), so
+        // Base Camp's entry finds a black window and fades in. Nothing here
+        // may clear the buffer between a screen's last present and its exit
+        // fade — that clear was the reported hard cut.
         release_mouse();
-        game->fadeblack(0);
         read_campaign_intro(game);
-        game->refresh();
         grab_mouse();
-        game->clear();
         return result.id;
     }
 
@@ -3417,10 +3428,10 @@ void picker_reinit_after_game()
     screen* const current_screen = og::runtime::current_session->myscreen_;
     current_screen->set_active_canvas(current_screen->last_presented_canvas());
     current_screen->fadeblack(0);
-    // #200: this IS the fade back to the menu, and it only blackened whichever
-    // canvas was last presented. Clear the other one too, and tell the next
-    // menu entry not to fade the stale image out a second time.
-    og::ui::note_menu_faded_to_black();
+    // #200: this IS the fade back to the menu (a no-op when the last screen
+    // — the results panel — already faded itself out), and it only blackened
+    // whichever canvas was last presented. Clear the other one too; the next
+    // menu entry finds a black window and fades in only.
     current_screen->clearbuffer();
     current_screen->set_active_canvas(CanvasTarget::UI);
     current_screen->clearbuffer();

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -210,11 +210,13 @@ void picker_mainmenu_loop()
     }
 }
 
-static void picker_initialize_shared_menu_state()
+// The tiled title backdrop every picker screen composes over: four quadrant
+// pixies pinned to the 320x200 corners. Factored out of menu entry so the one
+// loader serves both callers — picker_main below and the UX-shot probe, whose
+// networked fixtures build a screen directly and would otherwise capture a
+// frame no player ever sees (chrome on black).
+void picker_load_menu_backdrops()
 {
-    clear_allbuttons();
-
-    // Set backdrops to nullptr
     pks().backpics[0] = read_pixie_file("mainul.png");
     pks().backpics[1] = read_pixie_file("mainur.png");
     pks().backpics[2] = read_pixie_file("mainll.png");
@@ -228,6 +230,13 @@ static void picker_initialize_shared_menu_state()
     pks().backdrops[2]->setxy(0, 100);
     pks().backdrops[3] = make_picker_pixie(pks().backpics[3]);
     pks().backdrops[3]->setxy(160, 100);
+}
+
+static void picker_initialize_shared_menu_state()
+{
+    clear_allbuttons();
+
+    picker_load_menu_backdrops();
 
     og::runtime::current_session->myscreen_->viewob[0]->resize(PREF_VIEW_FULL);
     // No clear here (#237 ownership): whatever the window shows when the

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -746,6 +746,10 @@ public:
         clear_keyboard();
         pks().networking_clicked_room_slot = -1;
         begin_relay_room_list_view();
+        // #237 depth rule, applied by hand (this screen stays legacy —
+        // MenuEngine.networking_stays_legacy_v2_decision): fade the main
+        // menu out now, fade the first composed frame in below.
+        bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
 
         auto visible_room_count = [&]() -> int {
             if (!networking_settings_.use_room_code ||
@@ -1009,8 +1013,14 @@ public:
             }
 
             draw_highlight(buttons[highlighted_button]);
-            og::runtime::current_session->myscreen_->buffer_to_screen(
-                0, 0, 320, 200);
+            if (entry_fade_in_pending) {
+                // fadeblack presents the composed buffer itself (#237).
+                entry_fade_in_pending = false;
+                og::runtime::current_session->myscreen_->fadeblack(1);
+            } else {
+                og::runtime::current_session->myscreen_->buffer_to_screen(
+                    0, 0, 320, 200);
+            }
             og::input_native::sleep_ms(10);
         }
 
@@ -1093,10 +1103,12 @@ public:
 
         // The CHOSEN campaign's intro, now that the selection committed
         // (issue #186 — it used to show the default campaign's intro before
-        // the picker ever ran).
+        // the picker ever ran). #237: the cut to the intro is a context
+        // switch — fade the select screen out instead of hard-cutting. No
+        // black note: the scroller draws right after, and Base Camp's own
+        // entry fade-out owns the scroller's last frame.
         release_mouse();
-        game->clearbuffer();
-        game->swap();
+        game->fadeblack(0);
         read_campaign_intro(game);
         game->refresh();
         grab_mouse();
@@ -3378,7 +3390,7 @@ void picker_reinit_after_game()
     // #200: this IS the fade back to the menu, and it only blackened whichever
     // canvas was last presented. Clear the other one too, and tell the next
     // menu entry not to fade the stale image out a second time.
-    og::ui::suppress_next_menu_entry_fade_out();
+    og::ui::note_menu_faded_to_black();
     current_screen->clearbuffer();
     current_screen->set_active_canvas(CanvasTarget::UI);
     current_screen->clearbuffer();

--- a/src/interface/ui/picker.cpp
+++ b/src/interface/ui/picker.cpp
@@ -730,13 +730,18 @@ public:
 
     bool configure_networking() override
     {
-        // #237: the NETWORKING door is a lateral menu move (instant), and so
-        // is BACK; only a successful hookup's exit to Base Camp is a context
-        // switch, and Base Camp's own entry fades it.
-        og::ui::note_menu_peer_transition();
+        // #237: NETWORKING is a Base Camp strip door, and everything deeper
+        // than the main menu is instant both ways — but Base Camp EXITS
+        // before this screen runs, so the depth rule would read the entry
+        // (and the re-entry behind it) as a main-menu-boundary crossing and
+        // fade both. Note Instant on each leg to keep the door as snappy as
+        // its HIRE/TRAIN/DIFFICULTY siblings. Only a successful hookup
+        // leaves the lobby-config context, and Base Camp's own entry fades
+        // that one.
+        og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Instant);
         const bool hooked_up = configure_networking_body();
         if (!hooked_up)
-            og::ui::note_menu_peer_transition();
+            og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Instant);
         return hooked_up;
     }
 
@@ -760,11 +765,12 @@ public:
         begin_relay_room_list_view();
         // #237 depth rule, applied by hand (this screen stays legacy —
         // MenuEngine.networking_stays_legacy_v2_decision). The wrapper's
-        // peer note classifies this door as instant, and this call is the
-        // note's consumer (the swallow-even-if-unused discipline): it always
-        // returns false here, and the loop below presents plainly. If the
-        // wrapper's note is ever removed, this fades the menu out and the
-        // first presented frame cuts in a beat later — visible, not broken.
+        // Instant note classifies this door as a Base Camp strip door, and
+        // this call is the note's consumer (the swallow-even-if-unused
+        // discipline): it always returns false here, and the loop below
+        // presents plainly. If the wrapper's note is ever removed, this
+        // fades the menu out and the first presented frame cuts in a beat
+        // later — visible, not broken.
         (void)og::ui::begin_legacy_menu_entry_fade();
 
         auto visible_room_count = [&]() -> int {
@@ -1128,20 +1134,19 @@ public:
 
     void show_options() override
     {
-        // #237: SETTINGS is a lateral move inside the menu cluster — neither
-        // its entry nor the main menu's re-entry is a context switch.
-        og::ui::note_menu_peer_transition();
+        // #237: GAME SETTINGS is a main-menu door — Base Camp exits, the
+        // screen runs at depth 1, and the main menu re-enters at depth 1
+        // behind it. Both legs fade by the plain depth rule; no note.
         main_options();
-        og::ui::note_menu_peer_transition();
     }
 
     void show_help() override
     {
-        // #237: HELP's instant entry is a deliberate decision (the old
-        // spec pinned it); the way back stays instant too.
-        og::ui::note_menu_peer_transition();
+        // #237: same shape as SETTINGS — the depth rule fades HELP's entry
+        // and the main menu's re-entry. (Master's explicit "help never
+        // fades" spec field was half of the reported asymmetry: it entered
+        // instantly and faded on the way back.)
         show_general_help();
-        og::ui::note_menu_peer_transition();
     }
 
     void run_game() override
@@ -1151,11 +1156,10 @@ public:
 
     bool load_game() override
     {
-        // #237: same door as show_company_list — a lateral menu move. Only
-        // scripted test clients reach this legacy transition; the return
-        // side keeps run_picker's legacy mapping and fades per the next
-        // screen's own rule.
-        og::ui::note_menu_peer_transition();
+        // #237: same door as show_company_list — a main-menu door, so the
+        // depth rule fades it. Only scripted test clients reach this legacy
+        // transition; the return side keeps run_picker's legacy mapping and
+        // fades per the next screen's own rule.
         // §2.3: the slot menu is retired — loading IS the Company List.
         // (Reached only via run_picker's legacy LoadGame transition; the
         // main-menu LOAD door routes through show_company_list directly.)
@@ -1178,13 +1182,10 @@ public:
         // (a company opened: active slot + save + mount switched) proceeds
         // to team build; false (BACK / list emptied) re-presents the main
         // menu, whose entry refresh re-derives the CONTINUE/LOAD gate.
-        // #237: the door and the BACK path are lateral menu moves; only an
-        // OPENED company is a context switch (Base Camp's entry fades).
-        og::ui::note_menu_peer_transition();
-        const bool opened = og::ui::run_company_list_screen();
-        if (!opened)
-            og::ui::note_menu_peer_transition();
-        return opened;
+        // #237: LOAD is a main-menu door — the depth rule fades the list's
+        // entry, the re-entered main menu behind BACK, and (when a company
+        // opened) Base Camp instead. No note on any leg.
+        return og::ui::run_company_list_screen();
     }
 
     og::ui::PickerScreen screen_after_game() const override

--- a/src/interface/ui/picker_common.cpp
+++ b/src/interface/ui/picker_common.cpp
@@ -1729,14 +1729,23 @@ std::string format_base_camp_session_status(
     const std::string room_part = room.empty()
         ? head
         : std::format("{} {}", is_host ? "HOSTING" : "IN", room);
+    // One is one. A solo host reading "1 PLAYERS / 1 MACHINES" is the line
+    // telling him it cannot count, and the singular is always the SHORTER
+    // spelling — it can never push a rung off its band.
+    const auto counted = [](int value, std::string_view one,
+                            std::string_view many) {
+        return std::format("{} {}", value, value == 1 ? one : many);
+    };
     // The ladder, widest first: each rung is a whole spelling that either
     // fits or falls to the next — never a byte cut of the one above.
     // "PCS" is the everyday word for the thing "MACHINES" names precisely;
-    // at 1-digit counts the two rungs land exactly on the 41 and 34 bands.
+    // at 1-digit plural counts the two rungs land exactly on the 41 and 34
+    // bands, and the singular forms sit a word inside them.
     const std::array<std::string, 3> rungs{
-        std::format("{} PLAYERS / {} MACHINES", census.players,
-                    census.machines),
-        std::format("{} PLAYERS/{} PCS", census.players, census.machines),
+        std::format("{} / {}", counted(census.players, "PLAYER", "PLAYERS"),
+                    counted(census.machines, "MACHINE", "MACHINES")),
+        std::format("{}/{}", counted(census.players, "PLAYER", "PLAYERS"),
+                    counted(census.machines, "PC", "PCS")),
         std::format("{}P/{}M", census.players, census.machines)};
     for (const std::string& rung : rungs) {
         std::string status = std::format("{}: {}", room_part, rung);

--- a/src/interface/ui/picker_common.cpp
+++ b/src/interface/ui/picker_common.cpp
@@ -1481,22 +1481,6 @@ std::string clip_chars(std::string value, std::size_t max_chars)
     return value;
 }
 
-// A mid-word cut on a status line reads as corruption ("IRON KETTLE B"), so
-// a name that must lose characters loses whole words — as long as half the
-// budget survives; below that the whole-word remainder says less than the
-// bytes do.
-std::string clip_words(std::string value, std::size_t max_chars)
-{
-    if (value.size() <= max_chars)
-        return value;
-    const std::size_t space = value.find_last_of(' ', max_chars);
-    if (space != std::string::npos && space * 2 >= max_chars)
-        value.resize(space);
-    else
-        value.resize(max_chars);
-    return value;
-}
-
 } // namespace
 
 std::string clip_with_ellipsis(std::string value, std::size_t max_chars)
@@ -1723,19 +1707,6 @@ BaseCampSessionCensus count_base_camp_session_census(
     return census;
 }
 
-std::string base_camp_host_display_name(
-    const std::vector<og::sim::LobbyPlayer>& players)
-{
-    for (const og::sim::LobbyPlayer& player : players) {
-        if (!player.is_host)
-            continue;
-        if (!player.company.empty())
-            return clip_chars(player.company, 16);
-        return clip_chars(player.name, 16);
-    }
-    return {};
-}
-
 std::string format_base_camp_session_status(
     bool is_host,
     std::string_view room_code,
@@ -1747,49 +1718,35 @@ std::string format_base_camp_session_status(
     // Room codes display-clip at 12 (relay codes are 9-char "GLAD-XXXX";
     // the NETWORKING screen keeps the authoritative full form).
     const std::string room = clip_chars(std::string(room_code), 12);
-    if (is_host) {
-        // §9.12 budget note: "MACH / PLYR" is the recorded "shape like"
-        // latitude call — the spelled-out census overruns even the wide
-        // band at double-digit counts ("HOSTING GLAD-XXXX - 16 MACHINES /
-        // 16 PLAYERS" = 44). Beside HIRE the band is 34 and the everyday
-        // "HOSTING GLAD-7Q2F - 2 MACH / 3 PLYR" (35) no longer fits, so
-        // the census has a compact spelling too: "2M / 3P" says what
-        // "3 PLY" cannot.
-        const BaseCampSessionCensus census =
-            count_base_camp_session_census(players);
-        const std::string tight =
-            std::format("{}M / {}P", census.machines, census.players);
-        const auto compose = [&room](const std::string& census_part) {
-            return room.empty()
-                ? std::format("HOSTING {}", census_part)
-                : std::format("HOSTING {} - {}", room, census_part);
-        };
-        std::string status = compose(std::format(
-            "{} MACH / {} PLYR", census.machines, census.players));
-        if (status.size() > budget)
-            status = compose(tight);
-        // A pathological room code can still over-run: the census is the
-        // half that changes, so the room code (authoritative on the
-        // NETWORKING screen) is the half that goes.
-        if (status.size() > budget)
-            status = std::format("HOSTING {}", tight);
-        return clip_chars(std::move(status), budget);
+    const BaseCampSessionCensus census =
+        count_base_camp_session_census(players);
+    // PLAYERS FIRST. The rail shows this machine's seats only, so the count
+    // of everyone in the lobby has nowhere else to live; machines are the
+    // second-order fact (how many rooms the noise is coming from). The
+    // joiner's line drops "HOST: <company>" — the host's company already
+    // sits on every one of its roster rows, and the census does not.
+    const std::string head = is_host ? "HOSTING" : "JOINED";
+    const std::string room_part = room.empty()
+        ? head
+        : std::format("{} {}", is_host ? "HOSTING" : "IN", room);
+    // The ladder, widest first: each rung is a whole spelling that either
+    // fits or falls to the next — never a byte cut of the one above.
+    // "PCS" is the everyday word for the thing "MACHINES" names precisely;
+    // at 1-digit counts the two rungs land exactly on the 41 and 34 bands.
+    const std::array<std::string, 3> rungs{
+        std::format("{} PLAYERS / {} MACHINES", census.players,
+                    census.machines),
+        std::format("{} PLAYERS/{} PCS", census.players, census.machines),
+        std::format("{}P/{}M", census.players, census.machines)};
+    for (const std::string& rung : rungs) {
+        std::string status = std::format("{}: {}", room_part, rung);
+        if (status.size() <= budget)
+            return status;
     }
-    const std::string host_name = base_camp_host_display_name(players);
-    const std::string room_part =
-        room.empty() ? std::string("JOINED") : std::format("IN {}", room);
-    if (host_name.empty())
-        return clip_chars(room_part, budget);
-    std::string status = std::format("{} - HOST: {}", room_part, host_name);
-    if (status.size() <= budget)
-        return status;
-    // Tight band: "HOST: " is the label, the company is the information —
-    // drop the label first, then shed whole words off the company.
-    const std::size_t prefix = room_part.size() + 3;  // "<room> - "
-    status = std::format(
-        "{} - {}", room_part,
-        clip_words(host_name, prefix < budget ? budget - prefix : 0u));
-    return clip_chars(std::move(status), budget);
+    // A pathological room code can still over-run: the census is the half
+    // that changes, so the room code (authoritative on the NETWORKING
+    // screen) is the half that goes.
+    return clip_chars(std::format("{}: {}", head, rungs[2]), budget);
 }
 
 BaseCampLineB compose_base_camp_line_b(
@@ -2999,68 +2956,32 @@ int seats_still_claimable(const SeatClaimability& claim)
     return std::max(0, std::min(local_room, global_room));
 }
 
-int base_camp_seat_rail_ghost_count(const SeatRailGhostInputs& in)
+int base_camp_seat_rail_slot_cap(const SeatClaimability& claim)
 {
-    if (!in.on_last_page)
-        return 0;
-    const int claimable = seats_still_claimable(in.claim);
-    if (claimable <= 0)
-        return 0;
-    const int cards = std::clamp(in.visible_cards, 0, kSeatRailSlots);
-    return std::min(kSeatRailSlots - cards, claimable);
+    if (!claim.multiplayer_enabled)
+        return 1;
+    return std::clamp(claim.local_seat_cap, 1, kSeatRailSlots);
 }
 
-SeatRailLayout base_camp_seat_rail_layout(bool add_visible,
-                                          bool pagers_visible,
-                                          int visible_cards, int ghost_count)
+int base_camp_seat_rail_placeholder_count(const SeatClaimability& claim)
+{
+    return std::clamp(base_camp_seat_rail_slot_cap(claim) - claim.local_count,
+                      0, kSeatRailSlots);
+}
+
+SeatRailLayout base_camp_seat_rail_layout(int visible_cards,
+                                          int placeholder_count)
 {
     SeatRailLayout out;
-    out.add_visible = add_visible;
-    out.pagers_visible = pagers_visible;
     out.shown_cards = std::clamp(visible_cards, 0, kSeatRailSlots);
-    out.ghost_count =
-        std::clamp(ghost_count, 0, kSeatRailSlots - out.shown_cards);
-    out.slot_x.fill(kSeatRailX0);
-
-    const int slots = out.slot_count();
-    // The '>' pager anchors the rail's right margin whenever it is shown;
-    // the left-to-right run ([+], '<', slots) lays out against the gutter
-    // before it. A full row of slots justifies across that span (closing
-    // the run on the margin); a short row left-packs at the minimum gutter
-    // instead — stretching two or three controls across the panel reads as
-    // broken, and the anchored '>' keeps the right margin held either way.
-    if (pagers_visible)
-        out.next_x = kSeatRailRightX - kSeatRailPagerWidth;
-    const int run_elements =
-        (add_visible ? 1 : 0) + (pagers_visible ? 1 : 0) + slots;
-    const int run_face = (add_visible ? kSeatRailAddWidth : 0) +
-        (pagers_visible ? kSeatRailPagerWidth : 0) +
-        slots * kSeatRailCardWidth;
-    const int run_right = pagers_visible ? out.next_x - kSeatRailGap
-                                         : kSeatRailRightX;
-
-    int gap = kSeatRailGap;
-    int wide_gutters = 0;  // the leftmost gutters that take the odd pixel
-    if (slots == kSeatRailSlots && run_elements > 1) {
-        const int slack = std::max(0, run_right - kSeatRailX0 - run_face);
-        gap = slack / (run_elements - 1);
-        wide_gutters = slack % (run_elements - 1);
+    out.placeholder_count =
+        std::clamp(placeholder_count, 0, kSeatRailSlots - out.shown_cards);
+    // Every slot keeps its grid x whether or not it is live this frame: the
+    // hidden ones are what a returning player's seat lands back on.
+    for (int slot = 0; slot < kSeatRailSlots; ++slot) {
+        out.slot_x[static_cast<std::size_t>(slot)] =
+            kSeatRailX0 + slot * (kSeatRailCardWidth + kSeatRailGap);
     }
-
-    int pen = kSeatRailX0;
-    int gutter = 0;
-    const auto place = [&](int width) {
-        const int at = pen;
-        pen += width + gap + (gutter < wide_gutters ? 1 : 0);
-        ++gutter;
-        return at;
-    };
-    if (add_visible)
-        out.add_x = place(kSeatRailAddWidth);
-    if (pagers_visible)
-        out.prev_x = place(kSeatRailPagerWidth);
-    for (int slot = 0; slot < slots; ++slot)
-        out.slot_x[static_cast<std::size_t>(slot)] = place(kSeatRailCardWidth);
     return out;
 }
 

--- a/src/interface/ui/picker_common.cpp
+++ b/src/interface/ui/picker_common.cpp
@@ -3023,18 +3023,28 @@ SeatRailLayout base_camp_seat_rail_layout(bool add_visible,
     out.slot_x.fill(kSeatRailX0);
 
     const int slots = out.slot_count();
-    const int elements =
-        (add_visible ? 1 : 0) + (pagers_visible ? 2 : 0) + slots;
-    const int face = (add_visible ? kSeatRailAddWidth : 0) +
-        (pagers_visible ? 2 * kSeatRailPagerWidth : 0) +
+    // The '>' pager anchors the rail's right margin whenever it is shown;
+    // the left-to-right run ([+], '<', slots) lays out against the gutter
+    // before it. A full row of slots justifies across that span (closing
+    // the run on the margin); a short row left-packs at the minimum gutter
+    // instead — stretching two or three controls across the panel reads as
+    // broken, and the anchored '>' keeps the right margin held either way.
+    if (pagers_visible)
+        out.next_x = kSeatRailRightX - kSeatRailPagerWidth;
+    const int run_elements =
+        (add_visible ? 1 : 0) + (pagers_visible ? 1 : 0) + slots;
+    const int run_face = (add_visible ? kSeatRailAddWidth : 0) +
+        (pagers_visible ? kSeatRailPagerWidth : 0) +
         slots * kSeatRailCardWidth;
+    const int run_right = pagers_visible ? out.next_x - kSeatRailGap
+                                         : kSeatRailRightX;
 
     int gap = kSeatRailGap;
     int wide_gutters = 0;  // the leftmost gutters that take the odd pixel
-    if ((slots == kSeatRailSlots || pagers_visible) && elements > 1) {
-        const int slack = std::max(0, kSeatRailRightX - kSeatRailX0 - face);
-        gap = slack / (elements - 1);
-        wide_gutters = slack % (elements - 1);
+    if (slots == kSeatRailSlots && run_elements > 1) {
+        const int slack = std::max(0, run_right - kSeatRailX0 - run_face);
+        gap = slack / (run_elements - 1);
+        wide_gutters = slack % (run_elements - 1);
     }
 
     int pen = kSeatRailX0;
@@ -3051,8 +3061,6 @@ SeatRailLayout base_camp_seat_rail_layout(bool add_visible,
         out.prev_x = place(kSeatRailPagerWidth);
     for (int slot = 0; slot < slots; ++slot)
         out.slot_x[static_cast<std::size_t>(slot)] = place(kSeatRailCardWidth);
-    if (pagers_visible)
-        out.next_x = place(kSeatRailPagerWidth);
     return out;
 }
 

--- a/src/interface/ui/picker_common.cpp
+++ b/src/interface/ui/picker_common.cpp
@@ -2988,6 +2988,74 @@ void TrainSession::clamp_working_stats()
         working_->upgrade_to_level(original->level);
 }
 
+// --- Base Camp player-seat rail geometry (#243) ---
+
+int seats_still_claimable(const SeatClaimability& claim)
+{
+    if (!claim.multiplayer_enabled)
+        return 0;
+    const int local_room = claim.local_seat_cap - claim.local_count;
+    const int global_room = claim.global_cap - claim.global_count;
+    return std::max(0, std::min(local_room, global_room));
+}
+
+int base_camp_seat_rail_ghost_count(const SeatRailGhostInputs& in)
+{
+    if (!in.on_last_page)
+        return 0;
+    const int claimable = seats_still_claimable(in.claim);
+    if (claimable <= 0)
+        return 0;
+    const int cards = std::clamp(in.visible_cards, 0, kSeatRailSlots);
+    return std::min(kSeatRailSlots - cards, claimable);
+}
+
+SeatRailLayout base_camp_seat_rail_layout(bool add_visible,
+                                          bool pagers_visible,
+                                          int visible_cards, int ghost_count)
+{
+    SeatRailLayout out;
+    out.add_visible = add_visible;
+    out.pagers_visible = pagers_visible;
+    out.shown_cards = std::clamp(visible_cards, 0, kSeatRailSlots);
+    out.ghost_count =
+        std::clamp(ghost_count, 0, kSeatRailSlots - out.shown_cards);
+    out.slot_x.fill(kSeatRailX0);
+
+    const int slots = out.slot_count();
+    const int elements =
+        (add_visible ? 1 : 0) + (pagers_visible ? 2 : 0) + slots;
+    const int face = (add_visible ? kSeatRailAddWidth : 0) +
+        (pagers_visible ? 2 * kSeatRailPagerWidth : 0) +
+        slots * kSeatRailCardWidth;
+
+    int gap = kSeatRailGap;
+    int wide_gutters = 0;  // the leftmost gutters that take the odd pixel
+    if ((slots == kSeatRailSlots || pagers_visible) && elements > 1) {
+        const int slack = std::max(0, kSeatRailRightX - kSeatRailX0 - face);
+        gap = slack / (elements - 1);
+        wide_gutters = slack % (elements - 1);
+    }
+
+    int pen = kSeatRailX0;
+    int gutter = 0;
+    const auto place = [&](int width) {
+        const int at = pen;
+        pen += width + gap + (gutter < wide_gutters ? 1 : 0);
+        ++gutter;
+        return at;
+    };
+    if (add_visible)
+        out.add_x = place(kSeatRailAddWidth);
+    if (pagers_visible)
+        out.prev_x = place(kSeatRailPagerWidth);
+    for (int slot = 0; slot < slots; ++slot)
+        out.slot_x[static_cast<std::size_t>(slot)] = place(kSeatRailCardWidth);
+    if (pagers_visible)
+        out.next_x = place(kSeatRailPagerWidth);
+    return out;
+}
+
 // --- Player seats (#218 seat block) ---
 
 std::string company_abbreviation(std::string_view company)

--- a/src/interface/ui/picker_input.cpp
+++ b/src/interface/ui/picker_input.cpp
@@ -222,7 +222,8 @@ bool handle_menu_nav(button* buttons, int& highlighted_button, Sint32& retvalue,
             if(use_global_vbuttons)
             {
                 og::runtime::current_session->allbuttons_[static_cast<std::size_t>(highlighted_button)]->vdisplay(1);
-                og::runtime::current_session->allbuttons_[static_cast<std::size_t>(highlighted_button)]->vdisplay();
+                // Pressed, then released — both presented (see vbutton::vdisplay).
+                og::runtime::current_session->allbuttons_[static_cast<std::size_t>(highlighted_button)]->vdisplay(0);
                 if(og::runtime::current_session->allbuttons_[static_cast<std::size_t>(highlighted_button)]->myfunc)
                 {
                     // Coordinate-free activation: never leave a stale pointer

--- a/src/interface/ui/picker_main_menu.cpp
+++ b/src/interface/ui/picker_main_menu.cpp
@@ -96,10 +96,12 @@ bool picker_prepare_new_game_setup()
 	// Starting new game .. The campaign intro is NOT shown here anymore:
 	// the campaign select comes next, and the intro belongs to the campaign
 	// the player actually picks (SdlPickerClient::show_campaign_select).
+	// #237: this used to be a hard cut (clearbuffer + swap); a context
+	// switch fades. The note lets campaign select skip its own fade-out
+	// instead of playing black-to-black.
 	release_mouse();
-	game->clearbuffer();
-	game->swap();
-	game->refresh();
+	game->fadeblack(0);
+	og::ui::note_menu_faded_to_black();
 	grab_mouse();
 	game->clear();
 

--- a/src/interface/ui/picker_main_menu.cpp
+++ b/src/interface/ui/picker_main_menu.cpp
@@ -96,13 +96,10 @@ bool picker_prepare_new_game_setup()
 	// Starting new game .. The campaign intro is NOT shown here anymore:
 	// the campaign select comes next, and the intro belongs to the campaign
 	// the player actually picks (SdlPickerClient::show_campaign_select).
-	// #237: this used to be a hard cut (clearbuffer + swap); a context
-	// switch fades. The note lets campaign select skip its own fade-out
-	// instead of playing black-to-black.
-	release_mouse();
-	game->fadeblack(0);
-	og::ui::note_menu_faded_to_black();
-	grab_mouse();
+	// #237 ownership: name entry's exit already faded its own frame out
+	// (run_menu_screen's exit scope), so the window is black here and the
+	// clears above and below touch nothing a fade will read. Campaign select
+	// fades its first frame in over that black.
 	game->clear();
 
 	// Clear the playable-family labeling counters.

--- a/src/interface/ui/picker_sdl_defs.h
+++ b/src/interface/ui/picker_sdl_defs.h
@@ -198,24 +198,34 @@ inline constexpr int kCreateMenuGoIndex = 31;
 inline constexpr int kCreateMenuReadyIndex = 32;
 // Per-level player-seat assignment rail. Appended after the original
 // ordinals so every established Base Camp action index stays stable.
-// #236: the rail reads [+] | < | four cards | >. The ordinal that used to
-// carry the SEATS label — a second, worse-placed door to the team overview
-// the SCENARIO submenu already owned — carries the '+' now, at the rail's
-// left edge; the right-end ordinal the '+' vacated parks as a hidden spare
-// so no established index moved.
+// The rail is THIS MACHINE'S four seat slots, 35..38 — slot k IS local
+// controller profile k. A slot with no seat in it is an ADD PLAYER button
+// on the same ordinal, so a placeholder needs no ordinal of its own.
+//
+// PARKED. Ordinals 33, 34 and 39 carried the [+] and the two seat pagers
+// before remote seats left the rail. Ordinals are append-only — a removed
+// row would shift all 40 rows after it — so the three park exactly like
+// ordinal 40 has since #236: zero-size rect, empty label, hidden, no nav,
+// re-parked every frame by the rewire. Their names keep the history.
 inline constexpr int kBaseCampAddSeatIndex = 33;
 inline constexpr int kBaseCampSeatPagePrevIndex = 34;
 inline constexpr int kBaseCampSeatCardBase = 35; // seat_card_0..3 = 35..38
 inline constexpr int kBaseCampSeatPageNextIndex = 39;
 inline constexpr int kBaseCampSeatRailSpareIndex = 40;
+// The four parked rail ordinals, in table order, for the rewire's per-frame
+// re-park (and the layout test's spare sweep).
+inline constexpr std::array<int, 4> kBaseCampSeatRailSpares{
+    kBaseCampAddSeatIndex, kBaseCampSeatPagePrevIndex,
+    kBaseCampSeatPageNextIndex, kBaseCampSeatRailSpareIndex};
 // Per-row move-up controls are appended so every established Base Camp
 // ordinal remains stable. Only owned rows after the first owned roster member
 // expose one; activating it swaps that member with its predecessor.
 inline constexpr int kBaseCampMoveUpBase = 41; // roster_up_0..7 = 41..48
 inline constexpr int kBaseCampSeatCardsPerPage = 4;
-// The compact 57px seat card is drawn without the beveled inset, so its
-// budget is the full face: 57 / 6 = 9 characters, trailing pad included.
-inline constexpr int kBaseCampSeatCardLabelBudget = 9;
+// The 70px seat card is drawn without the beveled inset, so its budget is the
+// full face: 70 / 6 = 11 characters, trailing pad included. Eleven is what
+// makes "ADD PLAYER" and "LOBBY FULL" (10 each) fit a bare slot.
+inline constexpr int kBaseCampSeatCardLabelBudget = 11;
 // The compact seat-rail/move-up band's ordinal bounds: draw_menu_highlight
 // keeps its interior focus ring INSIDE this range so a card's ring can never
 // paint over its numbered team chip — appended zone rows past it take the

--- a/src/interface/ui/picker_sdl_defs.h
+++ b/src/interface/ui/picker_sdl_defs.h
@@ -232,6 +232,16 @@ inline constexpr int kBaseCampSeatCardLabelBudget = 11;
 // normal exterior ring.
 inline constexpr int kBaseCampInteriorRingFirstIndex = kBaseCampAddSeatIndex;
 inline constexpr int kBaseCampInteriorRingLastIndex = 48;
+namespace og::ui {
+// True when rail slot k (0..3) is a SEAT CARD this frame — the only shape
+// that packs a numbered team chip into the face's last nine pixels, and so
+// the only one whose focus ring needs the chip clearance. A bare slot's
+// ADD PLAYER / LOBBY FULL label is ten glyphs with no trailing pad: its ink
+// runs to x+64, and a ring cut back to x+60 would strike through it.
+// Reads the rewire's cached frame shape — the same one the chip pass reads,
+// so the ring and the chip can never disagree about which slots have one.
+bool base_camp_rail_slot_has_chip(int slot);
+} // namespace og::ui
 // --- The appended gameplay-zone band (docs/basecamp-zones-design.md
 // "Bounds arithmetic"): ordinals 49..71, statically PARKED at zero-size
 // rects with empty labels (gate-lattice safe) and re-banded per frame by the

--- a/src/interface/ui/picker_sdl_defs.h
+++ b/src/interface/ui/picker_sdl_defs.h
@@ -223,8 +223,10 @@ inline constexpr std::array<int, 4> kBaseCampSeatRailSpares{
 inline constexpr int kBaseCampMoveUpBase = 41; // roster_up_0..7 = 41..48
 inline constexpr int kBaseCampSeatCardsPerPage = 4;
 // The 70px seat card is drawn without the beveled inset, so its budget is the
-// full face: 70 / 6 = 11 characters, trailing pad included. Eleven is what
-// makes "ADD PLAYER" and "LOBBY FULL" (10 each) fit a bare slot.
+// full face: 70 / 6 = 11 characters, a seat label's two trailing pads
+// included. Eleven is what makes "ADD PLAYER" and "LOBBY FULL" (10 each) fit
+// a bare slot, and what leaves the widest card ("P16 " + a 5-char mapping
+// short name + both pads) exactly filling its face.
 inline constexpr int kBaseCampSeatCardLabelBudget = 11;
 // The compact seat-rail/move-up band's ordinal bounds: draw_menu_highlight
 // keeps its interior focus ring INSIDE this range so a card's ring can never
@@ -234,13 +236,18 @@ inline constexpr int kBaseCampInteriorRingFirstIndex = kBaseCampAddSeatIndex;
 inline constexpr int kBaseCampInteriorRingLastIndex = 48;
 namespace og::ui {
 // True when rail slot k (0..3) is a SEAT CARD this frame — the only shape
-// that packs a numbered team chip into the face's last nine pixels, and so
-// the only one whose focus ring needs the chip clearance. A bare slot's
-// ADD PLAYER / LOBBY FULL label is ten glyphs with no trailing pad: its ink
-// runs to x+64, and a ring cut back to x+60 would strike through it.
-// Reads the rewire's cached frame shape — the same one the chip pass reads,
-// so the ring and the chip can never disagree about which slots have one.
+// that packs a numbered team chip into the face's right end, and so the only
+// one whose focus ring needs the chip clearance. A bare slot's ADD PLAYER /
+// LOBBY FULL label is ten glyphs with no trailing pad: its ink runs to x+64,
+// and a ring cut back over the chip zone would strike through it. Answers
+// with the same count the chip pass paints, so the ring and the chip can
+// never disagree about which slots have one.
 bool base_camp_rail_slot_has_chip(int slot);
+// Pixels at a seat card's right end the focus ring must give up so its
+// (inclusive, +1-convention) right column lands on the last face pixel BEFORE
+// the chip. Derived from the card width and the chip offset — a geometry
+// change moves the ring with the chip instead of stranding a literal here.
+int base_camp_seat_chip_ring_clearance();
 } // namespace og::ui
 // --- The appended gameplay-zone band (docs/basecamp-zones-design.md
 // "Bounds arithmetic"): ordinals 49..71, statically PARKED at zero-size

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -1172,16 +1172,19 @@ Sint32 create_view_scenario_menu(Sint32 arg1)
     TRACE("picker", "view_scenario lines=%d page=%d",
           static_cast<int>(state.lines.size()), state.pager.page);
 
-    og::runtime::current_session->myscreen_->clearbuffer();
-
+    // No pre-run clear (#237 ownership): the spec's draw_background clears
+    // and repaints, and a clear between the previous screen's last present
+    // and a fade-out is the hard-cut class the video layer flags.
     pks().view_scenario_page_step = 0;
     g_view_scenario_engine_state = &state;
     const Sint32 retvalue = og::ui::run_menu_screen(
         og::ui::view_scenario_menu_screen_spec(), &state);
     g_view_scenario_engine_state = nullptr;
 
-    og::runtime::current_session->myscreen_->clearbuffer();
-
+    // No post-run clear (#237 ownership): a MENU_EXIT propagating through
+    // here (a remote start) reaches Base Camp's exit fade, which must read
+    // this screen's last presented frame. Base Camp's draw_background
+    // repaints on the ordinary BACK.
     if (retvalue & MENU_EXIT)
         return retvalue;
 
@@ -1548,7 +1551,8 @@ Sint32 create_progress_menu(Sint32 arg1)
     // legacy loop (it only normalized it and moved on).
     (void)arg1;
 
-    og::runtime::current_session->myscreen_->clearbuffer();
+    // No pre-run clear (#237 ownership — see create_view_scenario_menu);
+    // picker_progress_menu_engine_draw_background clears.
 
     // Get accessible levels
     std::vector<int> level_ids = get_accessible_levels();
@@ -1593,7 +1597,7 @@ Sint32 create_progress_menu(Sint32 arg1)
     const Sint32 retvalue = og::ui::run_menu_screen(
         og::ui::progress_menu_screen_spec(), &state);
 
-    og::runtime::current_session->myscreen_->clearbuffer();
+    // No post-run clear (#237 ownership — see create_view_scenario_menu).
     if (retvalue & MENU_EXIT)
         return retvalue;
     return MENU_REDRAW;
@@ -1889,7 +1893,8 @@ void picker_hire_menu_engine_draw_content(void* screen_state)
 // StartGame selected instead of re-detecting the start one loop later).
 Sint32 create_hire_menu(Sint32 arg1)
 {
-	og::runtime::current_session->myscreen_->clearbuffer();
+	// No pre-run clear (#237 ownership — see create_view_scenario_menu);
+	// picker_backdrop_draw_background clears.
 
     og::ui::HireSession hire_session(og::runtime::current_session->myscreen_->save_data, og::runtime::current_session->current_team_num_);
     pks().hire_session = &hire_session;
@@ -1914,7 +1919,7 @@ Sint32 create_hire_menu(Sint32 arg1)
         og::ui::run_menu_screen(og::ui::hire_menu_screen_spec(), &state);
 
 	pks().hire_session = nullptr;
-	og::runtime::current_session->myscreen_->clearbuffer();
+	// No post-run clear (#237 ownership — see create_view_scenario_menu).
 	//myscreen->clearscreen();
 	return retvalue;
 }
@@ -2209,7 +2214,8 @@ Sint32 create_train_menu(Sint32 arg1)
 		return MENU_OK;
 	}
 
-	og::runtime::current_session->myscreen_->clearbuffer();
+	// No pre-run clear (#237 ownership — see create_view_scenario_menu);
+	// picker_backdrop_draw_background clears.
 
     og::ui::TrainSession train_session(save);
     // §2.5 per-row TRAIN: a stashed base-camp seed slot opens the session
@@ -2241,7 +2247,7 @@ Sint32 create_train_menu(Sint32 arg1)
 
 	pks().train_session = nullptr;
 	pks().old_guy = nullptr;
-	og::runtime::current_session->myscreen_->clearbuffer();
+	// No post-run clear (#237 ownership — see create_view_scenario_menu).
 	//myscreen->clearscreen();
     if ((retvalue & MENU_EXIT) && team_build_start_selected())
     {
@@ -2792,9 +2798,10 @@ Sint32 go_menu(Sint32 arg1)
         og::runtime::current_session->myscreen_->set_active_canvas(
             og::runtime::current_session->myscreen_->last_presented_canvas());
         og::runtime::current_session->myscreen_->fadeblack(0);
-        // #200: this IS the fade back to the menu. Base Camp's entry must not
-        // play a second one over the stale pause-menu image.
-        og::ui::note_menu_faded_to_black();
+        // #200: this IS the fade back to the menu (a no-op when the results
+        // panel already faded itself out). The window is black from here, so
+        // Base Camp's entry cannot play a second fade over the stale
+        // pause-menu image — fadeblack(0) skips a black window.
 
         // Zardus: PORT: doesn't seem to be neccessary
         og::runtime::current_session->myscreen_->clearbuffer();

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -971,17 +971,25 @@ static Sint32 preview_pan_offset(Sint32 span, Sint32 ticks_per_px)
     return phase < span ? phase : span * 2 - phase;
 }
 
-// Borrowing the picker's viewob[0] must leave no residue on it. Nulling
-// control makes viewscreen::redraw take its control-less branch, which copies
-// the staged level's camera ONTO THE VIEW (render/view.cpp: topx =
-// data->level_visuals().topx). screen::relayout_views() then restores the
-// view's RECT and nothing else — viewscreen::resize never writes topx/topy,
-// which are set exactly once at construction — so the pan offset used to
-// survive the whole menu session and shift every pixie draw that goes through
-// the view: the picker backdrop, the graphic buttons, the main-menu logo and
-// the HIRE/TRAIN portrait walker (whose canvas-direct bevel stayed put, hence
-// "an empty box"). Destructor-based restore because the healed branch below
-// early-returns; a restore written at the end of the function never runs.
+// THE INVARIANT (#251): no menu draw may observe the preview camera. Every
+// menu pixie — the backdrop quadrants, the graphic buttons, the main-menu
+// logo, the HIRE/TRAIN portrait walker — is blitted as
+// `xpos - view->topx + view->xloc` through viewob[0], so any camera or
+// geometry this preview leaves on the view displaces the whole menu until
+// level start (the HIRE "empty box" report). Two halves keep it true:
+// draw_backdrop() below must stay ABOVE the borrow, and this guard restores
+// every field the borrow writes.
+//
+// It writes more than it looks: nulling control makes viewscreen::redraw take
+// its control-less branch, which copies the staged level's camera onto the
+// view (render/view.cpp: topx = data->level_visuals().topx), and the band
+// resize rewrites the whole render rect. topx/topy are otherwise assigned
+// exactly once, at construction — viewscreen::resize never touches them — so
+// no relayout can undo them; restoring the rect here as well is both exact
+// (screen::relayout_views re-derives it from prefs[PREF_VIEW] instead of the
+// PREF_VIEW_FULL the picker forces at entry) and free of relayout's side
+// effects. Destructor-based because the healed branch below early-returns; a
+// restore written at the end of the function never runs.
 namespace
 {
 class ScopedBorrowedView
@@ -989,7 +997,11 @@ class ScopedBorrowedView
 public:
     explicit ScopedBorrowedView(viewscreen& view)
         : view_(view), topx_(view.topx), topy_(view.topy),
-          control_(view.control), following_(view.following_)
+          xloc_(view.xloc), yloc_(view.yloc), xview_(view.xview),
+          yview_(view.yview), endx_(view.endx), endy_(view.endy),
+          slot_x_(view.slot_x_), slot_y_(view.slot_y_), slot_w_(view.slot_w_),
+          slot_h_(view.slot_h_), control_(view.control),
+          following_(view.following_)
     {
     }
 
@@ -997,6 +1009,16 @@ public:
     {
         view_.topx = topx_;
         view_.topy = topy_;
+        view_.xloc = xloc_;
+        view_.yloc = yloc_;
+        view_.xview = xview_;
+        view_.yview = yview_;
+        view_.endx = endx_;
+        view_.endy = endy_;
+        view_.slot_x_ = slot_x_;
+        view_.slot_y_ = slot_y_;
+        view_.slot_w_ = slot_w_;
+        view_.slot_h_ = slot_h_;
         view_.control = control_;
         view_.following_ = following_;
     }
@@ -1008,6 +1030,16 @@ private:
     viewscreen& view_;
     Sint32 topx_;
     Sint32 topy_;
+    Sint32 xloc_;
+    Sint32 yloc_;
+    Sint32 xview_;
+    Sint32 yview_;
+    Sint32 endx_;
+    Sint32 endy_;
+    Sint32 slot_x_;
+    Sint32 slot_y_;
+    Sint32 slot_w_;
+    Sint32 slot_h_;
     walker* control_;
     bool following_;
 };
@@ -1019,8 +1051,7 @@ private:
 // camera from the level's own LevelVisuals — TRAP B dangling-control never
 // applies because the pane never points control at a staged walker). Slow
 // horizontal pan surveys pitches wider than the band (direct-geometry views
-// have no zoom); geometry is restored via relayout_views after every draw and
-// the camera by ScopedBorrowedView.
+// have no zoom); ScopedBorrowedView restores the camera and the geometry.
 // Degradation states render text into the band — never a crash, never a
 // stale world presented as the stage; the census fallback lines still render
 // below through the content pass.
@@ -1067,7 +1098,6 @@ void picker_view_scenario_staged_draw_background(void* screen_state)
                          kViewScenarioPreviewBandW, kViewScenarioPreviewBandH);
             (void)view->redraw(state->scenario.get(), /*draw_radar=*/false);
         }
-        scr->relayout_views();
         return;
     }
 

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -2792,7 +2792,7 @@ Sint32 go_menu(Sint32 arg1)
         og::runtime::current_session->myscreen_->fadeblack(0);
         // #200: this IS the fade back to the menu. Base Camp's entry must not
         // play a second one over the stale pause-menu image.
-        og::ui::suppress_next_menu_entry_fade_out();
+        og::ui::note_menu_faded_to_black();
 
         // Zardus: PORT: doesn't seem to be neccessary
         og::runtime::current_session->myscreen_->clearbuffer();

--- a/src/interface/ui/picker_team_build.cpp
+++ b/src/interface/ui/picker_team_build.cpp
@@ -978,7 +978,9 @@ static Sint32 preview_pan_offset(Sint32 span, Sint32 ticks_per_px)
 // geometry this preview leaves on the view displaces the whole menu until
 // level start (the HIRE "empty box" report). Two halves keep it true:
 // draw_backdrop() below must stay ABOVE the borrow, and this guard restores
-// every field the borrow writes.
+// every camera and rect field the borrow writes (resize also restarts the
+// view's radar and sets screen::redrawme — both inert under the picker,
+// which draws no radar and reconstructs every view at launch).
 //
 // It writes more than it looks: nulling control makes viewscreen::redraw take
 // its control-less branch, which copies the staged level's camera onto the

--- a/src/interface/ui/results_screen.cpp
+++ b/src/interface/ui/results_screen.cpp
@@ -525,16 +525,23 @@ bool results_screen(int ending, int nextlevel, std::map<int, guy*>& before, std:
 
     // The popup and results panel share the fixed UI surface. Restore the
     // nearest-scaled gameplay backdrop so the closed popup does not remain
-    // visible around the results panel.
+    // visible around the results panel — and PRESENT it: the fade below
+    // reads the buffer, and a fade may only read a frame the window has
+    // shown (#237 ownership). The popup vanishes on this present, exactly as
+    // it did on the fade's first blended frame.
     if (canvas_target.entered_from_world())
+    {
         output.prepare_ui_canvas_from_world();
+        og::runtime::current_session->myscreen_->refresh();
+    }
 
-    // #237 depth rule, applied by hand (this hand-rolled loop never enters
-    // run_menu_screen): gameplay -> results is a context switch — fade the
-    // last mission frame out here, fade the first composed panel frame in at
-    // the loop's first present. The dismissed popup above stays a modal and
-    // never fades.
-    bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
+    // #237 ownership rule, applied by hand (this hand-rolled loop never
+    // enters run_menu_screen): gameplay -> results is a context switch — fade
+    // the last mission frame out here, fade the first composed panel frame in
+    // at the loop's first present, and fade the panel out again when this
+    // scope ends (before the canvas restore above it). The dismissed popup
+    // stays a modal and never fades.
+    og::ui::LegacyMenuFade entry_fade;
 
     // Clear any stale input events after popup closes
     // This helps prevent ASYNCIFY state issues in Emscripten
@@ -1112,13 +1119,8 @@ bool results_screen(int ending, int nextlevel, std::map<int, guy*>& before, std:
 	        }
         
         draw_highlight(buttons[highlighted_button]);
-        if (entry_fade_in_pending) {
-            // fadeblack presents the composed buffer itself (#237).
-            entry_fade_in_pending = false;
-            og::runtime::current_session->myscreen_->fadeblack(1);
-        } else {
-            og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
-        }
+        // The first frame fades in; every later one presents plainly (#237).
+        entry_fade.present_first(*og::runtime::current_session->myscreen_);
         og::input_native::sleep_ms(10);
 
         frame++;

--- a/src/interface/ui/results_screen.cpp
+++ b/src/interface/ui/results_screen.cpp
@@ -535,13 +535,21 @@ bool results_screen(int ending, int nextlevel, std::map<int, guy*>& before, std:
         og::runtime::current_session->myscreen_->refresh();
     }
 
+    // #237 ownership: the mission's tail — its last frame with the ending
+    // popup dismissed over it, re-presented just above — is this function's
+    // surface, and it exits HERE: fade it out now, while that frame is still
+    // the buffer, so the results panel's entry below finds the black window
+    // the ownership rule promises every entry. (Idempotent for a caller that
+    // already faded to black.) The dismissed popup stays a modal and never
+    // fades.
+    output.fadeblack(0);
+
     // #237 ownership rule, applied by hand (this hand-rolled loop never
-    // enters run_menu_screen): gameplay -> results is a context switch — fade
-    // the last mission frame out here, fade the first composed panel frame in
-    // at the loop's first present, and fade the panel out again when this
-    // scope ends (before the canvas restore above it). The dismissed popup
-    // stays a modal and never fades.
-    og::ui::LegacyMenuFade entry_fade;
+    // enters run_menu_screen): gameplay -> results is a context switch — the
+    // first composed panel frame fades in at the loop's first present, and
+    // the panel fades out again when this scope ends (before the canvas
+    // restore above it).
+    og::ui::LegacyMenuFade entry_fade("results");
 
     // Clear any stale input events after popup closes
     // This helps prevent ASYNCIFY state issues in Emscripten

--- a/src/interface/ui/results_screen.cpp
+++ b/src/interface/ui/results_screen.cpp
@@ -738,6 +738,12 @@ bool results_screen(int ending, int nextlevel, std::map<int, guy*>& before, std:
 
         // Get keys and stuff
         get_input_events(POLL);
+        // Pointer handoff: this loop consumes clicks with its own sampled
+        // edge detector below, never query_mouse(), so acknowledge the
+        // presses it saw or each click mints a collapsed-tap pending click
+        // that leaks into the next menu (the native twin of the web-only
+        // reset in picker_reinit_after_game).
+        acknowledge_mouse_presses();
 
         handle_menu_nav(buttons, highlighted_button, retvalue, false);
 

--- a/src/interface/ui/results_screen.cpp
+++ b/src/interface/ui/results_screen.cpp
@@ -6,6 +6,7 @@
  * (at your option) any later version.
  */
 #include <openglad/interface/ui/results_screen.h>
+#include <openglad/interface/ui/menu_screen_spec.h>
 #include <openglad/interface/ui/picker_common.h>
 #include <openglad/interface/base.h>
 #include <openglad/interface/button.h>
@@ -527,6 +528,13 @@ bool results_screen(int ending, int nextlevel, std::map<int, guy*>& before, std:
     // visible around the results panel.
     if (canvas_target.entered_from_world())
         output.prepare_ui_canvas_from_world();
+
+    // #237 depth rule, applied by hand (this hand-rolled loop never enters
+    // run_menu_screen): gameplay -> results is a context switch — fade the
+    // last mission frame out here, fade the first composed panel frame in at
+    // the loop's first present. The dismissed popup above stays a modal and
+    // never fades.
+    bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
 
     // Clear any stale input events after popup closes
     // This helps prevent ASYNCIFY state issues in Emscripten
@@ -1104,9 +1112,15 @@ bool results_screen(int ending, int nextlevel, std::map<int, guy*>& before, std:
 	        }
         
         draw_highlight(buttons[highlighted_button]);
-        og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
+        if (entry_fade_in_pending) {
+            // fadeblack presents the composed buffer itself (#237).
+            entry_fade_in_pending = false;
+            og::runtime::current_session->myscreen_->fadeblack(1);
+        } else {
+            og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
+        }
         og::input_native::sleep_ms(10);
-        
+
         frame++;
         if(frame > 1000000)
             frame = 0;

--- a/src/platform/sdl/game_session.cpp
+++ b/src/platform/sdl/game_session.cpp
@@ -37,8 +37,11 @@ PlatformBridge make_sdl_platform_bridge()
     PlatformBridge bridge;
 
     bridge.present_frame = [] {
+        // The whole ACTIVE canvas: a zoomed World canvas is wider than the
+        // classic 320x200, and a present must declare exactly what it shows
+        // (the fade-ownership invariant compares against that rect).
         if (E_Screen)
-            E_Screen->swap(0, 0, 320, 200);
+            E_Screen->swap(0, 0, E_Screen->canvas_w(), E_Screen->canvas_h());
     };
 
     bridge.play_sound = [](int sound_id) {

--- a/src/platform/sdl/glad.cpp
+++ b/src/platform/sdl/glad.cpp
@@ -235,7 +235,15 @@ void bootstrap_runtime(int argc, char* argv[])
     cfg.save_settings();
 #if defined(__EMSCRIPTEN__) && !defined(TESTING)
     if (og::platform::web::should_skip_intro_for_tests())
+    {
+        // #237 ownership: the loading dialog is the surface on the window,
+        // and skipping the intro means it exits here. The intro would have
+        // faded it out (intro_main's first fade); without the intro, the
+        // main menu's entry would find it unfaded — so fade it out now,
+        // where it exits.
+        og::runtime::current_session->myscreen_->fadeblack(0);
         return;
+    }
     EM_ASM({
         window.__opengladIntroActive = true;
         window.__opengladIntroTapPending = false;

--- a/src/platform/sdl/input_event_bridge.cpp
+++ b/src/platform/sdl/input_event_bridge.cpp
@@ -190,6 +190,7 @@ void handle_key_event(const void* native_event)
         if(og::runtime::current_session->raw_key_ == SDLK_ESCAPE)
             og::runtime::current_session->input_continue_ = true;
         og::runtime::current_session->key_press_event_ = 1;
+        ++og::runtime::current_session->key_press_serial_;
 
         if(event.key.key == SDLK_F10)
         {

--- a/src/platform/sdl/picker_lobby_network_client.cpp
+++ b/src/platform/sdl/picker_lobby_network_client.cpp
@@ -4593,7 +4593,7 @@ private:
                     !awaiting_round_ready_reset_)
                 {
                     // The correlated result can be empty when the global
-                    // capacity rejects a spectator's [+]. Empty is still a
+                    // capacity rejects a spectator's ADD PLAYER. Empty is still a
                     // complete authoritative answer and must stop retries.
                     join_confirmation_pending_ = false;
                     pending_join_request_id_ = 0;

--- a/src/platform/sdl/sai2x.cpp
+++ b/src/platform/sdl/sai2x.cpp
@@ -13,8 +13,11 @@
 #include <openglad/interface/input.h>
 #include <openglad/interface/screen.h>
 #include <openglad/interface/session_state.h>
+#include <algorithm>
 #include <array>
 #include <atomic>
+#include <cstring>
+#include <format>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -853,6 +856,11 @@ void Screen::set_vsync(bool on)
 
 Screen::~Screen()
 {
+#ifdef TESTING
+	for (PresentedSnapshot& snapshot : presented_snapshots_)
+		SDL_DestroySurface(snapshot.pixels);
+	presented_snapshots_.clear();
+#endif
 	destroy_render2();
 	destroy_gameplay_ui_overlay();
 	if (world_tex_ != ui_tex_)
@@ -1106,7 +1114,12 @@ bool Screen::set_world_canvas_size(int w, int h)
 	if (previous_texture != ui_tex_)
 		SDL_DestroyTexture(previous_texture);
 	if (previous_surface != ui_surf_)
+	{
+#ifdef TESTING
+		testing_forget_presented(previous_surface);
+#endif
 		SDL_DestroySurface(previous_surface);
+	}
 	return true;
 }
 
@@ -1394,6 +1407,9 @@ void Screen::destroy_gameplay_ui_overlay()
 		render_tex = world_tex_;
 	}
 	SDL_DestroyTexture(gameplay_ui_tex_);
+#ifdef TESTING
+	testing_forget_presented(gameplay_ui_surf_);
+#endif
 	SDL_DestroySurface(gameplay_ui_surf_);
 	gameplay_ui_tex_ = nullptr;
 	gameplay_ui_surf_ = nullptr;
@@ -1465,6 +1481,9 @@ bool Screen::recreate_render_backend()
 			// pass retries the split allocation transactionally.
 			LogError("recreate_render_backend: world texture creation failed "
 			         "for {}x{}: {}\n", world_w_, world_h_, SDL_GetError());
+#ifdef TESTING
+			testing_forget_presented(world_surf_);
+#endif
 			SDL_DestroySurface(world_surf_);
 			world_surf_ = ui_surf_;
 			world_tex_ = ui_tex_;
@@ -1534,6 +1553,9 @@ bool Screen::ensure_gameplay_ui_overlay()
 	SDL_SetTextureBlendMode(next_texture, SDL_BLENDMODE_BLEND);
 	SDL_SetTextureScaleMode(next_texture, SDL_SCALEMODE_NEAREST);
 	SDL_DestroyTexture(gameplay_ui_tex_);
+#ifdef TESTING
+	testing_forget_presented(gameplay_ui_surf_);
+#endif
 	SDL_DestroySurface(gameplay_ui_surf_);
 	gameplay_ui_surf_ = next_surface;
 	gameplay_ui_tex_ = next_texture;
@@ -1890,6 +1912,12 @@ void Screen::swap(int x, int y, int w, int h)
 		}
     }
     SDL_RenderPresent(renderer);
+	// The single present site: whatever the window showed before, it now
+	// shows this canvas. Only a completed fadeblack(false) sets the flag back.
+	window_is_black_ = false;
+#ifdef TESTING
+	testing_snapshot_presented(render);
+#endif
 	last_presented_ = active_ == CanvasTarget::GameplayUI
 		? CanvasTarget::World
 		: active_;
@@ -1914,6 +1942,147 @@ void Screen::swap(int x, int y, int w, int h)
 		set_active_canvas(active_);
 	}
 }
+
+#ifdef TESTING
+namespace
+{
+std::size_t surface_row_bytes(const SDL_Surface* surface)
+{
+	const SDL_PixelFormatDetails* details =
+		SDL_GetPixelFormatDetails(surface->format);
+	return static_cast<std::size_t>(surface->w) *
+		(details != nullptr ? details->bytes_per_pixel : 4u);
+}
+} // namespace
+
+void Screen::testing_snapshot_presented(SDL_Surface* surface)
+{
+	if (surface == nullptr)
+		return;
+	PresentedSnapshot* slot = nullptr;
+	for (PresentedSnapshot& candidate : presented_snapshots_)
+	{
+		if (candidate.surface == surface)
+		{
+			slot = &candidate;
+			break;
+		}
+	}
+	if (slot == nullptr)
+	{
+		presented_snapshots_.push_back({surface, nullptr});
+		slot = &presented_snapshots_.back();
+	}
+	if (slot->pixels != nullptr &&
+	    (slot->pixels->w != surface->w || slot->pixels->h != surface->h ||
+	     slot->pixels->format != surface->format))
+	{
+		SDL_DestroySurface(slot->pixels);
+		slot->pixels = nullptr;
+	}
+	if (slot->pixels == nullptr)
+	{
+		slot->pixels = SDL_CreateSurface(surface->w, surface->h, surface->format);
+		if (slot->pixels == nullptr)
+			return;
+	}
+	// Row copies (the two pitches need not match), not a blit: a blit may
+	// rewrite the unused X byte and the comparison below is byte-exact.
+	const std::size_t row_bytes = surface_row_bytes(surface);
+	const auto* src = static_cast<const Uint8*>(surface->pixels);
+	auto* dst = static_cast<Uint8*>(slot->pixels->pixels);
+	for (int y = 0; y < surface->h; ++y)
+	{
+		memcpy(dst + static_cast<std::size_t>(y) * static_cast<std::size_t>(slot->pixels->pitch),
+		       src + static_cast<std::size_t>(y) * static_cast<std::size_t>(surface->pitch),
+		       row_bytes);
+	}
+}
+
+void Screen::testing_forget_presented(SDL_Surface* surface)
+{
+	for (auto it = presented_snapshots_.begin(); it != presented_snapshots_.end(); ++it)
+	{
+		if (it->surface != surface)
+			continue;
+		SDL_DestroySurface(it->pixels);
+		presented_snapshots_.erase(it);
+		return;
+	}
+}
+
+bool Screen::testing_render_matches_presented(std::string* detail) const
+{
+	if (detail != nullptr)
+		detail->clear();
+	if (render == nullptr)
+	{
+		if (detail != nullptr)
+			*detail = "no render surface";
+		return false;
+	}
+	for (const PresentedSnapshot& snapshot : presented_snapshots_)
+	{
+		if (snapshot.surface != render)
+			continue;
+		if (snapshot.pixels == nullptr || snapshot.pixels->w != render->w ||
+		    snapshot.pixels->h != render->h ||
+		    snapshot.pixels->format != render->format)
+		{
+			if (detail != nullptr)
+				*detail = "presented at different dimensions";
+			return false;
+		}
+		const std::size_t row_bytes = surface_row_bytes(render);
+		const int bpp = static_cast<int>(row_bytes / static_cast<std::size_t>(render->w));
+		const auto* presented = static_cast<const Uint8*>(snapshot.pixels->pixels);
+		const auto* current = static_cast<const Uint8*>(render->pixels);
+		// Bounding box of every differing pixel: names the culprit draw
+		// (a whole-frame box is a clear; a button-sized one is a stale
+		// widget redraw) without a debugger.
+		int min_x = render->w, min_y = render->h, max_x = -1, max_y = -1;
+		for (int y = 0; y < render->h; ++y)
+		{
+			const Uint8* prow = presented + static_cast<std::size_t>(y) * static_cast<std::size_t>(snapshot.pixels->pitch);
+			const Uint8* crow = current + static_cast<std::size_t>(y) * static_cast<std::size_t>(render->pitch);
+			if (memcmp(prow, crow, row_bytes) == 0)
+				continue;
+			if (detail == nullptr)
+				return false;
+			for (int x = 0; x < render->w; ++x)
+			{
+				if (memcmp(prow + x * bpp, crow + x * bpp, static_cast<std::size_t>(bpp)) == 0)
+					continue;
+				min_x = std::min(min_x, x);
+				max_x = std::max(max_x, x);
+				min_y = std::min(min_y, y);
+				max_y = std::max(max_y, y);
+			}
+		}
+		if (max_x < 0)
+			return true;
+		*detail = std::format("render differs from the presented frame in x {}..{}, y {}..{} of {}x{}",
+		                      min_x, max_x, min_y, max_y, render->w, render->h);
+		return false;
+	}
+	if (detail != nullptr)
+		*detail = "never presented";
+	return false;
+}
+
+void Screen::testing_reset_window_state()
+{
+	window_is_black_ = false;
+	for (PresentedSnapshot& snapshot : presented_snapshots_)
+		SDL_DestroySurface(snapshot.pixels);
+	presented_snapshots_.clear();
+	testing_snapshot_presented(ui_surf_);
+	if (world_surf_ != ui_surf_)
+		testing_snapshot_presented(world_surf_);
+	if (gameplay_ui_surf_ != nullptr)
+		testing_snapshot_presented(gameplay_ui_surf_);
+}
+#endif
 
 void Screen::clear_window()
 {

--- a/src/platform/sdl/sai2x.cpp
+++ b/src/platform/sdl/sai2x.cpp
@@ -1962,7 +1962,10 @@ std::size_t surface_row_bytes(const SDL_Surface* surface)
 void Screen::testing_snapshot_presented(SDL_Surface* surface, int x, int y,
                                         int w, int h)
 {
-	if (surface == nullptr)
+	// A degenerate surface (zero-sized or pixel-less — the scaler's
+	// fail-closed probes present those) shows nothing worth remembering.
+	if (surface == nullptr || surface->pixels == nullptr || surface->w <= 0 ||
+	    surface->h <= 0)
 		return;
 	PresentedSnapshot* slot = nullptr;
 	for (PresentedSnapshot& candidate : presented_snapshots_)
@@ -1990,6 +1993,12 @@ void Screen::testing_snapshot_presented(SDL_Surface* surface, int x, int y,
 		slot->pixels = SDL_CreateSurface(surface->w, surface->h, surface->format);
 		if (slot->pixels == nullptr)
 			return;
+		if (slot->pixels->pixels == nullptr)
+		{
+			SDL_DestroySurface(slot->pixels);
+			slot->pixels = nullptr;
+			return;
+		}
 		// A fresh snapshot is black everywhere the first present does not
 		// cover: nothing outside its rect has been shown yet.
 		memset(slot->pixels->pixels, 0,

--- a/src/platform/sdl/sai2x.cpp
+++ b/src/platform/sdl/sai2x.cpp
@@ -1916,7 +1916,11 @@ void Screen::swap(int x, int y, int w, int h)
 	// shows this canvas. Only a completed fadeblack(false) sets the flag back.
 	window_is_black_ = false;
 #ifdef TESTING
-	testing_snapshot_presented(render);
+	// Only the rect this present declared: a partial present (a pressed
+	// button face, the help scroller's dialog) vouches for nothing outside
+	// it, so a stale full-frame redraw followed by a small present still
+	// reads as never presented at the next fade-out.
+	testing_snapshot_presented(render, x, y, w, h);
 #endif
 	last_presented_ = active_ == CanvasTarget::GameplayUI
 		? CanvasTarget::World
@@ -1955,7 +1959,8 @@ std::size_t surface_row_bytes(const SDL_Surface* surface)
 }
 } // namespace
 
-void Screen::testing_snapshot_presented(SDL_Surface* surface)
+void Screen::testing_snapshot_presented(SDL_Surface* surface, int x, int y,
+                                        int w, int h)
 {
 	if (surface == nullptr)
 		return;
@@ -1985,17 +1990,35 @@ void Screen::testing_snapshot_presented(SDL_Surface* surface)
 		slot->pixels = SDL_CreateSurface(surface->w, surface->h, surface->format);
 		if (slot->pixels == nullptr)
 			return;
+		// A fresh snapshot is black everywhere the first present does not
+		// cover: nothing outside its rect has been shown yet.
+		memset(slot->pixels->pixels, 0,
+		       static_cast<std::size_t>(slot->pixels->pitch) *
+		           static_cast<std::size_t>(slot->pixels->h));
 	}
+	// Clip the declared rect to the surface. The rect is what the present
+	// vouches for: the nearest path happens to upload the whole surface,
+	// but the SAI/Eagle path refreshes only this rect of its scaled scratch,
+	// so callers are held to what they declared.
+	const int x0 = std::max(0, x);
+	const int y0 = std::max(0, y);
+	const int x1 = std::min(surface->w, x + w);
+	const int y1 = std::min(surface->h, y + h);
+	if (x0 >= x1 || y0 >= y1)
+		return;
 	// Row copies (the two pitches need not match), not a blit: a blit may
 	// rewrite the unused X byte and the comparison below is byte-exact.
-	const std::size_t row_bytes = surface_row_bytes(surface);
+	const std::size_t bpp = surface_row_bytes(surface) /
+		static_cast<std::size_t>(surface->w);
+	const std::size_t span = static_cast<std::size_t>(x1 - x0) * bpp;
+	const std::size_t offset_x = static_cast<std::size_t>(x0) * bpp;
 	const auto* src = static_cast<const Uint8*>(surface->pixels);
 	auto* dst = static_cast<Uint8*>(slot->pixels->pixels);
-	for (int y = 0; y < surface->h; ++y)
+	for (int row = y0; row < y1; ++row)
 	{
-		memcpy(dst + static_cast<std::size_t>(y) * static_cast<std::size_t>(slot->pixels->pitch),
-		       src + static_cast<std::size_t>(y) * static_cast<std::size_t>(surface->pitch),
-		       row_bytes);
+		memcpy(dst + static_cast<std::size_t>(row) * static_cast<std::size_t>(slot->pixels->pitch) + offset_x,
+		       src + static_cast<std::size_t>(row) * static_cast<std::size_t>(surface->pitch) + offset_x,
+		       span);
 	}
 }
 
@@ -2072,15 +2095,22 @@ bool Screen::testing_render_matches_presented(std::string* detail) const
 
 void Screen::testing_reset_window_state()
 {
-	window_is_black_ = false;
+	// Black, as a completed exit fade leaves it (and as a process starts):
+	// the next fading entry finds the ownership rule's promised state, and
+	// a test that presents a frame of its own then owes that frame's
+	// fade-out like any other screen.
+	window_is_black_ = true;
 	for (PresentedSnapshot& snapshot : presented_snapshots_)
 		SDL_DestroySurface(snapshot.pixels);
 	presented_snapshots_.clear();
-	testing_snapshot_presented(ui_surf_);
+	const auto snapshot_whole = [this](SDL_Surface* surface) {
+		if (surface != nullptr)
+			testing_snapshot_presented(surface, 0, 0, surface->w, surface->h);
+	};
+	snapshot_whole(ui_surf_);
 	if (world_surf_ != ui_surf_)
-		testing_snapshot_presented(world_surf_);
-	if (gameplay_ui_surf_ != nullptr)
-		testing_snapshot_presented(gameplay_ui_surf_);
+		snapshot_whole(world_surf_);
+	snapshot_whole(gameplay_ui_surf_);
 }
 #endif
 

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -3788,6 +3788,13 @@ int sdl_video::FadeBetween(
 		old_locked = false;
 	}
 
+	// The animation below aborts on a key press, and key_press_event_ is a
+	// sticky "pressed since the last clear" flag — the tap that dismissed
+	// the previous screen would still be set here and end this fade on its
+	// first frame. Clear it now so the abort means a press DURING the fade
+	// (a held key keeps skipping: OS key repeat re-sets it mid-fade).
+	clear_key_press_event();
+
 	//Fade from old to new surface.  Effect takes constant time.
 #ifdef TESTING
 	// In test mode, just do a direct blit instead of animated fade

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -3861,6 +3861,7 @@ namespace
 {
 std::mutex s_fade_violation_mutex;
 std::vector<std::string> s_fade_violation_messages;
+} // namespace
 
 void report_fade_violation(const char* what)
 {
@@ -3870,7 +3871,6 @@ void report_fade_violation(const char* what)
     std::lock_guard<std::mutex> lock(s_fade_violation_mutex);
     s_fade_violation_messages.emplace_back(what);
 }
-} // namespace
 
 std::vector<std::string> fade_violation_messages()
 {
@@ -3898,6 +3898,11 @@ void sdl_video::testing_reset_window_state()
     if (E_Screen != nullptr)
         E_Screen->testing_reset_window_state();
 }
+
+void sdl_video::testing_report_fade_violation(const char* what)
+{
+    og::video_testing::report_fade_violation(what);
+}
 #endif
 
 int sdl_video::fadeblack(bool fade_in)
@@ -3911,7 +3916,8 @@ int sdl_video::fadeblack(bool fade_in)
         return 0;
     }
 #ifdef TESTING
-    // The two invariants, checked at the fade itself (see video_sdl.h).
+    // The two fade-site invariants (see video_sdl.h; the entry invariant
+    // lives in the menu runner, which knows what an entry is).
     if (fade_in && !E_Screen->window_is_black())
         og::video_testing::report_fade_violation(
             "fade-in without a fade-out (the window is not black)");

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -3788,12 +3788,14 @@ int sdl_video::FadeBetween(
 		old_locked = false;
 	}
 
-	// The animation below aborts on a key press, and key_press_event_ is a
-	// sticky "pressed since the last clear" flag — the tap that dismissed
-	// the previous screen would still be set here and end this fade on its
-	// first frame. Clear it now so the abort means a press DURING the fade
-	// (a held key keeps skipping: OS key repeat re-sets it mid-fade).
-	clear_key_press_event();
+	// The animation below aborts on a key pressed DURING the fade — an edge
+	// on the press serial, never the sticky key_press_event_ latch (the tap
+	// that dismissed the previous screen is still latched here and would
+	// end this fade on its first frame; the intro's pages read that latch
+	// to abort, so it must not be cleared either). A held key still skips:
+	// OS key repeat advances the serial mid-fade.
+	const unsigned press_serial_at_start = query_key_press_serial();
+	(void)press_serial_at_start;  // the TESTING branch runs no animation
 
 	//Fade from old to new surface.  Effect takes constant time.
 #ifdef TESTING
@@ -3812,7 +3814,7 @@ int sdl_video::FadeBetween(
 		dwNow = SDL_GetTicks();
 
 		get_input_events(POLL);
-		if (query_key_press_event())
+		if (query_key_press_serial() != press_serial_at_start)
 		{
 			i = -1;
 			break;

--- a/src/platform/sdl/video_sdl.cpp
+++ b/src/platform/sdl/video_sdl.cpp
@@ -39,6 +39,7 @@
 #include <openglad/interface/game_context.h>
 #include <memory>
 #include <limits>
+#include <mutex>
 #include <span>
 #include <tuple>
 #include <vector>
@@ -3851,8 +3852,79 @@ int sdl_video::fade_between(void* old_surface, void* new_surface,
                        static_cast<SDL_Surface*>(dest_surface));
 }
 
+#ifdef TESTING
+namespace og::video_testing
+{
+std::atomic<int> g_fade_violations{0};
+
+namespace
+{
+std::mutex s_fade_violation_mutex;
+std::vector<std::string> s_fade_violation_messages;
+
+void report_fade_violation(const char* what)
+{
+    TRACE("video", "FADE VIOLATION: %s", what);
+    LogError("FADE VIOLATION: {}\n", what);
+    ++g_fade_violations;
+    std::lock_guard<std::mutex> lock(s_fade_violation_mutex);
+    s_fade_violation_messages.emplace_back(what);
+}
+} // namespace
+
+std::vector<std::string> fade_violation_messages()
+{
+    std::lock_guard<std::mutex> lock(s_fade_violation_mutex);
+    return s_fade_violation_messages;
+}
+
+void reset_fade_violations()
+{
+    std::lock_guard<std::mutex> lock(s_fade_violation_mutex);
+    s_fade_violation_messages.clear();
+    g_fade_violations.store(0);
+}
+} // namespace og::video_testing
+#endif
+
+bool sdl_video::window_is_black()
+{
+    return E_Screen == nullptr || E_Screen->window_is_black();
+}
+
+#ifdef TESTING
+void sdl_video::testing_reset_window_state()
+{
+    if (E_Screen != nullptr)
+        E_Screen->testing_reset_window_state();
+}
+#endif
+
 int sdl_video::fadeblack(bool fade_in)
 {
+    // Fade ownership (docs/menu-engine.md): a fade-out of a window that
+    // already shows black has nothing to fade. Skipped without touching
+    // FadeBetween, so the trace counts the flow tests pin stay honest.
+    if (!fade_in && E_Screen->window_is_black())
+    {
+        TRACE("video", "fadeblack: window already black, skipped");
+        return 0;
+    }
+#ifdef TESTING
+    // The two invariants, checked at the fade itself (see video_sdl.h).
+    if (fade_in && !E_Screen->window_is_black())
+        og::video_testing::report_fade_violation(
+            "fade-in without a fade-out (the window is not black)");
+    if (!fade_in)
+    {
+        std::string detail;
+        if (!E_Screen->testing_render_matches_presented(&detail))
+            og::video_testing::report_fade_violation(
+                ("fade-out from a frame that was never presented (the render "
+                 "buffer was cleared or redrawn after its last present: " +
+                 detail + ")").c_str());
+    }
+#endif
 	// Sized to the active canvas: FadeBetween requires exact dim matches
 	// with E_Screen->render.
 	SDL_Surface* black = SDL_CreateSurface(active_canvas_w(), active_canvas_h(), SDL_PIXELFORMAT_XRGB8888);
@@ -3867,5 +3939,13 @@ int sdl_video::fadeblack(bool fade_in)
         i = FadeBetween(E_Screen->render, black, E_Screen->render); // fade to black
 
 	SDL_DestroySurface(black);
+	// Stamped AFTER FadeBetween: its terminal swap presents the black frame
+	// and, like every present, clears the flag. A 0 return means the fade
+	// never ran (a precondition failure), so the window keeps its state; an
+	// aborted fade (-1) still presented black.
+	if (!fade_in && i != 0)
+	{
+		E_Screen->set_window_black(true);
+	}
 	return i;
 }

--- a/tests/coverage_internal/campaign_picker_internal.inc
+++ b/tests/coverage_internal/campaign_picker_internal.inc
@@ -7,13 +7,29 @@ namespace
 std::atomic<std::uint64_t> s_campaign_picker_entered_count{0};
 std::atomic<std::uint64_t> s_campaign_picker_action_count{0};
 std::atomic<bool> s_campaign_picker_abort_pending{false};
+// Default ON: an un-driven browser accepts the current campaign after its
+// first presented frame (pick_campaign). The integration listener re-arms it
+// at every test start; tests that drive the browser disarm it.
+std::atomic<bool> s_campaign_picker_auto_accept{true};
 } // namespace
+
+void campaign_picker_testing_set_auto_accept(bool enabled)
+{
+    s_campaign_picker_auto_accept.store(enabled, std::memory_order_release);
+}
+
+bool campaign_picker_testing_auto_accept()
+{
+    return s_campaign_picker_auto_accept.load(std::memory_order_acquire);
+}
 
 void campaign_picker_testing_input_reset()
 {
     s_campaign_picker_entered_count.store(0, std::memory_order_release);
     s_campaign_picker_action_count.store(0, std::memory_order_release);
     s_campaign_picker_abort_pending.store(false, std::memory_order_release);
+    // A test resetting the browser's input is about to DRIVE it.
+    s_campaign_picker_auto_accept.store(false, std::memory_order_release);
 }
 
 void campaign_picker_testing_abort()

--- a/tests/curses/test_curses_network.cpp
+++ b/tests/curses/test_curses_network.cpp
@@ -577,12 +577,13 @@ TEST(CursesNetwork, roster_reflects_two_players)
         << "the roster must identify teams with their player-facing colors";
 
     // §9.12 (G5) census parity: the terminal lobby carries the same
-    // session-status line as the SDL base camp header — role + machine/
-    // player census for the host, host company for the joiner (the curses
-    // lobby has no relay room code, so the room half stays empty).
-    EXPECT_TRUE(status_contains(*host_lobby, "HOSTING 2 MACH / 2 PLYR"));
+    // session-status line as the SDL base camp header — role plus the
+    // players/machines census on BOTH sides (the curses lobby has no relay
+    // room code, so the room half stays empty).
+    EXPECT_TRUE(status_contains(*host_lobby,
+                                "HOSTING: 2 PLAYERS / 2 MACHINES"));
     EXPECT_TRUE(status_contains(*join_lobby,
-                                "JOINED - HOST: HOST CURSES CO"));
+                                "JOINED: 2 PLAYERS / 2 MACHINES"));
 
     // The joiner should also observe the shared lobby (>=1 player visible).
     bool join_sees_lobby = false;

--- a/tests/e2e/wasm-game.spec.js
+++ b/tests/e2e/wasm-game.spec.js
@@ -327,7 +327,11 @@ async function openWebDisplayOptions(page) {
   for (let i = 0; i < 2; ++i) {
     await pressPickerKey(page, 's');
   }
-  await pressPickerKey(page, 'z', 300);
+  // GAME SETTINGS is a main-menu door: on web (no TESTING) that is a real
+  // 500ms fade-out plus a 500ms fade-in, and the fade loop blocks the main
+  // thread and swallows key presses (#237). Settle past both before the next
+  // key, or DISPLAY's chain starts inside the fade.
+  await pressPickerKey(page, 'z', 1_500);
 
   // GAME SETTINGS starts on BACK; DISPLAY is two rows below it. On web the
   // mode/resolution rows are hidden, so DISPLAY jumps BACK -> overscan -> Zoom.
@@ -342,7 +346,9 @@ async function leaveWebDisplayOptions(page) {
   // Backspace is the web back key: physical Escape is swallowed by the engine
   // on web builds (browser-reserved for fullscreen exit).
   await pressPickerKey(page, 'Backspace', 300);
-  await pressPickerKey(page, 'Backspace', 500);
+  // The second Backspace leaves GAME SETTINGS for the main menu — the return
+  // half of the same door, so the same 1000ms of blocking fade (#237).
+  await pressPickerKey(page, 'Backspace', 1_500);
 }
 
 async function restoreDisplayDefaultsDuringGameplay(page, runtimeLogs) {
@@ -1037,6 +1043,11 @@ test.describe('Game Interaction', () => {
     await waitForRenderedFrames(page, 2);
     await page.keyboard.press('Enter');
     await waitForRenderedFrames(page, 6);
+    // Whatever Enter opened is a main-menu door, and on web those fade for a
+    // real second (#237). Capturing inside the fade grabs a solid-black frame
+    // that hasVisualContent() rejects — settle past it first.
+    await page.waitForTimeout(1_500);
+    await waitForRenderedFrames(page, 2);
 
     // Take screenshot after navigation
     const afterScreenshot = await getCanvasScreenshot(page);

--- a/tests/e2e/wasm-game.spec.js
+++ b/tests/e2e/wasm-game.spec.js
@@ -9,6 +9,7 @@ const {
   startSeededSinglePlayerFromPicker,
   waitForGameLoad,
   waitForGameplayProgress,
+  waitForPickerReady,
   waitForGameplayRenderSamples,
   waitForRenderedFrames,
 } = require('./wasm_helpers');
@@ -313,6 +314,12 @@ async function pressPickerKey(page, key, settlingMs = 150) {
 }
 
 async function openWebDisplayOptions(page) {
+  // waitForGameLoad only sees the DOM loading overlay, which the emscripten
+  // runtime clears before main() reaches the picker; the in-canvas loading
+  // dialog then fades out (#237 ownership) and the main menu fades in, so
+  // keys sent on the overlay's disappearance land before any menu exists.
+  // Wait for the picker itself, as every other picker-driving flow does.
+  await waitForPickerReady(page);
   // Emscripten starts forwarding keyboard input after a real canvas click.
   // Use an inert corner rather than focusCanvas(). Its center used to land
   // on the old player-count buttons and still sits among live menu faces.

--- a/tests/integration/integration_main.cpp
+++ b/tests/integration/integration_main.cpp
@@ -13,6 +13,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <unistd.h>
 #include <utility>
 #include <vector>
@@ -201,25 +202,81 @@ std::condition_variable s_main_thread_task_cv;
 std::vector<std::pair<std::uint64_t, std::function<void()>>>
     s_main_thread_tasks;
 std::uint64_t s_main_thread_task_next = 0;
+// High-water mark of tickets that actually RAN. Tasks run in post order, so
+// one mark answers every waiter — as long as the discarded set below is
+// consulted FIRST: cancelling ticket N and then running N+1 would otherwise
+// report N as run.
 std::uint64_t s_main_thread_task_settled = 0;
+// Tickets resolved by cancellation instead of execution (a wait that timed
+// out, or a drain at a test boundary). A waiter on one of these gets false.
+std::set<std::uint64_t> s_main_thread_tasks_discarded;
+// Bumped by every drain. A batch the pump already swapped out of the queue
+// re-checks it before each task, so a task belonging to a finished test can
+// never run inside the next one.
+std::uint64_t s_main_thread_task_generation = 0;
+
+// What a waiter sees for its ticket.
+enum class MainThreadTaskFate
+{
+    Pending,
+    Ran,
+    Discarded,
+};
+
+MainThreadTaskFate main_thread_task_fate_locked(std::uint64_t ticket)
+{
+    if (s_main_thread_tasks_discarded.count(ticket) != 0)
+        return MainThreadTaskFate::Discarded;
+    if (s_main_thread_task_settled >= ticket)
+        return MainThreadTaskFate::Ran;
+    return MainThreadTaskFate::Pending;
+}
+
+// Removes a still-queued task and marks it discarded. Returns false when the
+// ticket is no longer in the queue (already run, or mid-flight on the pump).
+bool cancel_queued_main_thread_task_locked(std::uint64_t ticket)
+{
+    for (auto it = s_main_thread_tasks.begin(); it != s_main_thread_tasks.end();
+         ++it)
+    {
+        if (it->first != ticket)
+            continue;
+        s_main_thread_tasks.erase(it);
+        s_main_thread_tasks_discarded.insert(ticket);
+        return true;
+    }
+    return false;
+}
 
 // Installed as og::ui::g_picker_main_thread_pump. Tasks run OUTSIDE the queue
-// lock (they re-enter menu/lobby code freely) and settle in post order, so a
-// single high-water mark answers every waiter.
+// lock (they re-enter menu/lobby code freely) and settle in post order.
 void run_main_thread_tasks()
 {
     std::vector<std::pair<std::uint64_t, std::function<void()>>> batch;
+    std::uint64_t generation = 0;
     {
         std::lock_guard<std::mutex> lock(s_main_thread_task_mutex);
         batch.swap(s_main_thread_tasks);
+        generation = s_main_thread_task_generation;
     }
     for (auto& [ticket, task] : batch)
     {
-        if (task)
+        bool run_it = false;
+        {
+            std::lock_guard<std::mutex> lock(s_main_thread_task_mutex);
+            // A drain (or this ticket's own timeout) landed while the batch
+            // was running: the rest of it belongs to a scope that is over.
+            run_it = s_main_thread_task_generation == generation &&
+                     s_main_thread_tasks_discarded.count(ticket) == 0;
+        }
+        if (run_it && task)
             task();
         {
             std::lock_guard<std::mutex> lock(s_main_thread_task_mutex);
-            s_main_thread_task_settled = ticket;
+            if (run_it)
+                s_main_thread_task_settled = ticket;
+            else
+                s_main_thread_tasks_discarded.insert(ticket);
         }
         s_main_thread_task_cv.notify_all();
     }
@@ -309,16 +366,62 @@ std::uint64_t post_main_thread_task(std::function<void()> task)
 
 bool wait_for_main_thread_task(std::uint64_t ticket, int timeout_ms)
 {
+    const auto ticket_id = static_cast<unsigned long long>(ticket);
     std::unique_lock<std::mutex> lock(s_main_thread_task_mutex);
-    const bool settled = s_main_thread_task_cv.wait_for(
-        lock, std::chrono::milliseconds(timeout_ms),
-        [ticket] { return s_main_thread_task_settled >= ticket; });
-    if (!settled)
+    MainThreadTaskFate fate = MainThreadTaskFate::Pending;
+    const bool resolved = s_main_thread_task_cv.wait_for(
+        lock, std::chrono::milliseconds(timeout_ms), [ticket, &fate] {
+            fate = main_thread_task_fate_locked(ticket);
+            return fate != MainThreadTaskFate::Pending;
+        });
+    if (resolved)
+    {
+        if (fate == MainThreadTaskFate::Ran)
+            return true;
+        std::fprintf(stderr,
+                     "  [interact] main-thread task %llu was DISCARDED before "
+                     "it ran\n",
+                     ticket_id);
+        return false;
+    }
+    // Timed out. Cancel the ticket so it can never run later — against a
+    // caller's stack that has since gone away, or inside the next test.
+    if (cancel_queued_main_thread_task_locked(ticket))
+    {
         std::fprintf(stderr,
                      "  [interact] TIMEOUT waiting for main-thread task %llu "
-                     "(%d ms)\n",
-                     static_cast<unsigned long long>(ticket), timeout_ms);
-    return settled;
+                     "(%d ms); cancelled while still queued\n",
+                     ticket_id, timeout_ms);
+        return false;
+    }
+    // Not in the queue: it either settled in the instant the wait expired, or
+    // the pump is running it right now. A running task cannot be cancelled,
+    // so wait for it to finish rather than returning to a scope it may still
+    // be reading.
+    if (main_thread_task_fate_locked(ticket) == MainThreadTaskFate::Ran)
+        return true;
+    std::fprintf(stderr,
+                 "  [interact] TIMEOUT waiting for main-thread task %llu "
+                 "(%d ms); it is already running — waiting it out\n",
+                 ticket_id, timeout_ms);
+    const bool finished = s_main_thread_task_cv.wait_for(
+        lock, std::chrono::milliseconds(timeout_ms), [ticket, &fate] {
+            fate = main_thread_task_fate_locked(ticket);
+            return fate != MainThreadTaskFate::Pending;
+        });
+    if (finished && fate == MainThreadTaskFate::Ran)
+        return true;
+    if (!finished)
+    {
+        // The pump never came back. Nothing can make this safe; say so loudly
+        // and report the task as not run.
+        s_main_thread_tasks_discarded.insert(ticket);
+        std::fprintf(stderr,
+                     "  [interact] main-thread task %llu NEVER FINISHED (%d "
+                     "ms); its captures may still be read\n",
+                     ticket_id, timeout_ms);
+    }
+    return false;
 }
 
 void drain_main_thread_tasks()
@@ -326,7 +429,16 @@ void drain_main_thread_tasks()
     {
         std::lock_guard<std::mutex> lock(s_main_thread_task_mutex);
         s_main_thread_tasks.clear();
-        s_main_thread_task_settled = s_main_thread_task_next;
+        // Every posted ticket that has not run yet is discarded: the queued
+        // ones cleared just now, plus anything a batch still holds (the
+        // generation bump stops the pump from running those). A task the
+        // pump happens to be executing at this instant is counted with them
+        // — it belongs to a scope that is already over, so its waiter is
+        // told "not run" rather than being handed a result nobody can use.
+        for (std::uint64_t ticket = s_main_thread_task_settled + 1;
+             ticket <= s_main_thread_task_next; ++ticket)
+            s_main_thread_tasks_discarded.insert(ticket);
+        ++s_main_thread_task_generation;
     }
     s_main_thread_task_cv.notify_all();
 }

--- a/tests/integration/integration_main.cpp
+++ b/tests/integration/integration_main.cpp
@@ -90,6 +90,11 @@ void reset_integration_ui_state()
         og::runtime::current_session->input_hw_->mouse_buttons = 0;
         og::runtime::current_session->input_hw_->picker_was_left_down = false;
         og::runtime::current_session->input_hw_->picker_was_right_down = false;
+        // Also drop the collapsed-tap pending-click queue (file-static in
+        // input.cpp, unreachable from here by field writes): a test that
+        // clicked inside a self-pumping surface must not leak phantom
+        // clicks into the next test under --gtest_shuffle.
+        reset_mouse_click_tracking();
     }
 
     if (og::runtime::current_session->picker_ != nullptr) {

--- a/tests/integration/integration_main.cpp
+++ b/tests/integration/integration_main.cpp
@@ -44,6 +44,7 @@ extern "C" void __gcov_dump(void);
 #include <openglad/platform/game_session.h>
 #include <openglad/platform/local_transport_shadow.h>
 #include <openglad/platform/screen_lifecycle.h>
+#include <openglad/platform/video_sdl.h>
 #include <openglad/resources/company.h>
 #include <openglad/resources/gparser.h>
 #include <openglad/resources/io.h>
@@ -59,6 +60,7 @@ extern std::atomic<bool> g_test_in_game;
 extern std::atomic<int> g_test_game_epoch;
 void picker_testing_yes_or_no_queue_clear();
 void picker_testing_set_force_real_dialogs(bool enabled);
+void campaign_picker_testing_set_auto_accept(bool enabled);
 #endif
 
 namespace {
@@ -179,9 +181,14 @@ void reset_integration_ui_state()
     g_test_game_epoch.store(0, std::memory_order_release);
     picker_testing_yes_or_no_queue_clear();
     picker_testing_set_force_real_dialogs(false);
-    // #237: a test that noted "faded to black" (or aborted mid-screen) must
-    // not leak transition state into the tests declared after it.
+    // #237: a test that aborted mid-screen (or left an override pending) must
+    // not leak transition state into the tests declared after it — and the
+    // window it left (black after an exit fade, or showing its last frame)
+    // must not either: every canvas counts as presented as it stands.
     og::ui::menu_transition_testing_reset();
+    if (og::runtime::current_session->myscreen_ != nullptr)
+        og::runtime::current_session->myscreen_->testing_reset_window_state();
+    campaign_picker_testing_set_auto_accept(true);
 #endif
     results_screen_testing_set_force_full(false);
 }
@@ -290,13 +297,28 @@ public:
         drain_main_thread_tasks();
         og::ui::g_picker_main_thread_pump = &run_main_thread_tasks;
         reset_integration_ui_state();
+        // After the window reset above: the reset itself never fades.
+        og::video_testing::reset_fade_violations();
     }
 
     void OnTestEnd(const ::testing::TestInfo&) override
     {
         og::ui::g_picker_main_thread_pump = nullptr;
         drain_main_thread_tasks();
+        // Fade-ownership invariants (video_sdl.h): a fade-in over a window
+        // that is not black, or a fade-out of a buffer the window never
+        // showed. Every flow test in this binary is an oracle for the class;
+        // read BEFORE the reset below so a violation always fails the test
+        // that caused it.
+        for (const std::string& violation :
+             og::video_testing::fade_violation_messages())
+        {
+            ADD_FAILURE() << "FADE VIOLATION: " << violation
+                          << " — see docs/menu-engine.md, \"Drawing and "
+                             "transitions\"";
+        }
         reset_integration_ui_state();
+        og::video_testing::reset_fade_violations();
     }
 };
 

--- a/tests/integration/integration_main.cpp
+++ b/tests/integration/integration_main.cpp
@@ -2,15 +2,20 @@
 
 #include <SDL3/SDL.h>
 
+#include <chrono>
+#include <condition_variable>
 #include <csignal>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <format>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <unistd.h>
+#include <utility>
+#include <vector>
 
 #ifdef __linux__
 #include <sys/prctl.h>
@@ -30,6 +35,7 @@ extern "C" void __gcov_dump(void);
 #include <openglad/interface/render/view.h>
 #include <openglad/interface/screen.h>
 #include <openglad/interface/ui/results_screen.h>
+#include <openglad/interface/ui/picker_lobby_client.h>
 #include <openglad/interface/ui/picker_ui_state.h>
 #include <openglad/legacy/base.h>
 #include <openglad/interface/game_context.h>
@@ -42,6 +48,9 @@ extern "C" void __gcov_dump(void);
 
 extern int g_picker_mainmenu_calls;
 extern int g_picker_max_mainmenu_calls;
+// Main-thread task queue, declared for injectors in tests/test_interact.h and
+// defined at the bottom of this file.
+void drain_main_thread_tasks();
 #ifdef TESTING
 extern bool g_test_remove_exits;
 extern std::atomic<bool> g_test_in_game;
@@ -180,16 +189,52 @@ void handle_test_signal(int sig)
     _exit(128 + sig);
 }
 
+// --- Main-thread task queue (issue #257) -----------------------------------
+// Injector threads post state mutations here; the menu runner drains them at
+// the top of each frame. See tests/test_interact.h for the contract.
+std::mutex s_main_thread_task_mutex;
+std::condition_variable s_main_thread_task_cv;
+std::vector<std::pair<std::uint64_t, std::function<void()>>>
+    s_main_thread_tasks;
+std::uint64_t s_main_thread_task_next = 0;
+std::uint64_t s_main_thread_task_settled = 0;
+
+// Installed as og::ui::g_picker_main_thread_pump. Tasks run OUTSIDE the queue
+// lock (they re-enter menu/lobby code freely) and settle in post order, so a
+// single high-water mark answers every waiter.
+void run_main_thread_tasks()
+{
+    std::vector<std::pair<std::uint64_t, std::function<void()>>> batch;
+    {
+        std::lock_guard<std::mutex> lock(s_main_thread_task_mutex);
+        batch.swap(s_main_thread_tasks);
+    }
+    for (auto& [ticket, task] : batch)
+    {
+        if (task)
+            task();
+        {
+            std::lock_guard<std::mutex> lock(s_main_thread_task_mutex);
+            s_main_thread_task_settled = ticket;
+        }
+        s_main_thread_task_cv.notify_all();
+    }
+}
+
 class WorldCleanupListener final : public ::testing::EmptyTestEventListener
 {
 public:
     void OnTestStart(const ::testing::TestInfo&) override
     {
+        drain_main_thread_tasks();
+        og::ui::g_picker_main_thread_pump = &run_main_thread_tasks;
         reset_integration_ui_state();
     }
 
     void OnTestEnd(const ::testing::TestInfo&) override
     {
+        og::ui::g_picker_main_thread_pump = nullptr;
+        drain_main_thread_tasks();
         reset_integration_ui_state();
     }
 };
@@ -248,6 +293,38 @@ void seed_stray_company_slots_from_env()
 std::mutex& get_allbuttons_mutex()
 {
     return s_allbuttons_mutex;
+}
+
+std::uint64_t post_main_thread_task(std::function<void()> task)
+{
+    std::lock_guard<std::mutex> lock(s_main_thread_task_mutex);
+    const std::uint64_t ticket = ++s_main_thread_task_next;
+    s_main_thread_tasks.emplace_back(ticket, std::move(task));
+    return ticket;
+}
+
+bool wait_for_main_thread_task(std::uint64_t ticket, int timeout_ms)
+{
+    std::unique_lock<std::mutex> lock(s_main_thread_task_mutex);
+    const bool settled = s_main_thread_task_cv.wait_for(
+        lock, std::chrono::milliseconds(timeout_ms),
+        [ticket] { return s_main_thread_task_settled >= ticket; });
+    if (!settled)
+        std::fprintf(stderr,
+                     "  [interact] TIMEOUT waiting for main-thread task %llu "
+                     "(%d ms)\n",
+                     static_cast<unsigned long long>(ticket), timeout_ms);
+    return settled;
+}
+
+void drain_main_thread_tasks()
+{
+    {
+        std::lock_guard<std::mutex> lock(s_main_thread_task_mutex);
+        s_main_thread_tasks.clear();
+        s_main_thread_task_settled = s_main_thread_task_next;
+    }
+    s_main_thread_task_cv.notify_all();
 }
 
 int main(int argc, char** argv)

--- a/tests/integration/integration_main.cpp
+++ b/tests/integration/integration_main.cpp
@@ -34,6 +34,7 @@ extern "C" void __gcov_dump(void);
 #include <openglad/interface/input.h>
 #include <openglad/interface/render/view.h>
 #include <openglad/interface/screen.h>
+#include <openglad/interface/ui/menu_screen_spec.h>
 #include <openglad/interface/ui/results_screen.h>
 #include <openglad/interface/ui/picker_lobby_client.h>
 #include <openglad/interface/ui/picker_ui_state.h>
@@ -177,6 +178,9 @@ void reset_integration_ui_state()
     g_test_game_epoch.store(0, std::memory_order_release);
     picker_testing_yes_or_no_queue_clear();
     picker_testing_set_force_real_dialogs(false);
+    // #237: a test that noted "faded to black" (or aborted mid-screen) must
+    // not leak transition state into the tests declared after it.
+    og::ui::menu_transition_testing_reset();
 #endif
     results_screen_testing_set_force_full(false);
 }

--- a/tests/integration/sdl_video_default_lifecycle.cpp
+++ b/tests/integration/sdl_video_default_lifecycle.cpp
@@ -103,8 +103,17 @@ int main(int argc, char* argv[])
             // exercise the actual timed fade loop with a short, deterministic
             // duration and verify both terminal frames.
             sdl_display->fadeDuration = 60;
+            ok &= require(display->window_is_black(),
+                          "a window that never presented shows black");
+            ok &= require(display->fadeblack(false) == 0,
+                          "fade-to-black of a never-presented window is a no-op");
             sdl_display->clearbuffer();
             sdl_display->pointb(20, 20, 200, 80, 40);
+            // Present the reference frame: a fade-out reads the buffer and
+            // is a no-op until something has been shown.
+            sdl_display->buffer_to_screen(0, 0, 320, 200);
+            ok &= require(!display->window_is_black(),
+                          "a present clears the black-window state");
             Uint8 expected_red = 0;
             Uint8 expected_green = 0;
             Uint8 expected_blue = 0;
@@ -117,6 +126,8 @@ int main(int argc, char* argv[])
                 "fade reference pixel is visible");
             ok &= require(display->fadeblack(false) == 1,
                           "production fade-to-black completes");
+            ok &= require(display->window_is_black(),
+                          "a completed fade-to-black blackens the window");
             Uint8 black_red = 1;
             Uint8 black_green = 1;
             Uint8 black_blue = 1;
@@ -141,6 +152,8 @@ int main(int argc, char* argv[])
                 frame_begin, frame_begin + frame_bytes);
             ok &= require(display->fadeblack(true) == 1,
                           "production fade-from-black completes");
+            ok &= require(!display->window_is_black(),
+                          "the fade-in's terminal present clears the black state");
             ok &= require(
                 std::memcmp(
                     E_Screen->render->pixels,

--- a/tests/integration/test_back_to_mainmenu.cpp
+++ b/tests/integration/test_back_to_mainmenu.cpp
@@ -50,10 +50,9 @@ static int back_test_injector(void* data)
 
     // === Iteration 1: Click CONTINUE then BACK ===
 
-    // Wait for mainmenu to initialize and complete fadeblack.
-    // The main menu's run_menu_screen entry (EnterTransition::FadeWithInitialDraw)
-    // publishes its buttons, then fades out, composes, and fades in — the fade
-    // takes ~500ms and eats SDL events.
+    // Wait for mainmenu to initialize. Its depth-1 entry fades (#237
+    // derivation), but fades are INSTANT under TESTING — the 750ms is a
+    // generic settle for the runner loop, not fade timing.
     wait_for_interactable("continue_game", 5000);
     SDL_Delay(750);
     state->times_saw_mainmenu++;
@@ -61,7 +60,7 @@ static int back_test_injector(void* data)
     fprintf(stderr, "  [test] Iteration 1: clicking continue_game\n");
     interact("continue_game");
 
-    // Wait for create_team_menu to init (Base Camp's FadeAroundEntry fades,
+    // Wait for create_team_menu to init (Base Camp's depth-1 entry fades,
     // then the runner loop's reload guard loads the level)
     SDL_Delay(500);
     wait_for_interactable("go", 10000);

--- a/tests/integration/test_campaign_and_level_picker.cpp
+++ b/tests/integration/test_campaign_and_level_picker.cpp
@@ -35,6 +35,7 @@ int toInt(const std::string& s);
 int campaign_picker_testing_exercise_entry_draw_paths();
 void campaign_picker_testing_input_reset();
 void campaign_picker_testing_abort();
+void campaign_picker_testing_set_auto_accept(bool enabled);
 std::uint64_t campaign_picker_testing_entered_count();
 std::uint64_t campaign_picker_testing_action_count();
 // results_screen.cpp helper
@@ -806,6 +807,9 @@ TEST(CampaignAndLevelPicker, campaign_picker_draw_loop_exits_on_q)
     end = 0;
 
     g_picker_q_release.store(false, std::memory_order_release);
+    // This test drives the browser (q exits it); the un-driven default
+    // would accept the current campaign after the first frame instead.
+    campaign_picker_testing_set_auto_accept(false);
     std::uint64_t entered_baseline = campaign_picker_testing_entered_count();
     ScopedSdlThread thread(SDL_CreateThread(
         hold_q_key_for_picker, "picker_q_hold", &entered_baseline));
@@ -821,8 +825,9 @@ TEST(CampaignAndLevelPicker, campaign_picker_draw_loop_exits_on_q)
     ASSERT_TRUE(out.id.empty()) << "q exit path should not select a campaign";
 
     // #237: entered with no menu screen open (depth 0), campaign select is a
-    // context switch — exactly one fade-out plus the first-frame fade-in.
-    // Under TESTING each fadeblack traces one FadeBetween line.
+    // context switch — one fade-out, the first-frame fade-in, and (the
+    // ownership rule) its own exit fade-out. Under TESTING each fadeblack
+    // that runs traces one FadeBetween line.
     int fades = 0;
     {
         std::lock_guard<std::mutex> lock(g_trace_mutex);
@@ -833,9 +838,11 @@ TEST(CampaignAndLevelPicker, campaign_picker_draw_loop_exits_on_q)
                 ++fades;
         }
     }
-    EXPECT_EQ(2, fades)
-        << "#237: a top-level campaign-select entry must fade out and in "
-           "exactly once";
+    EXPECT_EQ(3, fades)
+        << "#237: a top-level campaign-select entry must fade out, in, and "
+           "out again at its exit — exactly once each";
+    EXPECT_TRUE(og::runtime::current_session->myscreen_->window_is_black())
+        << "the browser's exit leaves the window black for the next screen";
 }
 
 

--- a/tests/integration/test_campaign_and_level_picker.cpp
+++ b/tests/integration/test_campaign_and_level_picker.cpp
@@ -825,9 +825,10 @@ TEST(CampaignAndLevelPicker, campaign_picker_draw_loop_exits_on_q)
     ASSERT_TRUE(out.id.empty()) << "q exit path should not select a campaign";
 
     // #237: entered with no menu screen open (depth 0), campaign select is a
-    // context switch — one fade-out, the first-frame fade-in, and (the
-    // ownership rule) its own exit fade-out. Under TESTING each fadeblack
-    // that runs traces one FadeBetween line.
+    // context switch — the first-frame fade-in and (the ownership rule) its
+    // own exit fade-out. The test boundary leaves the window black, so the
+    // entry's fade-out has nothing to fade and is skipped (no trace). Under
+    // TESTING each fadeblack that runs traces one FadeBetween line.
     int fades = 0;
     {
         std::lock_guard<std::mutex> lock(g_trace_mutex);
@@ -838,9 +839,9 @@ TEST(CampaignAndLevelPicker, campaign_picker_draw_loop_exits_on_q)
                 ++fades;
         }
     }
-    EXPECT_EQ(3, fades)
-        << "#237: a top-level campaign-select entry must fade out, in, and "
-           "out again at its exit — exactly once each";
+    EXPECT_EQ(2, fades)
+        << "#237: over a black window a top-level campaign-select entry fades "
+           "in, and out again at its exit — exactly once each";
     EXPECT_TRUE(og::runtime::current_session->myscreen_->window_is_black())
         << "the browser's exit leaves the window black for the next screen";
 }

--- a/tests/integration/test_campaign_and_level_picker.cpp
+++ b/tests/integration/test_campaign_and_level_picker.cpp
@@ -811,6 +811,7 @@ TEST(CampaignAndLevelPicker, campaign_picker_draw_loop_exits_on_q)
         hold_q_key_for_picker, "picker_q_hold", &entered_baseline));
     ASSERT_TRUE(thread.valid()) << "failed to create picker q-hold thread";
 
+    trace_clear();
     CampaignResult out = pick_campaign(&og::runtime::current_session->myscreen_->save_data, false);
     g_picker_q_release.store(true, std::memory_order_release);
 
@@ -818,6 +819,23 @@ TEST(CampaignAndLevelPicker, campaign_picker_draw_loop_exits_on_q)
 
     ASSERT_EQ(0, thread_result);
     ASSERT_TRUE(out.id.empty()) << "q exit path should not select a campaign";
+
+    // #237: entered with no menu screen open (depth 0), campaign select is a
+    // context switch — exactly one fade-out plus the first-frame fade-in.
+    // Under TESTING each fadeblack traces one FadeBetween line.
+    int fades = 0;
+    {
+        std::lock_guard<std::mutex> lock(g_trace_mutex);
+        for (const TraceEntry& entry : g_trace_buffer)
+        {
+            if (entry.category == "video" &&
+                entry.message.find("FadeBetween") != std::string::npos)
+                ++fades;
+        }
+    }
+    EXPECT_EQ(2, fades)
+        << "#237: a top-level campaign-select entry must fade out and in "
+           "exactly once";
 }
 
 

--- a/tests/integration/test_campaign_sprite_uaf.cpp
+++ b/tests/integration/test_campaign_sprite_uaf.cpp
@@ -227,6 +227,12 @@ int set_campaign_flow_injector(void*)
     if (!wait_for_counter_above(campaign_picker_testing_entered_count,
                                 entered_before))
         return 2;
+    // The SET CAMPAIGN click is still HELD when the picker enters (the
+    // entered counter bumps before interact()'s release lands), and the
+    // picker's entry baseline holds fire until that click has been seen up
+    // once (pointer handoff). Let the release land in its own picker frame
+    // before pressing again — same cadence idiom as the BACK click below.
+    SDL_Delay(300);
     // ENTER ID sits under DELETE/RESET; take its center from the pure layout.
     const og::ui::PickerRect id_button =
         og::ui::campaign_picker_layout().id_button;

--- a/tests/integration/test_canvas_scale.cpp
+++ b/tests/integration/test_canvas_scale.cpp
@@ -22,6 +22,7 @@
 #include <openglad/interface/render/view.h>
 #include <openglad/interface/render/view_layout.h>
 #include <openglad/interface/input.h>
+#include <openglad/interface/ui/menu_screen_spec.h>
 #include <openglad/core/test_trace.h>
 #include <openglad/resources/gparser.h>
 #include <gtest/gtest.h>
@@ -1273,6 +1274,11 @@ TEST(CanvasScale, level_editor_filters_map_but_keeps_controls_on_crisp_overlay)
     SDL_Thread* stopper = SDL_CreateThread(
         stop_editor_after_render, "editor_overlay_stopper", nullptr);
     ASSERT_NE(nullptr, stopper);
+    // This test reads the editor's LAST present back; a transition would
+    // discard it (a fade owns every World swap and drops the prepared
+    // overlay). Called directly at depth 0 the editor would fade itself in
+    // and out, so classify this entry as instant — the sanctioned override.
+    og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Instant);
     (void)level_editor();
     SDL_WaitThread(stopper, nullptr);
     s->world().end = 0;
@@ -1404,11 +1410,13 @@ TEST(CanvasScale, fadeblack_matches_the_grown_world_canvas)
     ASSERT_EQ(640, E_Screen->world_w());
     E_Screen->set_active_canvas(CanvasTarget::World);
 
-    // Paint a pixel outside the classic 320x200 area, then fade to black:
+    // Paint a pixel outside the classic 320x200 area, present it (a fade may
+    // only read a frame the window has shown), then fade to black:
     // FadeBetween requires exact dim/pitch matches against the ACTIVE render
     // target, so a hardcoded 320x200 black surface would abort with "width
     // mismatch" and return 0 — and never darken the grown corner.
     s->pointb(639, 399, 47);
+    s->buffer_to_screen(0, 0, s->canvas_w(), s->canvas_h());
     EXPECT_EQ(1, s->fadeblack(false)) << "fade-to-black must run at 640x400";
     Uint8 r = 255, g = 255, b = 255;
     s->get_pixel(639, 399, &r, &g, &b);
@@ -1426,9 +1434,12 @@ TEST(CanvasScale, smart_smoothed_fade_discards_prepared_gameplay_ui)
     E_Screen->set_world_zoom(og::kZoomStepsMax, og::WorldScaleMode::Sai,
                              320, 200);
     E_Screen->set_active_canvas(CanvasTarget::World);
+    SDL_FillSurfaceRect(E_Screen->render, nullptr, 0x00ffffffu);
+    // The scenery is a presented frame (a fade may only read one); the
+    // overlay prepared AFTER it is exactly what the fade must discard.
+    s->buffer_to_screen(0, 0, s->canvas_w(), s->canvas_h());
     E_Screen->begin_gameplay_frame();
     ASSERT_TRUE(E_Screen->gameplay_ui_overlay_active());
-    SDL_FillSurfaceRect(E_Screen->render, nullptr, 0x00ffffffu);
     {
         ScopedGameplayUiCanvas gameplay_ui(*s);
         const SDL_Rect hud_rect{10, 10, 8, 8};

--- a/tests/integration/test_cloud_ui.cpp
+++ b/tests/integration/test_cloud_ui.cpp
@@ -140,7 +140,7 @@ int cloud_flow_injector(void* data)
     FlowState* state = static_cast<FlowState*>(data);
 
     wait_for_interactable("cloud", 10000);
-    SDL_Delay(750);  // FadeWithInitialDraw settle
+    SDL_Delay(750);  // menu-entry settle
     fprintf(stderr, "  [test] clicking CLOUD\n");
     interact("cloud");
 

--- a/tests/integration/test_cloud_ui.cpp
+++ b/tests/integration/test_cloud_ui.cpp
@@ -25,6 +25,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -114,7 +115,27 @@ struct FlowState {
     bool finished = false;
     bool saw_cloud_screen = false;
     bool clicked_all = false;
+    // #237 symmetry pin, the nested main-menu door (run_nested_menu_door):
+    // CLOUD SAVES runs INSIDE the still-open main menu, so the depth rule
+    // cannot see it and the door site brackets the fade by hand.
+    int fades_added_by_cloud_door = -1;
+    int fades_added_by_cloud_return = -1;
 };
+
+// Under TESTING every fadeblack takes FadeBetween's test-mode branch, which
+// traces exactly one "video" line per fade — so counting those lines counts
+// fades.
+int count_fade_between_traces()
+{
+    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    int fades = 0;
+    for (const TraceEntry& entry : g_trace_buffer) {
+        if (entry.category == "video" &&
+            entry.message.find("FadeBetween") != std::string::npos)
+            ++fades;
+    }
+    return fades;
+}
 
 // Block until a trace line shows up, the way wait_for_interactable polls the
 // button list. trace_contains takes the trace mutex, so the injector thread
@@ -142,11 +163,15 @@ int cloud_flow_injector(void* data)
     wait_for_interactable("cloud", 10000);
     SDL_Delay(750);  // menu-entry settle
     fprintf(stderr, "  [test] clicking CLOUD\n");
+    const int fades_before_door = count_fade_between_traces();
     interact("cloud");
 
+    int fades_inside_cloud = -1;
     if (wait_for_interactable("cloud_passphrase", 5000)) {
         state->saw_cloud_screen = true;
         SDL_Delay(750);
+        state->fades_added_by_cloud_door =
+            count_fade_between_traces() - fades_before_door;
         fprintf(stderr, "  [test] setting the passphrase (queued)\n");
         interact("cloud_passphrase");
 
@@ -175,6 +200,7 @@ int cloud_flow_injector(void* data)
         if (ok) {
             SDL_Delay(750);
             fprintf(stderr, "  [test] leaving the cloud screen\n");
+            fades_inside_cloud = count_fade_between_traces();
             interact("back");
         }
         state->clicked_all = ok;
@@ -182,6 +208,10 @@ int cloud_flow_injector(void* data)
 
     if (wait_for_interactable("begin_new_game", 10000)) {
         SDL_Delay(750);
+        if (fades_inside_cloud >= 0) {
+            state->fades_added_by_cloud_return =
+                count_fade_between_traces() - fades_inside_cloud;
+        }
         fprintf(stderr, "  [test] quitting from the main menu\n");
         interact("quit");
     }
@@ -268,6 +298,16 @@ TEST(CloudUi, upload_then_download_through_the_cloud_screen)
     ASSERT_TRUE(state.saw_cloud_screen) << "the CLOUD door must open";
     ASSERT_TRUE(state.clicked_all)
         << "every cloud button must have come back interactable in time";
+
+    // #237: CLOUD SAVES is a main-menu door whose screen runs nested inside
+    // the still-open main menu — no depth distinguishes it from a Base Camp
+    // subscreen, so run_nested_menu_door brackets both halves by hand.
+    EXPECT_EQ(2, state.fades_added_by_cloud_door)
+        << "#237: the CLOUD door must fade on the way IN (fade-out + the "
+           "nested entry's fade-in)";
+    EXPECT_EQ(2, state.fades_added_by_cloud_return)
+        << "#237 symmetry: and exactly as much on the way BACK — the door "
+           "fades out and the main-menu loop fades its next frame in";
 
     // Passphrase: the DERIVED key persisted (D9), pinned to the D2 vector.
     EXPECT_EQ("73270125791ba273", cfg.get_setting("cloud", "key"));

--- a/tests/integration/test_company_list.cpp
+++ b/tests/integration/test_company_list.cpp
@@ -192,7 +192,29 @@ struct FlowState {
     bool saw_team_menu = false;
     bool saw_load_hidden_after_empty = false;
     bool saw_continue_hidden_after_empty = false;
+    // #237 derivation pins, counted around the real doors this flow already
+    // drives. -1 means the injector never reached the read, which fails the
+    // exact assertions in the test body.
+    int fades_added_by_load_door = -1;
+    int fades_added_by_backups_door = -1;
 };
+
+// Under TESTING every fadeblack lands in FadeBetween's test-mode branch,
+// which traces exactly one "video" line per fade — so counting those lines
+// counts fades. (#237: the rule is derived in run_menu_screen, never
+// declared per screen, so only a real door driven through the real screens
+// can pin which side of it a screen is on.)
+int count_fade_between_traces()
+{
+    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    int fades = 0;
+    for (const TraceEntry& entry : g_trace_buffer) {
+        if (entry.category == "video" &&
+            entry.message.find("FadeBetween") != std::string::npos)
+            ++fades;
+    }
+    return fades;
+}
 
 // --- open flow -------------------------------------------------------------
 
@@ -391,14 +413,24 @@ int backups_and_empty_injector(void* data)
 
     wait_for_interactable("load_company", 5000);
     SDL_Delay(750);
+    // #237: LOAD is a door on the open main menu — a peer transition, so the
+    // Company List enters instantly.
+    const int fades_before_load = count_fade_between_traces();
     interact("load_company");
 
     if (wait_for_interactable("company_bak_0", 5000)) {
         SDL_Delay(750);
+        state->fades_added_by_load_door =
+            count_fade_between_traces() - fades_before_load;
         fprintf(stderr, "  [test] clicking the BK door\n");
+        // #237: the Backups view is opened from the open Company List — a
+        // nested run_menu_screen, which never fades whatever it is.
+        const int fades_before_backups = count_fade_between_traces();
         interact("company_bak_0");  // §2.4: opens the (empty) Backups view
         if (wait_for_backups_view()) {
             SDL_Delay(750);  // menu-entry settle
+            state->fades_added_by_backups_door =
+                count_fade_between_traces() - fades_before_backups;
             fprintf(stderr, "  [test] backing out of the empty backups view\n");
             interact("back");
         }
@@ -976,6 +1008,16 @@ TEST(CompanyList, backups_door_opens_empty_view_and_empty_delete_exits)
     ASSERT_FALSE(trace_contains("confirm", "REWIND TO THIS BACKUP?"))
         << "an empty backups view has nothing to confirm";
     ASSERT_FALSE(user_file_exists("save/wp3lastd.gtl"));
+    // #237 derivation, on the real doors rather than on a spec field: both
+    // are opened from an already-open menu, so neither fades. (The kind
+    // assertions in test_menu_engine name the screens; these say what the
+    // engine does with them.)
+    EXPECT_EQ(0, state.fades_added_by_load_door)
+        << "#237: the LOAD door is a peer transition — entering the Company "
+           "List from the open main menu must add no fade";
+    EXPECT_EQ(0, state.fades_added_by_backups_door)
+        << "#237: COMPANY BACKUPS is opened from the open Company List — a "
+           "nested entry never fades";
     ASSERT_TRUE(state.saw_load_hidden_after_empty)
         << "no companies left: the main-menu gate must hide LOAD";
     ASSERT_TRUE(state.saw_continue_hidden_after_empty)

--- a/tests/integration/test_company_list.cpp
+++ b/tests/integration/test_company_list.cpp
@@ -207,7 +207,8 @@ int open_row_injector(void* data)
     fprintf(stderr, "  [test] clicking LOAD\n");
     interact("load_company");
 
-    // The Company List fades in (a depth-1 entry under the #237 rule).
+    // The Company List enters instantly (the LOAD door is a #237 peer
+    // transition — no fade).
     if (wait_for_interactable("company_row_0", 5000)) {
         SDL_Delay(750);
         fprintf(stderr, "  [test] opening company row 0\n");

--- a/tests/integration/test_company_list.cpp
+++ b/tests/integration/test_company_list.cpp
@@ -197,6 +197,7 @@ struct FlowState {
     // exact assertions in the test body.
     int fades_added_by_load_door = -1;
     int fades_added_by_backups_door = -1;
+    int fades_added_by_load_return = -1;
 };
 
 // Under TESTING every fadeblack lands in FadeBetween's test-mode branch,
@@ -229,8 +230,7 @@ int open_row_injector(void* data)
     fprintf(stderr, "  [test] clicking LOAD\n");
     interact("load_company");
 
-    // The Company List enters instantly (the LOAD door is a #237 peer
-    // transition — no fade).
+    // The Company List fades in (#237: LOAD is a main-menu door).
     if (wait_for_interactable("company_row_0", 5000)) {
         SDL_Delay(750);
         fprintf(stderr, "  [test] opening company row 0\n");
@@ -413,11 +413,12 @@ int backups_and_empty_injector(void* data)
 
     wait_for_interactable("load_company", 5000);
     SDL_Delay(750);
-    // #237: LOAD is a door on the open main menu — a peer transition, so the
-    // Company List enters instantly.
+    // #237: LOAD is a main-menu door — the Company List crosses the boundary
+    // and fades, and the main menu fades again behind it.
     const int fades_before_load = count_fade_between_traces();
     interact("load_company");
 
+    int fades_inside_list = -1;
     if (wait_for_interactable("company_bak_0", 5000)) {
         SDL_Delay(750);
         state->fades_added_by_load_door =
@@ -436,6 +437,10 @@ int backups_and_empty_injector(void* data)
         }
         if (wait_for_interactable("company_del_0", 5000)) {
             SDL_Delay(400);
+            // The return leg of the LOAD door: emptying the list exits the
+            // screen and re-presents the main menu. Nothing between here and
+            // the main menu fades (the confirm is trace-only under TESTING).
+            fades_inside_list = count_fade_between_traces();
             fprintf(stderr,
                     "  [test] deleting the last company (confirm YES)\n");
             interact("company_del_0");  // empties the list -> screen exits
@@ -445,6 +450,10 @@ int backups_and_empty_injector(void* data)
     // Back on a re-entered main menu whose gate must hide CONTINUE/LOAD.
     if (wait_for_interactable("begin_new_game", 10000)) {
         SDL_Delay(750);
+        if (fades_inside_list >= 0) {
+            state->fades_added_by_load_return =
+                count_fade_between_traces() - fades_inside_list;
+        }
         state->saw_load_hidden_after_empty = !has_interactable("load_company");
         state->saw_continue_hidden_after_empty =
             !has_interactable("continue_game");
@@ -1008,16 +1017,18 @@ TEST(CompanyList, backups_door_opens_empty_view_and_empty_delete_exits)
     ASSERT_FALSE(trace_contains("confirm", "REWIND TO THIS BACKUP?"))
         << "an empty backups view has nothing to confirm";
     ASSERT_FALSE(user_file_exists("save/wp3lastd.gtl"));
-    // #237 derivation, on the real doors rather than on a spec field: both
-    // are opened from an already-open menu, so neither fades. (The kind
-    // assertions in test_menu_engine name the screens; these say what the
-    // engine does with them.)
-    EXPECT_EQ(0, state.fades_added_by_load_door)
-        << "#237: the LOAD door is a peer transition — entering the Company "
-           "List from the open main menu must add no fade";
+    // #237 derivation, on the real doors rather than on a spec field. (The
+    // kind assertions in test_menu_engine name the screens; these say what
+    // the engine does with them.)
+    EXPECT_EQ(2, state.fades_added_by_load_door)
+        << "#237: LOAD is a main-menu door — the Company List crosses the "
+           "boundary and fades out + in";
+    EXPECT_EQ(2, state.fades_added_by_load_return)
+        << "#237 symmetry: the way back out of the Company List must fade "
+           "exactly as much as the way in";
     EXPECT_EQ(0, state.fades_added_by_backups_door)
         << "#237: COMPANY BACKUPS is opened from the open Company List — a "
-           "nested entry never fades";
+           "nested entry never fades, in either direction";
     ASSERT_TRUE(state.saw_load_hidden_after_empty)
         << "no companies left: the main-menu gate must hide LOAD";
     ASSERT_TRUE(state.saw_continue_hidden_after_empty)

--- a/tests/integration/test_company_list.cpp
+++ b/tests/integration/test_company_list.cpp
@@ -203,11 +203,11 @@ int open_row_injector(void* data)
     state->started = true;
 
     wait_for_interactable("load_company", 5000);
-    SDL_Delay(750);  // FadeWithInitialDraw settle
+    SDL_Delay(750);  // menu-entry settle
     fprintf(stderr, "  [test] clicking LOAD\n");
     interact("load_company");
 
-    // The Company List fades in (FadeAroundEntry).
+    // The Company List fades in (a depth-1 entry under the #237 rule).
     if (wait_for_interactable("company_row_0", 5000)) {
         SDL_Delay(750);
         fprintf(stderr, "  [test] opening company row 0\n");
@@ -234,7 +234,7 @@ int open_other_company_and_toggle_injector(void* data)
     state->started = true;
 
     wait_for_interactable("load_company", 5000);
-    SDL_Delay(750);  // FadeWithInitialDraw settle
+    SDL_Delay(750);  // menu-entry settle
     interact("load_company");
 
     if (wait_for_interactable("company_row_0", 5000)) {
@@ -397,7 +397,7 @@ int backups_and_empty_injector(void* data)
         fprintf(stderr, "  [test] clicking the BK door\n");
         interact("company_bak_0");  // §2.4: opens the (empty) Backups view
         if (wait_for_backups_view()) {
-            SDL_Delay(750);  // FadeAroundEntry settle
+            SDL_Delay(750);  // menu-entry settle
             fprintf(stderr, "  [test] backing out of the empty backups view\n");
             interact("back");
         }
@@ -440,7 +440,7 @@ int restore_backup_injector(void* data)
         fprintf(stderr, "  [test] opening the backups view\n");
         interact("company_bak_0");
         if (wait_for_interactable("backup_row_0", 5000)) {
-            SDL_Delay(750);  // FadeAroundEntry settle
+            SDL_Delay(750);  // menu-entry settle
             // First click: the queued NO leaves everything alone.
             fprintf(stderr, "  [test] restoring row 0 (confirm NO)\n");
             interact("backup_row_0");
@@ -535,14 +535,14 @@ int continue_torn_newest_injector(void* data)
     state->started = true;
 
     wait_for_interactable("continue_game", 5000);
-    SDL_Delay(750);  // FadeWithInitialDraw settle
+    SDL_Delay(750);  // menu-entry settle
     fprintf(stderr, "  [test] clicking CONTINUE (torn newest)\n");
     interact("continue_game");
 
     // The failure popup is trace-only under TESTING; CONTINUE falls through
     // to the Company List (rows ts desc: 0 = torn newest, 1 = good previous).
     if (wait_for_interactable("company_row_1", 5000)) {
-        SDL_Delay(750);  // FadeAroundEntry settle
+        SDL_Delay(750);  // menu-entry settle
         fprintf(stderr, "  [test] opening the good row from the fallback list\n");
         interact("company_row_1");
         if (wait_for_team_menu()) {

--- a/tests/integration/test_company_list.cpp
+++ b/tests/integration/test_company_list.cpp
@@ -198,6 +198,7 @@ struct FlowState {
     int fades_added_by_load_door = -1;
     int fades_added_by_backups_door = -1;
     int fades_added_by_load_return = -1;
+    int fades_added_by_open_row = -1;
 };
 
 // Under TESTING every fadeblack lands in FadeBetween's test-mode branch,
@@ -234,11 +235,17 @@ int open_row_injector(void* data)
     if (wait_for_interactable("company_row_0", 5000)) {
         SDL_Delay(750);
         fprintf(stderr, "  [test] opening company row 0\n");
+        // #237 symmetry leg: opening a company leaves the list for Base Camp
+        // — a main-menu-boundary crossing, so it fades out and in like every
+        // other door off the main menu.
+        const int fades_before_open = count_fade_between_traces();
         interact("company_row_0");
 
         if (wait_for_team_menu()) {
             state->saw_team_menu = true;
             SDL_Delay(750);
+            state->fades_added_by_open_row =
+                count_fade_between_traces() - fades_before_open;
             fprintf(stderr, "  [test] clicking back from team menu\n");
             interact("back");
         }
@@ -715,6 +722,9 @@ TEST(CompanyList, open_row_zero_repoints_active_company)
     ASSERT_TRUE(state.finished);
     ASSERT_TRUE(state.saw_team_menu)
         << "opening a company should land on team build (base camp)";
+    EXPECT_EQ(2, state.fades_added_by_open_row)
+        << "#237: the company list -> Base Camp leg crosses the main-menu "
+           "boundary — it fades out and back in, like every main-menu door";
     ASSERT_TRUE(trace_contains("company_list", "open wp3openb"))
         << "row 0 must be the most-recent company";
     ASSERT_EQ("wp3openb", og::data::active_company_slot())

--- a/tests/integration/test_ctf_ui.cpp
+++ b/tests/integration/test_ctf_ui.cpp
@@ -788,6 +788,18 @@ bool wait_for_picker_trace(const char* substring, int count, int timeout_ms)
     return false;
 }
 
+// Land a level id the way a host's SET LEVEL click does. The raw save write
+// alone would be clobbered by the next poll's apply_state_to_save, and the
+// lobby commit races that same poll from an injector thread — so both halves
+// run as one task on the menu thread (#257).
+bool set_scen_num_through_lobby(short scen_num)
+{
+    return run_on_main_thread([scen_num] {
+        og::runtime::current_session->myscreen_->save_data.scen_num = scen_num;
+        picker_lobby_sync_settings_from_save();
+    });
+}
+
 } // namespace
 
 // Classic-campaign SCENARIO flow (#218 — transformed from the retired
@@ -1041,8 +1053,12 @@ int view_scenario_refresh_injector(void* data)
     // stands in for the host's SettingsChange by updating the lobby the
     // way the click callbacks do).
     state->restages_before_change = count_stage_trace_containing("restaged");
-    og::runtime::current_session->myscreen_->save_data.ctf_team_count = 3;
-    picker_lobby_sync_settings_from_save();
+    // Save write + lobby commit as one menu-thread task (#257): the commit
+    // races the main thread's poll_and_apply from here.
+    (void)run_on_main_thread([] {
+        og::runtime::current_session->myscreen_->save_data.ctf_team_count = 3;
+        picker_lobby_sync_settings_from_save();
+    });
     state->refresh_seen =
         wait_for_picker_trace("view_scenario refresh lines=", 1, 5000);
     SDL_Delay(300);
@@ -1245,7 +1261,16 @@ struct DegradeFlowState
     bool failed_health_seen = false;
     bool recovery_refresh_seen = false;
     bool reentry_refused = false;
+    // Every save mutation this flow makes is handed to the menu thread; a
+    // task the loop never ran would make the phases below meaningless.
+    bool save_edits_ran_on_main_thread = true;
 };
+
+// Levels stuffed into the completed-levels ledger to push the staged setup
+// past the u16 inner-message cap (og::sim::kMaxStagedInnerMessageBytes). The
+// refusal is what the flow proves, so the count must stay far above the cap.
+constexpr int kDegradeLedgerFirstLevel = 100000;
+constexpr int kDegradeLedgerLevels = 17000;
 
 int view_scenario_degrade_injector(void* data)
 {
@@ -1274,10 +1299,17 @@ int view_scenario_degrade_injector(void* data)
     // fails the debounced restage at the wire cap. The pane must degrade
     // honestly — Failed health, STAGING FAILED band text, the healed claim
     // dropped — while the viewer stays parked.
-    std::set<int>& degrade_ledger = og::runtime::current_session
-        ->myscreen_->save_data.completed_levels["modes"];
-    for (int level = 100000; level < 117000; ++level)
-        degrade_ledger.insert(level);
+    //
+    // The ledger is a std::set inside a std::map and the menu thread walks
+    // both every frame (host_save_stage_digest), so the mutation runs THERE,
+    // between two frames — including the map subscript, which is itself a
+    // node insert (#257).
+    state->save_edits_ran_on_main_thread &= run_on_main_thread([] {
+        std::set<int>& ledger = og::runtime::current_session
+            ->myscreen_->save_data.completed_levels["modes"];
+        for (int i = 0; i < kDegradeLedgerLevels; ++i)
+            ledger.insert(kDegradeLedgerFirstLevel + i);
+    });
     for (int waited_ms = 0; waited_ms < 5000; waited_ms += 50)
     {
         og::ui::IPickerLobbyClient* const lobby =
@@ -1297,15 +1329,16 @@ int view_scenario_degrade_injector(void* data)
     // lands (the SET LEVEL half of the stale-joiner hole): the one-shot
     // rebuild shows the load refusal, and the next honest id heals the
     // viewer end to end (fresh scratch load, render-copy heal, census).
-    degrade_ledger.clear();
+    state->save_edits_ran_on_main_thread &= run_on_main_thread([] {
+        og::runtime::current_session->myscreen_->save_data
+            .completed_levels["modes"].clear();
+    });
     SDL_Delay(600);
     const int refreshes_before_moves =
         count_picker_trace_containing("view_scenario refresh lines=");
-    og::runtime::current_session->myscreen_->save_data.scen_num = 9999;
-    picker_lobby_sync_settings_from_save();
+    state->save_edits_ran_on_main_thread &= set_scen_num_through_lobby(9999);
     SDL_Delay(600);
-    og::runtime::current_session->myscreen_->save_data.scen_num = 500;
-    picker_lobby_sync_settings_from_save();
+    state->save_edits_ran_on_main_thread &= set_scen_num_through_lobby(500);
     state->recovery_refresh_seen = wait_for_picker_trace(
         "view_scenario refresh lines=", refreshes_before_moves + 1, 5000);
     SDL_Delay(300);
@@ -1316,16 +1349,14 @@ int view_scenario_degrade_injector(void* data)
     interact("back");
     SDL_Delay(300);
     wait_for_interactable("view_scenario", 10000);
-    og::runtime::current_session->myscreen_->save_data.scen_num = 9999;
-    picker_lobby_sync_settings_from_save();
+    state->save_edits_ran_on_main_thread &= set_scen_num_through_lobby(9999);
     SDL_Delay(600);
     interact("view_scenario");
     SDL_Delay(300);
     state->reentry_refused = wait_for_interactable("view_scenario", 5000);
 
     // Restore a loadable id, then unwind to the main menu.
-    og::runtime::current_session->myscreen_->save_data.scen_num = 500;
-    picker_lobby_sync_settings_from_save();
+    state->save_edits_ran_on_main_thread &= set_scen_num_through_lobby(500);
     SDL_Delay(400);
     wait_for_interactable("progress", 10000);
     SDL_Delay(300);
@@ -1360,6 +1391,8 @@ TEST(CtfUi, view_scenario_degrades_and_recovers_on_level_moves)
 
     EXPECT_TRUE(state.finished) << "injector should complete the flow";
     EXPECT_TRUE(state.viewer_opened) << "VIEW LEVEL should open its frame";
+    EXPECT_TRUE(state.save_edits_ran_on_main_thread)
+        << "every save edit must have run on the menu thread's pump";
     EXPECT_TRUE(state.failed_health_seen)
         << "the unloadable level's restage must land as Failed health "
            "while the viewer is parked";
@@ -1427,9 +1460,11 @@ int view_scenario_staged_pane_injector(void* data)
     // Cycle TROOPS to FAIR through the lobby (the sync path a host click
     // takes): the owner's change key moves, ONE debounced restage lands,
     // and the refreshed report shows the min-headcount matched squads.
-    og::runtime::current_session->myscreen_->save_data
-        .ctf_strip_scenario_troops = og::sim::kTroopsMatched;
-    picker_lobby_sync_settings_from_save();
+    (void)run_on_main_thread([] {
+        og::runtime::current_session->myscreen_->save_data
+            .ctf_strip_scenario_troops = og::sim::kTroopsMatched;
+        picker_lobby_sync_settings_from_save();
+    });
     state->matched_line_seen = wait_for_picker_trace(
         "MATCHED BOTS (2)", 1, 5000);
     SDL_Delay(300);

--- a/tests/integration/test_ctf_ui.cpp
+++ b/tests/integration/test_ctf_ui.cpp
@@ -1264,6 +1264,9 @@ struct DegradeFlowState
     // Every save mutation this flow makes is handed to the menu thread; a
     // task the loop never ran would make the phases below meaningless.
     bool save_edits_ran_on_main_thread = true;
+    // The same for the reads: the staged-health poll runs on the pump, and a
+    // poll that never got there must not read as "not failed yet".
+    bool lobby_reads_ran_on_main_thread = true;
 };
 
 // Levels stuffed into the completed-levels ledger to push the staged setup
@@ -1310,13 +1313,22 @@ int view_scenario_degrade_injector(void* data)
         for (int i = 0; i < kDegradeLedgerLevels; ++i)
             ledger.insert(kDegradeLedgerFirstLevel + i);
     });
+    // The staged health lives on the active lobby client, which the menu
+    // thread's per-frame picker_lobby_poll() mutates — and can replace — so
+    // each poll iteration reads it THERE and hands back only the answer
+    // (#257). Same cadence and ceiling as before.
     for (int waited_ms = 0; waited_ms < 5000; waited_ms += 50)
     {
-        og::ui::IPickerLobbyClient* const lobby =
-            og::ui::active_picker_lobby_client();
-        if (lobby != nullptr &&
-            lobby->staged_preview_health() ==
-                og::ui::IPickerLobbyClient::StagedPreviewHealth::Failed)
+        bool failed = false;
+        state->lobby_reads_ran_on_main_thread &=
+            run_on_main_thread([&failed] {
+                og::ui::IPickerLobbyClient* const lobby =
+                    og::ui::active_picker_lobby_client();
+                failed = lobby != nullptr &&
+                    lobby->staged_preview_health() ==
+                        og::ui::IPickerLobbyClient::StagedPreviewHealth::Failed;
+            });
+        if (failed)
         {
             state->failed_health_seen = true;
             break;
@@ -1393,6 +1405,8 @@ TEST(CtfUi, view_scenario_degrades_and_recovers_on_level_moves)
     EXPECT_TRUE(state.viewer_opened) << "VIEW LEVEL should open its frame";
     EXPECT_TRUE(state.save_edits_ran_on_main_thread)
         << "every save edit must have run on the menu thread's pump";
+    EXPECT_TRUE(state.lobby_reads_ran_on_main_thread)
+        << "every staged-health poll must have run on the menu thread's pump";
     EXPECT_TRUE(state.failed_health_seen)
         << "the unloadable level's restage must land as Failed health "
            "while the viewer is parked";

--- a/tests/integration/test_fade_ownership.cpp
+++ b/tests/integration/test_fade_ownership.cpp
@@ -262,10 +262,16 @@ TEST(FadeOwnership, new_game_flow_fades_every_leg_symmetrically)
     EXPECT_EQ(8, count_fades(traces) - state.fades_at_new_game_click)
         << "four legs, two fades each";
 
+    // No door in this flow is the NETWORKING shape, so no exit scope may
+    // have skipped its fade-out for a pending Instant note.
+    EXPECT_FALSE(trace_contains("video", "exit fade skipped: Instant note pending"))
+        << "an Instant note leaked into the new-game flow";
+
     // The other half of the pin: no fade in this flow read a frame the
-    // window never showed, and no fade-in ran over a non-black window. The
-    // listener fails this test on any violation; asserted here too so the
-    // count above can never pass on a black-to-black fade.
+    // window never showed, no fade-in ran over a non-black window, and no
+    // entry found a window the previous screen left unfaded. The listener
+    // fails this test on any violation; asserted here too so the count above
+    // can never pass on a black-to-black fade.
     EXPECT_EQ(0, og::video_testing::g_fade_violations.load())
         << "fade-ownership invariant violated: "
         << (og::video_testing::fade_violation_messages().empty()

--- a/tests/integration/test_fade_ownership.cpp
+++ b/tests/integration/test_fade_ownership.cpp
@@ -1,0 +1,274 @@
+// #237 fade ownership, the end-to-end pin: BEGIN NEW GAME -> name entry
+// ACCEPT -> campaign select ACCEPT -> intro dismiss -> Base Camp, every leg
+// counted separately. Two of those legs (campaign select -> intro, intro ->
+// Base Camp) are the ones that shipped as hard cuts twice: a screen::clear()
+// between the outgoing screen's last present and its fade-out turned the
+// fade black-to-black. Under the ownership rule (docs/menu-engine.md,
+// "Drawing and transitions") every screen fades itself out at its own exit,
+// and the video layer's TESTING invariants flag any fade that reads a frame
+// the window never showed — integration_main's listener turns those into a
+// failure of THIS test, so the per-leg counts below are only half the pin.
+//
+// Under TESTING every fadeblack that runs takes FadeBetween's test-mode
+// branch, which traces exactly one "video" FadeBetween line — so counting
+// those lines between the legs' own trace markers counts fades per leg.
+#include <gtest/gtest.h>
+#include <SDL3/SDL.h>
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <openglad/core/test_trace.h>
+#include <openglad/gameplay/guy.h>
+#include <openglad/interface/button.h>
+#include <openglad/interface/screen.h>
+#include <openglad/legacy/base.h>
+#include <openglad/platform/video_sdl.h>
+#include <openglad/resources/save_data.h>
+#include "../../src/interface/ui/picker_sdl_defs.h"
+#include "test_input_helpers.h"
+#include "test_interact.h"
+
+void picker_main(Sint32 argc, char** argv);
+extern int g_picker_mainmenu_calls;
+extern int g_picker_max_mainmenu_calls;
+
+#include <openglad/interface/ui/picker_ui_state.h>
+
+namespace
+{
+
+PickerState& pks()
+{
+    return *og::runtime::current_session->picker_;
+}
+
+void cleanup_picker_state()
+{
+    for (int i = 0; i < 5; i++)
+    {
+        pks().backdrops[static_cast<std::size_t>(i)].reset();
+        pks().backpics[i].free();
+    }
+    clear_allbuttons();
+    og::runtime::current_session->localbuttons_ = nullptr;
+    pks().main_columns_pix.reset();
+    pks().main_columns_data.free();
+    pks().main_title_logo_pix.reset();
+    pks().main_title_logo_data.free();
+}
+
+bool is_fade(const TraceEntry& entry)
+{
+    return entry.category == "video" &&
+        entry.message.find("FadeBetween") != std::string::npos;
+}
+
+bool is_marker(const TraceEntry& entry, const char* category,
+               const char* needle)
+{
+    return entry.category == category &&
+        entry.message.find(needle) != std::string::npos;
+}
+
+int count_fades(const std::vector<TraceEntry>& entries)
+{
+    int fades = 0;
+    for (const TraceEntry& entry : entries)
+        if (is_fade(entry))
+            ++fades;
+    return fades;
+}
+
+// Fades strictly between the first occurrence of marker A and the first
+// occurrence of marker B after it. -1 when either marker is missing (the leg
+// never ran), so a vanished leg fails loudly instead of counting 0.
+int fades_between(const std::vector<TraceEntry>& entries,
+                  const char* cat_a, const char* needle_a,
+                  const char* cat_b, const char* needle_b)
+{
+    std::size_t i = 0;
+    for (; i < entries.size(); ++i)
+        if (is_marker(entries[i], cat_a, needle_a))
+            break;
+    if (i == entries.size())
+        return -1;
+    int fades = 0;
+    for (++i; i < entries.size(); ++i)
+    {
+        if (is_marker(entries[i], cat_b, needle_b))
+            return fades;
+        if (is_fade(entries[i]))
+            ++fades;
+    }
+    return -1;
+}
+
+// Fades after the first occurrence of a marker, to the end of the copy.
+int fades_after(const std::vector<TraceEntry>& entries, const char* category,
+                const char* needle)
+{
+    std::size_t i = 0;
+    for (; i < entries.size(); ++i)
+        if (is_marker(entries[i], category, needle))
+            break;
+    if (i == entries.size())
+        return -1;
+    int fades = 0;
+    for (++i; i < entries.size(); ++i)
+        if (is_fade(entries[i]))
+            ++fades;
+    return fades;
+}
+
+struct FlowState {
+    bool started = false;
+    bool finished = false;
+    bool saw_name_entry = false;
+    bool saw_base_camp = false;
+    // Leg 1, measured live: main menu -> name entry.
+    int fades_added_by_name_entry = -1;
+    // The trace buffer as of Base Camp settled, before BACK: legs 2-4 are
+    // read off this copy by marker on the main thread.
+    std::vector<TraceEntry> traces_at_base_camp;
+    int fades_at_new_game_click = -1;
+};
+
+bool wait_for_team_menu(int timeout_ms)
+{
+    int elapsed = 0;
+    constexpr int poll_interval = 50;
+    while (elapsed < timeout_ms)
+    {
+        if (has_interactable("hire_troops") && has_interactable("networking"))
+            return true;
+        SDL_Delay(poll_interval);
+        elapsed += poll_interval;
+    }
+    return false;
+}
+
+int count_fade_between_traces()
+{
+    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    return count_fades(g_trace_buffer);
+}
+
+int new_game_full_flow_injector(void* data)
+{
+    og::runtime::ensure_thread_session();
+    auto* state = static_cast<FlowState*>(data);
+    state->started = true;
+
+    if (!wait_for_interactable("begin_new_game", 5000))
+        return 1;
+    SDL_Delay(750);
+    state->fades_at_new_game_click = count_fade_between_traces();
+    interact("begin_new_game");
+
+    if (!wait_for_interactable("company_name_accept", 5000))
+        return 2;
+    state->saw_name_entry = true;
+    SDL_Delay(750); // menu-entry settle
+    state->fades_added_by_name_entry =
+        count_fade_between_traces() - state->fades_at_new_game_click;
+    interact("company_name_accept");
+
+    // Campaign select auto-accepts and the intro auto-dismisses, each one
+    // presented frame in; Base Camp follows with no further input.
+    if (!wait_for_team_menu(20000))
+        return 3;
+    state->saw_base_camp = true;
+    SDL_Delay(750); // Base Camp's entry settle
+    {
+        std::lock_guard<std::mutex> lock(g_trace_mutex);
+        state->traces_at_base_camp = g_trace_buffer;
+    }
+
+    SDL_Delay(300);
+    interact("back");
+    state->finished = true;
+    return 0;
+}
+
+} // namespace
+
+TEST(FadeOwnership, new_game_flow_fades_every_leg_symmetrically)
+{
+    trace_clear();
+    og::runtime::current_session->myscreen_->save_data.current_campaign =
+        "gladiator";
+    og::runtime::current_session->myscreen_->save_data.scen_num = 1;
+    og::runtime::current_session->myscreen_->save_data.numplayers = 1;
+    og::runtime::current_session->myscreen_->save_data.save("save0");
+
+    FlowState state;
+    SDL_Thread* thread = SDL_CreateThread(new_game_full_flow_injector,
+                                          "new_game_full_flow", &state);
+    ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
+
+    g_picker_mainmenu_calls = 0;
+    g_picker_max_mainmenu_calls = 1;
+    picker_main(0, nullptr);
+
+    int thread_result = -1;
+    SDL_WaitThread(thread, &thread_result);
+    cleanup_picker_state();
+    g_picker_max_mainmenu_calls = 0;
+
+    ASSERT_EQ(0, thread_result) << "the injector stalled at stage " << thread_result;
+    ASSERT_TRUE(state.finished);
+    ASSERT_TRUE(state.saw_name_entry);
+    ASSERT_TRUE(state.saw_base_camp)
+        << "the flow must reach Base Camp through the real campaign select "
+           "and intro";
+
+    const std::vector<TraceEntry>& traces = state.traces_at_base_camp;
+
+    // The legs ran for real: their markers are in the buffer.
+    ASSERT_TRUE(trace_contains("name_entry", "accept"));
+    ASSERT_TRUE(trace_contains("campaign_picker", "first frame presented"))
+        << "campaign select must present a real frame under TESTING";
+    ASSERT_TRUE(trace_contains("campaign_picker", "auto-accept gladiator"))
+        << "the un-driven browser accepts the current campaign";
+    ASSERT_TRUE(trace_contains("help", "scroller presented"))
+        << "the campaign intro must present a real frame under TESTING";
+    ASSERT_TRUE(trace_contains("help", "scroller auto-dismissed"));
+
+    // Leg 1: main menu -> name entry. The main menu's exit fades out, name
+    // entry fades in.
+    EXPECT_EQ(2, state.fades_added_by_name_entry)
+        << "leg 1 (main menu -> name entry): one fade-out + one fade-in";
+    // Leg 2: name entry ACCEPT -> campaign select's first frame. Name entry's
+    // exit fades out; the browser's entry fade-out is a no-op on the black
+    // window, its first frame fades in.
+    EXPECT_EQ(2, fades_between(traces, "name_entry", "accept",
+                               "campaign_picker", "first frame presented"))
+        << "leg 2 (name entry -> campaign select): one fade-out + one fade-in";
+    // Leg 3: campaign select ACCEPT -> the intro's first frame. The browser
+    // fades itself out; the intro fades in over black.
+    EXPECT_EQ(2, fades_between(traces, "campaign_picker", "auto-accept",
+                               "help", "scroller presented"))
+        << "leg 3 (campaign select -> intro): the reported hard cut — the "
+           "browser's own exit fade-out, then the intro's fade-in";
+    // Leg 4: intro dismiss -> Base Camp. The intro fades itself out; Base
+    // Camp's entry fade-out is a no-op on the black window, its cold frame
+    // fades in; every later Base Camp frame presents plainly.
+    EXPECT_EQ(2, fades_after(traces, "help", "scroller auto-dismissed"))
+        << "leg 4 (intro -> Base Camp): the reported hard cut — the intro's "
+           "own exit fade-out, then Base Camp's fade-in";
+    // The whole door, main menu click to Base Camp: four symmetric legs.
+    EXPECT_EQ(8, count_fades(traces) - state.fades_at_new_game_click)
+        << "four legs, two fades each";
+
+    // The other half of the pin: no fade in this flow read a frame the
+    // window never showed, and no fade-in ran over a non-black window. The
+    // listener fails this test on any violation; asserted here too so the
+    // count above can never pass on a black-to-black fade.
+    EXPECT_EQ(0, og::video_testing::g_fade_violations.load())
+        << "fade-ownership invariant violated: "
+        << (og::video_testing::fade_violation_messages().empty()
+                ? std::string()
+                : og::video_testing::fade_violation_messages().front());
+}

--- a/tests/integration/test_fairy_death.cpp
+++ b/tests/integration/test_fairy_death.cpp
@@ -255,16 +255,25 @@ static int fairy_injector(void* data)
     // The hire screen draws current_guy_ every frame, so replacing that
     // unique_ptr from here would free a portrait the menu thread is reading
     // (#257). The whole cycle runs as one task between two frames.
+    //
+    // pks().hire_session is a raw pointer to the HireSession that lives on
+    // create_hire_menu's stack and is nulled on the way out, so the task
+    // re-checks it on the menu thread: a task that lands on the frame the
+    // hire screen exits must cycle nothing rather than dereference the dead
+    // session. The family check below then fails the run honestly.
     if (!run_on_main_thread([] {
+            auto* const session = pks().hire_session;
+            if (session == nullptr)
+                return;
             for (int i = 0; i < FAERIE_INDEX + 2 &&
                             (!og::runtime::current_session->current_guy_ ||
                              og::runtime::current_session->current_guy_->family !=
                                  FAMILY_FAERIE);
                  i++) {
-                pks().hire_session->next_family();
+                session->next_family();
                 og::runtime::current_session->current_type_ =
-                    pks().hire_session->family_index();
-                if (const guy* recruit = pks().hire_session->current_recruit())
+                    session->family_index();
+                if (const guy* recruit = session->current_recruit())
                     og::runtime::current_session->current_guy_ =
                         std::make_unique<guy>(*recruit);
             }

--- a/tests/integration/test_fairy_death.cpp
+++ b/tests/integration/test_fairy_death.cpp
@@ -252,16 +252,24 @@ static int fairy_injector(void* data)
     // directly so coverage builds do not depend on processing 12 injected NEXT
     // clicks before the HIRE ME button path is exercised.
     fprintf(stderr, "  [test] cycling to fairy (cycle_guy x%d)\n", FAERIE_INDEX);
-    for (int i = 0; i < FAERIE_INDEX + 2 &&
-                    (!og::runtime::current_session->current_guy_ ||
-                     og::runtime::current_session->current_guy_->family != FAMILY_FAERIE);
-         i++) {
-        pks().hire_session->next_family();
-        og::runtime::current_session->current_type_ =
-            pks().hire_session->family_index();
-        if (const guy* recruit = pks().hire_session->current_recruit())
-            og::runtime::current_session->current_guy_ =
-                std::make_unique<guy>(*recruit);
+    // The hire screen draws current_guy_ every frame, so replacing that
+    // unique_ptr from here would free a portrait the menu thread is reading
+    // (#257). The whole cycle runs as one task between two frames.
+    if (!run_on_main_thread([] {
+            for (int i = 0; i < FAERIE_INDEX + 2 &&
+                            (!og::runtime::current_session->current_guy_ ||
+                             og::runtime::current_session->current_guy_->family !=
+                                 FAMILY_FAERIE);
+                 i++) {
+                pks().hire_session->next_family();
+                og::runtime::current_session->current_type_ =
+                    pks().hire_session->family_index();
+                if (const guy* recruit = pks().hire_session->current_recruit())
+                    og::runtime::current_session->current_guy_ =
+                        std::make_unique<guy>(*recruit);
+            }
+        })) {
+        return fail_fairy_run(state, "hire menu cycle never reached the menu thread");
     }
 
     if (!og::runtime::current_session->current_guy_ ||
@@ -307,10 +315,13 @@ static int fairy_injector(void* data)
     if (fairy->family != FAMILY_FAERIE)
         return fail_fairy_run(state, "expected lone hired unit to be the fairy");
 
-    fairy->constitution = kFairyFragileConstitution;
-    fairy->armor = kFairyFragileArmor;
-
-    og::runtime::current_session->myscreen_->save_data.scen_num = 4;
+    // Roster stats and the level id land on the menu thread too: the team
+    // menu's per-frame label sync reads both (#257).
+    (void)run_on_main_thread([fairy] {
+        fairy->constitution = kFairyFragileConstitution;
+        fairy->armor = kFairyFragileArmor;
+        og::runtime::current_session->myscreen_->save_data.scen_num = 4;
+    });
     set_game_speed(0.0f);
 
     fprintf(stderr, "  [test] clicking go\n");

--- a/tests/integration/test_game_loop.cpp
+++ b/tests/integration/test_game_loop.cpp
@@ -5727,6 +5727,12 @@ struct WorldZoomGameGuard
         cfg.apply_setting("graphics", "zoom", "0.5");
         cfg.apply_setting("graphics", "smoothing", "off");
         apply_world_scale_from_cfg();
+        // The production precondition for glad_init's fade: the picker's UI
+        // frame is on the window. An earlier test may have left World as the
+        // last presented canvas, and the zoom above just REALLOCATED that
+        // surface — glad_init would fade a canvas the window never showed.
+        s->set_active_canvas(CanvasTarget::UI);
+        s->refresh();
     }
 
     ~WorldZoomGameGuard()
@@ -5995,6 +6001,11 @@ TEST(GameLoop, zoom_half_splitscreen_layout_tracks_window_resizes)
     for (int i = 0; i < 2; i++)
         canvas_zoom_gameplay::expect_pane_matches_layout(
             s, i, initial_world.w, initial_world.h);
+    // The resize reallocated the World canvas; present a frame on it as the
+    // running game loop would, so the next glad_init's fade-out reads a
+    // canvas the window has shown (the fade-ownership invariant).
+    s->redraw();
+    s->swap();
 
     // ---- 4 players: quadrants on the grown canvas --------------------------
     s->world().end = 0;

--- a/tests/integration/test_input_more.cpp
+++ b/tests/integration/test_input_more.cpp
@@ -193,3 +193,75 @@ TEST(InputMore, collapsed_right_click_is_delivered_exactly_once)
         << "the collapsed click is a one-shot event";
     reset_mouse_click_tracking();
 }
+
+// The mint behind the editor-exit phantom click: a surface that pumps its
+// own events and never runs query_mouse() leaves every press "unqueried",
+// so every release mints a collapsed-tap pending click. The per-frame
+// acknowledgement is the fix at the mint; the handoff reset is the fix at
+// the boundary.
+TEST(InputMore, acknowledge_mouse_presses_stops_the_collapsed_tap_mint)
+{
+    clear_events();
+    mouse_state.left = false;
+    mouse_state.right = false;
+    input_hardware_state().picker_was_left_down = false;
+    input_hardware_state().picker_was_right_down = false;
+    reset_mouse_click_tracking();
+
+    auto mouse_event = [](Uint32 type) {
+        SDL_Event event{};
+        event.type = type;
+        event.button.button = SDL_BUTTON_LEFT;
+        event.button.down = type == SDL_EVENT_MOUSE_BUTTON_DOWN;
+        event.button.clicks = 1;
+        event.button.x = og::runtime::current_session->viewport_offset_x_ +
+            og::runtime::current_session->viewport_w_ / 2.0f;
+        event.button.y = og::runtime::current_session->viewport_offset_y_ +
+            og::runtime::current_session->viewport_h_ / 2.0f;
+        return event;
+    };
+    SDL_Event down = mouse_event(SDL_EVENT_MOUSE_BUTTON_DOWN);
+    SDL_Event up = mouse_event(SDL_EVENT_MOUSE_BUTTON_UP);
+
+    // An unacknowledged pump (the pre-fix level editor shape) accumulates
+    // one pending click per click.
+    handle_mouse_event(down);
+    handle_mouse_event(up);
+    handle_mouse_event(down);
+    handle_mouse_event(up);
+    ASSERT_EQ(2, og::input::testing_pending_left_clicks())
+        << "an unacknowledged pump mints one collapsed tap per click";
+    EXPECT_TRUE(take_pending_left_click());
+    EXPECT_TRUE(take_pending_left_click());
+    EXPECT_FALSE(take_pending_left_click());
+
+    // acknowledge_mouse_presses() between the press frame and the release
+    // frame is query_mouse()'s bookkeeping: the release mints nothing.
+    handle_mouse_event(down);
+    acknowledge_mouse_presses();
+    handle_mouse_event(up);
+    ASSERT_EQ(0, og::input::testing_pending_left_clicks());
+    EXPECT_FALSE(take_pending_left_click())
+        << "an acknowledged press must not mint a pending click on release";
+
+    // Per-press bookkeeping, not a standing veto: a press and release that
+    // both land before the next acknowledgement still mint their tap.
+    handle_mouse_event(down);
+    handle_mouse_event(up);
+    EXPECT_TRUE(take_pending_left_click())
+        << "a collapsed pair between acknowledgements is a real tap";
+    EXPECT_FALSE(take_pending_left_click());
+
+    // And the surface handoff drops whatever an offender accumulated.
+    handle_mouse_event(down);
+    handle_mouse_event(up);
+    handle_mouse_event(down);
+    handle_mouse_event(up);
+    ASSERT_EQ(2, og::input::testing_pending_left_clicks());
+    reset_mouse_click_tracking();
+    ASSERT_EQ(0, og::input::testing_pending_left_clicks());
+    EXPECT_FALSE(take_pending_left_click())
+        << "reset_mouse_click_tracking must drop the accumulated queue";
+
+    reset_mouse_click_tracking();
+}

--- a/tests/integration/test_level_editor_interactions.cpp
+++ b/tests/integration/test_level_editor_interactions.cpp
@@ -798,9 +798,11 @@ int editor_door_fade_injector(void* /*data*/)
 // fades itself out at its exit (before its post-loop reset draw and clear
 // touch the buffer). Dropping the fade-in (as the editor once did) left the
 // door at 1 fade in against 2 back, the asymmetry the invariant forbids.
-// Counted here: 2 in, then the editor's own exit fade-out. Its partner, the
-// parent menu loop's fade-in off the black window, has no parent loop in
-// this test — the black window is asserted instead, and
+// Counted here: the editor's first-frame fade-in (the test boundary leaves
+// the window black, so the door's fade-out of the "menu" is a traceless
+// no-op), then the editor's own exit fade-out. Its partner, the parent menu
+// loop's fade-in off the black window, has no parent loop in this test —
+// the black window is asserted instead, and
 // MenuEngine.nested_menu_door_bracket_* pins the loop half.
 TEST(LevelEditorInteractions, level_editor_door_fades_symmetrically)
 {
@@ -818,10 +820,9 @@ TEST(LevelEditorInteractions, level_editor_door_fades_symmetrically)
     og::runtime::current_session->myscreen_->world().end = 0;
 
     const int total = count_fade_between_traces();
-    EXPECT_EQ(3, total)
-        << "the door owes 2 fades in (the menu's fade-out + the editor's own "
-           "first-frame fade-in) and the editor opens the way back with its "
-           "own exit fade-out";
+    EXPECT_EQ(2, total)
+        << "over a black window the door fades the editor's first frame in, "
+           "and the editor opens the way back with its own exit fade-out";
     EXPECT_TRUE(og::runtime::current_session->myscreen_->window_is_black())
         << "the editor's exit leaves the window black; the still-open parent "
            "menu loop's next present is the matching fade-in";

--- a/tests/integration/test_level_editor_interactions.cpp
+++ b/tests/integration/test_level_editor_interactions.cpp
@@ -792,14 +792,16 @@ int editor_door_fade_injector(void* /*data*/)
 }
 } // namespace
 
-// #237 flow pin, the LEVEL EDITOR door through the REAL body: the bracket
-// fades the menu out and notes Fade, and level_editor() has to spend that
-// note on a fadeblack(1) present of its first composed frame — discarding it
-// (as the editor once did) left the door at 1 fade in against 2 back, the
-// asymmetry the invariant forbids. Counted here: 2 in, then the bracket's
-// way-back fade-out. Its partner, the parent menu loop's fade-in off the
-// black note, has no parent loop in this test — the note is asserted instead,
-// and MenuEngine.nested_menu_door_bracket_* pins the loop half.
+// #237 flow pin, the LEVEL EDITOR door through the REAL body: the door notes
+// Fade, and level_editor()'s LegacyMenuFade spends it — the still-open menu
+// fades out, the editor's first composed frame fades in, and the editor
+// fades itself out at its exit (before its post-loop reset draw and clear
+// touch the buffer). Dropping the fade-in (as the editor once did) left the
+// door at 1 fade in against 2 back, the asymmetry the invariant forbids.
+// Counted here: 2 in, then the editor's own exit fade-out. Its partner, the
+// parent menu loop's fade-in off the black window, has no parent loop in
+// this test — the black window is asserted instead, and
+// MenuEngine.nested_menu_door_bracket_* pins the loop half.
 TEST(LevelEditorInteractions, level_editor_door_fades_symmetrically)
 {
     og::ui::menu_transition_testing_reset();
@@ -817,10 +819,11 @@ TEST(LevelEditorInteractions, level_editor_door_fades_symmetrically)
 
     const int total = count_fade_between_traces();
     EXPECT_EQ(3, total)
-        << "the door owes 2 fades in (bracket fade-out + the editor's own "
-           "first-frame fade-in) and opens the way back with its fade-out";
-    EXPECT_TRUE(og::ui::consume_menu_faded_to_black())
-        << "the way back hands the still-open parent menu loop a black note; "
-           "its next present is the matching fade-in";
+        << "the door owes 2 fades in (the menu's fade-out + the editor's own "
+           "first-frame fade-in) and the editor opens the way back with its "
+           "own exit fade-out";
+    EXPECT_TRUE(og::runtime::current_session->myscreen_->window_is_black())
+        << "the editor's exit leaves the window black; the still-open parent "
+           "menu loop's next present is the matching fade-in";
     og::ui::menu_transition_testing_reset();
 }

--- a/tests/integration/test_level_editor_interactions.cpp
+++ b/tests/integration/test_level_editor_interactions.cpp
@@ -1,6 +1,7 @@
 #include <openglad/interface/screen.h>
 #include <openglad/interface/input.h>
 #include <openglad/interface/ui/level_editor_state.h>
+#include <openglad/interface/ui/menu_screen_spec.h>
 #include <openglad/platform/game_session.h>
 #include <openglad/core/test_trace.h>
 #include <gtest/gtest.h>
@@ -759,4 +760,67 @@ TEST(LevelEditorInteractions, object_brush_team_stays_in_the_authorable_range)
 {
     ASSERT_EQ(0, level_editor_test_object_brush_team_range())
         << "object-brush team range failed at the negated check index";
+}
+
+namespace
+{
+int count_fade_between_traces()
+{
+    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    int fades = 0;
+    for (const TraceEntry& entry : g_trace_buffer)
+    {
+        if (entry.category == "video" &&
+            entry.message.find("FadeBetween") != std::string::npos)
+            ++fades;
+    }
+    return fades;
+}
+
+// Ends the editor as soon as the door's two way-in fades have landed — or
+// after a bounded wait, so a regression that drops one fails the pin instead
+// of hanging the group.
+int editor_door_fade_injector(void* /*data*/)
+{
+    og::runtime::ensure_thread_session();
+    constexpr int kTimeoutMs = 8000;
+    for (int waited = 0; waited < kTimeoutMs && count_fade_between_traces() < 2;
+         waited += 10)
+        SDL_Delay(10);
+    og::runtime::current_session->myscreen_->world().end = 1;
+    return 0;
+}
+} // namespace
+
+// #237 flow pin, the LEVEL EDITOR door through the REAL body: the bracket
+// fades the menu out and notes Fade, and level_editor() has to spend that
+// note on a fadeblack(1) present of its first composed frame — discarding it
+// (as the editor once did) left the door at 1 fade in against 2 back, the
+// asymmetry the invariant forbids. Counted here: 2 in, then the bracket's
+// way-back fade-out. Its partner, the parent menu loop's fade-in off the
+// black note, has no parent loop in this test — the note is asserted instead,
+// and MenuEngine.nested_menu_door_bracket_* pins the loop half.
+TEST(LevelEditorInteractions, level_editor_door_fades_symmetrically)
+{
+    og::ui::menu_transition_testing_reset();
+    og::runtime::current_session->myscreen_->world().end = 0;
+    trace_clear();
+
+    SDL_Thread* thread = SDL_CreateThread(editor_door_fade_injector,
+                                          "editor_door_fade", nullptr);
+    ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
+
+    (void)og::ui::run_nested_menu_door(&level_editor);
+
+    SDL_WaitThread(thread, nullptr);
+    og::runtime::current_session->myscreen_->world().end = 0;
+
+    const int total = count_fade_between_traces();
+    EXPECT_EQ(3, total)
+        << "the door owes 2 fades in (bracket fade-out + the editor's own "
+           "first-frame fade-in) and opens the way back with its fade-out";
+    EXPECT_TRUE(og::ui::consume_menu_faded_to_black())
+        << "the way back hands the still-open parent menu loop a black note; "
+           "its next present is the matching fade-in";
+    og::ui::menu_transition_testing_reset();
 }

--- a/tests/integration/test_level_editor_interactions.cpp
+++ b/tests/integration/test_level_editor_interactions.cpp
@@ -828,3 +828,205 @@ TEST(LevelEditorInteractions, level_editor_door_fades_symmetrically)
            "menu loop's next present is the matching fade-in";
     og::ui::menu_transition_testing_reset();
 }
+
+// ---------------------------------------------------------------------------
+// The editor-exit phantom click (the reporter's literal scenario): exit the
+// LEVEL EDITOR through its own File -> Exit menu, hover BEGIN NEW GAME during
+// the fade back to the main menu — and BEGIN NEW GAME activates itself.
+// Mechanism: the editor pumps its own events and reads the mouse only via
+// query_mouse_no_poll(), so every click made inside it mints a coordinate-less
+// collapsed-tap pending click (input.cpp g_pending_left_clicks); the main
+// menu's leftmouse() then pairs one with the LIVE pointer on its first
+// post-door frame. The pointer-handoff rule (docs/menu-engine.md, "Pointer
+// handoff") forbids exactly this: no screen may consume a click minted on
+// another surface.
+
+#include <openglad/interface/ui/picker_ui_state.h>
+#include "test_interact.h"
+
+void picker_main(Sint32 argc, char** argv);
+extern int g_picker_mainmenu_calls;
+extern int g_picker_max_mainmenu_calls;
+
+static inline PickerState& pks_phantom()
+{
+    return *og::runtime::current_session->picker_;
+}
+
+namespace
+{
+struct PhantomClickState {
+    std::atomic<bool> started{false};
+    std::atomic<bool> editor_opened{false};
+    std::atomic<bool> editor_closed{false};
+    std::atomic<bool> phantom_fired{false};
+    std::atomic<bool> finished{false};
+};
+
+// Editor clicks go through the same UI-canvas-pinned transform interact()
+// uses: under picker_main the window runs at the configured scale (2x), so
+// raw window coordinates would land on the wrong editor pixels. While the
+// editor is open both canvases are 320x200, so the UI transform is exact.
+void phantom_click_at_canvas(int game_x, int game_y, int delay_ms)
+{
+    const auto [wx, wy] = ui_canvas_to_window(static_cast<float>(game_x),
+                                              static_cast<float>(game_y));
+    if (delay_ms > 0) {
+        inject_click(static_cast<int>(wx), static_cast<int>(wy), delay_ms);
+    } else {
+        // A quick tap: press+release land in one editor pump (a collapsed
+        // tap — the exact shape the pending-click queue exists for).
+        inject_mouse_down(static_cast<int>(wx), static_cast<int>(wy));
+        inject_mouse_up(static_cast<int>(wx), static_cast<int>(wy));
+    }
+}
+
+// Bounded wait on the FadeBetween trace count — the editor-side observable.
+// allbuttons[] is NOT one: the editor never rebuilds it, so main-menu ids
+// stay visible to has_interactable() while the editor is open.
+bool phantom_wait_for_fades(int at_least, int timeout_ms)
+{
+    for (int waited = 0; waited < timeout_ms; waited += 10) {
+        if (count_fade_between_traces() >= at_least)
+            return true;
+        SDL_Delay(10);
+    }
+    return count_fade_between_traces() >= at_least;
+}
+
+void cleanup_phantom_picker_state()
+{
+    for (int i = 0; i < 5; i++) {
+        pks_phantom().backdrops[static_cast<std::size_t>(i)].reset();
+        pks_phantom().backpics[i].free();
+    }
+    clear_allbuttons();
+    og::runtime::current_session->localbuttons_ = nullptr;
+    pks_phantom().main_columns_pix.reset();
+    pks_phantom().main_columns_data.free();
+    pks_phantom().main_title_logo_pix.reset();
+    pks_phantom().main_title_logo_data.free();
+}
+
+int editor_exit_phantom_injector(void* data)
+{
+    og::runtime::ensure_thread_session();
+    PhantomClickState* st = static_cast<PhantomClickState*>(data);
+    st->started = true;
+
+    if (!wait_for_interactable("level_edit", 10000)) {
+        st->finished = true;
+        return 1;
+    }
+    SDL_Delay(750);
+    const int fades_before_door = count_fade_between_traces();
+    interact("level_edit");
+
+    // Editor entry = the door's two way-in fades (the still-open menu's
+    // fade-out plus the editor's first-frame fade-in). Bounded wait so a
+    // regression fails instead of hanging the group.
+    if (!phantom_wait_for_fades(fades_before_door + 2, 10000)) {
+        // Recovery so the group never hangs: end whatever is open, then
+        // leave; the editor_opened guard reds the test.
+        og::runtime::current_session->myscreen_->world().end = 1;
+        SDL_Delay(500);
+        interact("quit");
+        st->finished = true;
+        return 2;
+    }
+    st->editor_opened = true;
+    SDL_Delay(500);  // let the editor's loop settle on its first frames
+
+    // The reporter's exit, at the editor's own menu geometry
+    // (level_editor.cpp menu init: File 0..30 x 0..20 opens Campaign >/
+    // Level >/Exit rows at x 0..65, 20px pitch — Exit is y 60..80; the
+    // save-confirm it can raise is answered instantly from the TESTING
+    // queue the test armed, with no event loop run).
+    phantom_click_at_canvas(15, 10, 30);   // File (opens on the release)
+    SDL_Delay(300);
+    phantom_click_at_canvas(32, 70, 0);    // Exit — a quick collapsed tap
+    // The hover: ONLY a motion, queued right behind Exit's release so the
+    // pointer is over BEGIN NEW GAME (80,55 140x20 -> centre (150,65))
+    // before the main menu's first post-door frame. No click follows.
+    {
+        const auto [mx, my] = ui_canvas_to_window(150.0f, 65.0f);
+        inject_mouse_motion(static_cast<int>(mx), static_cast<int>(my));
+    }
+
+    // The way back is two more fades: the editor's own exit fade-out plus
+    // the parent menu loop's fade-in off the black window.
+    if (!phantom_wait_for_fades(fades_before_door + 4, 10000)) {
+        og::runtime::current_session->myscreen_->world().end = 1;
+        SDL_Delay(500);
+        interact("quit");
+        st->finished = true;
+        return 3;
+    }
+    st->editor_closed = true;
+
+    // The phantom: pre-fix, one of the File/Exit pending clicks is spent
+    // at the hovered pointer on the menu's first post-door frame,
+    // activating BEGIN NEW GAME and opening the company-name-entry screen.
+    if (wait_for_interactable("company_name_accept", 2500)) {
+        st->phantom_fired = true;
+        SDL_Delay(750);
+        interact("back");  // escape the name entry so the test cannot hang
+        SDL_Delay(300);
+        wait_for_interactable("level_edit", 10000);
+    }
+
+    SDL_Delay(500);
+    interact("quit");  // ends mainmenu(); the TESTING call cap does the rest
+    st->finished = true;
+    return 0;
+}
+} // namespace
+
+TEST(LevelEditorInteractions, editor_exit_clicks_cannot_activate_the_main_menu)
+{
+    og::ui::menu_transition_testing_reset();
+    og::runtime::current_session->myscreen_->world().end = 0;
+
+    // A save of our own so the flow is deterministic under --gtest_shuffle
+    // (picker_main loads save0 and the editor opens that campaign's level).
+    og::runtime::current_session->myscreen_->save_data.scen_num = 1;
+    og::runtime::current_session->myscreen_->save_data.numplayers = 1;
+    og::runtime::current_session->myscreen_->save_data.current_campaign =
+        "gladiator";
+    og::runtime::current_session->myscreen_->save_data.save("save0");
+
+    // The editor's entry path can mark the level changed, so File -> Exit
+    // raises the "Quit without saving?" confirm. Queue the YES: the TESTING
+    // prompt path answers from the queue and returns at once — it runs no
+    // event loop, so the collapsed-tap pending queue the phantom rides on
+    // is untouched, exactly as in the reporter's clean-exit scenario.
+    picker_testing_yes_or_no_queue_clear();
+    picker_testing_yes_or_no_queue_push(true);
+
+    trace_clear();
+    PhantomClickState st;
+    SDL_Thread* thread = SDL_CreateThread(editor_exit_phantom_injector,
+                                          "phantom_injector", &st);
+    ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
+
+    g_picker_mainmenu_calls = 0;
+    g_picker_max_mainmenu_calls = 1;
+    picker_main(0, nullptr);
+    SDL_WaitThread(thread, nullptr);
+    cleanup_phantom_picker_state();
+    g_picker_max_mainmenu_calls = 0;
+    og::runtime::current_session->myscreen_->world().end = 0;
+    picker_testing_yes_or_no_queue_clear();
+
+    ASSERT_TRUE(st.started.load()) << "injector thread never started";
+    ASSERT_TRUE(st.finished.load()) << "injector thread never finished";
+    ASSERT_TRUE(st.editor_opened.load())
+        << "guard: the LEVEL EDITOR door never opened, the pin has no teeth";
+    ASSERT_TRUE(st.editor_closed.load())
+        << "guard: the File->Exit clicks never closed the editor";
+    EXPECT_FALSE(st.phantom_fired.load())
+        << "phantom click: the File->Exit clicks made INSIDE the editor were "
+           "spent on the main menu — hovering BEGIN NEW GAME during the fade "
+           "activated it with no click";
+    og::ui::menu_transition_testing_reset();
+}

--- a/tests/integration/test_level_progress.cpp
+++ b/tests/integration/test_level_progress.cpp
@@ -43,11 +43,9 @@ static int event_injector_thread(void* data)
     EventSequence* seq = static_cast<EventSequence*>(data);
     seq->started = true;
 
-    // Wait for mainmenu to initialize and complete fadeblack.
-    // The main menu's run_menu_screen entry (EnterTransition::FadeWithInitialDraw)
-    // publishes its buttons, then fades out, composes, and fades in — the fade
-    // takes ~500ms and eats SDL events. We wait for the button to exist then add
-    // extra delay so the fade finishes and the event loop is ready.
+    // Wait for mainmenu to initialize. Its depth-1 entry fades (#237
+    // derivation), but fades are INSTANT under TESTING — the 750ms is a
+    // generic settle for the runner loop, not fade timing.
     wait_for_interactable("continue_game", 5000);
     SDL_Delay(750);
 
@@ -55,10 +53,10 @@ static int event_injector_thread(void* data)
     fprintf(stderr, "  [test] Step 1: clicking continue_game\n");
     interact("continue_game");
 
-    // Wait for create_team_menu to init after fade + level load. Base Camp
-    // enters with EnterTransition::FadeAroundEntry (a fade-out unless the
-    // post-game teardown already suppressed it, the cold compose, a fade-in);
-    // the level reload happens in the runner loop's reload guard.
+    // Wait for create_team_menu to init after fade + level load. Base Camp's
+    // depth-1 entry fades (a fade-out unless a teardown noted the surface
+    // black, the cold compose, a fade-in); the level reload happens in the
+    // runner loop's reload guard.
     // PROGRESS lives inside the SCENARIO subscreen now.
     SDL_Delay(500);
     wait_for_interactable("scenario", 10000);

--- a/tests/integration/test_mass_coverage.cpp
+++ b/tests/integration/test_mass_coverage.cpp
@@ -557,7 +557,12 @@ TEST(MassCoverage, video_fade_between) {
     SDL_DestroySurface(d);
 }
 
-TEST(MassCoverage, video_fadeblack) { (void)og::runtime::current_session->myscreen_->fadeblack(true); }
+TEST(MassCoverage, video_fadeblack)
+{
+    // Out first (the window shows a frame at the test boundary), then in.
+    ASSERT_EQ(1, og::runtime::current_session->myscreen_->fadeblack(false));
+    ASSERT_EQ(1, og::runtime::current_session->myscreen_->fadeblack(true));
+}
 TEST(MassCoverage, video_darken_screen) { og::runtime::current_session->myscreen_->darken_screen(); }
 
 // text.cpp uncovered

--- a/tests/integration/test_mass_coverage.cpp
+++ b/tests/integration/test_mass_coverage.cpp
@@ -559,9 +559,14 @@ TEST(MassCoverage, video_fade_between) {
 
 TEST(MassCoverage, video_fadeblack)
 {
-    // Out first (the window shows a frame at the test boundary), then in.
-    ASSERT_EQ(1, og::runtime::current_session->myscreen_->fadeblack(false));
-    ASSERT_EQ(1, og::runtime::current_session->myscreen_->fadeblack(true));
+    // The test boundary leaves the window black: a fade-out there has
+    // nothing to fade and is skipped (0). Present a frame so there is
+    // something to fade out, then out (1), then in (1).
+    screen& scr = *og::runtime::current_session->myscreen_;
+    ASSERT_EQ(0, scr.fadeblack(false)) << "idempotent on a black window";
+    scr.buffer_to_screen(0, 0, scr.canvas_w(), scr.canvas_h());
+    ASSERT_EQ(1, scr.fadeblack(false));
+    ASSERT_EQ(1, scr.fadeblack(true));
 }
 TEST(MassCoverage, video_darken_screen) { og::runtime::current_session->myscreen_->darken_screen(); }
 

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -33,6 +33,7 @@
 #include <openglad/interface/ui/picker_common.h>
 #include <openglad/interface/ui/picker_lobby_client.h>
 #include <openglad/interface/ui/picker_ui_state.h>
+#include <openglad/platform/video_sdl.h>
 #include <openglad/resources/gparser.h>
 #include <openglad/resources/io_common.h>
 #include <openglad/resources/save_data.h>
@@ -616,7 +617,7 @@ bool nested_door_parent_frame_tick(void* /*state*/, int frame)
 
 } // namespace
 
-TEST(MenuEngine, depth_rule_root_entry_fades_out_and_in)
+TEST(MenuEngine, depth_rule_root_entry_fades_in_and_out_at_exit)
 {
     static constexpr og::ui::MenuButtonSpec kRows[] = {
         {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
@@ -633,19 +634,24 @@ TEST(MenuEngine, depth_rule_root_entry_fades_out_and_in)
     g_synth_spec = &spec;
     g_start_game_requested = true;
 
+    // The test boundary leaves the window black — what every exit fade
+    // leaves, and what the ownership rule promises every entry.
+    ASSERT_TRUE(og::runtime::current_session->myscreen_->window_is_black());
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
-    EXPECT_EQ(3, count_fade_between_traces())
-        << "a depth-1 Screen entry is a context switch: one fade-out on "
-           "entry, one fade-in — and, the ownership rule, one fade-out of "
-           "its own last frame at exit";
+    EXPECT_EQ(2, count_fade_between_traces())
+        << "a depth-1 Screen entry is a context switch: the entry fade-out "
+           "is a no-op on the black window the previous exit left, then one "
+           "fade-in — and, the ownership rule, one fade-out of its own last "
+           "frame at exit";
     EXPECT_TRUE(og::runtime::current_session->myscreen_->window_is_black())
         << "the exit fade-out leaves the window black for whatever opens next";
     EXPECT_EQ(0, og::ui::menu_screen_depth())
         << "the RAII depth bracket must restore on exit";
+    EXPECT_EQ(0, og::video_testing::g_fade_violations.load());
 }
 
-TEST(MenuEngine, depth_rule_already_black_entry_fades_in_only)
+TEST(MenuEngine, depth_rule_entry_over_an_unfaded_window_is_a_violation)
 {
     static constexpr og::ui::MenuButtonSpec kRows[] = {
         {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
@@ -664,8 +670,9 @@ TEST(MenuEngine, depth_rule_already_black_entry_fades_in_only)
     g_start_game_requested = true;
 
     // A teardown (a gameplay exit, the intro's last page) genuinely faded
-    // the window to black — no note, the video layer knows.
-    scr->fadeblack(0);
+    // the window to black — no note, the video layer knows. (The boundary
+    // already left it black; the fade is the no-op that proves it.)
+    EXPECT_EQ(0, scr->fadeblack(0));
     ASSERT_TRUE(scr->window_is_black());
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
@@ -673,16 +680,32 @@ TEST(MenuEngine, depth_rule_already_black_entry_fades_in_only)
         << "a black window suppresses the entry fade-out (#200: fadeblack(0) "
            "is a no-op on a black window); the fade-in and the exit "
            "fade-out remain";
+    EXPECT_EQ(0, og::video_testing::g_fade_violations.load());
 
-    // The state is the WINDOW's, not a one-shot note: put a frame on it and
-    // the next entry fades fully again.
+    // The state is the WINDOW's, not a one-shot note: put a frame on it
+    // that nobody fades out, and the next entry finds it unfaded. The entry
+    // still fades it out (production never hard-cuts) — and under TESTING
+    // that deferred fade-out is the entry invariant's violation: the surface
+    // on the window exited without its own fade-out.
     scr->buffer_to_screen(0, 0, 320, 200);
     ASSERT_FALSE(scr->window_is_black());
     g_start_game_requested = true;
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
     EXPECT_EQ(3, count_fade_between_traces())
-        << "a presented frame is faded out on entry, in, and out at exit";
+        << "an unfaded frame is still faded out on entry, then in, and out "
+           "at exit";
+    EXPECT_EQ(1, og::video_testing::g_fade_violations.load())
+        << "the entry that absorbed the missing exit fade must report it";
+    const std::vector<std::string> violations =
+        og::video_testing::fade_violation_messages();
+    ASSERT_EQ(1u, violations.size());
+    EXPECT_EQ("entry found an unfaded window: the previous surface exited "
+              "without its fade-out (depth_black)",
+              violations.front());
+    // This test triggered the violation on purpose; the listener would
+    // otherwise fail it at OnTestEnd.
+    og::video_testing::reset_fade_violations();
 }
 
 TEST(MenuEngine, depth_rule_nested_entry_never_fades)
@@ -716,10 +739,11 @@ TEST(MenuEngine, depth_rule_nested_entry_never_fades)
     EXPECT_EQ(1, g_depth_rule_child_content_draws)
         << "the nested child paints exactly its one loop frame — no pre-loop "
            "cold compose on a non-fading entry, no missed frame either";
-    EXPECT_EQ(3, count_fade_between_traces())
-        << "only the parent's depth-1 entry fades (out, in, and out again at "
-           "its exit); a nested run_menu_screen call (a subscreen door) "
-           "produces ZERO fades on either side";
+    EXPECT_EQ(2, count_fade_between_traces())
+        << "only the parent's depth-1 entry fades (in over the black window "
+           "the boundary left, and out again at its exit); a nested "
+           "run_menu_screen call (a subscreen door) produces ZERO fades on "
+           "either side";
 }
 
 TEST(MenuEngine, entry_fade_override_instant_suppresses_a_depth_one_fade)
@@ -750,9 +774,9 @@ TEST(MenuEngine, entry_fade_override_instant_suppresses_a_depth_one_fade)
     g_start_game_requested = true;
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
-    EXPECT_EQ(3, count_fade_between_traces())
+    EXPECT_EQ(2, count_fade_between_traces())
         << "the override is one-shot — the next depth-1 entry fades again "
-           "(out, in, and out at its exit)";
+           "(in over the black window, and out at its exit)";
 
     // Swallow-even-if-unused: an Overlay entry consumes a stale override.
     og::ui::MenuScreenSpec overlay = make_synth_spec(kRows, 1, "entry_ov");
@@ -765,12 +789,12 @@ TEST(MenuEngine, entry_fade_override_instant_suppresses_a_depth_one_fade)
     g_synth_spec = &spec;
     g_start_game_requested = true;
     // The overlay's remote-start return presented nothing, so the window is
-    // still black from the previous exit; put a frame on it so the next
-    // crossing has something to fade out.
-    og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
+    // still black from the previous exit — the state every fading entry
+    // expects. A leaked Instant note would make this crossing 0.
+    ASSERT_TRUE(og::runtime::current_session->myscreen_->window_is_black());
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
-    EXPECT_EQ(3, count_fade_between_traces())
+    EXPECT_EQ(2, count_fade_between_traces())
         << "a non-fading entry must still clear the override or it "
            "suppresses the NEXT main-menu crossing's fade";
 }
@@ -811,21 +835,30 @@ TEST(MenuEngine, instant_note_pending_at_exit_skips_the_exit_fade)
 
     trace_clear();
     (void)og::ui::run_menu_screen(spec);
-    EXPECT_EQ(2, count_fade_between_traces())
-        << "entry out + in only: an Instant note pending at exit means the "
+    EXPECT_EQ(1, count_fade_between_traces())
+        << "entry fade-in only: an Instant note pending at exit means the "
            "door being opened is instant, so the exit fade-out is skipped";
+    EXPECT_TRUE(trace_contains("video", "exit fade skipped: Instant note pending"))
+        << "the skipped exit fade is traced, so flow pins can hold it to the "
+           "one door it is for";
     EXPECT_FALSE(scr->window_is_black())
         << "the screen's last frame stays on the window for the instant door";
 
-    // The note survives the exit for the door's own entry to consume.
+    // The note survives the exit for the door's own entry to consume: that
+    // entry fades nothing IN. It still OWNS its exit — a screen entered
+    // instantly (Base Camp back from the NETWORKING door) fades its last
+    // frame out when it leaves for a boundary crossing, unless another
+    // Instant note is pending at that exit.
     g_start_game_requested = true;
     spec.frame_tick = nullptr;
     spec.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
-    EXPECT_EQ(0, count_fade_between_traces())
-        << "the pending Instant note reaches the next entry and makes it "
-           "instant both ways";
+    EXPECT_EQ(1, count_fade_between_traces())
+        << "the pending Instant note makes the entry instant (no fade-in); "
+           "the exit fade-out is still owed and runs";
+    EXPECT_TRUE(scr->window_is_black())
+        << "the instantly-entered screen fades its last frame out on exit";
 }
 
 TEST(MenuEngine, entry_fade_override_fade_forces_a_nested_entry_to_fade)
@@ -854,25 +887,30 @@ TEST(MenuEngine, entry_fade_override_fade_forces_a_nested_entry_to_fade)
     // Control: the same nested entry with NO override adds zero fades.
     trace_clear();
     (void)og::ui::run_menu_screen(parent);
-    EXPECT_EQ(3, count_fade_between_traces())
+    EXPECT_EQ(2, count_fade_between_traces())
         << "control: without an override only the parent's depth-1 entry "
-           "fades (out, in, out at exit) — the nested door adds nothing";
+           "fades (in over the black window, out at exit) — the nested door "
+           "adds nothing";
 
     // The CLOUD SAVES / LEVEL EDITOR shape: a Fade override makes the same
     // nested entry fade out, in, and — owning its exit — out again. The
     // parent ends right after the child returns, so its own exit fade-out
     // finds the window already black and is a no-op. (The control run's exit
-    // left the window black too; present a frame so this run starts from a
-    // visible one, like the control did.)
-    og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
+    // left the window black, exactly as the boundary did before it.)
+    ASSERT_TRUE(og::runtime::current_session->myscreen_->window_is_black());
     g_depth_rule_child_fade_override = true;
     trace_clear();
     (void)og::ui::run_menu_screen(parent);
     g_depth_rule_child_fade_override = false;
     g_depth_rule_child_spec = nullptr;
-    EXPECT_EQ(5, count_fade_between_traces())
-        << "a Fade override forces the nested entry to fade: the parent's 2 "
-           "plus the door's own fade-out + fade-in + exit fade-out";
+    EXPECT_EQ(4, count_fade_between_traces())
+        << "a Fade override forces the nested entry to fade: the parent's "
+           "fade-in plus the door's own fade-out (of the still-open parent — "
+           "not a violation, the parent has not exited) + fade-in + exit "
+           "fade-out";
+    EXPECT_EQ(0, og::video_testing::g_fade_violations.load())
+        << "a nested door's fade-out of its still-open parent is the door's "
+           "by contract";
 }
 
 TEST(MenuEngine, nested_menu_door_bracket_fades_symmetrically)
@@ -905,19 +943,20 @@ TEST(MenuEngine, nested_menu_door_bracket_fades_symmetrically)
     (void)og::ui::run_menu_screen(parent);
     g_depth_rule_child_spec = nullptr;
 
-    // The real CLOUD SAVES / LEVEL EDITOR round trip: parent entry (2), then
-    // the door's two halves, measured as deltas so the symmetry invariant —
-    // fades(in) == fades(back) — is what is asserted. Under the ownership
-    // rule the way back is the nested screen's OWN exit fade-out plus the
-    // parent loop's fade-in off the black window it finds.
-    ASSERT_EQ(2, g_nested_door_fades_at_open)
-        << "the parent's own depth-1 entry must have faded before the door";
-    ASSERT_EQ(4, g_nested_door_fades_inside_door)
+    // The real CLOUD SAVES / LEVEL EDITOR round trip: parent entry (1, in
+    // over the black window the boundary left), then the door's two halves,
+    // measured as deltas so the symmetry invariant — fades(in) ==
+    // fades(back) — is what is asserted. Under the ownership rule the way
+    // back is the nested screen's OWN exit fade-out plus the parent loop's
+    // fade-in off the black window it finds.
+    ASSERT_EQ(1, g_nested_door_fades_at_open)
+        << "the parent's own depth-1 entry must have faded in before the door";
+    ASSERT_EQ(3, g_nested_door_fades_inside_door)
         << "the way in is a fade-out plus the nested entry's fade-in";
     ASSERT_NE(-1, g_nested_door_fades_after_return)
         << "the parent loop never ran a frame after the door";
-    EXPECT_EQ(7, count_fade_between_traces())
-        << "2 (parent entry) + 2 (door in) + 2 (door back) + 1 (the parent's "
+    EXPECT_EQ(6, count_fade_between_traces())
+        << "1 (parent entry) + 2 (door in) + 2 (door back) + 1 (the parent's "
            "own exit fade-out)";
     EXPECT_EQ(2, g_nested_door_fades_inside_door - g_nested_door_fades_at_open)
         << "#237 symmetry: entering a nested main-menu door fades exactly "
@@ -959,8 +998,8 @@ TEST(MenuEngine, nested_menu_door_bracket_is_symmetric_for_a_legacy_body)
     (void)og::ui::run_menu_screen(parent);
     g_nested_door_body_fn = nullptr;
 
-    ASSERT_EQ(2, g_nested_door_fades_at_open)
-        << "the parent's own depth-1 entry must have faded before the door";
+    ASSERT_EQ(1, g_nested_door_fades_at_open)
+        << "the parent's own depth-1 entry must have faded in before the door";
     ASSERT_NE(-1, g_legacy_door_fades_inside_door)
         << "the legacy door body never ran";
     ASSERT_NE(-1, g_nested_door_fades_after_return)
@@ -978,8 +1017,8 @@ TEST(MenuEngine, nested_menu_door_bracket_is_symmetric_for_a_legacy_body)
     EXPECT_EQ(fades_back, fades_in)
         << "#237 symmetry, the reported bug class: a door that fades once in "
            "and twice back is exactly what the invariant forbids";
-    EXPECT_EQ(7, count_fade_between_traces())
-        << "2 (parent entry) + 2 (in) + 2 (back) + 1 (the parent's own exit)";
+    EXPECT_EQ(6, count_fade_between_traces())
+        << "1 (parent entry) + 2 (in) + 2 (back) + 1 (the parent's own exit)";
 }
 
 TEST(MenuEngine, depth_rule_overlay_never_fades_even_over_a_black_window)
@@ -1033,16 +1072,32 @@ TEST(MenuEngine, legacy_menu_fade_owns_out_in_and_out_again)
     EXPECT_EQ(0, count_fade_between_traces());
     EXPECT_FALSE(scr->window_is_black());
 
-    // Bare context switch (depth 0): fade-out at construction, the first
-    // present fades in, the scope's end fades out again.
+    // Bare context switch (depth 0) over a frame nobody faded out (the
+    // instant screen's plain present above): the construction fade-out
+    // still runs — production never hard-cuts — and under TESTING it is
+    // the entry invariant's violation, named after the screen. Then the
+    // first present fades in and the scope's end fades out again.
     trace_clear();
+    ASSERT_FALSE(scr->window_is_black());
     {
-        og::ui::LegacyMenuFade entry_fade;
+        og::ui::LegacyMenuFade entry_fade("legacy_test");
         EXPECT_TRUE(entry_fade.active());
         EXPECT_TRUE(entry_fade.fade_in_pending());
         EXPECT_EQ(1, count_fade_between_traces())
             << "the previous frame fades out at construction";
         EXPECT_TRUE(scr->window_is_black());
+        EXPECT_EQ(1, og::video_testing::g_fade_violations.load())
+            << "that fade-out was the previous surface's job";
+        {
+            const std::vector<std::string> violations =
+                og::video_testing::fade_violation_messages();
+            ASSERT_EQ(1u, violations.size());
+            EXPECT_EQ("entry found an unfaded window: the previous surface "
+                      "exited without its fade-out (legacy_test)",
+                      violations.front());
+        }
+        // Triggered on purpose; the listener would otherwise fail this test.
+        og::video_testing::reset_fade_violations();
         entry_fade.present_first(*scr);
         EXPECT_EQ(2, count_fade_between_traces())
             << "the first present fades in";
@@ -1075,6 +1130,26 @@ TEST(MenuEngine, legacy_menu_fade_owns_out_in_and_out_again)
     }
     EXPECT_EQ(2, count_fade_between_traces())
         << "the destructor adds nothing after an explicit end()";
+
+    // Instant-in, fade-out-at-exit (the NETWORKING hookup shape): an
+    // Instant-noted scope fades nothing on entry and presents plainly, but
+    // the screen leaves its context on a successful hookup and owns that
+    // exit — fade_out_at_exit() makes end() fade its last frame out, so the
+    // fading entry behind it finds a black window.
+    og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Instant);
+    trace_clear();
+    {
+        og::ui::LegacyMenuFade entry_fade("legacy_hookup");
+        EXPECT_FALSE(entry_fade.active());
+        entry_fade.present_first(*scr);
+        EXPECT_EQ(0, count_fade_between_traces()) << "instant in";
+        EXPECT_FALSE(scr->window_is_black());
+        entry_fade.fade_out_at_exit();
+    }
+    EXPECT_EQ(1, count_fade_between_traces())
+        << "the exit fade-out runs even though the entry did not fade in";
+    EXPECT_TRUE(scr->window_is_black());
+    EXPECT_EQ(0, og::video_testing::g_fade_violations.load());
 }
 
 // The override's other half at depth 0's mirror: nested under an open menu

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -548,44 +548,46 @@ bool depth_rule_parent_frame_tick(void* /*state*/, int frame)
 }
 
 // The run_nested_menu_door probe: the door body is the nested screen, and
-// the parent loop keeps running afterwards so its next present can turn the
-// bracket's black note into the fade back in.
+// the parent loop keeps running afterwards so its next present finds the
+// black window the door's exit left and fades back in.
 int g_nested_door_fades_at_open = -1;
 int g_nested_door_fades_inside_door = -1;
+int g_nested_door_fades_after_return = -1;
+
+// Samples INSIDE the nested screen, on its first loop frame: after its entry
+// fade-out + fade-in, before its own exit fade-out — exactly the cost of the
+// way in. (Sampling in the door body after run_menu_screen returned would
+// already include the exit fade, which the ownership rule moved there.)
+bool nested_door_child_frame_tick(void* /*state*/, int frame)
+{
+    if (frame == 1)
+        g_nested_door_fades_inside_door = count_fade_between_traces();
+    return frame < 2;
+}
 
 Sint32 nested_door_body()
 {
     if (g_depth_rule_child_spec != nullptr)
         (void)og::ui::run_menu_screen(*g_depth_rule_child_spec);
-    // Sampled HERE, inside the door: the bracket's way-back fade-out has not
-    // run yet, so this is exactly the cost of the way in.
-    g_nested_door_fades_inside_door = count_fade_between_traces();
     return MENU_REDRAW;
 }
 
 // The LEGACY door-body shape (the level editor): the body runs no runner
-// entry at all, so it owes the notes the same swallow by hand and has to
-// spend the Fade note itself — begin_legacy_menu_entry_fade(), then present
-// the first composed frame with fadeblack(1) instead of the plain present.
-// Discarding that return is what left the editor door at 1 fade in / 2 back.
+// entry at all, so it applies the ownership rule by hand — LegacyMenuFade
+// consumes the door's Fade note, fades the still-open parent out, fades the
+// body's first composed frame in at present_first(), and fades the body out
+// when the scope ends. Dropping any half of that is the 1-in / 2-back
+// asymmetry the editor door once shipped.
 int g_legacy_door_fades_inside_door = -1;
 
 Sint32 legacy_nested_door_body()
 {
-    bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
+    og::ui::LegacyMenuFade entry_fade;
     screen* const scr = og::runtime::current_session->myscreen_;
     // The body's own loop, one frame of it: compose, then present once.
-    if (entry_fade_in_pending)
-    {
-        entry_fade_in_pending = false;
-        scr->fadeblack(1);
-    }
-    else
-    {
-        scr->buffer_to_screen(0, 0, 320, 200);
-    }
-    // Sampled inside the door, before the bracket's way-back fade-out: this
-    // is exactly the cost of the way in.
+    entry_fade.present_first(*scr);
+    // Sampled inside the door, before the scope's exit fade-out: this is
+    // exactly the cost of the way in.
     g_legacy_door_fades_inside_door = count_fade_between_traces();
     return MENU_REDRAW;
 }
@@ -602,6 +604,12 @@ bool nested_door_parent_frame_tick(void* /*state*/, int frame)
         (void)og::ui::run_nested_menu_door(g_nested_door_body_fn);
         // Keep the loop alive: the fade back in happens on the NEXT present.
         return true;
+    }
+    if (frame == 2)
+    {
+        // The parent's frame-1 present (the fade back in) has landed; its
+        // own exit fade-out has not.
+        g_nested_door_fades_after_return = count_fade_between_traces();
     }
     return frame < 3;
 }
@@ -627,9 +635,12 @@ TEST(MenuEngine, depth_rule_root_entry_fades_out_and_in)
 
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
-    EXPECT_EQ(2, count_fade_between_traces())
-        << "a depth-1 Screen entry is a context switch: exactly one fade-out "
-           "plus one fade-in";
+    EXPECT_EQ(3, count_fade_between_traces())
+        << "a depth-1 Screen entry is a context switch: one fade-out on "
+           "entry, one fade-in — and, the ownership rule, one fade-out of "
+           "its own last frame at exit";
+    EXPECT_TRUE(og::runtime::current_session->myscreen_->window_is_black())
+        << "the exit fade-out leaves the window black for whatever opens next";
     EXPECT_EQ(0, og::ui::menu_screen_depth())
         << "the RAII depth bracket must restore on exit";
 }
@@ -645,25 +656,33 @@ TEST(MenuEngine, depth_rule_already_black_entry_fades_in_only)
     FakeLobbyClient lobby;
     og::ui::install_active_picker_lobby_client(&lobby);
     og::ui::menu_transition_testing_reset();
+    screen* const scr = og::runtime::current_session->myscreen_;
 
     og::ui::MenuScreenSpec spec = make_synth_spec(kRows, 1, "depth_black");
     spec.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
     g_synth_spec = &spec;
     g_start_game_requested = true;
 
-    og::ui::note_menu_faded_to_black();
-    trace_clear();
-    EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
-    EXPECT_EQ(1, count_fade_between_traces())
-        << "a teardown's black note suppresses the entry fade-out (#200); "
-           "only the fade-in runs";
-
-    // One-shot: the note was consumed by that entry.
-    g_start_game_requested = true;
+    // A teardown (a gameplay exit, the intro's last page) genuinely faded
+    // the window to black — no note, the video layer knows.
+    scr->fadeblack(0);
+    ASSERT_TRUE(scr->window_is_black());
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
     EXPECT_EQ(2, count_fade_between_traces())
-        << "the black note is one-shot — the next entry fades fully again";
+        << "a black window suppresses the entry fade-out (#200: fadeblack(0) "
+           "is a no-op on a black window); the fade-in and the exit "
+           "fade-out remain";
+
+    // The state is the WINDOW's, not a one-shot note: put a frame on it and
+    // the next entry fades fully again.
+    scr->buffer_to_screen(0, 0, 320, 200);
+    ASSERT_FALSE(scr->window_is_black());
+    g_start_game_requested = true;
+    trace_clear();
+    EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
+    EXPECT_EQ(3, count_fade_between_traces())
+        << "a presented frame is faded out on entry, in, and out at exit";
 }
 
 TEST(MenuEngine, depth_rule_nested_entry_never_fades)
@@ -697,9 +716,10 @@ TEST(MenuEngine, depth_rule_nested_entry_never_fades)
     EXPECT_EQ(1, g_depth_rule_child_content_draws)
         << "the nested child paints exactly its one loop frame — no pre-loop "
            "cold compose on a non-fading entry, no missed frame either";
-    EXPECT_EQ(2, count_fade_between_traces())
-        << "only the parent's depth-1 entry fades; a nested run_menu_screen "
-           "call (a subscreen door) produces ZERO fades";
+    EXPECT_EQ(3, count_fade_between_traces())
+        << "only the parent's depth-1 entry fades (out, in, and out again at "
+           "its exit); a nested run_menu_screen call (a subscreen door) "
+           "produces ZERO fades on either side";
 }
 
 TEST(MenuEngine, entry_fade_override_instant_suppresses_a_depth_one_fade)
@@ -724,14 +744,15 @@ TEST(MenuEngine, entry_fade_override_instant_suppresses_a_depth_one_fade)
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
     EXPECT_EQ(0, count_fade_between_traces())
         << "an Instant override (the NETWORKING door, whose Base Camp parent "
-           "already exited) suppresses the depth-1 fade";
+           "already exited) suppresses the depth-1 fade — entry and exit";
 
     // One-shot: the note was consumed by that entry.
     g_start_game_requested = true;
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
-    EXPECT_EQ(2, count_fade_between_traces())
-        << "the override is one-shot — the next depth-1 entry fades again";
+    EXPECT_EQ(3, count_fade_between_traces())
+        << "the override is one-shot — the next depth-1 entry fades again "
+           "(out, in, and out at its exit)";
 
     // Swallow-even-if-unused: an Overlay entry consumes a stale override.
     og::ui::MenuScreenSpec overlay = make_synth_spec(kRows, 1, "entry_ov");
@@ -743,11 +764,68 @@ TEST(MenuEngine, entry_fade_override_instant_suppresses_a_depth_one_fade)
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(overlay));
     g_synth_spec = &spec;
     g_start_game_requested = true;
+    // The overlay's remote-start return presented nothing, so the window is
+    // still black from the previous exit; put a frame on it so the next
+    // crossing has something to fade out.
+    og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
-    EXPECT_EQ(2, count_fade_between_traces())
+    EXPECT_EQ(3, count_fade_between_traces())
         << "a non-fading entry must still clear the override or it "
            "suppresses the NEXT main-menu crossing's fade";
+}
+
+// The Instant note's other job under the ownership rule: NETWORKING is an
+// instant door that Base Camp EXITS to open, so the note is set inside Base
+// Camp (the click intercept) and Base Camp's exit scope must honor it —
+// skip the exit fade-out and leave the note for the door's entry.
+namespace
+{
+
+bool instant_exit_frame_tick(void* /*state*/, int frame)
+{
+    if (frame == 1)
+        og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Instant);
+    return frame < 2;
+}
+
+} // namespace
+
+TEST(MenuEngine, instant_note_pending_at_exit_skips_the_exit_fade)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    og::ui::menu_transition_testing_reset();
+    screen* const scr = og::runtime::current_session->myscreen_;
+
+    og::ui::MenuScreenSpec spec = make_synth_spec(kRows, 1, "instant_exit");
+    spec.frame_tick = &instant_exit_frame_tick;
+    g_synth_spec = &spec;
+    g_start_game_requested = false;
+
+    trace_clear();
+    (void)og::ui::run_menu_screen(spec);
+    EXPECT_EQ(2, count_fade_between_traces())
+        << "entry out + in only: an Instant note pending at exit means the "
+           "door being opened is instant, so the exit fade-out is skipped";
+    EXPECT_FALSE(scr->window_is_black())
+        << "the screen's last frame stays on the window for the instant door";
+
+    // The note survives the exit for the door's own entry to consume.
+    g_start_game_requested = true;
+    spec.frame_tick = nullptr;
+    spec.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
+    trace_clear();
+    EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
+    EXPECT_EQ(0, count_fade_between_traces())
+        << "the pending Instant note reaches the next entry and makes it "
+           "instant both ways";
 }
 
 TEST(MenuEngine, entry_fade_override_fade_forces_a_nested_entry_to_fade)
@@ -776,20 +854,25 @@ TEST(MenuEngine, entry_fade_override_fade_forces_a_nested_entry_to_fade)
     // Control: the same nested entry with NO override adds zero fades.
     trace_clear();
     (void)og::ui::run_menu_screen(parent);
-    EXPECT_EQ(2, count_fade_between_traces())
+    EXPECT_EQ(3, count_fade_between_traces())
         << "control: without an override only the parent's depth-1 entry "
-           "fades — the nested door adds nothing";
+           "fades (out, in, out at exit) — the nested door adds nothing";
 
     // The CLOUD SAVES / LEVEL EDITOR shape: a Fade override makes the same
-    // nested entry fade out and in.
+    // nested entry fade out, in, and — owning its exit — out again. The
+    // parent ends right after the child returns, so its own exit fade-out
+    // finds the window already black and is a no-op. (The control run's exit
+    // left the window black too; present a frame so this run starts from a
+    // visible one, like the control did.)
+    og::runtime::current_session->myscreen_->buffer_to_screen(0, 0, 320, 200);
     g_depth_rule_child_fade_override = true;
     trace_clear();
     (void)og::ui::run_menu_screen(parent);
     g_depth_rule_child_fade_override = false;
     g_depth_rule_child_spec = nullptr;
-    EXPECT_EQ(4, count_fade_between_traces())
+    EXPECT_EQ(5, count_fade_between_traces())
         << "a Fade override forces the nested entry to fade: the parent's 2 "
-           "plus the door's own fade-out + fade-in";
+           "plus the door's own fade-out + fade-in + exit fade-out";
 }
 
 TEST(MenuEngine, nested_menu_door_bracket_fades_symmetrically)
@@ -805,7 +888,7 @@ TEST(MenuEngine, nested_menu_door_bracket_fades_symmetrically)
     og::ui::menu_transition_testing_reset();
 
     og::ui::MenuScreenSpec child = make_synth_spec(kRows, 1, "door_child");
-    child.frame_tick = &depth_rule_child_frame_tick;
+    child.frame_tick = &nested_door_child_frame_tick;
     child.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
 
     og::ui::MenuScreenSpec parent = make_synth_spec(kRows, 1, "door_parent");
@@ -815,6 +898,7 @@ TEST(MenuEngine, nested_menu_door_bracket_fades_symmetrically)
     g_start_game_requested = false;
     g_nested_door_fades_at_open = -1;
     g_nested_door_fades_inside_door = -1;
+    g_nested_door_fades_after_return = -1;
     g_nested_door_body_fn = &nested_door_body;
 
     trace_clear();
@@ -822,27 +906,33 @@ TEST(MenuEngine, nested_menu_door_bracket_fades_symmetrically)
     g_depth_rule_child_spec = nullptr;
 
     // The real CLOUD SAVES / LEVEL EDITOR round trip: parent entry (2), then
-    // the bracket's own two halves, measured as deltas so the symmetry
-    // invariant — fades(in) == fades(back) — is what is asserted.
+    // the door's two halves, measured as deltas so the symmetry invariant —
+    // fades(in) == fades(back) — is what is asserted. Under the ownership
+    // rule the way back is the nested screen's OWN exit fade-out plus the
+    // parent loop's fade-in off the black window it finds.
     ASSERT_EQ(2, g_nested_door_fades_at_open)
         << "the parent's own depth-1 entry must have faded before the door";
     ASSERT_EQ(4, g_nested_door_fades_inside_door)
         << "the way in is a fade-out plus the nested entry's fade-in";
-    EXPECT_EQ(6, count_fade_between_traces())
-        << "2 (parent entry) + 2 (door in) + 2 (door back)";
+    ASSERT_NE(-1, g_nested_door_fades_after_return)
+        << "the parent loop never ran a frame after the door";
+    EXPECT_EQ(7, count_fade_between_traces())
+        << "2 (parent entry) + 2 (door in) + 2 (door back) + 1 (the parent's "
+           "own exit fade-out)";
     EXPECT_EQ(2, g_nested_door_fades_inside_door - g_nested_door_fades_at_open)
         << "#237 symmetry: entering a nested main-menu door fades exactly "
            "once (out + in)";
-    EXPECT_EQ(2, count_fade_between_traces() - g_nested_door_fades_inside_door)
+    EXPECT_EQ(2, g_nested_door_fades_after_return - g_nested_door_fades_inside_door)
         << "#237 symmetry: the way back must fade exactly as much as the way "
-           "in — the door fades out and the parent loop fades back in";
+           "in — the door fades itself out and the parent loop fades back in";
 }
 
 // The other half of run_nested_menu_door's contract: the LEVEL EDITOR shape,
 // whose body is a hand-rolled loop rather than a run_menu_screen entry. The
-// bracket alone cannot make that door symmetric — the way in is only complete
-// once the body spends the Fade note on its own first frame. Regression pin
-// for the editor's discarded fade-in (1 in / 2 back).
+// door alone cannot make that door symmetric — the body applies the
+// ownership rule by hand through LegacyMenuFade (out of the parent, in on its
+// first frame, out at its exit). Regression pin for the editor's discarded
+// fade-in (1 in / 2 back).
 TEST(MenuEngine, nested_menu_door_bracket_is_symmetric_for_a_legacy_body)
 {
     static constexpr og::ui::MenuButtonSpec kRows[] = {
@@ -861,6 +951,7 @@ TEST(MenuEngine, nested_menu_door_bracket_is_symmetric_for_a_legacy_body)
     g_depth_rule_child_spec = nullptr;
     g_start_game_requested = false;
     g_nested_door_fades_at_open = -1;
+    g_nested_door_fades_after_return = -1;
     g_legacy_door_fades_inside_door = -1;
     g_nested_door_body_fn = &legacy_nested_door_body;
 
@@ -872,21 +963,26 @@ TEST(MenuEngine, nested_menu_door_bracket_is_symmetric_for_a_legacy_body)
         << "the parent's own depth-1 entry must have faded before the door";
     ASSERT_NE(-1, g_legacy_door_fades_inside_door)
         << "the legacy door body never ran";
+    ASSERT_NE(-1, g_nested_door_fades_after_return)
+        << "the parent loop never ran a frame after the door";
     const int fades_in = g_legacy_door_fades_inside_door -
         g_nested_door_fades_at_open;
-    const int fades_back = count_fade_between_traces() -
+    const int fades_back = g_nested_door_fades_after_return -
         g_legacy_door_fades_inside_door;
     EXPECT_EQ(2, fades_in)
-        << "#237: a legacy door body must honor the Fade note — the bracket's "
-           "fade-out plus the body's own fadeblack(1) first frame";
+        << "#237: a legacy door body must honor the Fade note — the scope's "
+           "fade-out of the parent plus its own fadeblack(1) first frame";
     EXPECT_EQ(2, fades_back)
-        << "the door fades out and the parent loop fades back in";
+        << "the scope fades the body out at its exit and the parent loop "
+           "fades back in";
     EXPECT_EQ(fades_back, fades_in)
         << "#237 symmetry, the reported bug class: a door that fades once in "
            "and twice back is exactly what the invariant forbids";
+    EXPECT_EQ(7, count_fade_between_traces())
+        << "2 (parent entry) + 2 (in) + 2 (back) + 1 (the parent's own exit)";
 }
 
-TEST(MenuEngine, depth_rule_overlay_never_fades_and_swallows_black_note)
+TEST(MenuEngine, depth_rule_overlay_never_fades_even_over_a_black_window)
 {
     static constexpr og::ui::MenuButtonSpec kRows[] = {
         {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
@@ -897,6 +993,7 @@ TEST(MenuEngine, depth_rule_overlay_never_fades_and_swallows_black_note)
     FakeLobbyClient lobby;
     og::ui::install_active_picker_lobby_client(&lobby);
     og::ui::menu_transition_testing_reset();
+    screen* const scr = og::runtime::current_session->myscreen_;
 
     og::ui::MenuScreenSpec spec = make_synth_spec(kRows, 1, "depth_overlay");
     spec.kind = og::ui::MenuScreenKind::Overlay;
@@ -904,43 +1001,84 @@ TEST(MenuEngine, depth_rule_overlay_never_fades_and_swallows_black_note)
     g_synth_spec = &spec;
     g_start_game_requested = true;
 
-    og::ui::note_menu_faded_to_black();
+    // A teardown genuinely left the window black.
+    scr->fadeblack(0);
+    ASSERT_TRUE(scr->window_is_black());
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
     EXPECT_EQ(0, count_fade_between_traces())
-        << "an Overlay (the pause family) never fades, even at depth 1";
-    EXPECT_FALSE(og::ui::consume_menu_faded_to_black())
-        << "swallow-even-if-unused: a non-fading entry must still clear the "
-           "black note or it leaks one screen forward";
+        << "an Overlay (the pause family) never fades, even at depth 1 and "
+           "even over a black window";
+    EXPECT_TRUE(scr->window_is_black())
+        << "the remote-start return presented nothing, so the window state "
+           "is untouched: it is the WINDOW's, not a note an entry swallows";
 }
 
-TEST(MenuEngine, legacy_entry_fade_honors_the_override_and_black_notes)
+TEST(MenuEngine, legacy_menu_fade_owns_out_in_and_out_again)
 {
     EngineTestGuard guard;
     og::ui::menu_transition_testing_reset();
+    screen* const scr = og::runtime::current_session->myscreen_;
 
-    // Instant-noted door (the NETWORKING shape): no fade, caller presents
-    // its first frame directly.
+    // Instant-noted door (the NETWORKING shape): inactive — no fade on
+    // entry, a plain first present, no fade at exit.
     og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Instant);
     trace_clear();
-    EXPECT_FALSE(og::ui::begin_legacy_menu_entry_fade());
+    {
+        og::ui::LegacyMenuFade entry_fade;
+        EXPECT_FALSE(entry_fade.active());
+        EXPECT_FALSE(entry_fade.fade_in_pending());
+        entry_fade.present_first(*scr);
+    }
     EXPECT_EQ(0, count_fade_between_traces());
+    EXPECT_FALSE(scr->window_is_black());
 
-    // Bare context switch: fade-out now, caller fades its first frame in.
+    // Bare context switch (depth 0): fade-out at construction, the first
+    // present fades in, the scope's end fades out again.
     trace_clear();
-    EXPECT_TRUE(og::ui::begin_legacy_menu_entry_fade());
-    EXPECT_EQ(1, count_fade_between_traces());
+    {
+        og::ui::LegacyMenuFade entry_fade;
+        EXPECT_TRUE(entry_fade.active());
+        EXPECT_TRUE(entry_fade.fade_in_pending());
+        EXPECT_EQ(1, count_fade_between_traces())
+            << "the previous frame fades out at construction";
+        EXPECT_TRUE(scr->window_is_black());
+        entry_fade.present_first(*scr);
+        EXPECT_EQ(2, count_fade_between_traces())
+            << "the first present fades in";
+        EXPECT_FALSE(entry_fade.fade_in_pending());
+        EXPECT_FALSE(scr->window_is_black());
+        entry_fade.present_first(*scr);
+        EXPECT_EQ(2, count_fade_between_traces())
+            << "every later present is plain";
+    }
+    EXPECT_EQ(3, count_fade_between_traces())
+        << "the scope's end fades the screen's last frame out";
+    EXPECT_TRUE(scr->window_is_black());
 
-    // Already-black teardown hand-off: no fade-out, but the caller still
-    // owns a fade-in.
-    og::ui::note_menu_faded_to_black();
+    // Already-black hand-off (a teardown faded first): no entry fade-out —
+    // fadeblack(0) is a no-op on a black window — but the fade-in and the
+    // exit fade-out are still owed.
     trace_clear();
-    EXPECT_TRUE(og::ui::begin_legacy_menu_entry_fade());
-    EXPECT_EQ(0, count_fade_between_traces());
+    {
+        og::ui::LegacyMenuFade entry_fade;
+        EXPECT_TRUE(entry_fade.active());
+        EXPECT_EQ(0, count_fade_between_traces());
+        entry_fade.present_first(*scr);
+        EXPECT_EQ(1, count_fade_between_traces());
+        // end() is explicit for bodies that must fade before later teardown
+        // touches the buffer; it is idempotent and the destructor backs it.
+        entry_fade.end();
+        EXPECT_EQ(2, count_fade_between_traces());
+        entry_fade.end();
+        EXPECT_EQ(2, count_fade_between_traces()) << "end() is idempotent";
+    }
+    EXPECT_EQ(2, count_fade_between_traces())
+        << "the destructor adds nothing after an explicit end()";
 }
 
 // The override's other half at depth 0's mirror: nested under an open menu
-// screen the legacy helper normally declines (Base Camp's SET CAMPAIGN), and
+// screen the legacy scope normally declines (Base Camp's SET CAMPAIGN), and
 // a Fade note flips exactly that decision.
 namespace
 {
@@ -956,7 +1094,8 @@ bool legacy_nested_fade_frame_tick(void* /*state*/, int frame)
         if (g_legacy_nested_note_fade)
             og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Fade);
         trace_clear();
-        g_legacy_nested_fade_result = og::ui::begin_legacy_menu_entry_fade();
+        og::ui::LegacyMenuFade entry_fade;
+        g_legacy_nested_fade_result = entry_fade.active();
         g_legacy_nested_fade_traces = count_fade_between_traces();
         return false;
     }
@@ -987,7 +1126,7 @@ TEST(MenuEngine, legacy_entry_fade_override_reaches_a_nested_depth)
     g_legacy_nested_fade_traces = -1;
     (void)og::ui::run_menu_screen(parent);
     EXPECT_FALSE(g_legacy_nested_fade_result)
-        << "nested under an open menu screen the legacy helper declines";
+        << "nested under an open menu screen the legacy scope declines";
     EXPECT_EQ(0, g_legacy_nested_fade_traces);
 
     g_legacy_nested_note_fade = true;
@@ -998,7 +1137,7 @@ TEST(MenuEngine, legacy_entry_fade_override_reaches_a_nested_depth)
     EXPECT_TRUE(g_legacy_nested_fade_result)
         << "a Fade override reaches a nested legacy entry too";
     EXPECT_EQ(1, g_legacy_nested_fade_traces)
-        << "it fades the surface out and hands the caller the fade-in";
+        << "it fades the surface out at construction and owes the fade-in";
 }
 
 // ---------------------------------------------------------------------------
@@ -2942,8 +3081,8 @@ TEST(MenuEngine, main_menu_registry_and_spec_shape)
     EXPECT_EQ(og::ui::RemoteStartExit::BreakWithSelection,
               spec.remote_start_exit);
     // Fading is derived (#237): a Screen kind at a run_picker top-level
-    // entry (depth 1) fades; the intro's black note suppresses the
-    // cold-start fade-out.
+    // entry (depth 1) fades; after the intro the window is already black,
+    // so the cold-start fade-out is the video layer's no-op.
     EXPECT_EQ(og::ui::MenuScreenKind::Screen, spec.kind);
     EXPECT_TRUE(spec.polls_lobby);
     EXPECT_FALSE(spec.right_click_enabled);

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -1022,6 +1022,87 @@ TEST(MenuEngine, nested_menu_door_bracket_is_symmetric_for_a_legacy_body)
         << "1 (parent entry) + 2 (in) + 2 (back) + 1 (the parent's own exit)";
 }
 
+namespace
+{
+// The OFFENDER shape behind the editor-exit phantom click: a legacy door
+// body that pumps its own events (get_input_events(POLL)) and never runs
+// query_mouse()'s press acknowledgement, so a click made ON the body mints
+// a collapsed-tap pending click through the real input.cpp path — a click
+// with no coordinates. The body then parks the pointer over the parent's
+// row and returns, exactly the File->Exit-then-hover repro.
+Sint32 phantom_minting_door_body()
+{
+    og::ui::LegacyMenuFade entry_fade;
+    screen* const scr = og::runtime::current_session->myscreen_;
+    entry_fade.present_first(*scr);
+
+    // One click on the body's own surface, at the body's own coordinates
+    // (the viewport centre — inside the active canvas so the DOWN counts),
+    // pumped by the body itself with no acknowledgement between the frames.
+    const int cx = static_cast<int>(
+        og::runtime::current_session->viewport_offset_x_ +
+        og::runtime::current_session->viewport_w_ / 2);
+    const int cy = static_cast<int>(
+        og::runtime::current_session->viewport_offset_y_ +
+        og::runtime::current_session->viewport_h_ / 2);
+    inject_mouse_down(cx, cy);
+    get_input_events(POLL);
+    inject_mouse_up(cx, cy);
+    get_input_events(POLL);
+
+    // The hover: ONLY a motion, onto the parent row's centre (engine_back
+    // is 10,10 50x15 -> game (35,17)), before the body returns.
+    const auto [row_x, row_y] = ui_canvas_to_window(35.0f, 17.0f);
+    inject_mouse_motion(static_cast<int>(row_x), static_cast<int>(row_y));
+    get_input_events(POLL);
+    return MENU_REDRAW;
+}
+} // namespace
+
+// The pointer-handoff contract at the door (docs/menu-engine.md, "Pointer
+// handoff"): no screen may consume a click minted on another surface. The
+// parent's only row is its exit row, so a phantom activation breaks the
+// parent loop before its post-door frame and the frame-2 sample stays -1 —
+// a latch-free observable that cannot hang.
+TEST(MenuEngine, nested_door_exit_click_cannot_activate_the_parent_row)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    og::ui::menu_transition_testing_reset();
+    reset_mouse_click_tracking();
+
+    og::ui::MenuScreenSpec parent = make_synth_spec(kRows, 1, "door_parent");
+    parent.frame_tick = &nested_door_parent_frame_tick;
+    g_synth_spec = &parent;
+    g_depth_rule_child_spec = nullptr;
+    g_start_game_requested = false;
+    g_nested_door_fades_at_open = -1;
+    g_nested_door_fades_inside_door = -1;
+    g_nested_door_fades_after_return = -1;
+    g_nested_door_body_fn = &phantom_minting_door_body;
+
+    trace_clear();
+    (void)og::ui::run_menu_screen(parent);
+    g_nested_door_body_fn = nullptr;
+
+    ASSERT_EQ(1, g_nested_door_fades_at_open)
+        << "the parent's own depth-1 entry must have faded in before the door";
+    ASSERT_NE(-1, g_nested_door_fades_after_return)
+        << "the parent loop never reached its post-door frame: the click "
+           "minted INSIDE the door was spent on the parent's row at the "
+           "hovered pointer position (phantom activation)";
+    EXPECT_EQ(0, og::input::testing_pending_left_clicks())
+        << "the door must hand the parent a clean pointer: no pending click "
+           "minted on the door's surface may survive the handoff";
+    reset_mouse_click_tracking();
+}
+
 TEST(MenuEngine, depth_rule_overlay_never_fades_even_over_a_black_window)
 {
     static constexpr og::ui::MenuButtonSpec kRows[] = {

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -451,13 +451,19 @@ void depth_rule_child_draw_content(void* /*state*/)
     ++g_depth_rule_child_content_draws;
 }
 
+// The child paints its first frame through the LOOP (after the frame_tick
+// veto check — a non-fading entry composes nothing before it, so a screen
+// vetoed on frame 1 flashes nothing) and exits on its second tick.
+bool depth_rule_child_frame_tick(void* /*state*/, int frame)
+{
+    return frame < 2;
+}
+
 bool depth_rule_parent_frame_tick(void* /*state*/, int frame)
 {
     if (frame == 1 && g_depth_rule_child_spec != nullptr)
     {
-        g_start_game_requested = true;  // preempts the child's loop instantly
         (void)og::ui::run_menu_screen(*g_depth_rule_child_spec);
-        g_start_game_requested = false;
         return false;  // end the parent loop after the child returns
     }
     return frame < 3;
@@ -537,6 +543,7 @@ TEST(MenuEngine, depth_rule_nested_entry_never_fades)
 
     og::ui::MenuScreenSpec child = make_synth_spec(kRows, 1, "depth_child");
     child.draw_content = &depth_rule_child_draw_content;
+    child.frame_tick = &depth_rule_child_frame_tick;
     child.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
 
     og::ui::MenuScreenSpec parent = make_synth_spec(kRows, 1, "depth_parent");
@@ -551,7 +558,8 @@ TEST(MenuEngine, depth_rule_nested_entry_never_fades)
     g_depth_rule_child_spec = nullptr;
 
     EXPECT_EQ(1, g_depth_rule_child_content_draws)
-        << "the nested child must still compose (and present) its cold frame";
+        << "the nested child paints exactly its one loop frame — no pre-loop "
+           "cold compose on a non-fading entry, no missed frame either";
     EXPECT_EQ(2, count_fade_between_traces())
         << "only the parent's depth-1 entry fades; a nested run_menu_screen "
            "call (a subscreen door) produces ZERO fades";

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -394,6 +394,78 @@ TEST(MenuEngine, blocking_control_remap_polls_and_aborts_for_remote_start)
            "sequence as soon as the host start is launchable";
 }
 
+// ---------------------------------------------------------------------------
+// #257 queue contract: a ticket whose wait timed out, and a ticket a drain
+// threw away, are both CANCELLED — the pump must never run either one
+// afterwards, and neither may be reported to its waiter as a success. The
+// control task proves the pump really ran during the same frames, so the
+// zero below is a cancellation and not a dead pump.
+namespace
+{
+
+std::atomic<int> g_cancelled_task_runs{0};
+std::atomic<int> g_control_task_runs{0};
+
+bool task_queue_probe_frame_tick(void* /*state*/, int frame)
+{
+    if (frame == 1) {
+        // Posted from the menu thread itself: the NEXT frame's pump runs it.
+        (void)post_main_thread_task([] { ++g_control_task_runs; });
+    }
+    return frame < 4;
+}
+
+} // namespace
+
+TEST(MenuEngine, timed_out_and_drained_main_thread_tasks_never_run)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    g_cancelled_task_runs = 0;
+    g_control_task_runs = 0;
+
+    og::ui::MenuScreenSpec spec = make_synth_spec(kRows, 1, "task_queue_probe");
+    spec.frame_tick = &task_queue_probe_frame_tick;
+    g_synth_spec = &spec;
+
+    // Case 1 — the wait timed out. No menu loop is running here, so nothing
+    // can pump this ticket: the wait must expire AND take the task out of
+    // the queue with it.
+    const MainThreadTaskTicket timed_out =
+        post_main_thread_task([] { ++g_cancelled_task_runs; });
+    EXPECT_FALSE(wait_for_main_thread_task(timed_out, 250))
+        << "a task no pump can reach must not report success";
+    // Four real frames of pump. The control task (posted from inside the
+    // loop) runs; the cancelled one may not.
+    (void)og::ui::run_menu_screen(spec);
+    EXPECT_EQ(1, g_control_task_runs.load())
+        << "the pump must have run during those frames, or the zero below "
+           "proves nothing";
+    EXPECT_EQ(0, g_cancelled_task_runs.load())
+        << "#257: a timed-out task must never execute later — its captures "
+           "may be gone by then";
+
+    // Case 2 — a drain discards what it clears, and the waiter is released
+    // with false, never with a settled mark the drain moved past it.
+    const MainThreadTaskTicket drained =
+        post_main_thread_task([] { ++g_cancelled_task_runs; });
+    drain_main_thread_tasks();
+    EXPECT_FALSE(wait_for_main_thread_task(drained, 250))
+        << "a drained task must be reported as not run";
+    (void)og::ui::run_menu_screen(spec);
+    EXPECT_EQ(2, g_control_task_runs.load())
+        << "the second run must have pumped too";
+    EXPECT_EQ(0, g_cancelled_task_runs.load())
+        << "#257: a drained task belongs to a scope that is over — the next "
+           "screen's pump must not run it";
+}
+
 TEST(MenuEngine, depth_one_entry_composes_content_before_fade_in)
 {
     static constexpr og::ui::MenuButtonSpec kRows[] = {
@@ -3251,6 +3323,15 @@ struct MenuCallbackStateGuard
 
     ~MenuCallbackStateGuard()
     {
+        // Drop the installed lobby client FIRST. Every test that uses this
+        // guard also stack-allocates a FakeLobbyClient after it, so that
+        // double is already destroyed by the time this runs — and
+        // install_base_camp_state_for_screen re-derives the seat rail, which
+        // reads picker_lobby_players(). Without this the rail walks a dead
+        // double (SIGSEGV copying its player vector). EngineTestGuard, which
+        // is declared before this one, still restores the real client after
+        // us.
+        og::ui::install_active_picker_lobby_client(nullptr);
         og::ui::install_base_camp_state_for_screen(nullptr);
         og::ui::install_seat_settings_state_for_screen(nullptr);
         og::ui::install_company_list_state_for_screen(nullptr);

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -448,8 +448,12 @@ int dual_surface_injector(void* data)
     SDL_Delay(300);
 
     // The lobby-rewrites-save moment: no click precedes this write, so only
-    // the runner's per-frame label sync can surface it.
-    og::runtime::current_session->myscreen_->save_data.respawn_mode = 2;
+    // the runner's per-frame label sync can surface it. Posting it keeps
+    // that intent — the write still lands with no click, just between two
+    // frames instead of inside one (#257).
+    (void)run_on_main_thread([] {
+        og::runtime::current_session->myscreen_->save_data.respawn_mode = 2;
+    });
 
     const std::string want = "Respawns: Everyone";
     for (int attempt = 0; attempt < 100; ++attempt) {

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -4121,7 +4121,7 @@ TEST(MenuEngine, base_camp_rail_and_add_seat_boundaries_are_behavioral)
     // rail shows that one card and three ADD PLAYER slots; GO's up-link lands
     // on the rail's rightmost slot.
     spec.nav.rewire(buttons, count, highlighted);
-    EXPECT_EQ("P5 WASD ", buttons[kBaseCampSeatCardBase].label);
+    EXPECT_EQ("P5 WASD  ", buttons[kBaseCampSeatCardBase].label);
     EXPECT_EQ("ADD PLAYER", buttons[kBaseCampSeatCardBase + 1].label);
     EXPECT_EQ(kBaseCampSeatCardBase + kBaseCampSeatCardsPerPage - 1,
               buttons[kCreateMenuGoIndex].nav.up);
@@ -4136,7 +4136,7 @@ TEST(MenuEngine, base_camp_rail_and_add_seat_boundaries_are_behavioral)
     ASSERT_EQ(2u, state.local_seat_indices.size())
         << "the fixture must hand the rail a local index the roster lacks";
     spec.nav.rewire(buttons, count, highlighted);
-    EXPECT_EQ("P1 WASD ", buttons[kBaseCampSeatCardBase].label);
+    EXPECT_EQ("P1 WASD  ", buttons[kBaseCampSeatCardBase].label);
     EXPECT_EQ("ADD PLAYER", buttons[kBaseCampSeatCardBase + 1].label)
         << "the hole becomes a door, not a blank card";
     ASSERT_NE(nullptr, spec.rows[kBaseCampSeatCardBase + 1].state_override);
@@ -4146,7 +4146,7 @@ TEST(MenuEngine, base_camp_rail_and_add_seat_boundaries_are_behavioral)
     lobby.local_indices = {4};
     og::ui::base_camp_refresh_rows(state);
     spec.nav.rewire(buttons, count, highlighted);
-    ASSERT_EQ("P5 WASD ", buttons[kBaseCampSeatCardBase].label);
+    ASSERT_EQ("P5 WASD  ", buttons[kBaseCampSeatCardBase].label);
 
     // The four parked rail ordinals answer nothing at all.
     for (const int spare : kBaseCampSeatRailSpares)

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -22,6 +22,7 @@
 #include <openglad/gameplay/guy.h>
 #include <openglad/interface/button.h>
 #include <openglad/interface/input.h>
+#include <openglad/interface/input_hardware_state.h>
 #include <openglad/interface/input_mappings.h>
 #include <openglad/interface/render/view.h>
 #include <openglad/interface/screen.h>
@@ -4116,17 +4117,18 @@ TEST(MenuEngine, base_camp_rail_and_add_seat_boundaries_are_behavioral)
     const int count = spec.count_accessor();
     int highlighted = kBaseCampSeatCardBase;
 
-    // Five seats create the two-page rail. With [+] unavailable, GO's up
-    // link must land on NEXT, and punctuation is ignored in the compact
-    // remote-company abbreviation.
-    buttons[kBaseCampAddSeatIndex].hidden = true;
+    // Five seats in the lobby, ONE of them this machine's (global P5). The
+    // rail shows that one card and three ADD PLAYER slots; GO's up-link lands
+    // on the rail's rightmost slot.
     spec.nav.rewire(buttons, count, highlighted);
-    EXPECT_EQ("P1 IRO ", buttons[kBaseCampSeatCardBase].label);
-    EXPECT_EQ(kBaseCampSeatPageNextIndex,
+    EXPECT_EQ("P5 WASD ", buttons[kBaseCampSeatCardBase].label);
+    EXPECT_EQ("ADD PLAYER", buttons[kBaseCampSeatCardBase + 1].label);
+    EXPECT_EQ(kBaseCampSeatCardBase + kBaseCampSeatCardsPerPage - 1,
               buttons[kCreateMenuGoIndex].nav.up);
 
-    // #236: the ordinal the '+' vacated answers nothing at all.
-    EXPECT_EQ(0, spec.on_spec_row(kBaseCampSeatRailSpareIndex, &state));
+    // The four parked rail ordinals answer nothing at all.
+    for (const int spare : kBaseCampSeatRailSpares)
+        EXPECT_EQ(0, spec.on_spec_row(spare, &state)) << "spare " << spare;
 
     const int untouched_highlight = 123;
     int defensive_highlight = untouched_highlight;
@@ -4136,13 +4138,16 @@ TEST(MenuEngine, base_camp_rail_and_add_seat_boundaries_are_behavioral)
 
 #ifndef DISABLE_MULTIPLAYER
     // Each denial is separately observable and must avoid calling the next
-    // layer. Rewind the debounce stamp so the capacity rule is what decides.
+    // layer — and every one of them is reached THROUGH A SLOT, because the
+    // slot is the door. Rewind the debounce stamp so the capacity rule is
+    // what decides. A slot the rail has no seat for is the add path: with
+    // one local seat that is slot one.
+    constexpr int kBareSlot = kBaseCampSeatCardBase + 1;
     state.last_seat_add_ms = -1;
     lobby.local_seats = MAX_PLAYERS;
     lobby.add_seat_calls = 0;
     trace_clear();
-    EXPECT_EQ(MENU_OK,
-              spec.on_spec_row(kBaseCampAddSeatIndex, &state));
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBareSlot, &state));
     EXPECT_EQ(0, lobby.add_seat_calls);
     EXPECT_TRUE(trace_contains("popup", "LOCAL LIMIT IS 4"));
 
@@ -4154,8 +4159,7 @@ TEST(MenuEngine, base_camp_rail_and_add_seat_boundaries_are_behavioral)
             static_cast<std::uint8_t>(i), "FULL LOBBY"));
     }
     trace_clear();
-    EXPECT_EQ(MENU_OK,
-              spec.on_spec_row(kBaseCampAddSeatIndex, &state));
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBareSlot, &state));
     EXPECT_EQ(0, lobby.add_seat_calls);
     EXPECT_TRUE(trace_contains("popup", "LOBBY FULL"));
 
@@ -4164,10 +4168,29 @@ TEST(MenuEngine, base_camp_rail_and_add_seat_boundaries_are_behavioral)
     lobby.local_indices = {0};
     lobby.add_seat_result = false;
     trace_clear();
-    EXPECT_EQ(MENU_OK,
-              spec.on_spec_row(kBaseCampAddSeatIndex, &state));
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBareSlot, &state));
     EXPECT_EQ(1, lobby.add_seat_calls);
     EXPECT_TRUE(trace_contains("popup", "ADD DENIED"));
+
+    // THE DEVICE CAP IS ENFORCED BY THE DOOR, not by the lobby client behind
+    // it: picker_lobby_add_local_seat is a build-limit backstop only. Drive a
+    // slot on a single-seat device with a seat already claimed and the add
+    // must die at the gate, naming the hardware.
+    {
+        const bool saved_device_class =
+            input_hardware_state().single_seat_device;
+        input_hardware_state().single_seat_device = true;
+        state.last_seat_add_ms = -1;
+        lobby.local_seats = 1;
+        lobby.add_seat_result = true;
+        lobby.add_seat_calls = 0;
+        trace_clear();
+        EXPECT_EQ(MENU_OK, spec.on_spec_row(kBareSlot, &state));
+        EXPECT_EQ(0, lobby.add_seat_calls)
+            << "the device cap must stop the add before the lobby sees it";
+        EXPECT_TRUE(trace_contains("popup", "ATTACH A GAMEPAD TO ADD SEATS"));
+        input_hardware_state().single_seat_device = saved_device_class;
+    }
 #endif
 }
 

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -557,6 +557,54 @@ TEST(MenuEngine, depth_rule_nested_entry_never_fades)
            "call (a subscreen door) produces ZERO fades";
 }
 
+TEST(MenuEngine, depth_rule_peer_note_keeps_a_lateral_move_instant)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    og::ui::menu_transition_testing_reset();
+
+    og::ui::MenuScreenSpec spec = make_synth_spec(kRows, 1, "depth_peer");
+    spec.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
+    g_synth_spec = &spec;
+    g_start_game_requested = true;
+
+    og::ui::note_menu_peer_transition();
+    trace_clear();
+    EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
+    EXPECT_EQ(0, count_fade_between_traces())
+        << "a noted menu-cluster peer entry (SETTINGS/HELP/LOAD/NETWORKING "
+           "doors and the way back) is not a context switch: no fade";
+
+    // One-shot: the note was consumed by that entry.
+    g_start_game_requested = true;
+    trace_clear();
+    EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
+    EXPECT_EQ(2, count_fade_between_traces())
+        << "the peer note is one-shot — the next root entry fades again";
+
+    // Swallow-even-if-unused: an Overlay entry consumes a stale peer note.
+    og::ui::MenuScreenSpec overlay = make_synth_spec(kRows, 1, "depth_peer_ov");
+    overlay.kind = og::ui::MenuScreenKind::Overlay;
+    overlay.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
+    g_synth_spec = &overlay;
+    g_start_game_requested = true;
+    og::ui::note_menu_peer_transition();
+    EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(overlay));
+    g_synth_spec = &spec;
+    g_start_game_requested = true;
+    trace_clear();
+    EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
+    EXPECT_EQ(2, count_fade_between_traces())
+        << "a non-fading entry must still clear the peer note or it "
+           "suppresses the NEXT context switch's fade";
+}
+
 TEST(MenuEngine, depth_rule_overlay_never_fades_and_swallows_black_note)
 {
     static constexpr og::ui::MenuButtonSpec kRows[] = {
@@ -583,6 +631,31 @@ TEST(MenuEngine, depth_rule_overlay_never_fades_and_swallows_black_note)
     EXPECT_FALSE(og::ui::consume_menu_faded_to_black())
         << "swallow-even-if-unused: a non-fading entry must still clear the "
            "black note or it leaks one screen forward";
+}
+
+TEST(MenuEngine, legacy_entry_fade_honors_peer_and_black_notes)
+{
+    EngineTestGuard guard;
+    og::ui::menu_transition_testing_reset();
+
+    // Peer-noted door (the NETWORKING shape): no fade, caller presents
+    // its first frame directly.
+    og::ui::note_menu_peer_transition();
+    trace_clear();
+    EXPECT_FALSE(og::ui::begin_legacy_menu_entry_fade());
+    EXPECT_EQ(0, count_fade_between_traces());
+
+    // Bare context switch: fade-out now, caller fades its first frame in.
+    trace_clear();
+    EXPECT_TRUE(og::ui::begin_legacy_menu_entry_fade());
+    EXPECT_EQ(1, count_fade_between_traces());
+
+    // Already-black teardown hand-off: no fade-out, but the caller still
+    // owns a fade-in.
+    og::ui::note_menu_faded_to_black();
+    trace_clear();
+    EXPECT_TRUE(og::ui::begin_legacy_menu_entry_fade());
+    EXPECT_EQ(0, count_fade_between_traces());
 }
 
 // ---------------------------------------------------------------------------
@@ -2164,8 +2237,9 @@ TEST(MenuEngine, help_screen_spec_shape_pins)
     EXPECT_TRUE(spec.exit_on_redraw);
     EXPECT_EQ(MENU_REDRAW, spec.exit_value);
     EXPECT_TRUE(spec.polls_lobby);
-    // Fading is derived (#237): a Screen kind — the main menu's HELP door
-    // (depth 1) fades, Base Camp's nested HELP door does not.
+    // Fading is derived (#237): a Screen kind, but the main menu's HELP
+    // door dispatches with a peer note (a lateral menu move) and Base
+    // Camp's HELP door is nested — neither entry fades.
     EXPECT_EQ(og::ui::MenuScreenKind::Screen, spec.kind);
     EXPECT_EQ(kHelpMenuBackIndex, spec.default_highlight);
     EXPECT_NE(nullptr, spec.frame_tick) << "wheel -> page steps";

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -4126,6 +4126,28 @@ TEST(MenuEngine, base_camp_rail_and_add_seat_boundaries_are_behavioral)
     EXPECT_EQ(kBaseCampSeatCardBase + kBaseCampSeatCardsPerPage - 1,
               buttons[kCreateMenuGoIndex].nav.up);
 
+    // A local index the ROSTER does not carry stops the rail rather than
+    // leaving a hole in it: the lobby and the collected roster can disagree
+    // for a frame after a join, and a slot that claimed "card" with nothing to
+    // name would draw a blank face. Seat 9 is not in this five-seat lobby, so
+    // the rail names the one seat it can and offers the rest as doors.
+    lobby.local_indices = {0, 9};
+    og::ui::base_camp_refresh_rows(state);
+    ASSERT_EQ(2u, state.local_seat_indices.size())
+        << "the fixture must hand the rail a local index the roster lacks";
+    spec.nav.rewire(buttons, count, highlighted);
+    EXPECT_EQ("P1 WASD ", buttons[kBaseCampSeatCardBase].label);
+    EXPECT_EQ("ADD PLAYER", buttons[kBaseCampSeatCardBase + 1].label)
+        << "the hole becomes a door, not a blank card";
+    ASSERT_NE(nullptr, spec.rows[kBaseCampSeatCardBase + 1].state_override);
+    EXPECT_EQ(og::ui::RowState::Visible,
+              spec.rows[kBaseCampSeatCardBase + 1].state_override(
+                  og::ui::MenuLabelContext{}));
+    lobby.local_indices = {4};
+    og::ui::base_camp_refresh_rows(state);
+    spec.nav.rewire(buttons, count, highlighted);
+    ASSERT_EQ("P5 WASD ", buttons[kBaseCampSeatCardBase].label);
+
     // The four parked rail ordinals answer nothing at all.
     for (const int spare : kBaseCampSeatRailSpares)
         EXPECT_EQ(0, spec.on_spec_row(spare, &state)) << "spare " << spare;

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -531,12 +531,46 @@ bool depth_rule_child_frame_tick(void* /*state*/, int frame)
     return frame < 2;
 }
 
+// Set to force the nested entry below through the Fade override (the shape
+// CLOUD SAVES and the LEVEL EDITOR use).
+bool g_depth_rule_child_fade_override = false;
+
 bool depth_rule_parent_frame_tick(void* /*state*/, int frame)
 {
     if (frame == 1 && g_depth_rule_child_spec != nullptr)
     {
+        if (g_depth_rule_child_fade_override)
+            og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Fade);
         (void)og::ui::run_menu_screen(*g_depth_rule_child_spec);
         return false;  // end the parent loop after the child returns
+    }
+    return frame < 3;
+}
+
+// The run_nested_menu_door probe: the door body is the nested screen, and
+// the parent loop keeps running afterwards so its next present can turn the
+// bracket's black note into the fade back in.
+int g_nested_door_fades_at_open = -1;
+int g_nested_door_fades_inside_door = -1;
+
+Sint32 nested_door_body()
+{
+    if (g_depth_rule_child_spec != nullptr)
+        (void)og::ui::run_menu_screen(*g_depth_rule_child_spec);
+    // Sampled HERE, inside the door: the bracket's way-back fade-out has not
+    // run yet, so this is exactly the cost of the way in.
+    g_nested_door_fades_inside_door = count_fade_between_traces();
+    return MENU_REDRAW;
+}
+
+bool nested_door_parent_frame_tick(void* /*state*/, int frame)
+{
+    if (frame == 1)
+    {
+        g_nested_door_fades_at_open = count_fade_between_traces();
+        (void)og::ui::run_nested_menu_door(&nested_door_body);
+        // Keep the loop alive: the fade back in happens on the NEXT present.
+        return true;
     }
     return frame < 3;
 }
@@ -637,7 +671,7 @@ TEST(MenuEngine, depth_rule_nested_entry_never_fades)
            "call (a subscreen door) produces ZERO fades";
 }
 
-TEST(MenuEngine, depth_rule_peer_note_keeps_a_lateral_move_instant)
+TEST(MenuEngine, entry_fade_override_instant_suppresses_a_depth_one_fade)
 {
     static constexpr og::ui::MenuButtonSpec kRows[] = {
         {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
@@ -649,40 +683,127 @@ TEST(MenuEngine, depth_rule_peer_note_keeps_a_lateral_move_instant)
     og::ui::install_active_picker_lobby_client(&lobby);
     og::ui::menu_transition_testing_reset();
 
-    og::ui::MenuScreenSpec spec = make_synth_spec(kRows, 1, "depth_peer");
+    og::ui::MenuScreenSpec spec = make_synth_spec(kRows, 1, "entry_instant");
     spec.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
     g_synth_spec = &spec;
     g_start_game_requested = true;
 
-    og::ui::note_menu_peer_transition();
+    og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Instant);
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
     EXPECT_EQ(0, count_fade_between_traces())
-        << "a noted menu-cluster peer entry (SETTINGS/HELP/LOAD/NETWORKING "
-           "doors and the way back) is not a context switch: no fade";
+        << "an Instant override (the NETWORKING door, whose Base Camp parent "
+           "already exited) suppresses the depth-1 fade";
 
     // One-shot: the note was consumed by that entry.
     g_start_game_requested = true;
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
     EXPECT_EQ(2, count_fade_between_traces())
-        << "the peer note is one-shot — the next root entry fades again";
+        << "the override is one-shot — the next depth-1 entry fades again";
 
-    // Swallow-even-if-unused: an Overlay entry consumes a stale peer note.
-    og::ui::MenuScreenSpec overlay = make_synth_spec(kRows, 1, "depth_peer_ov");
+    // Swallow-even-if-unused: an Overlay entry consumes a stale override.
+    og::ui::MenuScreenSpec overlay = make_synth_spec(kRows, 1, "entry_ov");
     overlay.kind = og::ui::MenuScreenKind::Overlay;
     overlay.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
     g_synth_spec = &overlay;
     g_start_game_requested = true;
-    og::ui::note_menu_peer_transition();
+    og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Instant);
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(overlay));
     g_synth_spec = &spec;
     g_start_game_requested = true;
     trace_clear();
     EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
     EXPECT_EQ(2, count_fade_between_traces())
-        << "a non-fading entry must still clear the peer note or it "
-           "suppresses the NEXT context switch's fade";
+        << "a non-fading entry must still clear the override or it "
+           "suppresses the NEXT main-menu crossing's fade";
+}
+
+TEST(MenuEngine, entry_fade_override_fade_forces_a_nested_entry_to_fade)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    og::ui::menu_transition_testing_reset();
+
+    og::ui::MenuScreenSpec child = make_synth_spec(kRows, 1, "entry_fade_child");
+    child.frame_tick = &depth_rule_child_frame_tick;
+    child.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
+
+    og::ui::MenuScreenSpec parent =
+        make_synth_spec(kRows, 1, "entry_fade_parent");
+    parent.frame_tick = &depth_rule_parent_frame_tick;
+    g_synth_spec = &parent;
+    g_depth_rule_child_spec = &child;
+    g_start_game_requested = false;
+
+    // Control: the same nested entry with NO override adds zero fades.
+    trace_clear();
+    (void)og::ui::run_menu_screen(parent);
+    EXPECT_EQ(2, count_fade_between_traces())
+        << "control: without an override only the parent's depth-1 entry "
+           "fades — the nested door adds nothing";
+
+    // The CLOUD SAVES / LEVEL EDITOR shape: a Fade override makes the same
+    // nested entry fade out and in.
+    g_depth_rule_child_fade_override = true;
+    trace_clear();
+    (void)og::ui::run_menu_screen(parent);
+    g_depth_rule_child_fade_override = false;
+    g_depth_rule_child_spec = nullptr;
+    EXPECT_EQ(4, count_fade_between_traces())
+        << "a Fade override forces the nested entry to fade: the parent's 2 "
+           "plus the door's own fade-out + fade-in";
+}
+
+TEST(MenuEngine, nested_menu_door_bracket_fades_symmetrically)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    og::ui::menu_transition_testing_reset();
+
+    og::ui::MenuScreenSpec child = make_synth_spec(kRows, 1, "door_child");
+    child.frame_tick = &depth_rule_child_frame_tick;
+    child.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
+
+    og::ui::MenuScreenSpec parent = make_synth_spec(kRows, 1, "door_parent");
+    parent.frame_tick = &nested_door_parent_frame_tick;
+    g_synth_spec = &parent;
+    g_depth_rule_child_spec = &child;
+    g_start_game_requested = false;
+    g_nested_door_fades_at_open = -1;
+    g_nested_door_fades_inside_door = -1;
+
+    trace_clear();
+    (void)og::ui::run_menu_screen(parent);
+    g_depth_rule_child_spec = nullptr;
+
+    // The real CLOUD SAVES / LEVEL EDITOR round trip: parent entry (2), then
+    // the bracket's own two halves, measured as deltas so the symmetry
+    // invariant — fades(in) == fades(back) — is what is asserted.
+    ASSERT_EQ(2, g_nested_door_fades_at_open)
+        << "the parent's own depth-1 entry must have faded before the door";
+    ASSERT_EQ(4, g_nested_door_fades_inside_door)
+        << "the way in is a fade-out plus the nested entry's fade-in";
+    EXPECT_EQ(6, count_fade_between_traces())
+        << "2 (parent entry) + 2 (door in) + 2 (door back)";
+    EXPECT_EQ(2, g_nested_door_fades_inside_door - g_nested_door_fades_at_open)
+        << "#237 symmetry: entering a nested main-menu door fades exactly "
+           "once (out + in)";
+    EXPECT_EQ(2, count_fade_between_traces() - g_nested_door_fades_inside_door)
+        << "#237 symmetry: the way back must fade exactly as much as the way "
+           "in — the door fades out and the parent loop fades back in";
 }
 
 TEST(MenuEngine, depth_rule_overlay_never_fades_and_swallows_black_note)
@@ -713,14 +834,14 @@ TEST(MenuEngine, depth_rule_overlay_never_fades_and_swallows_black_note)
            "black note or it leaks one screen forward";
 }
 
-TEST(MenuEngine, legacy_entry_fade_honors_peer_and_black_notes)
+TEST(MenuEngine, legacy_entry_fade_honors_the_override_and_black_notes)
 {
     EngineTestGuard guard;
     og::ui::menu_transition_testing_reset();
 
-    // Peer-noted door (the NETWORKING shape): no fade, caller presents
+    // Instant-noted door (the NETWORKING shape): no fade, caller presents
     // its first frame directly.
-    og::ui::note_menu_peer_transition();
+    og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Instant);
     trace_clear();
     EXPECT_FALSE(og::ui::begin_legacy_menu_entry_fade());
     EXPECT_EQ(0, count_fade_between_traces());
@@ -736,6 +857,68 @@ TEST(MenuEngine, legacy_entry_fade_honors_peer_and_black_notes)
     trace_clear();
     EXPECT_TRUE(og::ui::begin_legacy_menu_entry_fade());
     EXPECT_EQ(0, count_fade_between_traces());
+}
+
+// The override's other half at depth 0's mirror: nested under an open menu
+// screen the legacy helper normally declines (Base Camp's SET CAMPAIGN), and
+// a Fade note flips exactly that decision.
+namespace
+{
+
+bool g_legacy_nested_fade_result = false;
+int g_legacy_nested_fade_traces = -1;
+bool g_legacy_nested_note_fade = false;
+
+bool legacy_nested_fade_frame_tick(void* /*state*/, int frame)
+{
+    if (frame == 1)
+    {
+        if (g_legacy_nested_note_fade)
+            og::ui::note_menu_entry_fade(og::ui::MenuEntryFade::Fade);
+        trace_clear();
+        g_legacy_nested_fade_result = og::ui::begin_legacy_menu_entry_fade();
+        g_legacy_nested_fade_traces = count_fade_between_traces();
+        return false;
+    }
+    return frame < 3;
+}
+
+} // namespace
+
+TEST(MenuEngine, legacy_entry_fade_override_reaches_a_nested_depth)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    og::ui::menu_transition_testing_reset();
+
+    og::ui::MenuScreenSpec parent = make_synth_spec(kRows, 1, "legacy_nested");
+    parent.frame_tick = &legacy_nested_fade_frame_tick;
+    g_synth_spec = &parent;
+    g_start_game_requested = false;
+
+    g_legacy_nested_note_fade = false;
+    g_legacy_nested_fade_result = true;
+    g_legacy_nested_fade_traces = -1;
+    (void)og::ui::run_menu_screen(parent);
+    EXPECT_FALSE(g_legacy_nested_fade_result)
+        << "nested under an open menu screen the legacy helper declines";
+    EXPECT_EQ(0, g_legacy_nested_fade_traces);
+
+    g_legacy_nested_note_fade = true;
+    g_legacy_nested_fade_result = false;
+    g_legacy_nested_fade_traces = -1;
+    (void)og::ui::run_menu_screen(parent);
+    g_legacy_nested_note_fade = false;
+    EXPECT_TRUE(g_legacy_nested_fade_result)
+        << "a Fade override reaches a nested legacy entry too";
+    EXPECT_EQ(1, g_legacy_nested_fade_traces)
+        << "it fades the surface out and hands the caller the fade-in";
 }
 
 // ---------------------------------------------------------------------------
@@ -2317,9 +2500,9 @@ TEST(MenuEngine, help_screen_spec_shape_pins)
     EXPECT_TRUE(spec.exit_on_redraw);
     EXPECT_EQ(MENU_REDRAW, spec.exit_value);
     EXPECT_TRUE(spec.polls_lobby);
-    // Fading is derived (#237): a Screen kind, but the main menu's HELP
-    // door dispatches with a peer note (a lateral menu move) and Base
-    // Camp's HELP door is nested — neither entry fades.
+    // Fading is derived (#237): a Screen kind entered at depth 1 through the
+    // main menu's HELP door, so it fades — and so does the main menu behind
+    // BACK. (HELP has no Base Camp row; ShowHelp is main-menu-only.)
     EXPECT_EQ(og::ui::MenuScreenKind::Screen, spec.kind);
     EXPECT_EQ(kHelpMenuBackIndex, spec.default_highlight);
     EXPECT_NE(nullptr, spec.frame_tick) << "wheel -> page steps";

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -394,7 +394,7 @@ TEST(MenuEngine, blocking_control_remap_polls_and_aborts_for_remote_start)
            "sequence as soon as the host start is launchable";
 }
 
-TEST(MenuEngine, fade_around_entry_composes_content_before_fade_in)
+TEST(MenuEngine, depth_one_entry_composes_content_before_fade_in)
 {
     static constexpr og::ui::MenuButtonSpec kRows[] = {
         {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
@@ -405,8 +405,8 @@ TEST(MenuEngine, fade_around_entry_composes_content_before_fade_in)
     FakeLobbyClient lobby;
     og::ui::install_active_picker_lobby_client(&lobby);
 
+    // Default kind (Screen) at depth 1: the #237 derivation fades this entry.
     og::ui::MenuScreenSpec spec = make_synth_spec(kRows, 1, "fade_content");
-    spec.enter = og::ui::EnterTransition::FadeAroundEntry;
     spec.draw_content = &synth_draw_content;
     spec.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
     g_synth_spec = &spec;
@@ -417,6 +417,172 @@ TEST(MenuEngine, fade_around_entry_composes_content_before_fade_in)
     EXPECT_EQ(1, g_synth_content_draws)
         << "the cold fade frame must include content before the loop's first "
            "full draw";
+}
+
+// ---------------------------------------------------------------------------
+// #237 depth rule: whether an entry fades is DERIVED (kind + menu-stack
+// depth), never declared per screen. Under TESTING each fadeblack lands in
+// FadeBetween's test-mode branch, tracing exactly one line per fade.
+namespace
+{
+
+int count_fade_between_traces()
+{
+    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    int fades = 0;
+    for (const TraceEntry& entry : g_trace_buffer)
+    {
+        if (entry.category == "video" &&
+            entry.message.find("FadeBetween") != std::string::npos)
+        {
+            ++fades;
+        }
+    }
+    return fades;
+}
+
+// Nested-entry probe: the parent's first frame_tick opens the child screen
+// (the subscreen-door shape), then ends the parent loop.
+const og::ui::MenuScreenSpec* g_depth_rule_child_spec = nullptr;
+int g_depth_rule_child_content_draws = 0;
+
+void depth_rule_child_draw_content(void* /*state*/)
+{
+    ++g_depth_rule_child_content_draws;
+}
+
+bool depth_rule_parent_frame_tick(void* /*state*/, int frame)
+{
+    if (frame == 1 && g_depth_rule_child_spec != nullptr)
+    {
+        g_start_game_requested = true;  // preempts the child's loop instantly
+        (void)og::ui::run_menu_screen(*g_depth_rule_child_spec);
+        g_start_game_requested = false;
+        return false;  // end the parent loop after the child returns
+    }
+    return frame < 3;
+}
+
+} // namespace
+
+TEST(MenuEngine, depth_rule_root_entry_fades_out_and_in)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    og::ui::menu_transition_testing_reset();
+
+    og::ui::MenuScreenSpec spec = make_synth_spec(kRows, 1, "depth_root");
+    spec.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
+    g_synth_spec = &spec;
+    g_start_game_requested = true;
+
+    trace_clear();
+    EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
+    EXPECT_EQ(2, count_fade_between_traces())
+        << "a depth-1 Screen entry is a context switch: exactly one fade-out "
+           "plus one fade-in";
+    EXPECT_EQ(0, og::ui::menu_screen_depth())
+        << "the RAII depth bracket must restore on exit";
+}
+
+TEST(MenuEngine, depth_rule_already_black_entry_fades_in_only)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    og::ui::menu_transition_testing_reset();
+
+    og::ui::MenuScreenSpec spec = make_synth_spec(kRows, 1, "depth_black");
+    spec.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
+    g_synth_spec = &spec;
+    g_start_game_requested = true;
+
+    og::ui::note_menu_faded_to_black();
+    trace_clear();
+    EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
+    EXPECT_EQ(1, count_fade_between_traces())
+        << "a teardown's black note suppresses the entry fade-out (#200); "
+           "only the fade-in runs";
+
+    // One-shot: the note was consumed by that entry.
+    g_start_game_requested = true;
+    trace_clear();
+    EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
+    EXPECT_EQ(2, count_fade_between_traces())
+        << "the black note is one-shot — the next entry fades fully again";
+}
+
+TEST(MenuEngine, depth_rule_nested_entry_never_fades)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    og::ui::menu_transition_testing_reset();
+
+    og::ui::MenuScreenSpec child = make_synth_spec(kRows, 1, "depth_child");
+    child.draw_content = &depth_rule_child_draw_content;
+    child.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
+
+    og::ui::MenuScreenSpec parent = make_synth_spec(kRows, 1, "depth_parent");
+    parent.frame_tick = &depth_rule_parent_frame_tick;
+    g_synth_spec = &parent;
+    g_depth_rule_child_spec = &child;
+    g_depth_rule_child_content_draws = 0;
+    g_start_game_requested = false;
+
+    trace_clear();
+    (void)og::ui::run_menu_screen(parent);
+    g_depth_rule_child_spec = nullptr;
+
+    EXPECT_EQ(1, g_depth_rule_child_content_draws)
+        << "the nested child must still compose (and present) its cold frame";
+    EXPECT_EQ(2, count_fade_between_traces())
+        << "only the parent's depth-1 entry fades; a nested run_menu_screen "
+           "call (a subscreen door) produces ZERO fades";
+}
+
+TEST(MenuEngine, depth_rule_overlay_never_fades_and_swallows_black_note)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    og::ui::menu_transition_testing_reset();
+
+    og::ui::MenuScreenSpec spec = make_synth_spec(kRows, 1, "depth_overlay");
+    spec.kind = og::ui::MenuScreenKind::Overlay;
+    spec.remote_start = og::ui::RemoteStartScope::TeamBuildScope;
+    g_synth_spec = &spec;
+    g_start_game_requested = true;
+
+    og::ui::note_menu_faded_to_black();
+    trace_clear();
+    EXPECT_EQ(MENU_EXIT, og::ui::run_menu_screen(spec));
+    EXPECT_EQ(0, count_fade_between_traces())
+        << "an Overlay (the pause family) never fades, even at depth 1";
+    EXPECT_FALSE(og::ui::consume_menu_faded_to_black())
+        << "swallow-even-if-unused: a non-fading entry must still clear the "
+           "black note or it leaks one screen forward";
 }
 
 // ---------------------------------------------------------------------------
@@ -1290,12 +1456,13 @@ TEST(MenuEngine, company_list_spec_shape_and_nav_variants)
     const og::ui::MenuScreenSpec& spec = og::ui::company_list_menu_screen_spec();
 
     // Spec obligations (§2.3): main-scope remote start (a host GO launches a
-    // peer parked in the list), lobby poll, fade entry, the old load loop's
-    // BACK-first highlight, generic MenuSpecRow dispatch.
+    // peer parked in the list), lobby poll, the old load loop's BACK-first
+    // highlight, generic MenuSpecRow dispatch. Fading is derived (#237): a
+    // Screen kind, entered at depth 1 through the LOAD door, so it fades.
     EXPECT_EQ(std::string("company_list"), spec.name);
     EXPECT_EQ(og::ui::RemoteStartScope::MainScope, spec.remote_start);
     EXPECT_EQ(og::ui::RemoteStartExit::ReturnMenuExit, spec.remote_start_exit);
-    EXPECT_EQ(og::ui::EnterTransition::FadeAroundEntry, spec.enter);
+    EXPECT_EQ(og::ui::MenuScreenKind::Screen, spec.kind);
     EXPECT_TRUE(spec.polls_lobby);
     EXPECT_EQ(24, spec.default_highlight);
     EXPECT_TRUE(spec.on_spec_row != nullptr);
@@ -1551,12 +1718,13 @@ TEST(MenuEngine, company_backups_spec_shape_and_nav_variants)
         og::ui::company_backups_menu_screen_spec();
 
     // Spec obligations (§2.4): main-scope remote start (a host GO launches a
-    // peer parked in the sub-view), lobby poll, fade entry, row-0 highlight
-    // (the newest snapshot), generic MenuSpecRow dispatch.
+    // peer parked in the sub-view), lobby poll, row-0 highlight (the newest
+    // snapshot), generic MenuSpecRow dispatch. Fading is derived (#237): a
+    // Screen kind opened NESTED under the Company List, so it does not fade.
     EXPECT_EQ(std::string("company_backups"), spec.name);
     EXPECT_EQ(og::ui::RemoteStartScope::MainScope, spec.remote_start);
     EXPECT_EQ(og::ui::RemoteStartExit::ReturnMenuExit, spec.remote_start_exit);
-    EXPECT_EQ(og::ui::EnterTransition::FadeAroundEntry, spec.enter);
+    EXPECT_EQ(og::ui::MenuScreenKind::Screen, spec.kind);
     EXPECT_TRUE(spec.polls_lobby);
     EXPECT_EQ(0, spec.default_highlight);
     EXPECT_TRUE(spec.on_spec_row != nullptr);
@@ -1828,12 +1996,13 @@ TEST(MenuEngine, team_build_cluster_exit_semantics_pins)
     EXPECT_NE(nullptr, scenario->on_reset)
         << "a nested screen's reset must trigger the reload guard";
 
-    // TEAM BUILD: fade-bracketed entry, nested MENU_REDRAWs consumed by
-    // reset_buttons (exit_on_redraw false), reload guard on both hooks.
+    // TEAM BUILD: a Screen (its run_picker top-level entry fades by the #237
+    // derivation), nested MENU_REDRAWs consumed by reset_buttons
+    // (exit_on_redraw false), reload guard on both hooks.
     const og::ui::MenuScreenSpec* team_build =
         og::ui::menu_screen_host(og::ui::MenuScreenId::TeamBuild).spec;
     ASSERT_NE(nullptr, team_build);
-    EXPECT_EQ(og::ui::EnterTransition::FadeAroundEntry, team_build->enter);
+    EXPECT_EQ(og::ui::MenuScreenKind::Screen, team_build->kind);
     EXPECT_FALSE(team_build->exit_on_redraw);
     EXPECT_EQ(MENU_EXIT, team_build->exit_value);
     EXPECT_EQ(og::ui::RemoteStartScope::TeamBuildScope,
@@ -1995,9 +2164,9 @@ TEST(MenuEngine, help_screen_spec_shape_pins)
     EXPECT_TRUE(spec.exit_on_redraw);
     EXPECT_EQ(MENU_REDRAW, spec.exit_value);
     EXPECT_TRUE(spec.polls_lobby);
-    // DELIBERATE: today's help has no entry fade (and #200 is reworking the
-    // FadeAroundEntry path).
-    EXPECT_EQ(og::ui::EnterTransition::None, spec.enter);
+    // Fading is derived (#237): a Screen kind — the main menu's HELP door
+    // (depth 1) fades, Base Camp's nested HELP door does not.
+    EXPECT_EQ(og::ui::MenuScreenKind::Screen, spec.kind);
     EXPECT_EQ(kHelpMenuBackIndex, spec.default_highlight);
     EXPECT_NE(nullptr, spec.frame_tick) << "wheel -> page steps";
     EXPECT_NE(nullptr, spec.on_spec_row) << "tab/pager dispatch";
@@ -2341,8 +2510,8 @@ std::vector<ExpectedSpecRow> build_expected_shape(
 } // namespace
 
 // Registry + spec-shape pins. The main menu keeps the legacy remote-start
-// check (MainScope, break-with-selection), fade-bracketed entry, and
-// exit-bearing return. Player-count editing now belongs to Base Camp.
+// check (MainScope, break-with-selection) and exit-bearing return.
+// Player-count editing now belongs to Base Camp.
 TEST(MenuEngine, main_menu_registry_and_spec_shape)
 {
     const og::ui::MenuScreenHost& host =
@@ -2355,7 +2524,10 @@ TEST(MenuEngine, main_menu_registry_and_spec_shape)
     EXPECT_EQ(og::ui::RemoteStartScope::MainScope, spec.remote_start);
     EXPECT_EQ(og::ui::RemoteStartExit::BreakWithSelection,
               spec.remote_start_exit);
-    EXPECT_EQ(og::ui::EnterTransition::FadeWithInitialDraw, spec.enter);
+    // Fading is derived (#237): a Screen kind at a run_picker top-level
+    // entry (depth 1) fades; the intro's black note suppresses the
+    // cold-start fade-out.
+    EXPECT_EQ(og::ui::MenuScreenKind::Screen, spec.kind);
     EXPECT_TRUE(spec.polls_lobby);
     EXPECT_FALSE(spec.right_click_enabled);
     EXPECT_EQ(1, spec.default_highlight);  // continue_game, as the legacy loop

--- a/tests/integration/test_menu_engine.cpp
+++ b/tests/integration/test_menu_engine.cpp
@@ -563,12 +563,43 @@ Sint32 nested_door_body()
     return MENU_REDRAW;
 }
 
+// The LEGACY door-body shape (the level editor): the body runs no runner
+// entry at all, so it owes the notes the same swallow by hand and has to
+// spend the Fade note itself — begin_legacy_menu_entry_fade(), then present
+// the first composed frame with fadeblack(1) instead of the plain present.
+// Discarding that return is what left the editor door at 1 fade in / 2 back.
+int g_legacy_door_fades_inside_door = -1;
+
+Sint32 legacy_nested_door_body()
+{
+    bool entry_fade_in_pending = og::ui::begin_legacy_menu_entry_fade();
+    screen* const scr = og::runtime::current_session->myscreen_;
+    // The body's own loop, one frame of it: compose, then present once.
+    if (entry_fade_in_pending)
+    {
+        entry_fade_in_pending = false;
+        scr->fadeblack(1);
+    }
+    else
+    {
+        scr->buffer_to_screen(0, 0, 320, 200);
+    }
+    // Sampled inside the door, before the bracket's way-back fade-out: this
+    // is exactly the cost of the way in.
+    g_legacy_door_fades_inside_door = count_fade_between_traces();
+    return MENU_REDRAW;
+}
+
+// Which body the parent's door opens (the runner-shaped one, or the legacy
+// hand-rolled one). Set by each test before the parent loop runs.
+Sint32 (*g_nested_door_body_fn)() = nullptr;
+
 bool nested_door_parent_frame_tick(void* /*state*/, int frame)
 {
     if (frame == 1)
     {
         g_nested_door_fades_at_open = count_fade_between_traces();
-        (void)og::ui::run_nested_menu_door(&nested_door_body);
+        (void)og::ui::run_nested_menu_door(g_nested_door_body_fn);
         // Keep the loop alive: the fade back in happens on the NEXT present.
         return true;
     }
@@ -784,6 +815,7 @@ TEST(MenuEngine, nested_menu_door_bracket_fades_symmetrically)
     g_start_game_requested = false;
     g_nested_door_fades_at_open = -1;
     g_nested_door_fades_inside_door = -1;
+    g_nested_door_body_fn = &nested_door_body;
 
     trace_clear();
     (void)og::ui::run_menu_screen(parent);
@@ -804,6 +836,54 @@ TEST(MenuEngine, nested_menu_door_bracket_fades_symmetrically)
     EXPECT_EQ(2, count_fade_between_traces() - g_nested_door_fades_inside_door)
         << "#237 symmetry: the way back must fade exactly as much as the way "
            "in — the door fades out and the parent loop fades back in";
+}
+
+// The other half of run_nested_menu_door's contract: the LEVEL EDITOR shape,
+// whose body is a hand-rolled loop rather than a run_menu_screen entry. The
+// bracket alone cannot make that door symmetric — the way in is only complete
+// once the body spends the Fade note on its own first frame. Regression pin
+// for the editor's discarded fade-in (1 in / 2 back).
+TEST(MenuEngine, nested_menu_door_bracket_is_symmetric_for_a_legacy_body)
+{
+    static constexpr og::ui::MenuButtonSpec kRows[] = {
+        {.id = "engine_back", .label = "BACK", .hotkey = KEYSTATE_ESCAPE,
+         .x = 10, .y = 10, .w = 50, .h = 15,
+         .action = ButtonAction::ReturnMenu, .arg = MENU_EXIT, .nav = {}},
+    };
+    EngineTestGuard guard;
+    FakeLobbyClient lobby;
+    og::ui::install_active_picker_lobby_client(&lobby);
+    og::ui::menu_transition_testing_reset();
+
+    og::ui::MenuScreenSpec parent = make_synth_spec(kRows, 1, "door_parent");
+    parent.frame_tick = &nested_door_parent_frame_tick;
+    g_synth_spec = &parent;
+    g_depth_rule_child_spec = nullptr;
+    g_start_game_requested = false;
+    g_nested_door_fades_at_open = -1;
+    g_legacy_door_fades_inside_door = -1;
+    g_nested_door_body_fn = &legacy_nested_door_body;
+
+    trace_clear();
+    (void)og::ui::run_menu_screen(parent);
+    g_nested_door_body_fn = nullptr;
+
+    ASSERT_EQ(2, g_nested_door_fades_at_open)
+        << "the parent's own depth-1 entry must have faded before the door";
+    ASSERT_NE(-1, g_legacy_door_fades_inside_door)
+        << "the legacy door body never ran";
+    const int fades_in = g_legacy_door_fades_inside_door -
+        g_nested_door_fades_at_open;
+    const int fades_back = count_fade_between_traces() -
+        g_legacy_door_fades_inside_door;
+    EXPECT_EQ(2, fades_in)
+        << "#237: a legacy door body must honor the Fade note — the bracket's "
+           "fade-out plus the body's own fadeblack(1) first frame";
+    EXPECT_EQ(2, fades_back)
+        << "the door fades out and the parent loop fades back in";
+    EXPECT_EQ(fades_back, fades_in)
+        << "#237 symmetry, the reported bug class: a door that fades once in "
+           "and twice back is exactly what the invariant forbids";
 }
 
 TEST(MenuEngine, depth_rule_overlay_never_fades_and_swallows_black_note)

--- a/tests/integration/test_menu_layout.cpp
+++ b/tests/integration/test_menu_layout.cpp
@@ -1929,6 +1929,70 @@ TEST(MenuLayout, createmenu_basecamp_seat_rail_paging_labels_and_nav)
             EXPECT_EQ(rail_last, buttons[kCreateMenuGoIndex].nav.up)
                 << variant;
 
+            // #243: the rail is positioned per frame, so pin the RELATIONS
+            // every shape must satisfy rather than a second exact table (the
+            // full-rail coordinates already have one, and the pure layout
+            // function's own values are pinned in the picker_common units).
+            {
+                // The row opens on the panel's left rail — the same edge
+                // BACK starts on, in every shape, with or without the '+'.
+                EXPECT_EQ(8, buttons[rail_first].x) << variant;
+                EXPECT_EQ(buttons[kCreateMenuBackIndex].x,
+                          buttons[rail_first].x)
+                    << variant << " (the rail opens on BACK's edge)";
+
+                // One baseline, one card width, one gutter. The '>' is left
+                // out of the gutter run: on a partly filled last page the
+                // ghost slots sit between it and the final card, and a ghost
+                // is chrome with no button of its own.
+                const int baseline = buttons[rail_first].y;
+                const std::size_t contiguous =
+                    paged ? rail.size() - 1 : rail.size();
+                int widest = -1;
+                int narrowest = -1;
+                for (std::size_t i = 1; i < contiguous; ++i)
+                {
+                    const button& left = buttons[rail[i - 1]];
+                    const button& right = buttons[rail[i]];
+                    const int gap = right.x - (left.x + left.sizex);
+                    widest = widest < 0 ? gap : std::max(widest, gap);
+                    narrowest = narrowest < 0 ? gap : std::min(narrowest, gap);
+                    EXPECT_GE(gap, 7) << variant << " gutter " << i;
+                    EXPECT_EQ(baseline, right.y) << variant << " row " << i;
+                }
+                if (widest >= 0)
+                {
+                    // Justifying leaves a remainder; the leftmost gutters
+                    // absorb it one pixel at a time, so no two gutters on the
+                    // row can differ by more than that pixel.
+                    EXPECT_LE(widest - narrowest, 1)
+                        << variant << " uneven gutters";
+                }
+                for (int card = 0; card < visible; ++card)
+                {
+                    EXPECT_EQ(57, buttons[kBaseCampSeatCardBase + card].sizex)
+                        << variant << " card " << card
+                        << " (the nine-character label budget)";
+                }
+
+                // Justified shapes close on the panel's right rail. With the
+                // arrows up the '>' owns that edge; with four cards on a
+                // single page the fourth card does.
+                if (paged)
+                {
+                    const button& next_arrow =
+                        buttons[kBaseCampSeatPageNextIndex];
+                    EXPECT_EQ(312, next_arrow.x + next_arrow.sizex) << variant;
+                }
+                else if (visible == kBaseCampSeatCardsPerPage)
+                {
+                    const button& last_card =
+                        buttons[kBaseCampSeatCardBase +
+                                kBaseCampSeatCardsPerPage - 1];
+                    EXPECT_EQ(312, last_card.x + last_card.sizex) << variant;
+                }
+            }
+
             check_no_overlaps(buttons, count, variant.c_str());
             check_bounds(buttons, count, variant.c_str());
             check_nav_closed_and_reachable(

--- a/tests/integration/test_menu_layout.cpp
+++ b/tests/integration/test_menu_layout.cpp
@@ -2,6 +2,7 @@
 #include <openglad/core/test_trace.h>
 #include <openglad/gameplay/guy.h>
 #include <openglad/gameplay/script/pack_scripts.h>
+#include <openglad/interface/device_seats.h>
 #include <openglad/interface/input.h>
 #include <openglad/interface/ui/campaign_picker_session.h>
 #include <openglad/interface/input_hardware_state.h>
@@ -691,23 +692,24 @@ TEST(MenuLayout, createmenu_basecamp_geometry_and_nav)
         // for networked joiners).
         {"ready", "READY", 262, 178, 50, 18, MenuNav{.up = 15, .left = 30},
          true},
-        // #236: the '+' opens the rail at the left edge (the SEATS door it
-        // replaced duplicated SCENARIO's team-overview button), and the
-        // retired right-end ordinal parks like a zone spare.
-        {"add_seat", "+", 8, 164, 14, 10,
-         MenuNav{.down = 27, .right = 34}, false},
-        {"seat_page_prev", "<", 29, 164, 10, 10,
-         MenuNav{.down = 27, .left = 33, .right = 35}, true},
-        {"seat_card_0", "", 46, 164, 57, 10,
-         MenuNav{.left = 34, .right = 36}, false},
-        {"seat_card_1", "", 110, 164, 57, 10,
-         MenuNav{.left = 35, .right = 37}, false},
-        {"seat_card_2", "", 174, 164, 57, 10,
-         MenuNav{.left = 36, .right = 38}, false},
-        {"seat_card_3", "", 238, 164, 57, 10,
-         MenuNav{.left = 37, .right = 39}, false},
-        {"seat_page_next", ">", 302, 164, 10, 10,
-         MenuNav{.down = 31, .left = 38}, true},
+        // The rail is this machine's four seat slots on a fixed grid: four
+        // 70px faces at 8/86/164/242, gutter 8, closing on the panel's right
+        // rail. Slots carry the static ADD PLAYER label — a slot with no seat
+        // in it IS the add button — and the rewire overwrites it with the
+        // seat's P#/mapping name once one lands. Ordinals 33/34/39 carried
+        // the retired [+] and the two seat pagers; ordinals are append-only,
+        // so all four spares park like a zone spare.
+        {"seat_rail_spare_0", "", 0, 0, 0, 0, MenuNav{}, true},
+        {"seat_rail_spare_1", "", 0, 0, 0, 0, MenuNav{}, true},
+        {"seat_card_0", "ADD PLAYER", 8, 164, 70, 10,
+         MenuNav{.down = 72, .right = 36}, false},
+        {"seat_card_1", "ADD PLAYER", 86, 164, 70, 10,
+         MenuNav{.down = 29, .left = 35, .right = 37}, false},
+        {"seat_card_2", "ADD PLAYER", 164, 164, 70, 10,
+         MenuNav{.down = 30, .left = 36, .right = 38}, false},
+        {"seat_card_3", "ADD PLAYER", 242, 164, 70, 10,
+         MenuNav{.down = 31, .left = 37}, false},
+        {"seat_rail_spare_2", "", 0, 0, 0, 0, MenuNav{}, true},
         {"seat_rail_spare", "", 0, 0, 0, 0, MenuNav{}, true},
         {"roster_up_0", "^", 301, 45, 9, 10,
          MenuNav{.left = 8}, true},
@@ -736,7 +738,7 @@ TEST(MenuLayout, createmenu_basecamp_geometry_and_nav)
         ASSERT_EQ(kCreateMenuButtonCount, count)
             << "base camp: 24 roster controls + 2 pagers + the SCEN line "
                "hit zone + HIRE + 4 strip buttons + the hidden READY twin + "
-               "8 seat-rail controls + 8 move-up controls + the 23-row "
+               "4 seat slots + 4 parked rail spares + 8 move-up controls + the 23-row "
                "parked zone band + the appended DIFFICULTY strip door";
         ASSERT_EQ(73, count);
         ASSERT_EQ(static_cast<int>(std::size(kExpected)),
@@ -759,10 +761,12 @@ TEST(MenuLayout, createmenu_basecamp_geometry_and_nav)
             EXPECT_EQ(want.nav.down, got.nav.down) << got.id;
             EXPECT_EQ(want.nav.left, got.nav.left) << got.id;
             EXPECT_EQ(want.nav.right, got.nav.right) << got.id;
-            // The compact rail uses the full face; established beveled
-            // controls retain their eight-pixel inset budget.
+            // The compact rail/move-up band uses the full face; established
+            // beveled controls retain their eight-pixel inset budget. The
+            // band opens at the first parked rail ordinal (33) and runs to
+            // the interior-ring bound, which is what the focus ring uses.
             const int label_budget =
-                i < kBaseCampAddSeatIndex
+                i < kBaseCampInteriorRingFirstIndex
                 ? (got.sizex - 8) / 6
                 : got.sizex / 6;
             EXPECT_LE(static_cast<int>(got.label.size()), label_budget)
@@ -904,9 +908,9 @@ TEST(MenuLayout, createmenu_basecamp_geometry_and_nav)
         EXPECT_EQ(buttons[kCreateMenuGoIndex].sizey,
                   buttons[kCreateMenuReadyIndex].sizey);
         EXPECT_EQ(buttons[kCreateMenuBackIndex].x,
-                  buttons[kBaseCampAddSeatIndex].x)
-            << "the rail's + and BACK share the base-camp left alignment "
-               "line";
+                  buttons[kBaseCampSeatCardBase].x)
+            << "the rail's first slot and BACK share the base-camp left "
+               "alignment line";
         // Each row's three actions have deliberate non-overlapping gutters:
         // deploy, TEAM color, then name/train.
         for (int r = 0; r < kBaseCampRosterRowsPerPage; ++r)
@@ -924,30 +928,45 @@ TEST(MenuLayout, createmenu_basecamp_geometry_and_nav)
                 << "training zone needs a gutter before move-up on row " << r;
         }
 
-        // #236: one gutter across the whole rail, from the '+' at the left
-        // edge to the '>' closing the right rail. The cards used to sit 1px
-        // apart; the freed SEATS width bought every neighbour the same
-        // seven pixels.
-        for (int left = kBaseCampAddSeatIndex;
-             left < kBaseCampSeatPageNextIndex; ++left)
+        // One gutter across the whole rail, from the first slot on BACK's
+        // left edge to the last closing the right rail. Every slot is the
+        // same width: the face IS the label budget, so a wider slot would
+        // silently mean a longer label on one card than on its neighbour.
+        for (int slot = 0; slot < kBaseCampSeatCardsPerPage; ++slot)
         {
-            EXPECT_EQ(7, buttons[left + 1].x -
-                             (buttons[left].x + buttons[left].sizex))
-                << "seat rail gutter after " << buttons[left].id;
-            EXPECT_EQ(buttons[kBaseCampAddSeatIndex].y, buttons[left + 1].y)
-                << "seat rail baseline at " << buttons[left + 1].id;
-            EXPECT_EQ(buttons[kBaseCampAddSeatIndex].sizey,
-                      buttons[left + 1].sizey)
-                << "seat rail height at " << buttons[left + 1].id;
+            const button& face = buttons[kBaseCampSeatCardBase + slot];
+            EXPECT_EQ(8 + 78 * slot, face.x) << "seat slot " << slot;
+            EXPECT_EQ(70, face.sizex) << "seat slot " << slot;
+            EXPECT_EQ(buttons[kBaseCampSeatCardBase].y, face.y)
+                << "seat rail baseline at " << face.id;
+            EXPECT_EQ(buttons[kBaseCampSeatCardBase].sizey, face.sizey)
+                << "seat rail height at " << face.id;
+            if (slot > 0)
+            {
+                const button& left = buttons[kBaseCampSeatCardBase + slot - 1];
+                EXPECT_EQ(8, face.x - (left.x + left.sizex))
+                    << "seat rail gutter after " << left.id;
+            }
         }
-        EXPECT_EQ(312, buttons[kBaseCampSeatPageNextIndex].x +
-                           buttons[kBaseCampSeatPageNextIndex].sizex)
+        EXPECT_EQ(312,
+                  buttons[kBaseCampSeatCardBase + kBaseCampSeatCardsPerPage - 1]
+                          .x +
+                      buttons[kBaseCampSeatCardBase +
+                              kBaseCampSeatCardsPerPage - 1]
+                          .sizex)
             << "the seat rail closes on the panel's right rail";
-        // The retired ordinal keeps its slot in the 73-button table and
-        // nothing else: a parked spare cannot be clicked or navigated to.
-        EXPECT_TRUE(buttons[kBaseCampSeatRailSpareIndex].hidden);
-        EXPECT_EQ(0, buttons[kBaseCampSeatRailSpareIndex].sizex);
-        EXPECT_EQ(0, buttons[kBaseCampSeatRailSpareIndex].sizey);
+        // The four retired ordinals keep their slots in the 73-button table
+        // and nothing else: a parked spare cannot be clicked or navigated to.
+        for (const int spare : kBaseCampSeatRailSpares)
+        {
+            EXPECT_TRUE(buttons[spare].hidden) << "spare " << spare;
+            EXPECT_EQ(0, buttons[spare].sizex) << "spare " << spare;
+            EXPECT_EQ(0, buttons[spare].sizey) << "spare " << spare;
+            EXPECT_EQ(-1, buttons[spare].nav.up) << "spare " << spare;
+            EXPECT_EQ(-1, buttons[spare].nav.down) << "spare " << spare;
+            EXPECT_EQ(-1, buttons[spare].nav.left) << "spare " << spare;
+            EXPECT_EQ(-1, buttons[spare].nav.right) << "spare " << spare;
+        }
 
         check_no_overlaps(buttons, count, "createmenu_basecamp");
         check_bounds(buttons, count, "createmenu_basecamp");
@@ -974,9 +993,10 @@ TEST(MenuLayout, createmenu_basecamp_grid_relations)
     const button& go = buttons[kCreateMenuGoIndex];
     const int rail_right = go.x + go.sizex;
     EXPECT_EQ(312, rail_right) << "GO closes the panel's outer right edge";
-    const std::vector<int> rail{kBaseCampPageNextIndex,
-                                kBaseCampSeatPageNextIndex,
-                                kCreateMenuReadyIndex};
+    const std::vector<int> rail{
+        kBaseCampPageNextIndex,
+        kBaseCampSeatCardBase + kBaseCampSeatCardsPerPage - 1,
+        kCreateMenuReadyIndex};
     for (const int index : rail)
     {
         const button& b = buttons[index];
@@ -994,19 +1014,23 @@ TEST(MenuLayout, createmenu_basecamp_grid_relations)
                "the 2px bevel)";
     }
 
-    // (b) The seat cards are one uniform run: equal widths, equal pitch, one
-    // baseline. #236 widened the pitch from 58 (a 1px hairline between
-    // faces) to 64 — the 57px card plus the rail's 7px gutter.
+    // (b) The seat slots are one uniform run: equal widths, equal pitch, one
+    // baseline. Retiring the [+] and the two pagers gave the four slots the
+    // whole row, widening the pitch from 64 (a 57px card plus a 7px gutter)
+    // to 78 — a 70px face plus 8.
+    const button& first_slot = buttons[kBaseCampSeatCardBase];
+    EXPECT_EQ(buttons[kCreateMenuBackIndex].x, first_slot.x)
+        << "the rail opens on BACK's left edge";
     for (int card = 0; card + 1 < kBaseCampSeatCardsPerPage; ++card)
     {
         const button& left = buttons[kBaseCampSeatCardBase + card];
         const button& right = buttons[kBaseCampSeatCardBase + card + 1];
-        EXPECT_EQ(64, right.x - left.x) << "seat card pitch at card " << card;
-        EXPECT_EQ(left.sizex + 7, right.x - left.x)
-            << "the card pitch is the card face plus the rail gutter";
+        EXPECT_EQ(78, right.x - left.x) << "seat slot pitch at slot " << card;
+        EXPECT_EQ(left.sizex + 8, right.x - left.x)
+            << "the slot pitch is the slot face plus the rail gutter";
         EXPECT_EQ(left.sizex, right.sizex)
-            << "seat card width at card " << card;
-        EXPECT_EQ(left.y, right.y) << "seat card baseline at card " << card;
+            << "seat slot width at slot " << card;
+        EXPECT_EQ(left.y, right.y) << "seat slot baseline at slot " << card;
     }
 
     // (c) The roster pagers are twins straddling the "p/N" strip: the space
@@ -1192,7 +1216,7 @@ TEST(MenuLayout, createmenu_basecamp_scripted_zone_bands_and_nav)
     EXPECT_EQ(0, buttons[kBaseCampZoneActionBase + 1].nav.down)
         << "the band's last row drops onto the roster's dep column";
     EXPECT_EQ(kBaseCampZoneActionBase + 1, buttons[0].nav.up);
-    EXPECT_EQ(kBaseCampAddSeatIndex, buttons[3].nav.down)
+    EXPECT_EQ(kBaseCampSeatCardBase, buttons[3].nav.down)
         << "the roster's last row bottoms out on the seat rail";
 
     // Pager stepping through the production dispatch windows the band.
@@ -1335,7 +1359,7 @@ TEST(MenuLayout, createmenu_basecamp_zone_two_bands_and_empty_company_spine)
     EXPECT_EQ(3, buttons[band0].nav.up);
     EXPECT_EQ(band1, buttons[band0].nav.down);
     EXPECT_EQ(band0, buttons[band1].nav.up);
-    EXPECT_EQ(kBaseCampAddSeatIndex, buttons[band1].nav.down)
+    EXPECT_EQ(kBaseCampSeatCardBase, buttons[band1].nav.down)
         << "the bottom band lands on the seat rail";
 
     // An empty company between two bands: the bands bridge straight across
@@ -1347,7 +1371,7 @@ TEST(MenuLayout, createmenu_basecamp_zone_two_bands_and_empty_company_spine)
         << "the band above bridges over an empty roster";
     EXPECT_EQ(band0, buttons[band1].nav.up)
         << "the band below climbs back over the empty roster";
-    EXPECT_EQ(kBaseCampAddSeatIndex, buttons[band1].nav.down);
+    EXPECT_EQ(kBaseCampSeatCardBase, buttons[band1].nav.down);
 
     // Empty company, both bands below: the spine opens on the first band
     // and its top row climbs to HIRE.
@@ -1356,14 +1380,14 @@ TEST(MenuLayout, createmenu_basecamp_zone_two_bands_and_empty_company_spine)
     EXPECT_EQ(kCreateMenuHireIndex, buttons[band0].nav.up)
         << "with no roster rows the first band's up-exit is HIRE";
     EXPECT_EQ(band1, buttons[band0].nav.down);
-    EXPECT_EQ(kBaseCampAddSeatIndex, buttons[band1].nav.down);
+    EXPECT_EQ(kBaseCampSeatCardBase, buttons[band1].nav.down);
 
     // Empty company, both bands above: the last band bottoms out on the
     // seat rail.
     rewire(both_above, "zone_empty_company_above");
     EXPECT_EQ(band0, buttons[kCreateMenuHireIndex].nav.down);
     EXPECT_EQ(band1, buttons[band0].nav.down);
-    EXPECT_EQ(kBaseCampAddSeatIndex, buttons[band1].nav.down)
+    EXPECT_EQ(kBaseCampSeatCardBase, buttons[band1].nav.down)
         << "no roster rows and nothing below: the band exits to the rail";
 
     og::ui::install_base_camp_state_for_screen(nullptr);
@@ -1670,20 +1694,23 @@ TEST(MenuLayout, createmenu_basecamp_roster_capability_lattice_reachable)
     (void)picker_createmenu_buttons();
 }
 
-// The seat rail has its own four-card pager, independent of the eight-row
-// company-roster pager. Pin every boundary shape through the production
-// rewire: empty, partial/full single page, first overflowing page, exact
-// two-page fill, and the lobby-wide 16-seat ceiling.
-TEST(MenuLayout, createmenu_basecamp_seat_rail_paging_labels_and_nav)
+// The rail is THIS MACHINE'S four seat slots, and what each slot IS depends
+// on three facts: how many seats this machine holds, how many the device can
+// seat, and whether the lobby has room for another. Pin the whole matrix
+// through the production rewire — a slot is a card, an ADD PLAYER door, a
+// dimmed LOBBY FULL face, or absent, and nothing else.
+TEST(MenuLayout, createmenu_basecamp_seat_rail_slot_matrix_labels_and_nav)
 {
-#if defined(DISABLE_MULTIPLAYER) || defined(USE_TOUCH_INPUT)
-    constexpr bool kAddSeatCompiledIn = false;
+    // A build with no multiplayer has ONE seat and no door to a second, so
+    // its rail is one slot wide whatever the device could seat.
+#ifdef DISABLE_MULTIPLAYER
+    constexpr bool kMultiplayerCompiledIn = false;
 #else
-    constexpr bool kAddSeatCompiledIn = true;
+    constexpr bool kMultiplayerCompiledIn = true;
 #endif
     FactoryMappingGuard mapping_guard;
-    EXPECT_EQ(9, kBaseCampSeatCardLabelBudget)
-        << "57px card face / 6px per character";
+    EXPECT_EQ(11, kBaseCampSeatCardLabelBudget)
+        << "70px slot face / 6px per character";
 
     struct LocalSeatRailLobby final : og::ui::IPickerLobbyClient
     {
@@ -1730,8 +1757,10 @@ TEST(MenuLayout, createmenu_basecamp_seat_rail_paging_labels_and_nav)
     {
         og::ui::IPickerLobbyClient* saved =
             og::ui::active_picker_lobby_client();
+        bool saved_device_class = input_hardware_state().single_seat_device;
         ~LobbyRestore()
         {
+            input_hardware_state().single_seat_device = saved_device_class;
             og::ui::install_base_camp_state_for_screen(nullptr);
             og::ui::install_active_picker_lobby_client(saved);
         }
@@ -1743,413 +1772,266 @@ TEST(MenuLayout, createmenu_basecamp_seat_rail_paging_labels_and_nav)
     ASSERT_NE(nullptr, spec.nav.rewire);
     ASSERT_NE(nullptr, spec.on_spec_row);
 
-    for (const int seat_count : {0, 1, 4, 5, 8, 16})
+    // The rail's own mapping names, in local-slot order (the factory profile
+    // pool): slot 0 is WASD, slot 1 the arrow glyphs.
+    const std::array<const char*, kBaseCampSeatCardsPerPage> kSlotOwner{
+        "WASD", og::input::kArrowGlyphs, "IJKL", "TFGH"};
+
+    int shapes_checked = 0;
+    for (const int local_count : {0, 1, 2, 3, 4})
     {
-        og::ui::BaseCampScreenState state;
-        state.page = og::ui::PageModel::make(
-            0, kBaseCampRosterRowsPerPage);
-        for (int i = 0; i < seat_count; ++i)
+        // A phone with nothing attached seats ONE player; a desktop four.
+        for (const bool phone : {false, true})
         {
-            state.seats.push_back(og::sim::LobbyPlayer{
-                .player_index = static_cast<std::uint8_t>(i),
-                .name = std::format("net-{}", i),
-                .company = "Iron Keep",
-                .team = static_cast<short>(i % SCORE_TEAM_COUNT),
-                .character_slots = {},
-                .ready = false,
-                .is_host = i == 0,
-            });
-        }
-        if (seat_count > 0)
-        {
-            state.local_seat_indices.push_back(0);
-            if (seat_count > 1)
-                state.local_seat_indices.push_back(
-                    static_cast<std::uint8_t>(seat_count - 1));
-        }
-        state.seat_page = og::ui::PageModel::make(
-            seat_count, kBaseCampSeatCardsPerPage);
-        lobby.players = state.seats;
-        lobby.local_indices = state.local_seat_indices;
-        og::ui::install_base_camp_state_for_screen(&state);
-
-        if (seat_count > kBaseCampSeatCardsPerPage)
-        {
-            EXPECT_EQ(MENU_OK,
-                      spec.on_spec_row(kBaseCampSeatPageNextIndex, &state));
-            EXPECT_EQ(1, state.seat_page.page);
-            EXPECT_EQ(MENU_OK,
-                      spec.on_spec_row(kBaseCampSeatPagePrevIndex, &state));
-            EXPECT_EQ(0, state.seat_page.page);
-        }
-
-        for (int page = 0; page < state.seat_page.page_count(); ++page)
-        {
-            state.seat_page.page = page;
-            button* buttons = picker_createmenu_buttons();
-            const int count = picker_createmenu_button_count();
-            int highlighted = kBaseCampAddSeatIndex;
-            spec.nav.rewire(buttons, count, highlighted);
-
-            const std::string variant = std::format(
-                "basecamp seats={} page={}", seat_count, page);
-            const bool paged =
-                seat_count > kBaseCampSeatCardsPerPage;
-            EXPECT_EQ(!paged,
-                      buttons[kBaseCampSeatPagePrevIndex].hidden)
-                << variant;
-            EXPECT_EQ(!paged,
-                      buttons[kBaseCampSeatPageNextIndex].hidden)
-                << variant;
-            EXPECT_EQ(!kAddSeatCompiledIn,
-                      buttons[kBaseCampAddSeatIndex].hidden)
-                << variant;
-            // The rewire re-parks the retired ordinal every frame.
-            EXPECT_TRUE(buttons[kBaseCampSeatRailSpareIndex].hidden)
-                << variant;
-            EXPECT_EQ(-1, buttons[kBaseCampSeatRailSpareIndex].nav.left)
-                << variant;
-            EXPECT_EQ(-1, buttons[kBaseCampSeatRailSpareIndex].nav.right)
-                << variant;
-            ASSERT_NE(nullptr,
-                      spec.rows[kBaseCampAddSeatIndex].state_override);
-            const og::ui::RowState add_state =
-                spec.rows[kBaseCampAddSeatIndex].state_override(
-                    og::ui::MenuLabelContext{});
-            if (!kAddSeatCompiledIn)
+            // A lobby at the 16-seat global ceiling has no room for another
+            // seat even though this machine's slots are still there.
+            for (const bool lobby_full : {false, true})
             {
-                EXPECT_EQ(og::ui::RowState::Hidden, add_state)
-                    << variant;
-            }
-            else
-            {
-                EXPECT_EQ(seat_count == og::sim::kMaxGlobalPlayers
-                              ? og::ui::RowState::Disabled
-                              : og::ui::RowState::Visible,
-                          add_state)
-                    << variant;
-            }
+                input_hardware_state().single_seat_device = phone;
+                const int slot_cap = (phone || !kMultiplayerCompiledIn)
+                    ? 1
+                    : kBaseCampSeatCardsPerPage;
 
-            const int first =
-                page * kBaseCampSeatCardsPerPage;
-            const int visible =
-                std::min(kBaseCampSeatCardsPerPage,
-                         seat_count - first);
-            // #236 rail order: [+] | < | cards | >.
-            std::vector<int> rail;
-            if (kAddSeatCompiledIn)
-                rail.push_back(kBaseCampAddSeatIndex);
-            if (paged)
-                rail.push_back(kBaseCampSeatPagePrevIndex);
-            for (int card = 0; card < kBaseCampSeatCardsPerPage; ++card)
-            {
-                const button& card_button =
-                    buttons[kBaseCampSeatCardBase + card];
-                EXPECT_EQ(card >= visible, card_button.hidden)
-                    << variant << " card " << card;
-                if (card >= visible)
-                    continue;
-
-                const int player_index = first + card;
-                // Local seat zero is this machine's first controller
-                // profile; the trailing seat is its second (the fixture
-                // hands the lobby exactly those two local indices).
-                const bool local =
-                    player_index == 0 ||
-                    (seat_count > 1 && player_index == seat_count - 1);
-                const char* const owner =
-                    !local ? "IRO"
-                           : (player_index == 0 ? "WASD"
-                                                : og::input::kArrowGlyphs);
-                // Design §2.3: a local card names its INPUT mapping. The
-                // 57px face is exactly nine characters INCLUDING the
-                // load-bearing trailing pad, so a two-digit global P#
-                // shortens the name rather than overflowing the bevel.
-                std::string expected =
-                    std::format("P{} {} ", player_index + 1, owner);
-                if (expected.size() >
-                    static_cast<std::size_t>(kBaseCampSeatCardLabelBudget))
+                og::ui::BaseCampScreenState state;
+                state.page = og::ui::PageModel::make(
+                    0, kBaseCampRosterRowsPerPage);
+                const int total_seats =
+                    lobby_full ? static_cast<int>(og::sim::kMaxGlobalPlayers)
+                               : local_count;
+                for (int i = 0; i < total_seats; ++i)
                 {
-                    expected = std::format(
-                        "P{} {} ", player_index + 1,
-                        std::string(owner).substr(
-                            0, std::strlen(owner) -
-                                   (expected.size() -
-                                    static_cast<std::size_t>(
-                                        kBaseCampSeatCardLabelBudget))));
+                    state.seats.push_back(og::sim::LobbyPlayer{
+                        .player_index = static_cast<std::uint8_t>(i),
+                        .name = std::format("net-{}", i),
+                        .company = "Iron Keep",
+                        .team = static_cast<short>(i % SCORE_TEAM_COUNT),
+                        .character_slots = {},
+                        .ready = false,
+                        .is_host = i == 0,
+                    });
                 }
-                EXPECT_EQ(expected, card_button.label)
-                    << variant << " card " << card;
-                EXPECT_LE(card_button.label.size(),
-                          static_cast<std::size_t>(
-                              kBaseCampSeatCardLabelBudget))
-                    << variant << " card " << card << " '"
-                    << card_button.label << "'";
-                EXPECT_EQ(' ', card_button.label.back())
-                    << "the team-chip clearance pad is load-bearing";
-                rail.push_back(kBaseCampSeatCardBase + card);
-            }
-            if (paged)
-                rail.push_back(kBaseCampSeatPageNextIndex);
-            ASSERT_FALSE(rail.empty()) << variant;
-            // Links from above enter at the rail's left end; the strip's
-            // right end climbs to its right end.
-            const int rail_first = rail.front();
-            const int rail_last = rail.back();
+                for (int i = 0; i < local_count; ++i)
+                    state.local_seat_indices.push_back(
+                        static_cast<std::uint8_t>(i));
+                lobby.players = state.seats;
+                lobby.local_indices = state.local_seat_indices;
+                og::ui::install_base_camp_state_for_screen(&state);
 
-            for (std::size_t i = 0; i < rail.size(); ++i)
-            {
-                const button& control = buttons[rail[i]];
-                EXPECT_EQ(i > 0 ? rail[i - 1] : -1, control.nav.left)
-                    << variant << " " << control.id;
-                EXPECT_EQ(i + 1 < rail.size() ? rail[i + 1] : -1,
-                          control.nav.right)
-                    << variant << " " << control.id;
-            }
+                button* buttons = picker_createmenu_buttons();
+                const int count = picker_createmenu_button_count();
+                int highlighted = kBaseCampSeatCardBase;
+                spec.nav.rewire(buttons, count, highlighted);
 
-            const auto visible_card_or_rail = [visible, rail_first](int card) {
-                return card < visible
-                    ? kBaseCampSeatCardBase + card
-                    : rail_first;
-            };
-            // HIRE lives in the roster header band now: its up-link is
-            // closed and the empty-roster rail climbs back up to it.
-            EXPECT_EQ(-1, buttons[kCreateMenuHireIndex].nav.up) << variant;
-            EXPECT_EQ(rail_first,
-                      buttons[kCreateMenuHireIndex].nav.down)
-                << variant << " (empty roster: HIRE drops to the rail)";
-            EXPECT_EQ(rail_first, buttons[kCreateMenuBackIndex].nav.up)
-                << variant << " (BACK climbs to the rail's left end)";
-            EXPECT_EQ(visible_card_or_rail(1),
-                      buttons[kCreateMenuScenarioIndex].nav.up)
-                << variant;
-            EXPECT_EQ(visible_card_or_rail(2),
-                      buttons[kCreateMenuNetworkingIndex].nav.up)
-                << variant;
-            EXPECT_EQ(rail_last, buttons[kCreateMenuGoIndex].nav.up)
-                << variant;
+                const std::string variant = std::format(
+                    "local={} device={} lobby={}", local_count,
+                    phone ? "phone" : "desktop",
+                    lobby_full ? "full" : "open");
+                ++shapes_checked;
 
-            // #243: the rail is positioned per frame, so pin the RELATIONS
-            // every shape must satisfy rather than a second exact table (the
-            // full-rail coordinates already have one, and the pure layout
-            // function's own values are pinned in the picker_common units).
-            {
-                // The row opens on the panel's left rail — the same edge
-                // BACK starts on, in every shape, with or without the '+'.
-                EXPECT_EQ(8, buttons[rail_first].x) << variant;
+                // The four retired ordinals are re-parked every frame.
+                for (const int spare : kBaseCampSeatRailSpares)
+                {
+                    EXPECT_TRUE(buttons[spare].hidden)
+                        << variant << " spare " << spare;
+                    EXPECT_EQ(-1, buttons[spare].nav.left)
+                        << variant << " spare " << spare;
+                    EXPECT_EQ(-1, buttons[spare].nav.right)
+                        << variant << " spare " << spare;
+                }
+
+                std::vector<int> rail;
+                for (int slot = 0; slot < kBaseCampSeatCardsPerPage; ++slot)
+                {
+                    const int ordinal = kBaseCampSeatCardBase + slot;
+                    const button& face = buttons[ordinal];
+                    const std::string where =
+                        variant + std::format(" slot {}", slot);
+
+                    // THE STATE RULE. Order matters: a seat this machine
+                    // already holds keeps its card whatever the caps say.
+                    const bool is_card = slot < local_count;
+                    const bool is_hidden = !is_card && slot >= slot_cap;
+                    const bool is_full =
+                        !is_card && !is_hidden &&
+                        (lobby_full || !kMultiplayerCompiledIn);
+
+                    EXPECT_EQ(is_hidden, face.hidden) << where;
+                    ASSERT_NE(nullptr, spec.rows[ordinal].state_override);
+                    const og::ui::RowState row_state =
+                        spec.rows[ordinal].state_override(
+                            og::ui::MenuLabelContext{});
+                    EXPECT_EQ(is_hidden ? og::ui::RowState::Hidden
+                                        : (is_full
+                                               ? og::ui::RowState::Disabled
+                                               : og::ui::RowState::Visible),
+                              row_state)
+                        << where;
+
+                    // The grid never moves: slot k is at 8 + 78k, 70 wide,
+                    // whether it holds a seat, an offer, or nothing.
+                    EXPECT_EQ(8 + 78 * slot, face.x) << where;
+                    EXPECT_EQ(70, face.sizex) << where;
+                    EXPECT_EQ(164, face.y) << where;
+
+                    if (is_card)
+                    {
+                        // Design §2.3: a local card names its INPUT mapping.
+                        // The face is exactly eleven characters INCLUDING the
+                        // load-bearing trailing pad.
+                        // #249: on a single-seat device the touchscreen IS
+                        // the controller, so the FIRST seat names the screen
+                        // instead of keys the device does not have. A later
+                        // seat exists only because a pad opened the cap, so
+                        // it keeps its own mapping name.
+                        const char* const owner =
+                            (phone && slot == 0)
+                            ? og::input::kScreenSeatOwnerLabel
+                            : kSlotOwner[static_cast<std::size_t>(slot)];
+                        EXPECT_EQ(std::format("P{} {} ", slot + 1, owner),
+                                  face.label)
+                            << where;
+                        EXPECT_EQ(' ', face.label.back())
+                            << where << ": the chip clearance pad is "
+                                        "load-bearing";
+                    }
+                    else if (is_full)
+                    {
+                        EXPECT_EQ("LOBBY FULL", face.label) << where;
+                    }
+                    else if (!is_hidden)
+                    {
+                        EXPECT_EQ("ADD PLAYER", face.label) << where;
+                    }
+                    EXPECT_LE(face.label.size(),
+                              static_cast<std::size_t>(
+                                  kBaseCampSeatCardLabelBudget))
+                        << where << " '" << face.label << "'";
+
+                    if (!is_hidden)
+                        rail.push_back(ordinal);
+                }
+
+                // Visible slots run contiguously from slot zero: a hole in
+                // the middle of the rail would strand the chain.
+                ASSERT_FALSE(rail.empty()) << variant;
+                EXPECT_EQ(kBaseCampSeatCardBase, rail.front()) << variant;
+                EXPECT_EQ(static_cast<std::size_t>(rail.back() -
+                                                   kBaseCampSeatCardBase + 1),
+                          rail.size())
+                    << variant << ": the rail has a hole in it";
+                EXPECT_EQ(8, buttons[rail.front()].x) << variant;
                 EXPECT_EQ(buttons[kCreateMenuBackIndex].x,
-                          buttons[rail_first].x)
+                          buttons[rail.front()].x)
                     << variant << " (the rail opens on BACK's edge)";
 
-                // One baseline, one card width, one gutter. The '>' is left
-                // out of the gutter run: on a partly filled last page the
-                // ghost slots sit between it and the final card, and a ghost
-                // is chrome with no button of its own.
-                const int baseline = buttons[rail_first].y;
-                const std::size_t contiguous =
-                    paged ? rail.size() - 1 : rail.size();
-                int widest = -1;
-                int narrowest = -1;
-                for (std::size_t i = 1; i < contiguous; ++i)
+                for (std::size_t i = 0; i < rail.size(); ++i)
                 {
-                    const button& left = buttons[rail[i - 1]];
-                    const button& right = buttons[rail[i]];
-                    const int gap = right.x - (left.x + left.sizex);
-                    widest = widest < 0 ? gap : std::max(widest, gap);
-                    narrowest = narrowest < 0 ? gap : std::min(narrowest, gap);
-                    EXPECT_GE(gap, 7) << variant << " gutter " << i;
-                    EXPECT_EQ(baseline, right.y) << variant << " row " << i;
-                }
-                if (widest >= 0)
-                {
-                    // Justifying leaves a remainder; the leftmost gutters
-                    // absorb it one pixel at a time, so no two gutters on the
-                    // row can differ by more than that pixel.
-                    EXPECT_LE(widest - narrowest, 1)
-                        << variant << " uneven gutters";
-                }
-                for (int card = 0; card < visible; ++card)
-                {
-                    EXPECT_EQ(57, buttons[kBaseCampSeatCardBase + card].sizex)
-                        << variant << " card " << card
-                        << " (the nine-character label budget)";
+                    const button& control = buttons[rail[i]];
+                    EXPECT_EQ(i > 0 ? rail[i - 1] : -1, control.nav.left)
+                        << variant << " " << control.id;
+                    EXPECT_EQ(i + 1 < rail.size() ? rail[i + 1] : -1,
+                              control.nav.right)
+                        << variant << " " << control.id;
                 }
 
-                // Justified shapes close on the panel's right rail. With the
-                // arrows up the '>' owns that edge; with four cards on a
-                // single page the fourth card does.
-                if (paged)
-                {
-                    const button& next_arrow =
-                        buttons[kBaseCampSeatPageNextIndex];
-                    EXPECT_EQ(312, next_arrow.x + next_arrow.sizex) << variant;
-                }
-                else if (visible == kBaseCampSeatCardsPerPage)
-                {
-                    const button& last_card =
-                        buttons[kBaseCampSeatCardBase +
-                                kBaseCampSeatCardsPerPage - 1];
-                    EXPECT_EQ(312, last_card.x + last_card.sizex) << variant;
-                }
-            }
-
-            check_no_overlaps(buttons, count, variant.c_str());
-            check_bounds(buttons, count, variant.c_str());
-            check_nav_closed_and_reachable(
-                buttons, count, kCreateMenuBackIndex, variant.c_str());
-
-            // The same rail page must close over READY for a joiner with an
-            // active seat: GO hides, the fourth card and the next arrow point
-            // down to READY, and READY points back up to the rail's right
-            // end. The '+' sits over BACK at the rail's left end now (#236),
-            // so it drops there in every shape.
-            lobby.host = false;
-            buttons = picker_createmenu_buttons();
-            highlighted = kBaseCampAddSeatIndex;
-            spec.nav.rewire(buttons, count, highlighted);
-            EXPECT_TRUE(buttons[kCreateMenuGoIndex].hidden) << variant;
-            EXPECT_EQ(seat_count == 0,
-                      buttons[kCreateMenuReadyIndex].hidden)
-                << variant;
-            EXPECT_EQ(seat_count > 0 ? kCreateMenuReadyIndex : -1,
-                      buttons[kCreateMenuNetworkingIndex].nav.right)
-                << variant;
-            if (seat_count > 0 &&
-                visible == kBaseCampSeatCardsPerPage)
-            {
-                EXPECT_EQ(kCreateMenuReadyIndex,
-                          buttons[kBaseCampSeatCardBase + 3].nav.down)
-                    << variant;
-            }
-            if (seat_count > 0 && paged)
-            {
-                EXPECT_EQ(kCreateMenuReadyIndex,
-                          buttons[kBaseCampSeatPageNextIndex].nav.down)
-                    << variant;
-            }
-            if (kAddSeatCompiledIn)
-            {
-                EXPECT_EQ(kCreateMenuBackIndex,
-                          buttons[kBaseCampAddSeatIndex].nav.down)
-                    << variant;
-            }
-            if (seat_count > 0)
-            {
-                EXPECT_EQ(rail_last,
-                          buttons[kCreateMenuReadyIndex].nav.up)
-                    << variant;
-            }
-            const std::string joiner_variant = variant + " joiner";
-            check_nav_closed_and_reachable(
-                buttons, count, kCreateMenuBackIndex,
-                joiner_variant.c_str());
-            lobby.host = true;
-        }
-    }
-
-    // A network peer may remain connected after removing its final local
-    // seat while one to four remote seats still fill the rail. Hosts retain
-    // GO; guests have neither GO nor READY until + activates a seat. Exercise
-    // every single-page width so card four can never fall through to a hidden
-    // GO/READY twin.
-    for (const int remote_count : {1, 2, 3, 4})
-    {
-        og::ui::BaseCampScreenState spectator_state;
-        spectator_state.page = og::ui::PageModel::make(
-            0, kBaseCampRosterRowsPerPage);
-        for (int i = 0; i < remote_count; ++i)
-        {
-            spectator_state.seats.push_back(og::sim::LobbyPlayer{
-                .player_index = static_cast<std::uint8_t>(i),
-                .name = std::format("remote-{}", i),
-                .company = "Iron Keep",
-                .team = static_cast<short>(i % SCORE_TEAM_COUNT),
-                .character_slots = {},
-                .ready = false,
-                .is_host = i == 0,
-            });
-        }
-        spectator_state.seat_page = og::ui::PageModel::make(
-            remote_count, kBaseCampSeatCardsPerPage);
-        lobby.players = spectator_state.seats;
-        lobby.local_indices.clear();
-        og::ui::install_base_camp_state_for_screen(&spectator_state);
-
-        for (const bool host : {false, true})
-        {
-            lobby.host = host;
-            button* buttons = picker_createmenu_buttons();
-            const int count = picker_createmenu_button_count();
-            int highlighted = kBaseCampAddSeatIndex;
-            spec.nav.rewire(buttons, count, highlighted);
-            const std::string variant = std::format(
-                "zero-seat {} remote-cards={}",
-                host ? "host" : "guest", remote_count);
-
-            EXPECT_EQ(!host, buttons[kCreateMenuGoIndex].hidden)
-                << variant;
-            EXPECT_TRUE(buttons[kCreateMenuReadyIndex].hidden)
-                << variant;
-            // Each card drops onto the strip door under its face; the
-            // re-gridded strip put DIFFICULTY under card zero. Card three
-            // still falls back one door to NETWORK when its GO/READY slot
-            // has no visible half.
-            constexpr std::array<int, kBaseCampSeatCardsPerPage>
-                kCardStripTargets{
-                    kCreateMenuDifficultyIndex,
-                    kCreateMenuScenarioIndex,
-                    kCreateMenuNetworkingIndex,
-                    kCreateMenuNetworkingIndex,
+                const int rail_first = rail.front();
+                const int rail_last = rail.back();
+                const auto visible_slot_or_rail = [&](int slot) {
+                    return slot < static_cast<int>(rail.size())
+                        ? kBaseCampSeatCardBase + slot
+                        : rail_first;
                 };
-            for (int card = 0; card < remote_count; ++card)
-            {
-                const int expected_down =
-                    card == kBaseCampSeatCardsPerPage - 1 && host
-                    ? kCreateMenuGoIndex
-                    : kCardStripTargets[static_cast<std::size_t>(card)];
-                EXPECT_EQ(expected_down,
-                          buttons[kBaseCampSeatCardBase + card].nav.down)
-                    << variant << " card " << card;
-            }
-            if (kAddSeatCompiledIn)
-            {
-                EXPECT_EQ(kCreateMenuBackIndex,
-                          buttons[kBaseCampAddSeatIndex].nav.down)
+                EXPECT_EQ(-1, buttons[kCreateMenuHireIndex].nav.up) << variant;
+                EXPECT_EQ(rail_first, buttons[kCreateMenuHireIndex].nav.down)
+                    << variant << " (empty roster: HIRE drops to the rail)";
+                EXPECT_EQ(rail_first, buttons[kCreateMenuBackIndex].nav.up)
+                    << variant << " (BACK climbs to the rail's left end)";
+                EXPECT_EQ(visible_slot_or_rail(1),
+                          buttons[kCreateMenuScenarioIndex].nav.up)
                     << variant;
+                EXPECT_EQ(visible_slot_or_rail(2),
+                          buttons[kCreateMenuNetworkingIndex].nav.up)
+                    << variant;
+                EXPECT_EQ(rail_last, buttons[kCreateMenuGoIndex].nav.up)
+                    << variant;
+                // Each slot drops onto its strip door; the last one falls
+                // back a door when the GO/READY slot has no visible half.
+                constexpr std::array<int, kBaseCampSeatCardsPerPage>
+                    kSlotStripTargets{kCreateMenuDifficultyIndex,
+                                      kCreateMenuScenarioIndex,
+                                      kCreateMenuNetworkingIndex,
+                                      kCreateMenuGoIndex};
+                for (const int ordinal : rail)
+                {
+                    const int slot = ordinal - kBaseCampSeatCardBase;
+                    EXPECT_EQ(kSlotStripTargets[static_cast<std::size_t>(slot)],
+                              buttons[ordinal].nav.down)
+                        << variant << " slot " << slot;
+                }
+                // The last visible slot closes the rail on the panel's right
+                // rail only when all four are up — a device-capped rail stops
+                // where the hardware stops.
+                if (rail.size() ==
+                    static_cast<std::size_t>(kBaseCampSeatCardsPerPage))
+                {
+                    EXPECT_EQ(312, buttons[rail_last].x +
+                                       buttons[rail_last].sizex)
+                        << variant;
+                }
+
+                check_no_overlaps(buttons, count, variant.c_str());
+                check_bounds(buttons, count, variant.c_str());
+                check_nav_closed_and_reachable(
+                    buttons, count, kCreateMenuBackIndex, variant.c_str());
+
+                // The same rail must close over READY for a joiner with an
+                // active seat: GO hides, the last visible slot points down to
+                // READY, and READY points back up to the rail's right end.
+                lobby.host = false;
+                buttons = picker_createmenu_buttons();
+                highlighted = kBaseCampSeatCardBase;
+                spec.nav.rewire(buttons, count, highlighted);
+                EXPECT_TRUE(buttons[kCreateMenuGoIndex].hidden) << variant;
+                EXPECT_EQ(local_count == 0,
+                          buttons[kCreateMenuReadyIndex].hidden)
+                    << variant;
+                EXPECT_EQ(local_count > 0 ? kCreateMenuReadyIndex : -1,
+                          buttons[kCreateMenuNetworkingIndex].nav.right)
+                    << variant;
+                if (local_count > 0)
+                {
+                    EXPECT_EQ(rail_last,
+                              buttons[kCreateMenuReadyIndex].nav.up)
+                        << variant;
+                    if (rail.size() == static_cast<std::size_t>(
+                                           kBaseCampSeatCardsPerPage))
+                    {
+                        EXPECT_EQ(kCreateMenuReadyIndex,
+                                  buttons[kBaseCampSeatCardBase + 3].nav.down)
+                            << variant;
+                    }
+                }
+                else if (rail.size() == static_cast<std::size_t>(
+                                            kBaseCampSeatCardsPerPage))
+                {
+                    // A zero-seat guest has neither half of the GO/READY
+                    // slot: the last slot falls back one door to NETWORK
+                    // rather than pointing keyboard focus at a hidden row.
+                    EXPECT_EQ(kCreateMenuNetworkingIndex,
+                              buttons[rail_last].nav.down)
+                        << variant;
+                }
+                const std::string joiner_variant = variant + " joiner";
+                check_nav_closed_and_reachable(
+                    buttons, count, kCreateMenuBackIndex,
+                    joiner_variant.c_str());
+                lobby.host = true;
+                og::ui::install_base_camp_state_for_screen(nullptr);
             }
-            check_nav_closed_and_reachable(
-                buttons, count, kCreateMenuBackIndex, variant.c_str());
         }
     }
-
-    // The row stays in the native rail but becomes visibly inert when this
-    // machine already owns four active seats. Touch/no-MP builds hide the
-    // same final slot altogether; both variants keep the authored cap rule.
-    lobby.players.resize(static_cast<std::size_t>(MAX_PLAYERS));
-    lobby.local_indices = {0, 1, 2, 3};
-    const og::ui::RowState local_cap_state =
-        spec.rows[kBaseCampAddSeatIndex].state_override(
-            og::ui::MenuLabelContext{});
-    EXPECT_EQ(kAddSeatCompiledIn ? og::ui::RowState::Disabled
-                                : og::ui::RowState::Hidden,
-              local_cap_state);
-
-    // #249: a single-seat device (a phone) reaches its cap three seats
-    // early — its touchscreen is the only controller it has — and the row
-    // HIDES rather than dims (matching the pause menu's + ADD PLAYER): on a
-    // phone a dimmed [+] reads as tappable and explains nothing, while an
-    // absent one that appears when a pad is plugged in explains itself.
-    {
-        const bool saved_device_class =
-            input_hardware_state().single_seat_device;
-        lobby.players.resize(1u);
-        lobby.local_indices = {0};
-        input_hardware_state().single_seat_device = true;
-        EXPECT_EQ(og::ui::RowState::Hidden,
-                  spec.rows[kBaseCampAddSeatIndex].state_override(
-                      og::ui::MenuLabelContext{}));
-        input_hardware_state().single_seat_device = saved_device_class;
-    }
+    EXPECT_EQ(20, shapes_checked)
+        << "5 local seat counts x 2 device classes x 2 lobby states";
 }
 
 // Design §2.2: the seat editor's INPUT cycler needed a band of its own —
@@ -2359,8 +2241,9 @@ TEST(MenuLayout, createmenu_basecamp_nav_matrix_keyboard_reachable)
                     // Rail controls over the strip's right end inherit GO as
                     // their native host down target. This matrix's synthetic
                     // joiner hides GO by hand, so close those links too.
-                    for (int i = kBaseCampAddSeatIndex;
-                         i <= kBaseCampSeatPageNextIndex; ++i)
+                    for (int i = kBaseCampSeatCardBase;
+                         i < kBaseCampSeatCardBase +
+                                 kBaseCampSeatCardsPerPage; ++i)
                     {
                         if (buttons[i].nav.down == kCreateMenuGoIndex)
                             buttons[i].nav.down = kCreateMenuNetworkingIndex;

--- a/tests/integration/test_menu_layout.cpp
+++ b/tests/integration/test_menu_layout.cpp
@@ -1875,9 +1875,10 @@ TEST(MenuLayout, createmenu_basecamp_seat_rail_slot_matrix_labels_and_nav)
 
                     if (is_card)
                     {
-                        // Design §2.3: a local card names its INPUT mapping.
-                        // The face is exactly eleven characters INCLUDING the
-                        // load-bearing trailing pad.
+                        // Design §2.3: a local card names its INPUT mapping,
+                        // followed by the two load-bearing trailing pads that
+                        // center the visible ink over the chip-free zone
+                        // rather than over the whole face.
                         // #249: on a single-seat device the touchscreen IS
                         // the controller, so the FIRST seat names the screen
                         // instead of keys the device does not have. A later
@@ -1887,11 +1888,12 @@ TEST(MenuLayout, createmenu_basecamp_seat_rail_slot_matrix_labels_and_nav)
                             (phone && slot == 0)
                             ? og::input::kScreenSeatOwnerLabel
                             : kSlotOwner[static_cast<std::size_t>(slot)];
-                        EXPECT_EQ(std::format("P{} {} ", slot + 1, owner),
+                        EXPECT_EQ(std::format("P{} {}  ", slot + 1, owner),
                                   face.label)
                             << where;
-                        EXPECT_EQ(' ', face.label.back())
-                            << where << ": the chip clearance pad is "
+                        ASSERT_GE(face.label.size(), 2u) << where;
+                        EXPECT_EQ("  ", face.label.substr(face.label.size() - 2))
+                            << where << ": both chip-clearance pads are "
                                         "load-bearing";
                     }
                     else if (is_full)

--- a/tests/integration/test_networking_menu.cpp
+++ b/tests/integration/test_networking_menu.cpp
@@ -359,8 +359,9 @@ int networking_join_injector(void* data)
         return 0;
     }
 
-    // Base Camp's own entry fade has to be over before the door is measured.
-    SDL_Delay(750);
+    // Generic settle before the door is measured (fades are instant under
+    // TESTING, so nothing here is waiting on an animation).
+    SDL_Delay(300);
     const int fades_before_door = count_fade_between_traces();
     interact("networking");
 
@@ -371,7 +372,7 @@ int networking_join_injector(void* data)
     }
 
     state->saw_networking_menu = true;
-    SDL_Delay(750);
+    SDL_Delay(150);  // generic settle (fades are instant under TESTING)
     state->fades_added_by_networking_door =
         count_fade_between_traces() - fades_before_door;
 

--- a/tests/integration/test_networking_menu.cpp
+++ b/tests/integration/test_networking_menu.cpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <initializer_list>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -310,6 +311,22 @@ bool interact_until_any_interactable(const std::string& id,
     return wait_for_any_interactable(ids, 0);
 }
 
+// Under TESTING every fadeblack takes FadeBetween's test-mode branch, which
+// traces exactly one "video" line per fade — so counting those lines counts
+// fades.
+int count_fade_between_traces()
+{
+    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    int fades = 0;
+    for (const TraceEntry& entry : g_trace_buffer)
+    {
+        if (entry.category == "video" &&
+            entry.message.find("FadeBetween") != std::string::npos)
+            ++fades;
+    }
+    return fades;
+}
+
 struct NetworkingJoinState
 {
     bool started = false;
@@ -322,6 +339,12 @@ struct NetworkingJoinState
     bool saw_join_relay_error_popup = false;
     bool stayed_in_submenu_after_join_error = false;
     bool returned_to_main_menu = false;
+    // #237: NETWORKING is a Base Camp strip door — instant, both ways, like
+    // its HIRE/TRAIN/DIFFICULTY siblings. Base Camp exits before the legacy
+    // screen runs, so the depth rule would fade BOTH legs without the
+    // Instant notes in SdlPickerClient::configure_networking.
+    int fades_added_by_networking_door = -1;
+    int fades_added_by_networking_back = -1;
 };
 
 int networking_join_injector(void* data)
@@ -336,7 +359,9 @@ int networking_join_injector(void* data)
         return 0;
     }
 
-    SDL_Delay(300);
+    // Base Camp's own entry fade has to be over before the door is measured.
+    SDL_Delay(750);
+    const int fades_before_door = count_fade_between_traces();
     interact("networking");
 
     if (!wait_for_interactable("network_ip", 10000))
@@ -346,7 +371,9 @@ int networking_join_injector(void* data)
     }
 
     state->saw_networking_menu = true;
-    SDL_Delay(150);
+    SDL_Delay(750);
+    state->fades_added_by_networking_door =
+        count_fade_between_traces() - fades_before_door;
 
     state->updated_ip = interact_until_label_contains(
         "network_ip", "10.24.8.16");
@@ -378,7 +405,15 @@ int networking_join_injector(void* data)
     if (has_interactable("network_back"))
     {
         SDL_Delay(150);
+        const int fades_before_back = count_fade_between_traces();
         interact("network_back");
+        // BACK re-presents Base Camp: the "networking" row is its own.
+        if (wait_for_interactable("networking", 10000))
+        {
+            SDL_Delay(750);
+            state->fades_added_by_networking_back =
+                count_fade_between_traces() - fades_before_back;
+        }
     }
 
     const Uint64 deadline = SDL_GetTicks() + 10000;
@@ -1133,6 +1168,16 @@ TEST(NetworkingMenu, room_code_join_invalid_relay_url_stays_in_submenu)
     ASSERT_TRUE(state.saw_join_relay_error_popup);
     ASSERT_TRUE(state.stayed_in_submenu_after_join_error);
     ASSERT_TRUE(state.returned_to_main_menu);
+    // #237: NETWORKING is a Base Camp strip door — symmetric-INSTANT, like
+    // HIRE/TRAIN/DIFFICULTY. Master faded the way back only; that was one of
+    // the reported asymmetries, and the fix was to make both legs match, not
+    // to fade both. Base Camp exits before the legacy screen runs, so the
+    // depth rule alone would fade them: the Instant notes in
+    // SdlPickerClient::configure_networking are what these two pins hold.
+    EXPECT_EQ(0, state.fades_added_by_networking_door)
+        << "#237: the NETWORKING door must stay instant";
+    EXPECT_EQ(0, state.fades_added_by_networking_back)
+        << "#237 symmetry: and so must BACK to Base Camp";
 }
 
 TEST(NetworkingMenu, submenu_validation_errors_stay_in_place)

--- a/tests/integration/test_networking_menu.cpp
+++ b/tests/integration/test_networking_menu.cpp
@@ -3,6 +3,7 @@
 #include <openglad/interface/platform_bridge.h>
 #include <openglad/interface/screen.h>
 #include <openglad/interface/ui/picker_ui_state.h>
+#include <openglad/platform/video_sdl.h>
 
 #include <gtest/gtest.h>
 #include <SDL3/SDL.h>
@@ -325,6 +326,24 @@ int count_fade_between_traces()
             ++fades;
     }
     return fades;
+}
+
+// #237: a fading screen's exit scope skips its fade-out when an Instant note
+// is pending — the door being opened is instant. Traced by the runner; the
+// NETWORKING door (Base Camp exits to open it) is the ONLY door that shape
+// is for, and these flows hold it to exactly that one occurrence.
+int count_instant_exit_skips()
+{
+    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    int skips = 0;
+    for (const TraceEntry& entry : g_trace_buffer)
+    {
+        if (entry.category == "video" &&
+            entry.message.find("exit fade skipped: Instant note pending") !=
+                std::string::npos)
+            ++skips;
+    }
+    return skips;
 }
 
 struct NetworkingJoinState
@@ -1179,6 +1198,12 @@ TEST(NetworkingMenu, room_code_join_invalid_relay_url_stays_in_submenu)
         << "#237: the NETWORKING door must stay instant";
     EXPECT_EQ(0, state.fades_added_by_networking_back)
         << "#237 symmetry: and so must BACK to Base Camp";
+    // The mechanism behind the 0 on the way in: Base Camp's exit scope
+    // skipped its fade-out for the pending Instant note — once, on this
+    // door, and nowhere else in the flow (CONTINUE in, BACK out, QUIT).
+    EXPECT_EQ(1, count_instant_exit_skips())
+        << "#237: the Instant-note exit skip happens exactly on the "
+           "NETWORKING door";
 }
 
 TEST(NetworkingMenu, submenu_validation_errors_stay_in_place)
@@ -1602,5 +1627,16 @@ TEST(NetworkingMenu, host_flow_enters_team_build_and_returns_to_main_menu)
     ASSERT_TRUE(state.returned_to_main_menu);
     ASSERT_EQ(0, trace_count("popup"))
         << "successful hosting should enter the lobby directly without an intermediate status popup";
+    // #237: the door in is the one Instant-note exit skip; the hookup exit
+    // is the legacy screen's OWN fade-out (fade_out_at_exit), so Base Camp's
+    // fading re-entry finds a black window — the listener holds that no
+    // entry in this flow found an unfaded one.
+    EXPECT_EQ(1, count_instant_exit_skips())
+        << "#237: the Instant-note exit skip happens exactly on the "
+           "NETWORKING door";
+    EXPECT_EQ(0, og::video_testing::g_fade_violations.load())
+        << (og::video_testing::fade_violation_messages().empty()
+                ? std::string()
+                : og::video_testing::fade_violation_messages().front());
 }
 #endif

--- a/tests/integration/test_new_game.cpp
+++ b/tests/integration/test_new_game.cpp
@@ -95,7 +95,7 @@ static int new_game_injector(void* data)
     // §2.2: BEGIN NEW GAME now opens the name-entry screen first. Accept the
     // generated company name to found the company.
     wait_for_interactable("company_name_accept", 5000);
-    SDL_Delay(750);  // FadeAroundEntry settle
+    SDL_Delay(750);  // menu-entry settle
     fprintf(stderr, "  [test] accepting generated company name\n");
     interact("company_name_accept");
 
@@ -187,7 +187,7 @@ static int name_entry_cancel_injector(void* data)
 
     // Name-entry appears. Reroll the suggestion, then BACK out (cancel).
     if (wait_for_interactable("company_name_reroll", 5000)) {
-        SDL_Delay(750);  // FadeAroundEntry settle
+        SDL_Delay(750);  // menu-entry settle
         fprintf(stderr, "  [test] clicking REROLL\n");
         interact("company_name_reroll");
         SDL_Delay(300);  // let the click release before the next press
@@ -281,7 +281,7 @@ static int name_entry_edit_injector(void* data)
     interact("begin_new_game");
 
     if (wait_for_interactable("company_name_value", 5000)) {
-        SDL_Delay(750);  // FadeAroundEntry settle
+        SDL_Delay(750);  // menu-entry settle
         fprintf(stderr, "  [test] clicking the name strip to edit\n");
         interact("company_name_value");  // opens input_string_value (blocks)
         SDL_Delay(400);  // let the engine dispatch + the editor start + clear

--- a/tests/integration/test_new_game.cpp
+++ b/tests/integration/test_new_game.cpp
@@ -80,6 +80,9 @@ struct NewGameState {
     // #237 derivation pin: fades counted across the BEGIN NEW GAME door.
     // -1 means the injector never reached the read.
     int fades_added_by_name_entry;
+    // #237 symmetry leg: fades counted across the name-entry BACK, from the
+    // cancel click to the re-presented main menu. -1 = never read.
+    int fades_added_by_name_entry_back;
 };
 
 // Under TESTING every fadeblack takes FadeBetween's test-mode branch, which
@@ -166,7 +169,7 @@ TEST(NewGame, begin_new_game) {
     og::runtime::current_session->myscreen_->save_data.team_size = 1;
     og::runtime::current_session->myscreen_->save_data.save("save0");
 
-    NewGameState state = { false, false, false, false, -1 };
+    NewGameState state = { false, false, false, false, -1, -1 };
     SDL_Thread* thread = SDL_CreateThread(new_game_injector, "new_game_test", &state);
     ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
 
@@ -224,8 +227,21 @@ static int name_entry_cancel_injector(void* data)
         interact("company_name_reroll");
         SDL_Delay(300);  // let the click release before the next press
         fprintf(stderr, "  [test] clicking BACK (cancel)\n");
+        // #237 symmetry: the way back out of a main-menu door owes exactly
+        // what the way in cost — the door fades out, the re-entered main menu
+        // fades in.
+        const int fades_before_back = count_fade_between_traces();
         interact("back");
         state->saw_team_menu = true;  // reused flag: reached & left name-entry
+        // The re-entered main menu is a SECOND mainmenu call, so this flow
+        // runs with g_picker_max_mainmenu_calls = 2 and leaves through QUIT.
+        if (wait_for_interactable("begin_new_game", 5000)) {
+            SDL_Delay(750);  // menu-entry settle
+            state->fades_added_by_name_entry_back =
+                count_fade_between_traces() - fades_before_back;
+            fprintf(stderr, "  [test] quitting from the main menu\n");
+            interact("quit");
+        }
     }
 
     state->finished = true;
@@ -244,13 +260,16 @@ TEST(NewGame, name_entry_back_cancels_without_founding) {
         "gladiator";
     og::runtime::current_session->myscreen_->save_data.save("save0");
 
-    NewGameState state = { false, false, false, false, -1 };
+    NewGameState state = { false, false, false, false, -1, -1 };
     SDL_Thread* thread =
         SDL_CreateThread(name_entry_cancel_injector, "name_entry_cancel", &state);
     ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
 
     g_picker_mainmenu_calls = 0;
-    g_picker_max_mainmenu_calls = 1;
+    // 2: the door's way in is one mainmenu call, the way back re-enters it —
+    // and the #237 return-leg pin can only be measured on a main menu that
+    // actually re-runs (the cap short-circuits present_menu straight to QUIT).
+    g_picker_max_mainmenu_calls = 2;
 
     picker_main(0, nullptr);
 
@@ -264,6 +283,9 @@ TEST(NewGame, name_entry_back_cancels_without_founding) {
     ASSERT_TRUE(state.saw_team_menu) << "should have reached the name-entry screen";
     ASSERT_TRUE(trace_contains("name_entry", "reroll")) << "REROLL should have fired";
     ASSERT_TRUE(trace_contains("name_entry", "cancel")) << "BACK should have cancelled";
+    EXPECT_EQ(2, state.fades_added_by_name_entry_back)
+        << "#237 symmetry: cancelling name entry returns to the main menu — "
+           "the way back must fade exactly as much as the way in (2)";
     // The loaded game survived: cancel founded nothing, so no reset ran.
     ASSERT_EQ(424242u, og::runtime::current_session->myscreen_->save_data.totalcash)
         << "cancel must not reset the loaded game";
@@ -345,7 +367,7 @@ static int name_entry_edit_injector(void* data)
 TEST(NewGame, name_entry_edit_strip_sets_company_name) {
     trace_clear();
 
-    NewGameState state = { false, false, false, false, -1 };
+    NewGameState state = { false, false, false, false, -1, -1 };
     SDL_Thread* thread =
         SDL_CreateThread(name_entry_edit_injector, "name_entry_edit", &state);
     ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";

--- a/tests/integration/test_new_game.cpp
+++ b/tests/integration/test_new_game.cpp
@@ -415,6 +415,7 @@ struct ContinuePlayerCountState {
     bool saw_three_seats = false;
     unsigned char live_count_after_continue = 0;
     std::array<bool, 4> visible_seat_cards{};
+    bool fourth_slot_offers_a_seat = false;
     std::string founded_slot;
     std::string continued_slot;
 };
@@ -442,24 +443,26 @@ static int continue_player_count_injector(void* data)
     state->saw_initial_base_camp = true;
     state->founded_slot = og::data::active_company_slot();
     SDL_Delay(750);
-    if (!wait_for_interactable("add_seat", 5000))
+    // A slot with no seat in it IS the add door: with one seat claimed, slot
+    // one wears ADD PLAYER, and the click lands when it stops wearing it.
+    if (!wait_for_interactable_label("seat_card_1", "ADD PLAYER", 5000))
         return 0;
     state->saw_seat_add = true;
     SDL_Delay(300);
     fprintf(stderr, "  [test] adding local seat 2 in Base Camp\n");
-    interact("add_seat");
-    if (!wait_for_interactable("seat_card_1", 5000))
+    interact("seat_card_1");
+    if (!wait_for_interactable_label_change("seat_card_1", "ADD PLAYER", 5000))
         return 0;
-    // The + row deliberately rejects a second activation inside 250 ms so a
-    // touch release cannot create two seats. Cross that boundary before the
+    // The add door deliberately rejects a second activation inside 250 ms so
+    // a touch release cannot create two seats. Cross that boundary before the
     // intentional second click.
     SDL_Delay(300);
     fprintf(stderr, "  [test] adding local seat 3 in Base Camp\n");
-    interact("add_seat");
-    if (!wait_for_interactable("seat_card_2", 5000))
+    interact("seat_card_2");
+    if (!wait_for_interactable_label_change("seat_card_2", "ADD PLAYER", 5000))
         return 0;
 
-    // Let the + release edge clear before injecting the next press.
+    // Let the release edge clear before injecting the next press.
     SDL_Delay(300);
     fprintf(stderr, "  [test] backing out of the new company's Base Camp\n");
     interact("back");
@@ -474,15 +477,20 @@ static int continue_player_count_injector(void* data)
         return 0;
     state->saw_continued_base_camp = true;
     state->continued_slot = og::data::active_company_slot();
+    // All four slots are on screen; three of them hold this machine's seats
+    // and the fourth still offers one. "Seat card" now means "a slot that is
+    // not the ADD PLAYER door".
+    const auto seat_card = [](int index) {
+        const std::string label =
+            interactable_label("seat_card_" + std::to_string(index));
+        return !label.empty() && label != "ADD PLAYER" &&
+            label != "LOBBY FULL";
+    };
     const auto wait_for_three_seat_cards = [&] {
         int elapsed = 0;
         constexpr int poll_interval = 50;
         while (elapsed < 5000) {
-            const bool first = has_interactable("seat_card_0");
-            const bool second = has_interactable("seat_card_1");
-            const bool third = has_interactable("seat_card_2");
-            const bool fourth = has_interactable("seat_card_3");
-            if (first && second && third && !fourth)
+            if (seat_card(0) && seat_card(1) && seat_card(2) && !seat_card(3))
                 return true;
             SDL_Delay(poll_interval);
             elapsed += poll_interval;
@@ -492,9 +500,10 @@ static int continue_player_count_injector(void* data)
     state->saw_three_seats = wait_for_three_seat_cards();
     for (std::size_t index = 0; index < state->visible_seat_cards.size();
          ++index) {
-        state->visible_seat_cards[index] =
-            has_interactable("seat_card_" + std::to_string(index));
+        state->visible_seat_cards[index] = seat_card(static_cast<int>(index));
     }
+    state->fourth_slot_offers_a_seat =
+        interactable_label("seat_card_3") == "ADD PLAYER";
 
     // Let CONTINUE's click-release edge clear before clicking BACK; otherwise
     // the synthetic second click can be swallowed and leave picker_main open.
@@ -572,6 +581,8 @@ TEST(NewGame, player_count_survives_back_then_continue)
     EXPECT_TRUE(state.visible_seat_cards[2]);
     EXPECT_FALSE(state.visible_seat_cards[3])
         << "three local players must render exactly three seat cards";
+    EXPECT_TRUE(state.fourth_slot_offers_a_seat)
+        << "the fourth slot stays on screen as the ADD PLAYER door";
 
     // The session setting must not leak into the company file. Offset 132 is
     // retained solely so historical GTL readers see a valid one-player save.

--- a/tests/integration/test_new_game.cpp
+++ b/tests/integration/test_new_game.cpp
@@ -77,7 +77,26 @@ struct NewGameState {
     bool finished;
     bool saw_team_menu;
     bool saw_networking_button;
+    // #237 derivation pin: fades counted across the BEGIN NEW GAME door.
+    // -1 means the injector never reached the read.
+    int fades_added_by_name_entry;
 };
+
+// Under TESTING every fadeblack takes FadeBetween's test-mode branch, which
+// traces exactly one "video" line per fade — so counting those lines counts
+// fades. The #237 rule is derived inside run_menu_screen rather than declared
+// on a spec, so only driving the real door proves which side a screen is on.
+static int count_fade_between_traces()
+{
+    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    int fades = 0;
+    for (const TraceEntry& entry : g_trace_buffer) {
+        if (entry.category == "video" &&
+            entry.message.find("FadeBetween") != std::string::npos)
+            ++fades;
+    }
+    return fades;
+}
 
 static int new_game_injector(void* data)
 {
@@ -90,12 +109,18 @@ static int new_game_injector(void* data)
     SDL_Delay(750);
 
     fprintf(stderr, "  [test] clicking begin_new_game\n");
+    // #237: the new-game cut is a context switch, and name entry is its first
+    // step — so its entry fades, unlike the doors that stay inside the menu
+    // cluster.
+    const int fades_before_new_game = count_fade_between_traces();
     interact("begin_new_game");
 
     // §2.2: BEGIN NEW GAME now opens the name-entry screen first. Accept the
     // generated company name to found the company.
     wait_for_interactable("company_name_accept", 5000);
     SDL_Delay(750);  // menu-entry settle
+    state->fades_added_by_name_entry =
+        count_fade_between_traces() - fades_before_new_game;
     fprintf(stderr, "  [test] accepting generated company name\n");
     interact("company_name_accept");
 
@@ -141,7 +166,7 @@ TEST(NewGame, begin_new_game) {
     og::runtime::current_session->myscreen_->save_data.team_size = 1;
     og::runtime::current_session->myscreen_->save_data.save("save0");
 
-    NewGameState state = { false, false, false, false };
+    NewGameState state = { false, false, false, false, -1 };
     SDL_Thread* thread = SDL_CreateThread(new_game_injector, "new_game_test", &state);
     ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
 
@@ -166,6 +191,13 @@ TEST(NewGame, begin_new_game) {
 
     // §2.2: the name-entry ACCEPT founded the company (traced with the chosen
     // display name), and that name landed in the 40-byte save_name field.
+    // #237, derived rather than declared: BEGIN NEW GAME is a context switch
+    // and name entry is its first step, so the entry fades out and back in
+    // exactly once. (Contrast the LOAD / BACKUPS doors, pinned at 0 in
+    // test_company_list.)
+    EXPECT_EQ(2, state.fades_added_by_name_entry)
+        << "#237: the name-entry screen is the new-game context switch — its "
+           "entry must fade out and in exactly once";
     ASSERT_TRUE(trace_contains("name_entry", "accept")) << "name-entry ACCEPT should have fired";
     ASSERT_FALSE(og::runtime::current_session->myscreen_->save_data.save_name.empty())
         << "the founded company's display name should be stamped into save_name";
@@ -212,7 +244,7 @@ TEST(NewGame, name_entry_back_cancels_without_founding) {
         "gladiator";
     og::runtime::current_session->myscreen_->save_data.save("save0");
 
-    NewGameState state = { false, false, false, false };
+    NewGameState state = { false, false, false, false, -1 };
     SDL_Thread* thread =
         SDL_CreateThread(name_entry_cancel_injector, "name_entry_cancel", &state);
     ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
@@ -313,7 +345,7 @@ static int name_entry_edit_injector(void* data)
 TEST(NewGame, name_entry_edit_strip_sets_company_name) {
     trace_clear();
 
-    NewGameState state = { false, false, false, false };
+    NewGameState state = { false, false, false, false, -1 };
     SDL_Thread* thread =
         SDL_CreateThread(name_entry_edit_injector, "name_entry_edit", &state);
     ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";

--- a/tests/integration/test_new_game.cpp
+++ b/tests/integration/test_new_game.cpp
@@ -128,9 +128,11 @@ static int new_game_injector(void* data)
     interact("company_name_accept");
 
     // The campaign intro no longer runs inside picker_prepare_new_game_setup
-    // (issue #186: it moved behind the campaign select, whose TESTING
-    // short-circuit skips it here), so the flow proceeds to the team-build
-    // menu without further input.
+    // (issue #186: it moved behind the campaign select). Under TESTING the
+    // browser auto-accepts the current campaign and the intro scroller
+    // dismisses itself, each after one real presented frame, so the flow
+    // proceeds to the team-build menu without further input (the per-leg
+    // fades of those two screens are pinned in test_fade_ownership.cpp).
     SDL_Delay(500);
     if (wait_for_team_menu()) {
         state->saw_team_menu = true;
@@ -348,10 +350,10 @@ static int name_entry_edit_injector(void* data)
         interact("company_name_accept");
     }
 
-    // No campaign intro here anymore (issue #186: it moved behind the
-    // campaign select, skipped under TESTING) — the flow reaches team build
-    // on its own. Unwind back to the main menu so picker_main can hit its
-    // Quit gate.
+    // The campaign select and intro run un-driven under TESTING (auto-accept
+    // and auto-dismiss after one presented frame each) — the flow reaches
+    // team build on its own. Unwind back to the main menu so picker_main can
+    // hit its Quit gate.
     SDL_Delay(500);
     if (wait_for_team_menu()) {
         state->saw_team_menu = true;
@@ -433,7 +435,8 @@ static int continue_player_count_injector(void* data)
         return 0;
 
     // picker_prepare_new_game_setup no longer blocks on the campaign intro
-    // (issue #186); the flow lands on Base Camp directly.
+    // (issue #186); the campaign select and intro run un-driven under
+    // TESTING and the flow lands on Base Camp on its own.
     if (!wait_for_team_menu())
         return 0;
     state->saw_initial_base_camp = true;

--- a/tests/integration/test_options_menu.cpp
+++ b/tests/integration/test_options_menu.cpp
@@ -502,14 +502,22 @@ static int options_injector(void* data)
             // the per-frame label sync must fall back to the classic
             // defaults, never a blank face.
             {
-                const std::string prev_zoom = cfg.get_setting("graphics", "zoom");
-                const std::string prev_smoothing =
-                    cfg.get_setting("graphics", "smoothing");
-                const std::string prev_render =
-                    cfg.get_setting("graphics", "render");
-                cfg.apply_setting("graphics", "zoom", "");
-                cfg.apply_setting("graphics", "smoothing", "");
-                cfg.apply_setting("graphics", "render", "normal");
+                // cfg is a map of maps the menu thread's label sync reads
+                // every frame, so the save/clear and the restore each run
+                // THERE as one task (#257). Capturing the saved values by
+                // reference is safe: the post is waited on before this scope
+                // ends.
+                std::string prev_zoom;
+                std::string prev_smoothing;
+                std::string prev_render;
+                (void)run_on_main_thread([&] {
+                    prev_zoom = cfg.get_setting("graphics", "zoom");
+                    prev_smoothing = cfg.get_setting("graphics", "smoothing");
+                    prev_render = cfg.get_setting("graphics", "render");
+                    cfg.apply_setting("graphics", "zoom", "");
+                    cfg.apply_setting("graphics", "smoothing", "");
+                    cfg.apply_setting("graphics", "render", "normal");
+                });
                 SDL_Delay(300);  // let the display loop run label-sync frames
                 for (const Interactable& item : get_interactables()) {
                     if (item.id == "display_zoom")
@@ -517,9 +525,11 @@ static int options_injector(void* data)
                     if (item.id == "display_smoothing")
                         state->smoothing_label_when_unset = item.label;
                 }
-                cfg.apply_setting("graphics", "zoom", prev_zoom);
-                cfg.apply_setting("graphics", "smoothing", prev_smoothing);
-                cfg.apply_setting("graphics", "render", prev_render);
+                (void)run_on_main_thread([&] {
+                    cfg.apply_setting("graphics", "zoom", prev_zoom);
+                    cfg.apply_setting("graphics", "smoothing", prev_smoothing);
+                    cfg.apply_setting("graphics", "render", prev_render);
+                });
                 SDL_Delay(150);
             }
             fprintf(stderr, "  [test] cycling display mode\n");
@@ -558,7 +568,8 @@ static int options_injector(void* data)
             // graphics/render value at "sai". Pin this selector to explicit
             // Off so the zoom traces are order-independent and exercise the
             // nearest path before the separate smoothing lap below.
-            cfg.apply_setting("graphics", "smoothing", "off");
+            (void)run_on_main_thread(
+                [] { cfg.apply_setting("graphics", "smoothing", "off"); });
             // Resolution application may have emitted canvas traces using a
             // legacy order-dependent smoothing value. From here onward only
             // the explicit zoom/smoothing laps may satisfy renderer checks.
@@ -633,10 +644,14 @@ static int options_injector(void* data)
                 if (is_gore) {
                     // Bring the loader in line with cfg first, so the click's
                     // direction is known whatever earlier tests left behind.
-                    loader* game_loader =
-                        og::runtime::current_session->myscreen_->myloader;
-                    if (game_loader != nullptr)
-                        game_loader->sync_gore_graphics();
+                    // It repaints sprite pixels the menu thread is drawing
+                    // from, so it runs there (#257).
+                    (void)run_on_main_thread([] {
+                        loader* game_loader =
+                            og::runtime::current_session->myscreen_->myloader;
+                        if (game_loader != nullptr)
+                            game_loader->sync_gore_graphics();
+                    });
                     blood_was_gory = live_blood_is_gory();
                 }
                 state->toggled_fx[s][t] = toggle.cycle

--- a/tests/integration/test_options_menu.cpp
+++ b/tests/integration/test_options_menu.cpp
@@ -176,6 +176,12 @@ struct OptionsState {
     // string (as in any process that never ran load_settings()).
     std::string zoom_label_when_unset;
     std::string smoothing_label_when_unset;
+    // #257: every cfg/keymap/sprite read and write this injector makes is
+    // handed to the menu thread's pump. A task that never ran there would
+    // leave the checks below judging state nobody changed (or, for the
+    // save/restore pair, leave the display screen on cleared cfg values), so
+    // the whole flow is only meaningful while this stays true.
+    bool main_thread_tasks_all_ran = true;
 };
 
 // blood.png is solid palette index 40 (the red); blood_friendly.png is drawn
@@ -196,6 +202,26 @@ static bool live_blood_is_gory()
                      static_cast<unsigned char>(40)) != blood.data.get() + len;
 }
 
+// #257, the read side. cfg is a map of maps whose nodes the menu thread's
+// per-frame label sync inserts into and whose std::strings it overwrites, so
+// an injector may not walk it either: post a task that copies the value out
+// on the menu thread and use the copy. A read that never reached the pump
+// returns false and fails whatever check asked for it — it never passes a
+// stale or torn value off as the live setting.
+static bool main_thread_cfg_setting(const char* category, const char* key,
+                                    std::string& out)
+{
+    return run_on_main_thread(
+        [&out, category, key] { out = cfg.get_setting(category, key); });
+}
+
+static bool main_thread_cfg_is_on(const char* category, const char* key,
+                                  bool& out)
+{
+    return run_on_main_thread(
+        [&out, category, key] { out = cfg.is_on(category, key); });
+}
+
 // Click an FX-subscreen toggle and report whether its cfg key flipped.
 // Under machine load a single click can be dropped (the press is still held
 // when the handler samples the mouse), so poll for the flip and re-click
@@ -205,14 +231,19 @@ static bool live_blood_is_gory()
 static bool toggle_effect_and_check_flip(const char* button_id, const char* category,
                                          const char* cfg_key)
 {
-    const bool before = cfg.is_on(category, cfg_key);
+    bool before = false;
+    if (!main_thread_cfg_is_on(category, cfg_key, before))
+        return false;
     const Uint64 deadline = SDL_GetTicks() + 5000;
     interact(button_id);
     for (;;) {
         // 300ms per the menu-test discipline: a shorter gap can land the next
         // click while this one's press is still held, and it gets dropped.
         SDL_Delay(300);
-        if (cfg.is_on(category, cfg_key) != before)
+        bool now = before;
+        if (!main_thread_cfg_is_on(category, cfg_key, now))
+            return false;
+        if (now != before)
             return true;
         if (SDL_GetTicks() >= deadline)
             return false;
@@ -225,16 +256,41 @@ static bool toggle_effect_and_check_flip(const char* button_id, const char* cate
 static bool click_cycle_step(const char* button_id, const char* category,
                              const char* cfg_key)
 {
-    const std::string before = cfg.get_setting(category, cfg_key);
+    std::string before;
+    if (!main_thread_cfg_setting(category, cfg_key, before))
+        return false;
     const Uint64 deadline = SDL_GetTicks() + 5000;
     interact(button_id);
     for (;;) {
         SDL_Delay(300);
-        if (cfg.get_setting(category, cfg_key) != before)
+        std::string now;
+        if (!main_thread_cfg_setting(category, cfg_key, now))
+            return false;
+        if (now != before)
             return true;
         if (SDL_GetTicks() >= deadline)
             return false;
         interact(button_id);
+    }
+}
+
+// The poll shape every lap below ends with: re-click until the stored value
+// reaches `expected`, deadline-bounded, reading cfg on the menu thread.
+static bool click_until_cfg_setting(const char* button_id, const char* category,
+                                    const char* cfg_key,
+                                    const std::string& expected)
+{
+    const Uint64 deadline = SDL_GetTicks() + 5000;
+    for (;;) {
+        std::string now;
+        if (!main_thread_cfg_setting(category, cfg_key, now))
+            return false;
+        if (now == expected)
+            return true;
+        if (SDL_GetTicks() >= deadline)
+            return false;
+        interact(button_id);
+        SDL_Delay(300);
     }
 }
 
@@ -246,7 +302,9 @@ static bool click_cycle_step(const char* button_id, const char* category,
 static bool cycle_effect_and_check_lap(const char* button_id, const char* category,
                                        const char* cfg_key)
 {
-    std::string expected = cfg.get_setting(category, cfg_key);
+    std::string expected;
+    if (!main_thread_cfg_setting(category, cfg_key, expected))
+        return false;
     for (int i = 0; i < 5; ++i)
         expected = og::ui::cycle_depth_fx(expected);
 
@@ -254,14 +312,7 @@ static bool cycle_effect_and_check_lap(const char* button_id, const char* catego
         if (!click_cycle_step(button_id, category, cfg_key))
             return false;
 
-    const Uint64 deadline = SDL_GetTicks() + 5000;
-    while (cfg.get_setting(category, cfg_key) != expected) {
-        if (SDL_GetTicks() >= deadline)
-            return false;
-        interact(button_id);
-        SDL_Delay(300);
-    }
-    return true;
+    return click_until_cfg_setting(button_id, category, cfg_key, expected);
 }
 
 // The SPEED cycler's eleven-step lap over cfg gameplay/timer_wait. The
@@ -271,7 +322,9 @@ static bool cycle_effect_and_check_lap(const char* button_id, const char* catego
 static bool cycle_game_speed_and_check_lap(const char* button_id,
                                            OptionsState* state)
 {
-    std::string expected = cfg.get_setting("gameplay", "timer_wait");
+    std::string expected;
+    if (!main_thread_cfg_setting("gameplay", "timer_wait", expected))
+        return false;
     for (int i = 0; i < 11; ++i)
         expected = og::ui::cycle_game_speed(expected);
 
@@ -279,21 +332,23 @@ static bool cycle_game_speed_and_check_lap(const char* button_id,
         if (!click_cycle_step(button_id, "gameplay", "timer_wait"))
             return false;
         if (i == 0) {
-            state->cfg_timer_wait_after_speed_click =
-                og::ui::parse_timer_wait(cfg.get_setting("gameplay", "timer_wait"));
-            state->world_timer_wait_after_speed_click = static_cast<int>(
-                og::runtime::current_session->myscreen_->world().timer_wait);
+            // Both halves of the pair are read on the menu thread, in one
+            // task: cfg is the map, world().timer_wait is the live sim field
+            // the same click writes.
+            if (!run_on_main_thread([state] {
+                    state->cfg_timer_wait_after_speed_click =
+                        og::ui::parse_timer_wait(
+                            cfg.get_setting("gameplay", "timer_wait"));
+                    state->world_timer_wait_after_speed_click =
+                        static_cast<int>(og::runtime::current_session
+                                             ->myscreen_->world().timer_wait);
+                }))
+                return false;
         }
     }
 
-    const Uint64 deadline = SDL_GetTicks() + 5000;
-    while (cfg.get_setting("gameplay", "timer_wait") != expected) {
-        if (SDL_GetTicks() >= deadline)
-            return false;
-        interact(button_id);
-        SDL_Delay(300);
-    }
-    return true;
+    return click_until_cfg_setting(button_id, "gameplay", "timer_wait",
+                                   expected);
 }
 
 // The zoom selector cycles over the resource-safe range for the current
@@ -304,7 +359,9 @@ static bool cycle_zoom_and_check_lap(const char* button_id,
                                      int minimum_steps)
 {
     const int lap_steps = og::kZoomStepsMax - minimum_steps + 1;
-    std::string expected = cfg.get_setting("graphics", "zoom");
+    std::string expected;
+    if (!main_thread_cfg_setting("graphics", "zoom", expected))
+        return false;
     for (int i = 0; i < lap_steps; ++i)
         expected = og::ui::cycle_zoom(expected, minimum_steps);
 
@@ -312,14 +369,7 @@ static bool cycle_zoom_and_check_lap(const char* button_id,
         if (!click_cycle_step(button_id, "graphics", "zoom"))
             return false;
 
-    const Uint64 deadline = SDL_GetTicks() + 5000;
-    while (cfg.get_setting("graphics", "zoom") != expected) {
-        if (SDL_GetTicks() >= deadline)
-            return false;
-        interact(button_id);
-        SDL_Delay(300);
-    }
-    return true;
+    return click_until_cfg_setting(button_id, "graphics", "zoom", expected);
 }
 
 // The smoothing selector's three-way lap (off -> sai -> eagle -> off) over
@@ -327,9 +377,15 @@ static bool cycle_zoom_and_check_lap(const char* button_id,
 // engine (the canvas dims are zoom-owned and stay put).
 static bool cycle_smoothing_and_check_lap(const char* button_id)
 {
-    std::string expected = og::ui::effective_smoothing_setting(
-        cfg.get_setting("graphics", "smoothing"),
-        cfg.get_setting("graphics", "render"));
+    std::string smoothing;
+    std::string render;
+    if (!run_on_main_thread([&smoothing, &render] {
+            smoothing = cfg.get_setting("graphics", "smoothing");
+            render = cfg.get_setting("graphics", "render");
+        }))
+        return false;
+    std::string expected =
+        og::ui::effective_smoothing_setting(smoothing, render);
     for (int i = 0; i < 3; ++i)
         expected = og::ui::cycle_smoothing(expected);
 
@@ -337,14 +393,8 @@ static bool cycle_smoothing_and_check_lap(const char* button_id)
         if (!click_cycle_step(button_id, "graphics", "smoothing"))
             return false;
 
-    const Uint64 deadline = SDL_GetTicks() + 5000;
-    while (cfg.get_setting("graphics", "smoothing") != expected) {
-        if (SDL_GetTicks() >= deadline)
-            return false;
-        interact(button_id);
-        SDL_Delay(300);
-    }
-    return true;
+    return click_until_cfg_setting(button_id, "graphics", "smoothing",
+                                   expected);
 }
 
 // Click the display-mode selector around one observable lap. Drivers without
@@ -352,12 +402,16 @@ static bool cycle_smoothing_and_check_lap(const char* button_id)
 // has two steps there and three where all modes are supported.
 static bool cycle_display_mode_and_check_lap(const char* button_id)
 {
-    const og::ui::DisplayMode start =
-        og::ui::parse_display_mode(cfg.get_setting("graphics", "fullscreen"));
+    std::string raw;
+    if (!main_thread_cfg_setting("graphics", "fullscreen", raw))
+        return false;
+    const og::ui::DisplayMode start = og::ui::parse_display_mode(raw);
     for (int i = 0; i < 3; ++i) {
         if (!click_cycle_step(button_id, "graphics", "fullscreen"))
             return false;
-        if (og::ui::parse_display_mode(cfg.get_setting("graphics", "fullscreen")) == start)
+        if (!main_thread_cfg_setting("graphics", "fullscreen", raw))
+            return false;
+        if (og::ui::parse_display_mode(raw) == start)
             return true;
     }
     return false;
@@ -366,9 +420,10 @@ static bool cycle_display_mode_and_check_lap(const char* button_id)
 static bool select_windowed_mode(const char* button_id)
 {
     for (int i = 0; i < 3; ++i) {
-        if (og::ui::parse_display_mode(
-                cfg.get_setting("graphics", "fullscreen")) ==
-            og::ui::DisplayMode::Windowed)
+        std::string raw;
+        if (!main_thread_cfg_setting("graphics", "fullscreen", raw))
+            return false;
+        if (og::ui::parse_display_mode(raw) == og::ui::DisplayMode::Windowed)
             return true;
         if (!click_cycle_step(button_id, "graphics", "fullscreen"))
             return false;
@@ -389,41 +444,56 @@ static std::string latest_trace_message(const char* category)
 // graphics/width follows the pure next_resolution orbit. Mirrors the
 // picker's resolution_choices(): only real platform modes in Exclusive;
 // otherwise the logical desktop-derived fallback plus the current cfg size.
-static std::vector<std::pair<int, int>> expected_resolution_choices()
+// The whole derivation runs on the menu thread (#257): it walks cfg for four
+// keys and asks the live screen (i.e. SDL) for the platform's mode list, both
+// of which the menu loop owns.
+static bool expected_resolution_choices(std::vector<std::pair<int, int>>& out,
+                                        std::pair<int, int>& current_out)
 {
-    screen* scr = og::runtime::current_session->myscreen_;
-	const og::ui::DisplayMode mode = og::ui::parse_display_mode(
-		cfg.get_setting("graphics", "fullscreen"));
-    const std::pair<int, int> current = og::ui::parse_resolution(
-        cfg.get_setting("graphics", "width"), cfg.get_setting("graphics", "height"));
-	const std::vector<std::pair<int, int>> display_modes =
-		mode == og::ui::DisplayMode::Exclusive
-			? scr->display_resolutions()
-			: std::vector<std::pair<int, int>>{};
-	const std::pair<int, int> desktop =
-		mode == og::ui::DisplayMode::Exclusive
-			? scr->desktop_resolution()
-			: scr->windowed_desktop_resolution();
-    return og::ui::build_resolution_choices(
-		display_modes, desktop, current, mode);
+    return run_on_main_thread([&out, &current_out] {
+        screen* scr = og::runtime::current_session->myscreen_;
+        const og::ui::DisplayMode mode = og::ui::parse_display_mode(
+            cfg.get_setting("graphics", "fullscreen"));
+        const std::pair<int, int> current = og::ui::parse_resolution(
+            cfg.get_setting("graphics", "width"),
+            cfg.get_setting("graphics", "height"));
+        const std::vector<std::pair<int, int>> display_modes =
+            mode == og::ui::DisplayMode::Exclusive
+                ? scr->display_resolutions()
+                : std::vector<std::pair<int, int>>{};
+        const std::pair<int, int> desktop =
+            mode == og::ui::DisplayMode::Exclusive
+                ? scr->desktop_resolution()
+                : scr->windowed_desktop_resolution();
+        current_out = current;
+        out = og::ui::build_resolution_choices(display_modes, desktop, current,
+                                               mode);
+    });
 }
 
 static bool cycle_resolution_and_check_lap(const char* button_id)
 {
     // First click: leaves the (off-list) boot default for its neighbor on
     // the current-inclusive lap.
-    const std::vector<std::pair<int, int>> start_list = expected_resolution_choices();
+    std::vector<std::pair<int, int>> start_list;
+    std::pair<int, int> start_current{0, 0};
+    if (!expected_resolution_choices(start_list, start_current))
+        return false;
     const std::pair<int, int> first = og::ui::next_resolution(
-        start_list, cfg.get_setting("graphics", "width"),
-        cfg.get_setting("graphics", "height"));
+        start_list, std::to_string(start_current.first),
+        std::to_string(start_current.second));
     if (start_list.size() <= 1)
-        return first == og::ui::parse_resolution(
-            cfg.get_setting("graphics", "width"), cfg.get_setting("graphics", "height"));
+        return first == start_current;
     if (!click_cycle_step(button_id, "graphics", "width"))
         return false;
     {
         const Uint64 deadline = SDL_GetTicks() + 5000;
-        while (cfg.get_setting("graphics", "width") != std::to_string(first.first)) {
+        for (;;) {
+            std::string width;
+            if (!main_thread_cfg_setting("graphics", "width", width))
+                return false;
+            if (width == std::to_string(first.first))
+                break;
             if (SDL_GetTicks() >= deadline)
                 return false;
             SDL_Delay(100);
@@ -432,19 +502,17 @@ static bool cycle_resolution_and_check_lap(const char* button_id)
 
     // From an in-list entry the lap is stationary: one full orbit of the
     // base list must return exactly here.
-    const std::vector<std::pair<int, int>> list = expected_resolution_choices();
-    const std::string lap_start = cfg.get_setting("graphics", "width");
+    std::vector<std::pair<int, int>> list;
+    std::pair<int, int> lap_current{0, 0};
+    if (!expected_resolution_choices(list, lap_current))
+        return false;
+    std::string lap_start;
+    if (!main_thread_cfg_setting("graphics", "width", lap_start))
+        return false;
     for (std::size_t i = 0; i < list.size(); ++i)
         if (!click_cycle_step(button_id, "graphics", "width"))
             return false;
-    const Uint64 deadline = SDL_GetTicks() + 5000;
-    while (cfg.get_setting("graphics", "width") != lap_start) {
-        if (SDL_GetTicks() >= deadline)
-            return false;
-        interact(button_id);
-        SDL_Delay(300);
-    }
-    return true;
+    return click_until_cfg_setting(button_id, "graphics", "width", lap_start);
 }
 
 static int options_injector(void* data)
@@ -476,9 +544,18 @@ static int options_injector(void* data)
         // them. Change P1's direction mode exactly as a player screen does
         // (the row calls this function), then check it survives the restore.
         fprintf(stderr, "  [test] changing the P1 direction mode\n");
-        toggle_player_control_mode(0);
+        // The toggle rewrites the live per-player key tables the menu loop
+        // samples every frame (sync_runtime_keys_to_active_mode +
+        // activate_mode_keymap_for_player), so it runs on the menu thread and
+        // reads the new mode back in the same task (#257).
+        int mode_after_toggle = state->initial_control_mode;
+        state->main_thread_tasks_all_ran &=
+            run_on_main_thread([&mode_after_toggle] {
+                toggle_player_control_mode(0);
+                mode_after_toggle = get_player_control_mode(0);
+            });
         state->changed_control_mode =
-            get_player_control_mode(0) != state->initial_control_mode;
+            mode_after_toggle != state->initial_control_mode;
 
         fprintf(stderr, "  [test] toggling sound\n");
         interact("toggle_sound");
@@ -505,19 +582,24 @@ static int options_injector(void* data)
                 // cfg is a map of maps the menu thread's label sync reads
                 // every frame, so the save/clear and the restore each run
                 // THERE as one task (#257). Capturing the saved values by
-                // reference is safe: the post is waited on before this scope
-                // ends.
+                // reference is safe because a wait that times out CANCELS its
+                // ticket (tests/test_interact.h): the restore either ran
+                // while these three strings were alive, or it never runs at
+                // all. Both results are folded into the flag the test asserts
+                // — a swallowed timeout would silently leave the display
+                // screen on the cleared values.
                 std::string prev_zoom;
                 std::string prev_smoothing;
                 std::string prev_render;
-                (void)run_on_main_thread([&] {
-                    prev_zoom = cfg.get_setting("graphics", "zoom");
-                    prev_smoothing = cfg.get_setting("graphics", "smoothing");
-                    prev_render = cfg.get_setting("graphics", "render");
-                    cfg.apply_setting("graphics", "zoom", "");
-                    cfg.apply_setting("graphics", "smoothing", "");
-                    cfg.apply_setting("graphics", "render", "normal");
-                });
+                state->main_thread_tasks_all_ran &=
+                    run_on_main_thread([&] {
+                        prev_zoom = cfg.get_setting("graphics", "zoom");
+                        prev_smoothing = cfg.get_setting("graphics", "smoothing");
+                        prev_render = cfg.get_setting("graphics", "render");
+                        cfg.apply_setting("graphics", "zoom", "");
+                        cfg.apply_setting("graphics", "smoothing", "");
+                        cfg.apply_setting("graphics", "render", "normal");
+                    });
                 SDL_Delay(300);  // let the display loop run label-sync frames
                 for (const Interactable& item : get_interactables()) {
                     if (item.id == "display_zoom")
@@ -525,11 +607,12 @@ static int options_injector(void* data)
                     if (item.id == "display_smoothing")
                         state->smoothing_label_when_unset = item.label;
                 }
-                (void)run_on_main_thread([&] {
-                    cfg.apply_setting("graphics", "zoom", prev_zoom);
-                    cfg.apply_setting("graphics", "smoothing", prev_smoothing);
-                    cfg.apply_setting("graphics", "render", prev_render);
-                });
+                state->main_thread_tasks_all_ran &=
+                    run_on_main_thread([&] {
+                        cfg.apply_setting("graphics", "zoom", prev_zoom);
+                        cfg.apply_setting("graphics", "smoothing", prev_smoothing);
+                        cfg.apply_setting("graphics", "render", prev_render);
+                    });
                 SDL_Delay(150);
             }
             fprintf(stderr, "  [test] cycling display mode\n");
@@ -568,7 +651,7 @@ static int options_injector(void* data)
             // graphics/render value at "sai". Pin this selector to explicit
             // Off so the zoom traces are order-independent and exercise the
             // nearest path before the separate smoothing lap below.
-            (void)run_on_main_thread(
+            state->main_thread_tasks_all_ran &= run_on_main_thread(
                 [] { cfg.apply_setting("graphics", "smoothing", "off"); });
             // Resolution application may have emitted canvas traces using a
             // legacy order-dependent smoothing value. From here onward only
@@ -588,18 +671,28 @@ static int options_injector(void* data)
                 click_cycle_step("brightness_plus", "graphics", "brightness") &&
                 click_cycle_step("brightness_plus", "graphics", "brightness");
             SDL_Delay(300);
-            state->cfg_brightness_after_two_plus =
-                og::ui::parse_brightness_steps(
-                    cfg.get_setting("graphics", "brightness"));
-            state->applied_brightness_after_two_plus =
-                static_cast<int>(display_brightness_steps());
+            // cfg and the applied gamma are both menu-thread state; read the
+            // pair in one task so they describe the same frame (#257).
+            state->main_thread_tasks_all_ran &=
+                run_on_main_thread([state] {
+                    state->cfg_brightness_after_two_plus =
+                        og::ui::parse_brightness_steps(
+                            cfg.get_setting("graphics", "brightness"));
+                    state->applied_brightness_after_two_plus =
+                        static_cast<int>(display_brightness_steps());
+                });
             state->stepped_brightness_down =
                 click_cycle_step("brightness_minus", "graphics", "brightness") &&
                 click_cycle_step("brightness_minus", "graphics", "brightness");
             SDL_Delay(300);
-            state->cfg_brightness_after_return =
-                og::ui::parse_brightness_steps(
-                    cfg.get_setting("graphics", "brightness"));
+            {
+                std::string brightness;
+                state->main_thread_tasks_all_ran &=
+                    main_thread_cfg_setting("graphics", "brightness",
+                                            brightness);
+                state->cfg_brightness_after_return =
+                    og::ui::parse_brightness_steps(brightness);
+            }
 
             // A full verified lap of the zoom cycle: every click steps cfg
             // graphics/zoom AND live-applies it to the world canvas (the
@@ -645,14 +738,17 @@ static int options_injector(void* data)
                     // Bring the loader in line with cfg first, so the click's
                     // direction is known whatever earlier tests left behind.
                     // It repaints sprite pixels the menu thread is drawing
-                    // from, so it runs there (#257).
-                    (void)run_on_main_thread([] {
-                        loader* game_loader =
-                            og::runtime::current_session->myscreen_->myloader;
-                        if (game_loader != nullptr)
-                            game_loader->sync_gore_graphics();
-                    });
-                    blood_was_gory = live_blood_is_gory();
+                    // from, so it runs there — and the sprite is read back in
+                    // the same task, before the next frame can touch it
+                    // (#257).
+                    state->main_thread_tasks_all_ran &=
+                        run_on_main_thread([&blood_was_gory] {
+                            loader* game_loader =
+                                og::runtime::current_session->myscreen_->myloader;
+                            if (game_loader != nullptr)
+                                game_loader->sync_gore_graphics();
+                            blood_was_gory = live_blood_is_gory();
+                        });
                 }
                 state->toggled_fx[s][t] = toggle.cycle
                     ? cycle_effect_and_check_lap(
@@ -661,15 +757,25 @@ static int options_injector(void* data)
                           toggle.button_id, toggle.category, toggle.key);
                 if (is_gore && state->toggled_fx[s][t]) {
                     // The click must repaint the live sprite, not just cfg.
+                    // Sprite pixels and cfg are both menu-thread state, so
+                    // each poll reads the pair THERE, as one frame's truth.
                     const Uint64 deadline = SDL_GetTicks() + 3000;
-                    while (live_blood_is_gory() == blood_was_gory &&
-                           SDL_GetTicks() < deadline) {
+                    bool gory = blood_was_gory;
+                    bool cfg_gore = false;
+                    for (;;) {
+                        state->main_thread_tasks_all_ran &=
+                            run_on_main_thread([&gory, &cfg_gore] {
+                                gory = live_blood_is_gory();
+                                cfg_gore = cfg.is_on("effects", "gore");
+                            });
+                        if (gory != blood_was_gory ||
+                            SDL_GetTicks() >= deadline)
+                            break;
                         SDL_Delay(50);
                     }
                     state->gore_sprite_followed_toggle =
-                        live_blood_is_gory() != blood_was_gory;
-                    state->gore_sprite_matches_cfg =
-                        live_blood_is_gory() == cfg.is_on("effects", "gore");
+                        gory != blood_was_gory;
+                    state->gore_sprite_matches_cfg = gory == cfg_gore;
                 }
             }
 
@@ -685,8 +791,13 @@ static int options_injector(void* data)
         fprintf(stderr, "  [test] restoring settings\n");
         interact("restore_defaults");
         SDL_Delay(300);
+        int mode_after_restore = state->initial_control_mode;
+        state->main_thread_tasks_all_ran &=
+            run_on_main_thread([&mode_after_restore] {
+                mode_after_restore = get_player_control_mode(0);
+            });
         state->settings_restore_preserved_controls =
-            get_player_control_mode(0) != state->initial_control_mode;
+            mode_after_restore != state->initial_control_mode;
 
         // Click BACK to return to main menu
         fprintf(stderr, "  [test] clicking options_back\n");
@@ -1002,6 +1113,10 @@ TEST(OptionsMenu, options_menu) {
     ASSERT_TRUE(state.started) << "injector thread should have started";
     ASSERT_TRUE(state.finished) << "injector thread should have completed";
     ASSERT_TRUE(state.saw_options) << "should have entered the options menu";
+    ASSERT_TRUE(state.main_thread_tasks_all_ran)
+        << "#257: every cfg / keymap / sprite read and write in this flow "
+           "must have run on the menu thread's pump; a timed-out task is "
+           "cancelled, so the checks below would judge state nobody changed";
     ASSERT_TRUE(state.changed_control_mode)
         << "the player-screen mode toggle should change the P1 direction mode";
     ASSERT_TRUE(state.settings_restore_preserved_controls)

--- a/tests/integration/test_overpowered_team.cpp
+++ b/tests/integration/test_overpowered_team.cpp
@@ -167,16 +167,20 @@ static int op_injector(void* data)
     // Programmatically crank every stat to ludicrous levels
     state->num_hired = og::runtime::current_session->myscreen_->save_data.team_size;
     fprintf(stderr, "  [test] hired %d characters, cheating stats\n", state->num_hired);
-    for (int i = 0; i < og::runtime::current_session->myscreen_->save_data.team_size; i++) {
-        guy* g = og::runtime::current_session->myscreen_->save_data.team_list[static_cast<std::size_t>(i)].get();
-        if (g) {
-            g->strength = 200;
-            g->dexterity = 200;
-            g->constitution = 200;
-            g->intelligence = 200;
-            g->armor = 200;
+    // On the menu thread (#257): the team menu draws these roster fields
+    // every frame.
+    (void)run_on_main_thread([] {
+        for (int i = 0; i < og::runtime::current_session->myscreen_->save_data.team_size; i++) {
+            guy* g = og::runtime::current_session->myscreen_->save_data.team_list[static_cast<std::size_t>(i)].get();
+            if (g) {
+                g->strength = 200;
+                g->dexterity = 200;
+                g->constitution = 200;
+                g->intelligence = 200;
+                g->armor = 200;
+            }
         }
-    }
+    });
 
     // Set up for auto-win: remove exits so level completes when enemies die
     g_test_remove_exits = true;

--- a/tests/integration/test_pause_menu.cpp
+++ b/tests/integration/test_pause_menu.cpp
@@ -353,7 +353,9 @@ TEST(PauseMenuPins, pause_menu_exact_table)
     EXPECT_FALSE(spec.polls_lobby);
     EXPECT_FALSE(spec.backdrop);
     EXPECT_EQ(og::ui::RemoteStartScope::None, spec.remote_start);
-    EXPECT_EQ(og::ui::EnterTransition::None, spec.enter);
+    // #237: the pause family are the only Overlay screens — true modals over
+    // the live world, never faded even at depth 1.
+    EXPECT_EQ(og::ui::MenuScreenKind::Overlay, spec.kind);
     EXPECT_FALSE(spec.exit_on_redraw);
 }
 
@@ -411,6 +413,8 @@ TEST(PauseMenuPins, pause_player_exact_table)
     EXPECT_TRUE(spec.exit_on_redraw);
     EXPECT_FALSE(spec.polls_lobby);
     EXPECT_EQ(og::ui::RemoteStartScope::None, spec.remote_start);
+    // #237: pause family = Overlay, never faded.
+    EXPECT_EQ(og::ui::MenuScreenKind::Overlay, spec.kind);
 }
 
 // ---------------------------------------------------------------------------
@@ -2506,10 +2510,11 @@ TEST(PauseMenuFlow, restart_mission_relaunches_level_through_picker_loop)
 // Regression (#200): quitting a scenario faded it out TWICE. The teardown in
 // go_menu fades whichever canvas was last presented (World, after the pause
 // menu's exit dance) and clears it, but the UI canvas still held the pause
-// menu image; Base Camp's EnterTransition::FadeAroundEntry then faded THAT
-// out as a second visible transition. On a WIN the results screen presents on
-// the UI canvas, so the second fade was an invisible no-op — hence "only when
-// I quit".
+// menu image; Base Camp's depth-1 entry fade (#237 derivation) then faded
+// THAT out as a second visible transition. On a WIN the results screen
+// presents on the UI canvas, so the second fade was an invisible no-op —
+// hence "only when I quit". The teardown's note_menu_faded_to_black() is
+// what suppresses the entry fade-out today.
 //
 // Under TESTING every fadeblack lands in FadeBetween's test-mode branch, which
 // traces one line per fade. Counting them across the quit is the pin: the

--- a/tests/integration/test_pause_menu.cpp
+++ b/tests/integration/test_pause_menu.cpp
@@ -2513,8 +2513,9 @@ TEST(PauseMenuFlow, restart_mission_relaunches_level_through_picker_loop)
 // menu image; Base Camp's depth-1 entry fade (#237 derivation) then faded
 // THAT out as a second visible transition. On a WIN the results screen
 // presents on the UI canvas, so the second fade was an invisible no-op —
-// hence "only when I quit". The teardown's note_menu_faded_to_black() is
-// what suppresses the entry fade-out today.
+// hence "only when I quit". Today the teardown's fade leaves the WINDOW
+// black (the video layer's single source of truth), and Base Camp's entry
+// fade-out is a no-op on a black window — no note to forget.
 //
 // Under TESTING every fadeblack lands in FadeBetween's test-mode branch, which
 // traces one line per fade. Counting them across the quit is the pin: the

--- a/tests/integration/test_picker_detail_menu_driven.cpp
+++ b/tests/integration/test_picker_detail_menu_driven.cpp
@@ -108,7 +108,10 @@ static int injector_thread_exit_detail_menu(void* data)
     const Uint64 deadline = SDL_GetTicks() + 5000;
     while (SDL_GetTicks() < deadline)
     {
-        if (og::runtime::current_session->allbuttons_[0] != nullptr) // "back" is index 0 in details_buttons
+        // Through the locking accessor: a raw allbuttons_[] read races
+        // init_buttons' publication (#257). BACK is the detail menu's
+        // first row, so its arrival means the menu is up.
+        if (has_interactable("back"))
             break;
         SDL_Delay(5);
     }

--- a/tests/integration/test_picker_network_client.cpp
+++ b/tests/integration/test_picker_network_client.cpp
@@ -7875,10 +7875,11 @@ TEST(PickerNetworkClient,
             host_client->lobby_players(),
             og::ui::kBaseCampLineBCharsHireVisible);
         EXPECT_FALSE(header.alert);
-        EXPECT_EQ("HOSTING GLAD-XKCD: 1 PLAYERS/1 PCS", header.text)
+        EXPECT_EQ("HOSTING GLAD-XKCD: 1 PLAYER/1 PC", header.text)
             << "a healthy hosted room shows role + room + census; beside "
                "HIRE the band is 34, so the census takes its everyday "
-               "spelling rather than losing a word to a byte cut";
+               "spelling rather than losing a word to a byte cut — and a "
+               "lobby of one says PLAYER and PC, not PLAYERS and PCS";
     }
 
     relay_server->stop();

--- a/tests/integration/test_picker_network_client.cpp
+++ b/tests/integration/test_picker_network_client.cpp
@@ -4957,8 +4957,8 @@ TEST(PickerNetworkClient, host_and_join_win_level1_then_ready_up_and_load_level2
             host_client->lobby_players(),
             og::ui::kBaseCampLineBCharsHireVisible);
         EXPECT_FALSE(header.alert) << "healthy link: status, not the alert";
-        EXPECT_EQ("HOSTING 2 MACH / 2 PLYR", header.text)
-            << "the host's line B carries role + census";
+        EXPECT_EQ("HOSTING: 2 PLAYERS / 2 MACHINES", header.text)
+            << "the host's line B carries role + census, players first";
     }
 
     // ---- Same window, JOINER view: own row first, the host's two rows
@@ -4990,9 +4990,10 @@ TEST(PickerNetworkClient, host_and_join_win_level1_then_ready_up_and_load_level2
             join_client->lobby_players(),
             og::ui::kBaseCampLineBCharsHireVisible);
         EXPECT_FALSE(header.alert) << "healthy link: status, not the alert";
-        EXPECT_EQ("JOINED - HOST: IRON KETTLE BAND", header.text)
-            << "the joiner's line B names the host machine's company "
-               "(direct join: no room code)";
+        EXPECT_EQ("JOINED: 2 PLAYERS / 2 MACHINES", header.text)
+            << "the joiner's line B carries the same census the host's does "
+               "(direct join: no room code). The host's company is on every "
+               "one of its roster rows; the census is on none of them.";
     }
 
     // ---- §2.9 flow 5 / §4.2 per-level reassembly, through the PRODUCTION
@@ -7874,10 +7875,10 @@ TEST(PickerNetworkClient,
             host_client->lobby_players(),
             og::ui::kBaseCampLineBCharsHireVisible);
         EXPECT_FALSE(header.alert);
-        EXPECT_EQ("HOSTING GLAD-XKCD - 1M / 1P", header.text)
-            << "a healthy hosted room shows role + room + census (the "
-               "compact census: the spelled-out shape is 35, one over the "
-               "band beside HIRE)";
+        EXPECT_EQ("HOSTING GLAD-XKCD: 1 PLAYERS/1 PCS", header.text)
+            << "a healthy hosted room shows role + room + census; beside "
+               "HIRE the band is 34, so the census takes its everyday "
+               "spelling rather than losing a word to a byte cut";
     }
 
     relay_server->stop();

--- a/tests/integration/test_results_screen_full_ui.cpp
+++ b/tests/integration/test_results_screen_full_ui.cpp
@@ -195,6 +195,24 @@ static int results_ui_troops_then_ok_injector(void* data)
     return 0;
 }
 
+// #237: gameplay -> results is a context switch, so the panel entry fades —
+// one fade-out plus one fade-in at the loop's first present. Under TESTING
+// each fadeblack traces exactly one FadeBetween line.
+int count_fade_between_traces()
+{
+    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    int fades = 0;
+    for (const TraceEntry& entry : g_trace_buffer)
+    {
+        if (entry.category == "video" &&
+            entry.message.find("FadeBetween") != std::string::npos)
+        {
+            ++fades;
+        }
+    }
+    return fades;
+}
+
 } // namespace
 
 TEST(ResultsScreenFullUi, overview_and_troops_paths)
@@ -292,6 +310,7 @@ TEST(ResultsScreenFullUi, overview_and_troops_paths)
     SDL_Thread* thread = SDL_CreateThread(results_ui_injector, "results_ui_injector", &st);
     ASSERT_TRUE(thread != nullptr) << "failed to create results injector thread";
 
+    trace_clear();
     const bool retry = results_screen(0, 2, before, after);
 
     int rc = 0;
@@ -302,6 +321,9 @@ TEST(ResultsScreenFullUi, overview_and_troops_paths)
 
     ASSERT_TRUE(st.started && st.finished) << "results UI injector should run";
     ASSERT_TRUE(!retry) << "OK path should not request retry";
+    EXPECT_EQ(2, count_fade_between_traces())
+        << "#237: the results entry is a context switch — exactly one "
+           "fade-out plus the first-frame fade-in, and nothing more";
     EXPECT_EQ(CanvasTarget::World, E_Screen->active_canvas());
     EXPECT_EQ(640, E_Screen->render->w);
     EXPECT_EQ(400, E_Screen->render->h);

--- a/tests/integration/test_results_screen_full_ui.cpp
+++ b/tests/integration/test_results_screen_full_ui.cpp
@@ -195,9 +195,11 @@ static int results_ui_troops_then_ok_injector(void* data)
     return 0;
 }
 
-// #237: gameplay -> results is a context switch, so the panel entry fades —
-// one fade-out plus one fade-in at the loop's first present. Under TESTING
-// each fadeblack traces exactly one FadeBetween line.
+// #237: gameplay -> results is a context switch, so the panel fades — one
+// fade-out of the mission frame, one fade-in at the loop's first present, and
+// (the ownership rule) one fade-out of its own last frame at exit, so the
+// teardown fade that follows in go_menu finds a black window and skips. Under
+// TESTING each fadeblack that runs traces exactly one FadeBetween line.
 int count_fade_between_traces()
 {
     std::lock_guard<std::mutex> lock(g_trace_mutex);
@@ -321,9 +323,11 @@ TEST(ResultsScreenFullUi, overview_and_troops_paths)
 
     ASSERT_TRUE(st.started && st.finished) << "results UI injector should run";
     ASSERT_TRUE(!retry) << "OK path should not request retry";
-    EXPECT_EQ(2, count_fade_between_traces())
-        << "#237: the results entry is a context switch — exactly one "
-           "fade-out plus the first-frame fade-in, and nothing more";
+    EXPECT_EQ(3, count_fade_between_traces())
+        << "#237: the results panel is a context switch — exactly one "
+           "fade-out, the first-frame fade-in, and its own exit fade-out";
+    EXPECT_TRUE(og::runtime::current_session->myscreen_->window_is_black())
+        << "the panel's exit leaves the window black for go_menu's teardown";
     EXPECT_EQ(CanvasTarget::World, E_Screen->active_canvas());
     EXPECT_EQ(640, E_Screen->render->w);
     EXPECT_EQ(400, E_Screen->render->h);

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -281,7 +281,7 @@ int mainmenu_no_company_injector(void *data) {
   og::runtime::ensure_thread_session();
   ShotState *state = static_cast<ShotState *>(data);
   wait_for_interactable("begin_new_game", 5000);
-  SDL_Delay(1500); // FadeWithInitialDraw settle
+  SDL_Delay(1500); // menu-entry settle
   state->captures += capture_frame("mainmenu_no_company");
   interact("quit");
   state->finished = true;
@@ -475,7 +475,7 @@ int company_list_injector(void *data) {
   SDL_Delay(1500);
   interact("load_company");
   if (wait_for_interactable("company_row_0", 5000)) {
-    SDL_Delay(1500); // FadeAroundEntry settle
+    SDL_Delay(1500); // menu-entry settle
     state->captures += capture_frame("company_list");
     interact("back");
   }
@@ -1596,7 +1596,7 @@ int help_screen_injector(void *data) {
   og::runtime::ensure_thread_session();
   ShotState *state = static_cast<ShotState *>(data);
   wait_for_interactable("help", 5000);
-  SDL_Delay(1500); // FadeWithInitialDraw settle on the main menu
+  SDL_Delay(1500); // menu-entry settle on the main menu
   interact("help");
   if (wait_for_interactable("help_tab_classes", 5000)) {
     SDL_Delay(500);

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -1049,10 +1049,100 @@ int many_seats_view_level_injector(void *data) {
 
 // --- VIEW LEVEL staged preview (#218, C10) ---------------------------------
 
+// The first staged frame, kept for the frame-to-frame comparison below.
+FramePixels g_view_level_first_frame;
+// The SCENARIO screen captured before the viewer ever opened: the backdrop as
+// it looks with a camera nobody has borrowed yet.
+FramePixels g_menu_before_viewer_frame;
+
+// The backdrop strip the #251 pin watches: everything under the preview frame,
+// down to the bottom of the canvas.
+constexpr int kBackdropStripTopY = 160;
+
+// The viewer's three button faces (kViewScenarioRows in menu_screen_specs).
+// Their labels are static, but a highlight box pulses up to 3 px OUTSIDE the
+// rect it decorates (picker_input.cpp draw_highlight insets by
+// sin(ticks_ms/300)*3), so the excluded rects carry that pulse as a margin.
+// Everything left in the strip is backdrop or static chrome.
+constexpr int kHighlightPulse = 3;
+struct ShotRect {
+  int x, y, w, h;
+};
+constexpr ShotRect kViewScenarioButtonRects[] = {
+    {10, 170, 44, 20}, {220, 170, 40, 20}, {270, 170, 40, 20}};
+
+bool in_view_scenario_button(int x, int y) {
+  for (const ShotRect &r : kViewScenarioButtonRects) {
+    if (x >= r.x - kHighlightPulse && x <= r.x + r.w + kHighlightPulse &&
+        y >= r.y - kHighlightPulse && y <= r.y + r.h + kHighlightPulse)
+      return true;
+  }
+  return false;
+}
+
+// Rows that carry nothing but backdrop on BOTH the SCENARIO screen and the
+// open viewer: the gap between the viewer's report-frame bevel (its bottom
+// edge is row 160) and the y=170 button band, and everything below both
+// screens' buttons. Comparing these ACROSS the two screens is what catches a
+// camera the borrow left at a fixed offset — a displacement that never
+// changes is identical in both in-viewer frames and invisible to the
+// frame-to-frame half.
+constexpr int kBackdropOnlyBands[][2] = {{161, 170}, {190, 200}};
+
+// Differing pixels between two frames over rows [y0, y1).
+std::size_t frame_diff_count(const FramePixels &a, const FramePixels &b, int y0,
+                             int y1, bool skip_button_rects) {
+  std::size_t differing = 0;
+  for (int y = y0; y < y1; ++y) {
+    for (int x = 0; x < 320; ++x) {
+      if (skip_button_rects && in_view_scenario_button(x, y))
+        continue;
+      const std::size_t i =
+          (static_cast<std::size_t>(y) * 320 + static_cast<std::size_t>(x)) * 3;
+      if (a[i] != b[i] || a[i + 1] != b[i + 1] || a[i + 2] != b[i + 2])
+        ++differing;
+    }
+  }
+  return differing;
+}
+
+// Wait-on-condition for the pan: poll the LIVE preview band through the same
+// presenter handshake capture_frame uses until it differs from the reference
+// frame. The pan is a triangle wave over query_timer at ~55 ms per pixel, so
+// this normally returns on the first poll; the ceiling is generous because a
+// loaded host can deschedule the presenter for seconds.
+bool wait_for_preview_band_pan(const FramePixels &reference, int timeout_ms) {
+  if (reference.size() != static_cast<std::size_t>(320 * 200 * 3))
+    return false;
+  screen *scr = og::runtime::current_session->myscreen_;
+  for (int waited = 0; waited < timeout_ms; waited += 100) {
+    SDL_Delay(100);
+    PresentedFramePause frame_pause;
+    if (!frame_pause.acquired())
+      return false;
+    for (int y = kViewScenarioPreviewBandY;
+         y < kViewScenarioPreviewBandY + kViewScenarioPreviewBandH; ++y) {
+      for (int x = kViewScenarioPreviewBandX;
+           x < kViewScenarioPreviewBandX + kViewScenarioPreviewBandW; ++x) {
+        Uint8 r = 0, g = 0, b = 0;
+        scr->get_pixel(x, y, &r, &g, &b);
+        const std::size_t i = (static_cast<std::size_t>(y) * 320 +
+                               static_cast<std::size_t>(x)) *
+                              3;
+        if (reference[i] != r || reference[i + 1] != g || reference[i + 2] != b)
+          return true;
+      }
+    }
+  }
+  fprintf(stderr, "  [uxshot] preview band never moved within %d ms\n",
+          timeout_ms);
+  return false;
+}
+
 // The band region the staged world renders into: (8,16)-(310,91) in classic
 // coordinates (picker_sdl_defs kViewScenarioPreviewBand*). A healed staged
 // pitch fills the band with terrain, so a blank band means the pane died.
-bool check_view_level_staged_band(const FramePixels &rgb) {
+bool staged_band_is_populated(const FramePixels &rgb) {
   std::size_t nonblack = 0;
   for (int y = 16; y < 16 + 76; ++y) {
     for (int x = 8; x < 8 + 303; ++x) {
@@ -1067,6 +1157,81 @@ bool check_view_level_staged_band(const FramePixels &rgb) {
             nonblack);
     return false;
   }
+  return true;
+}
+
+// The pre-viewer reference frame.
+bool stash_menu_before_viewer(const FramePixels &rgb) {
+  if (rgb.size() != static_cast<std::size_t>(320 * 200 * 3)) {
+    fprintf(stderr, "  [uxshot] pre-viewer frame is the wrong size\n");
+    return false;
+  }
+  g_menu_before_viewer_frame = rgb;
+  return true;
+}
+
+// The first in-viewer frame: checked against the pre-viewer backdrop, then
+// kept as the reference the second one is judged against.
+bool check_view_level_staged_band(const FramePixels &rgb) {
+  if (!staged_band_is_populated(rgb))
+    return false;
+  if (g_menu_before_viewer_frame.size() != rgb.size()) {
+    fprintf(stderr, "  [uxshot] no pre-viewer frame to compare against\n");
+    return false;
+  }
+  for (const auto &band : kBackdropOnlyBands) {
+    const std::size_t moved =
+        frame_diff_count(g_menu_before_viewer_frame, rgb, band[0], band[1],
+                         /*skip_button_rects=*/false);
+    if (moved != 0) {
+      fprintf(stderr,
+              "  [uxshot] backdrop rows %d..%d differ from the pre-viewer "
+              "menu: %zu px\n",
+              band[0], band[1] - 1, moved);
+      return false;
+    }
+  }
+  g_view_level_first_frame = rgb;
+  return true;
+}
+
+// #251, the second half of the intra-screen camera pin. draw_backdrop() paints
+// the four menu quadrants THROUGH viewob[0] at the top of the same hook that
+// then lends the view to the staged preview, so a camera left behind on the
+// view slides the whole menu background by the previous frame's pan offset.
+// Every other pin samples the camera after the viewer has already exited; only
+// frames captured WHILE it is open can see the slide. This one holds the
+// backdrop still between two pan phases; check_view_level_staged_band holds it
+// against the pre-viewer menu.
+bool check_view_level_staged_panned(const FramePixels &rgb) {
+  if (!staged_band_is_populated(rgb))
+    return false;
+  if (g_view_level_first_frame.size() != rgb.size()) {
+    fprintf(stderr, "  [uxshot] no first staged frame to compare against\n");
+    return false;
+  }
+  const std::size_t backdrop_diff =
+      frame_diff_count(g_view_level_first_frame, rgb, kBackdropStripTopY, 200,
+                       /*skip_button_rects=*/true);
+  const std::size_t band_diff = frame_diff_count(
+      g_view_level_first_frame, rgb, kViewScenarioPreviewBandY,
+      kViewScenarioPreviewBandY + kViewScenarioPreviewBandH,
+      /*skip_button_rects=*/false);
+  if (backdrop_diff != 0) {
+    fprintf(stderr,
+            "  [uxshot] backdrop strip moved between staged frames: %zu px\n",
+            backdrop_diff);
+    return false;
+  }
+  // Teeth: without a live pan the identical-backdrop half above would pass on
+  // a frozen screen.
+  if (band_diff == 0) {
+    fprintf(stderr, "  [uxshot] preview band never panned between frames\n");
+    return false;
+  }
+  fprintf(stderr,
+          "  [uxshot] staged pan: backdrop strip %zu px moved, band %zu px\n",
+          backdrop_diff, band_diff);
   return true;
 }
 
@@ -1117,7 +1282,8 @@ int view_level_staged_injector(void *data) {
       // left-packed VIEW LEVEL | PROGRESS row.
       if (wait_for_interactable("ctf_teams", 5000)) {
         SDL_Delay(300);
-        state->captures += capture_frame("scenario_match_band");
+        state->captures +=
+            capture_frame("scenario_match_band", &stash_menu_before_viewer);
       }
       interact("view_scenario");
       // The pane-heal trace is the "viewer is up and staged" signal.
@@ -1131,6 +1297,13 @@ int view_level_staged_injector(void *data) {
         SDL_Delay(800);
         state->captures +=
             capture_frame("view_level_staged", &check_view_level_staged_band);
+        // #251: a second frame from further along the same pan, so the
+        // backdrop can be judged against a frame that is unquestionably a
+        // different pan phase.
+        if (wait_for_preview_band_pan(g_view_level_first_frame, 8000)) {
+          state->captures += capture_frame("view_level_staged_panned",
+                                           &check_view_level_staged_panned);
+        }
         SDL_Delay(200);
         interact("back");
       }
@@ -1171,6 +1344,8 @@ int view_level_staged_injector(void *data) {
 // (UXSHOTS_DIR) and the blank-frame guard for the pane.
 TEST(UxShots, n_view_level_staged) {
   trace_clear();
+  g_view_level_first_frame.clear();
+  g_menu_before_viewer_frame.clear();
   CompanySlotCleanup cleanup{{"save0"}};
   {
     SaveData sd;
@@ -1205,10 +1380,16 @@ TEST(UxShots, n_view_level_staged) {
   cleanup_picker_state();
   g_picker_max_mainmenu_calls = 0;
   ASSERT_TRUE(state.finished);
-  // All three shots: the reshaped SCENARIO screen (#218 match-settings
-  // band), the staged band, then the HIRE portrait drawn in the same menu
-  // session right after the viewer closed.
-  ASSERT_EQ(3, state.captures);
+  // Only the healed branch borrows viewob[0], so a degraded pane would leave
+  // the #251 comparison with nothing to catch.
+  ASSERT_TRUE(trace_contains("picker", "view_scenario pane gen="))
+      << "the staged pane never healed: the camera pin below has no teeth";
+  // All four shots: the reshaped SCENARIO screen (#218 match-settings band),
+  // two staged frames a pan apart (#251), then the HIRE portrait drawn in the
+  // same menu session right after the viewer closed. A shot whose pixel
+  // oracle failed is not counted, so this equality is the pass/fail line for
+  // every check above.
+  ASSERT_EQ(4, state.captures);
 
   // The save0 load mounted the modes campaign; restore the default.
   (void)unmount_campaign_package_with_error(get_mounted_campaign());

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -297,9 +297,12 @@ int count_fade_between_traces() {
 
 // One main-menu-boundary crossing = one fadeblack(0) + one fadeblack(1), and
 // under TESTING each traces exactly one FadeBetween line
-// (menu_screen_runner.cpp run_menu_screen).
+// (menu_screen_runner.cpp run_menu_screen). The main menu's FIRST entry
+// finds the window already black — a process starts black, and the test
+// boundary resets it black — so only its fade-in runs (fade ownership: a
+// fade-out belongs to the surface that leaves, and nothing left).
 constexpr int kFadesPerCrossing = 2;
-constexpr int kMainMenuEntryFades = kFadesPerCrossing;
+constexpr int kMainMenuEntryFades = 1;
 
 // --- 1. main menu, no companies --------------------------------------------
 
@@ -421,7 +424,7 @@ TEST(UxShots, b1_game_settings) {
   ASSERT_TRUE(state.finished);
   ASSERT_EQ(1, state.captures);
   ASSERT_EQ(kMainMenuEntryFades, g_settings_fades_at_door.load())
-      << "#237: the main menu's own entry fades once";
+      << "#237: the main menu's first entry fades in over the black window";
   ASSERT_EQ(kFadesPerCrossing, g_settings_fades_inside_settings.load() -
                                    g_settings_fades_at_door.load())
       << "#237: the GAME SETTINGS door must fade on the way IN";
@@ -1827,9 +1830,10 @@ TEST(UxShots, n_help_screen) {
   // test, so everything counted here belongs to this run. Three crossings:
   // the main menu's own entry, the HELP door, and the main menu's re-entry.
   ASSERT_EQ(kMainMenuEntryFades, g_help_fades_at_door.load())
-      << "#237: entering the main menu is a boundary crossing and must fade "
-         "exactly once (fade-out + fade-in)";
-  ASSERT_EQ(3 * kFadesPerCrossing, g_help_fades_after_return.load())
+      << "#237: the main menu's first entry fades in over the black window "
+         "(nothing left, so nothing fades out)";
+  ASSERT_EQ(kMainMenuEntryFades + 2 * kFadesPerCrossing,
+            g_help_fades_after_return.load())
       << "#237: the HELP door and the way back are BOTH main-menu crossings "
          "— the round trip adds two fades, symmetrically";
   // The symmetry invariant itself, as two measured deltas.

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -679,13 +679,17 @@ int basecamp_paged_injector(void *data) {
         og::runtime::current_session->myscreen_->save_data.save_name.c_str(),
         has_interactable("roster_page_next") ? 1 : 0);
     {
-      const std::vector<og::sim::LobbyPlayer> players = picker_lobby_players();
-      fprintf(stderr, "  [uxshot] lobby players=%d\n",
-              static_cast<int>(players.size()));
-      for (const auto &p : players)
-        fprintf(stderr, "  [uxshot]   seat team=%d slots=%d company='%s'\n",
-                static_cast<int>(p.team),
-                static_cast<int>(p.character_slots.size()), p.company.c_str());
+      // Reading the seat roster walks LobbyServer state the menu thread's
+      // poll mutates, so the whole diagnostic runs there (#257).
+      (void)run_on_main_thread([] {
+        const std::vector<og::sim::LobbyPlayer> players = picker_lobby_players();
+        fprintf(stderr, "  [uxshot] lobby players=%d\n",
+                static_cast<int>(players.size()));
+        for (const auto &p : players)
+          fprintf(stderr, "  [uxshot]   seat team=%d slots=%d company='%s'\n",
+                  static_cast<int>(p.team),
+                  static_cast<int>(p.character_slots.size()), p.company.c_str());
+      });
     }
     shot->state.captures += capture_frame("basecamp_paged_p1");
     if (has_interactable("roster_page_next")) {

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -19,6 +19,7 @@
 #include <openglad/resources/io_common.h>
 #include <openglad/resources/save_data.h>
 
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <cstdio>
@@ -704,6 +705,9 @@ TEST(UxShots, f_backups) {
 struct NamedShot {
   ShotState state;
   const char *name;
+  // Optional pixel oracle run on the captured frame; a failed check does not
+  // count the capture, so the caller's ASSERT_EQ on `captures` is its verdict.
+  FrameCheck check = nullptr;
 };
 
 // The machine's seat declaration is LIVE SESSION state: it survives CONTINUE
@@ -772,8 +776,6 @@ int basecamp_paged_injector(void *data) {
       interact("roster_page_next");
       SDL_Delay(1500);
       shot->state.captures += capture_frame("basecamp_paged_p2");
-      SDL_Delay(120);
-      shot->state.captures += capture_frame("basecamp_paged_p2b");
     }
     SDL_Delay(200);
     interact("back");
@@ -1056,7 +1058,7 @@ int basecamp_net_injector(void *data) {
   NamedShot *shot = static_cast<NamedShot *>(data);
   if (wait_for_team_menu()) {
     SDL_Delay(1500);
-    shot->state.captures += capture_frame(shot->name);
+    shot->state.captures += capture_frame(shot->name, shot->check);
     SDL_Delay(200);
     interact("back");
   }
@@ -1128,6 +1130,12 @@ void run_basecamp_net_shot(const char *name, bool host_view,
   shot.name = name;
   SDL_Thread *thread = SDL_CreateThread(basecamp_net_injector, "ux_net", &shot);
   ASSERT_TRUE(thread != nullptr);
+  // The local shapes reach Base Camp through picker_main, which loads the
+  // title backdrop on the way in; these fixtures build the screen directly,
+  // so they load it themselves. Without it every pixel the chrome does not
+  // cover captures flat black — the frame no player ever sees — and the
+  // networked shots cannot be compared with the local ones at all.
+  picker_load_menu_backdrops();
   create_team_menu(0);
   SDL_WaitThread(thread, nullptr);
   cleanup_picker_state();
@@ -1644,6 +1652,7 @@ TEST(UxShots, n_view_level_seats) {
   SDL_Thread *thread =
       SDL_CreateThread(many_seats_view_level_injector, "ux_seats", &state);
   ASSERT_TRUE(thread != nullptr);
+  picker_load_menu_backdrops();  // see run_basecamp_net_shot
   create_team_menu(0);
   SDL_WaitThread(thread, nullptr);
   cleanup_picker_state();
@@ -1651,6 +1660,33 @@ TEST(UxShots, n_view_level_seats) {
   // The two-card rail over a seven-seat lobby, the VIEW LEVEL seat block,
   // and the networked DIFFICULTY screen with the re-homed CTRL row (#218).
   ASSERT_EQ(3, state.captures);
+}
+
+// A dimmed row is still a whole card. GREY, the disabled face shade, lands on
+// the same palette entry as BUTTON_RIGHT/BUTTON_BOTTOM, so an unguarded dim
+// swallows its own right and bottom bevels and the card reads as 69px wide
+// with a flat right edge. The three LOBBY FULL slots end at x=155/233/311
+// (card x + 69); each of those columns must differ from the face pixel beside
+// it. Row 168 is mid-face, clear of the label's ink and both horizontal
+// bevels.
+bool lobby_full_slots_keep_their_right_bevel(const FramePixels &rgb) {
+  const auto pixel = [&rgb](int x, int y) {
+    const std::size_t at = (static_cast<std::size_t>(y) * 320 +
+                            static_cast<std::size_t>(x)) *
+        3;
+    return std::array<Uint8, 3>{rgb[at], rgb[at + 1], rgb[at + 2]};
+  };
+  bool ok = true;
+  for (const int bevel_x : {155, 233, 311}) {
+    if (pixel(bevel_x, 168) == pixel(bevel_x - 1, 168)) {
+      fprintf(stderr,
+              "  [uxshot] LOBBY FULL card's right bevel at x=%d dissolved "
+              "into its dimmed face\n",
+              bevel_x);
+      ok = false;
+    }
+  }
+  return ok;
 }
 
 // A LOBBY AT THE CEILING. Sixteen seats, one of them this machine's: the rail
@@ -1674,9 +1710,11 @@ TEST(UxShots, n_basecamp_lobby_full) {
   ActiveLobbyGuard guard(&client);
   NamedShot shot;
   shot.name = "basecamp_lobby_full";
+  shot.check = &lobby_full_slots_keep_their_right_bevel;
   SDL_Thread *thread =
       SDL_CreateThread(basecamp_net_injector, "ux_full", &shot);
   ASSERT_TRUE(thread != nullptr);
+  picker_load_menu_backdrops();  // see run_basecamp_net_shot
   create_team_menu(0);
   SDL_WaitThread(thread, nullptr);
   cleanup_picker_state();
@@ -1954,7 +1992,10 @@ TEST(UxShots, i_basecamp_paged) {
   NamedShot shot;
   shot.name = "basecamp_paged_p1";
   run_basecamp_shot(shot, &basecamp_paged_injector);
-  ASSERT_EQ(3, shot.state.captures);
+  // Page 1 and page 2 — two states, two frames. The third capture this used
+  // to take was page 2 again, 120ms later: a byte-identical duplicate that
+  // proved nothing and cost a reviewer a comparison.
+  ASSERT_EQ(2, shot.state.captures);
 }
 
 } // namespace

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -706,6 +706,14 @@ struct NamedShot {
   const char *name;
 };
 
+// The machine's seat declaration is LIVE SESSION state: it survives CONTINUE
+// on purpose (docs §2.5), which means it also survives from one shot in this
+// binary to the next. Every rail shot declares the count it means to film.
+void declare_local_seats(int count) {
+  og::runtime::current_session->myscreen_->save_data.numplayers =
+      static_cast<unsigned char>(count);
+}
+
 int basecamp_shot_injector(void *data) {
   og::runtime::ensure_thread_session();
   NamedShot *shot = static_cast<NamedShot *>(data);
@@ -778,21 +786,33 @@ int basecamp_paged_injector(void *data) {
   return 0;
 }
 
-int basecamp_three_seats_injector(void *data) {
+// A bare slot IS the add door, so growing the rail means clicking slot 1,
+// then slot 2, then slot 3 — each one waits until it stops saying ADD PLAYER
+// before the next click, and the 250 ms debounce is crossed between them.
+struct SeatGrowthShot {
+  ShotState state;
+  const char *name = nullptr;
+  int target_seats = 1;  // seats this machine should end up holding
+};
+
+int basecamp_local_seats_injector(void *data) {
   og::runtime::ensure_thread_session();
-  NamedShot *shot = static_cast<NamedShot *>(data);
+  SeatGrowthShot *shot = static_cast<SeatGrowthShot *>(data);
   wait_for_interactable("continue_game", 5000);
   SDL_Delay(1500);
   interact("continue_game");
-  if (wait_for_team_menu() &&
-      wait_for_interactable("add_seat", 5000)) {
-    SDL_Delay(300);
-    interact("add_seat");
-    if (wait_for_interactable("seat_card_1", 5000)) {
-      SDL_Delay(300);  // cross the intentional 250 ms + debounce
-      interact("add_seat");
+  if (wait_for_team_menu()) {
+    bool grown = true;
+    for (int slot = 1; slot < shot->target_seats && grown; ++slot) {
+      const std::string id = "seat_card_" + std::to_string(slot);
+      grown = wait_for_interactable_label(id, "ADD PLAYER", 5000);
+      if (!grown)
+        break;
+      SDL_Delay(300);  // cross the intentional 250 ms add debounce
+      interact(id);
+      grown = wait_for_interactable_label_change(id, "ADD PLAYER", 5000);
     }
-    if (wait_for_interactable("seat_card_2", 5000)) {
+    if (grown) {
       SDL_Delay(1500);
       shot->state.captures += capture_frame(shot->name);
     }
@@ -807,7 +827,23 @@ int basecamp_three_seats_injector(void *data) {
   return 0;
 }
 
+void run_basecamp_seat_growth_shot(SeatGrowthShot &shot) {
+  declare_local_seats(1);
+  SDL_Thread *thread =
+      SDL_CreateThread(basecamp_local_seats_injector, "ux_bc_seats", &shot);
+  ASSERT_TRUE(thread != nullptr);
+  g_picker_mainmenu_calls = 0;
+  g_picker_max_mainmenu_calls = 2;
+  picker_main(0, nullptr);
+  SDL_WaitThread(thread, nullptr);
+  cleanup_picker_state();
+  g_picker_max_mainmenu_calls = 0;
+  ASSERT_TRUE(shot.state.finished);
+  ASSERT_GE(shot.state.captures, 1);
+}
+
 void run_basecamp_shot(NamedShot &shot, int (*injector)(void *)) {
+  declare_local_seats(1);
   SDL_Thread *thread = SDL_CreateThread(injector, "ux_bc", &shot);
   ASSERT_TRUE(thread != nullptr);
   g_picker_mainmenu_calls = 0;
@@ -831,8 +867,9 @@ TEST(UxShots, g_basecamp_solo) {
   run_basecamp_shot(shot, &basecamp_shot_injector);
 }
 
-// #243: the phone shape — a single-seat device hides [+] and draws no
-// ghosts; the lone seat card opens flush on the panel's left rail.
+// #249: the phone shape — a single-seat device has ONE slot, so the rail is
+// a lone seat card flush on the panel's left rail and nothing else. No ADD
+// PLAYER placeholder: an offer the hardware cannot accept is worse than none.
 int basecamp_phone_shot_injector(void *data) {
   og::runtime::ensure_thread_session();
   NamedShot *shot = static_cast<NamedShot *>(data);
@@ -881,15 +918,44 @@ TEST(UxShots, h_basecamp_empty) {
   run_basecamp_shot(shot, &basecamp_shot_injector);
 }
 
+// The rail's three interesting local shapes. basecamp_solo already shows
+// 1 card + 3 ADD PLAYER; these are 2+2, 3+1, and the full 4+0 — the only
+// shape with no placeholder in it, and the one that proves 4*70 + 3*8 closes
+// on the panel's right rail.
+TEST(UxShots, i_basecamp_two_local_seats) {
+  trace_clear();
+  CompanySlotCleanup cleanup{{"save0"}};
+  ASSERT_TRUE(seed_company_with_roster("save0", "IRON KETTLE BAND", 1700259200,
+                                       playtest_roster()));
+  ASSERT_TRUE(og::data::set_active_company_slot("save0"));
+  SeatGrowthShot shot;
+  shot.name = "basecamp_two_local_seats";
+  shot.target_seats = 2;
+  run_basecamp_seat_growth_shot(shot);
+}
+
 TEST(UxShots, i_basecamp_three_local_seats) {
   trace_clear();
   CompanySlotCleanup cleanup{{"save0"}};
   ASSERT_TRUE(seed_company_with_roster("save0", "IRON KETTLE BAND", 1700259200,
                                        playtest_roster()));
   ASSERT_TRUE(og::data::set_active_company_slot("save0"));
-  NamedShot shot;
+  SeatGrowthShot shot;
   shot.name = "basecamp_three_local_seats";
-  run_basecamp_shot(shot, &basecamp_three_seats_injector);
+  shot.target_seats = 3;
+  run_basecamp_seat_growth_shot(shot);
+}
+
+TEST(UxShots, i_basecamp_four_local_seats) {
+  trace_clear();
+  CompanySlotCleanup cleanup{{"save0"}};
+  ASSERT_TRUE(seed_company_with_roster("save0", "IRON KETTLE BAND", 1700259200,
+                                       playtest_roster()));
+  ASSERT_TRUE(og::data::set_active_company_slot("save0"));
+  SeatGrowthShot shot;
+  shot.name = "basecamp_four_local_seats";
+  shot.target_seats = 4;
+  run_basecamp_seat_growth_shot(shot);
 }
 
 // --- 10-12. networked base camp: host / joiner / degraded alert -------------
@@ -1101,22 +1167,18 @@ bool wait_for_interactable_at(const std::string &id, int x, int y,
   return false;
 }
 
-// Seven authoritative seats exercise the compact four-card rail, its pager,
-// and the VIEW LEVEL seat block reached through SCENARIO (#218 — the
-// surviving home of the seat->team overview). Internal network names
-// intentionally differ from public company names so the screenshots catch
-// any accidental transport-identity leak.
+// Seven authoritative seats across four machines, TWO of them this client's.
+// The rail shows those two and offers two more; the other five live on the
+// header line's census and in the VIEW LEVEL seat block reached through
+// SCENARIO (#218 — the surviving home of the seat->team overview). Internal
+// network names intentionally differ from public company names so the
+// screenshots catch any accidental transport-identity leak.
 int many_seats_view_level_injector(void *data) {
   og::runtime::ensure_thread_session();
   ShotState *state = static_cast<ShotState *>(data);
   if (wait_for_team_menu()) {
     SDL_Delay(1500);
-    state->captures += capture_frame("basecamp_net_seats_p1");
-    if (wait_for_interactable("seat_page_next", 5000)) {
-      interact("seat_page_next");
-      SDL_Delay(750);
-      state->captures += capture_frame("basecamp_net_seats_p2");
-    }
+    state->captures += capture_frame("basecamp_net_seats");
     interact("scenario");
     if (wait_for_interactable("view_scenario", 5000)) {
       SDL_Delay(300);
@@ -1586,9 +1648,40 @@ TEST(UxShots, n_view_level_seats) {
   SDL_WaitThread(thread, nullptr);
   cleanup_picker_state();
   ASSERT_TRUE(state.finished);
-  // Rail p1/p2, the VIEW LEVEL seat block, and the networked DIFFICULTY
-  // screen with the re-homed CTRL row (#218).
-  ASSERT_EQ(4, state.captures);
+  // The two-card rail over a seven-seat lobby, the VIEW LEVEL seat block,
+  // and the networked DIFFICULTY screen with the re-homed CTRL row (#218).
+  ASSERT_EQ(3, state.captures);
+}
+
+// A LOBBY AT THE CEILING. Sixteen seats, one of them this machine's: the rail
+// still shows all four of this machine's slots, and the three it cannot fill
+// wear a dimmed LOBBY FULL face. The header line reads the census that makes
+// it true.
+TEST(UxShots, n_basecamp_lobby_full) {
+  trace_clear();
+  seed_session_save_for_net();
+  FakeNetLobbyClient client;
+  client.host_view = false;
+  client.players.push_back(make_probe_seat(
+      0, "net-host", "IRON KETTLE BAND", true, true, foreign_roster(), 0, 1));
+  for (std::uint8_t index = 1; index < 16; ++index) {
+    client.players.push_back(make_probe_seat(
+        index, "net-crowd", index == 7 ? "JOIN RIVER BAND" : "OTHER BAND",
+        false, index % 2 == 0, {}, static_cast<short>(index % 4),
+        static_cast<og::sim::LobbyMachineId>(index / 2 + 1)));
+  }
+  client.local_indices = {7};
+  ActiveLobbyGuard guard(&client);
+  NamedShot shot;
+  shot.name = "basecamp_lobby_full";
+  SDL_Thread *thread =
+      SDL_CreateThread(basecamp_net_injector, "ux_full", &shot);
+  ASSERT_TRUE(thread != nullptr);
+  create_team_menu(0);
+  SDL_WaitThread(thread, nullptr);
+  cleanup_picker_state();
+  ASSERT_TRUE(shot.state.finished);
+  ASSERT_EQ(1, shot.state.captures);
 }
 
 // --- 13. full-screen help (#168): all three tabs plus a paged state -------

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -1592,11 +1592,29 @@ void help_park_pointer() {
   SDL_Delay(200);
 }
 
+// #237 wiring pin: the HELP door and the way back are lateral menu-cluster
+// moves (peer transitions) — the round-trip must add zero fades.
+std::atomic<int> g_help_fades_at_door{-1};
+std::atomic<int> g_help_fades_after_return{-1};
+
+int count_fade_between_traces() {
+  std::lock_guard<std::mutex> lock(g_trace_mutex);
+  int fades = 0;
+  for (const TraceEntry &entry : g_trace_buffer) {
+    if (entry.category == "video" &&
+        entry.message.find("FadeBetween") != std::string::npos) {
+      ++fades;
+    }
+  }
+  return fades;
+}
+
 int help_screen_injector(void *data) {
   og::runtime::ensure_thread_session();
   ShotState *state = static_cast<ShotState *>(data);
   wait_for_interactable("help", 5000);
   SDL_Delay(1500); // menu-entry settle on the main menu
+  g_help_fades_at_door = count_fade_between_traces();
   interact("help");
   if (wait_for_interactable("help_tab_classes", 5000)) {
     SDL_Delay(500);
@@ -1629,6 +1647,7 @@ int help_screen_injector(void *data) {
   }
   if (wait_for_interactable("begin_new_game", 10000)) {
     SDL_Delay(750);
+    g_help_fades_after_return = count_fade_between_traces();
     interact("quit");
   }
   state->finished = true;
@@ -1650,6 +1669,11 @@ TEST(UxShots, n_help_screen) {
   g_picker_max_mainmenu_calls = 0;
   ASSERT_TRUE(state.finished);
   ASSERT_EQ(5, state.captures);
+  ASSERT_GE(g_help_fades_at_door.load(), 0);
+  ASSERT_GE(g_help_fades_after_return.load(), 0);
+  EXPECT_EQ(g_help_fades_at_door.load(), g_help_fades_after_return.load())
+      << "#237: the HELP door and the return to the main menu are peer "
+         "transitions — the round-trip must add zero fades";
 }
 
 TEST(UxShots, i_basecamp_paged) {

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -203,6 +203,24 @@ bool wait_for_team_menu(int timeout_ms = kTeamMenuTimeoutMs) {
   return false;
 }
 
+// One keyboard-nav step, applied through the engine's testing hook (real key
+// events can't be driven from an injector thread — the blocking
+// hold-and-release loops in handle_menu_nav eat them mid-press).
+void menu_nav_step(int key) {
+  g_test_menu_nav_key = key;
+  SDL_Delay(200);
+}
+
+// Park the pointer at game coords (x, y). interact() leaves the cursor on the
+// button it clicked, and that hover highlight is the same yellow as the
+// keyboard-focus outline — a focus shot can only be told apart from a hover
+// one once no button is hovered.
+void park_pointer_at(float x, float y) {
+  const auto [win_x, win_y] = ui_canvas_to_window(x, y);
+  inject_mouse_motion(static_cast<int>(win_x), static_cast<int>(win_y));
+  SDL_Delay(200);
+}
+
 struct RosterSeed {
   const char *name;
   int family;
@@ -958,6 +976,123 @@ TEST(UxShots, i_basecamp_four_local_seats) {
   shot.name = "basecamp_four_local_seats";
   shot.target_seats = 4;
   run_basecamp_seat_growth_shot(shot);
+}
+
+// --- 9b. keyboard focus on a bare slot --------------------------------------
+
+// The rail's fixed grid, restated from the drawing side: slot k opens at
+// x = 8 + 78k and the face is 70 wide (og::ui::kSeatRail*), the cards run
+// y=164..173, and row 168 is mid-face — clear of the label ink's top and
+// bottom rows and of both horizontal bevels (the lobby_full oracle below
+// reads the same row).
+constexpr int kSeatCardX(int slot) {
+  return og::ui::kSeatRailX0 +
+         slot * (og::ui::kSeatRailCardWidth + og::ui::kSeatRailGap);
+}
+constexpr int kSeatCardTopY = 164;
+constexpr int kSeatCardHeight = 10;
+
+// Pixels where two rail slots' faces disagree, compared cell for cell at the
+// same offset inside each card.
+std::size_t seat_card_diff(const FramePixels &rgb, int slot_a, int slot_b) {
+  std::size_t differing = 0;
+  for (int dy = 0; dy < kSeatCardHeight; ++dy) {
+    for (int dx = 0; dx < og::ui::kSeatRailCardWidth; ++dx) {
+      const int y = kSeatCardTopY + dy;
+      const auto at = [&](int slot) {
+        return (static_cast<std::size_t>(y) * 320 +
+                static_cast<std::size_t>(kSeatCardX(slot) + dx)) *
+               3;
+      };
+      const std::size_t ia = at(slot_a);
+      const std::size_t ib = at(slot_b);
+      if (rgb[ia] != rgb[ib] || rgb[ia + 1] != rgb[ib + 1] ||
+          rgb[ia + 2] != rgb[ib + 2])
+        ++differing;
+    }
+  }
+  return differing;
+}
+
+// Solo leaves slots 1, 2 and 3 wearing the same ADD PLAYER face on the same
+// fixed grid, so the three cards are pixel-identical — until the keyboard
+// highlight lands on one of them. That makes the OTHER two their own
+// reference: no palette entry is named here, and a focus ring that never
+// arrived (or landed on the wrong slot) fails instead of quietly producing a
+// screenshot of three idle placeholders.
+bool check_placeholder_focus_ring(const FramePixels &rgb) {
+  const std::size_t focused = seat_card_diff(rgb, 1, 2);
+  const std::size_t idle = seat_card_diff(rgb, 2, 3);
+  if (idle != 0) {
+    fprintf(stderr,
+            "  [uxshot] placeholder focus: the two unfocused ADD PLAYER "
+            "slots differ in %zu pixels — no clean reference\n",
+            idle);
+    return false;
+  }
+  // The interior ring is a box inside a 70x10 face: even at the pulse's
+  // deepest inset it draws well over a hundred pixels. Twenty is a floor no
+  // stray glyph shift could clear, not a measurement.
+  if (focused < 20) {
+    fprintf(stderr,
+            "  [uxshot] placeholder focus: slot 1 differs from its idle "
+            "neighbour in only %zu pixels — no focus ring\n",
+            focused);
+    return false;
+  }
+  return true;
+}
+
+// The keyboard route to a bare slot, walked with saturating steps rather than
+// a counted path: every roster column's DOWN chain drains onto the rail and
+// then onto the command strip, whose rows have no down-link, so a surplus
+// DOWN is a no-op. The same holds for LEFT along the strip, which ends on
+// BACK. From BACK the rail's documented entry is UP (its leftmost live slot,
+// this machine's own seat here) and one RIGHT reaches slot 1 — the first
+// placeholder. Counting nothing means a roster page of a different length
+// cannot silently move the focus somewhere else.
+int basecamp_placeholder_focus_injector(void *data) {
+  og::runtime::ensure_thread_session();
+  NamedShot *shot = static_cast<NamedShot *>(data);
+  wait_for_interactable("continue_game", 5000);
+  SDL_Delay(1500);
+  interact("continue_game");
+  if (wait_for_team_menu()) {
+    SDL_Delay(1500);
+    // Left of the panel's rail and above the cards: no button owns this
+    // pixel, so nothing is hovered when the shot is taken.
+    park_pointer_at(2.0f, 162.0f);
+    for (int i = 0; i < 12; ++i)
+      menu_nav_step(KEY_DOWN);
+    for (int i = 0; i < 5; ++i)
+      menu_nav_step(KEY_LEFT);
+    menu_nav_step(KEY_UP);
+    menu_nav_step(KEY_RIGHT);
+    // menu_nav_enabled expires 5 s after the last press (picker_input.cpp),
+    // and the ring is only drawn while it holds — so the capture follows the
+    // last step immediately.
+    shot->state.captures += capture_frame(shot->name, shot->check);
+    SDL_Delay(200);
+    interact("back");
+  }
+  if (wait_for_interactable("begin_new_game", 10000)) {
+    SDL_Delay(750);
+    interact("quit");
+  }
+  shot->state.finished = true;
+  return 0;
+}
+
+TEST(UxShots, g3_basecamp_placeholder_focus) {
+  trace_clear();
+  CompanySlotCleanup cleanup{{"save0"}};
+  ASSERT_TRUE(seed_company_with_roster("save0", "IRON KETTLE BAND", 1700259200,
+                                       playtest_roster()));
+  ASSERT_TRUE(og::data::set_active_company_slot("save0"));
+  NamedShot shot;
+  shot.name = "basecamp_placeholder_focus";
+  shot.check = &check_placeholder_focus_ring;
+  run_basecamp_shot(shot, &basecamp_placeholder_focus_injector);
 }
 
 // --- 10-12. networked base camp: host / joiner / degraded alert -------------
@@ -1867,22 +2002,8 @@ bool check_help_editor_focused(const FramePixels &rgb) {
   return true;
 }
 
-// One keyboard-nav step, applied through the engine's testing hook (real key
-// events can't be driven from an injector thread).
-void help_nav_step(int key) {
-  g_test_menu_nav_key = key;
-  SDL_Delay(200);
-}
-
-// Park the pointer over the content frame. interact() leaves the cursor on the
-// button it clicked, and that hover highlight is the same yellow as the
-// keyboard-focus outline — the focus shot can only be told apart from its
-// reference once no button is hovered.
-void help_park_pointer() {
-  const auto [win_x, win_y] = ui_canvas_to_window(300.0f, 100.0f);
-  inject_mouse_motion(static_cast<int>(win_x), static_cast<int>(win_y));
-  SDL_Delay(200);
-}
+// Park the pointer over the HELP content frame (see park_pointer_at).
+void help_park_pointer() { park_pointer_at(300.0f, 100.0f); }
 
 // #237 symmetry pin: HELP is a main-menu door, so it fades on the way in AND
 // on the way back. The round trip is three crossings — the main menu's own
@@ -1920,9 +2041,9 @@ int help_screen_injector(void *data) {
     help_park_pointer();
     state->captures += capture_frame("help_editor", &check_help_editor_merged);
     // Walk the keyboard highlight from BACK onto the active (EDITOR) tab.
-    help_nav_step(KEY_UP);
-    help_nav_step(KEY_RIGHT);
-    help_nav_step(KEY_RIGHT);
+    menu_nav_step(KEY_UP);
+    menu_nav_step(KEY_RIGHT);
+    menu_nav_step(KEY_RIGHT);
     state->captures +=
         capture_frame("help_editor_focus", &check_help_editor_focused);
     SDL_Delay(300);

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -273,7 +273,27 @@ void reap_all_companies() {
 struct ShotState {
   bool finished = false;
   int captures = 0;
+  // #237 derivation pin, for the flows that drive a real door: the fades a
+  // door added, or -1 when the injector never reached the read.
+  int fades_added_by_nested_door = -1;
 };
+
+// Under TESTING every fadeblack takes FadeBetween's test-mode branch, which
+// traces exactly one "video" line per fade — so counting those lines counts
+// fades. The #237 rule is derived inside run_menu_screen from the menu-stack
+// depth, so only a real door driven through the real screens can pin which
+// side of the rule a screen is on.
+int count_fade_between_traces() {
+  std::lock_guard<std::mutex> lock(g_trace_mutex);
+  int fades = 0;
+  for (const TraceEntry &entry : g_trace_buffer) {
+    if (entry.category == "video" &&
+        entry.message.find("FadeBetween") != std::string::npos) {
+      ++fades;
+    }
+  }
+  return fades;
+}
 
 // --- 1. main menu, no companies --------------------------------------------
 
@@ -388,13 +408,22 @@ int seat_settings_injector(void *data) {
   if (wait_for_interactable("continue_game", 5000)) {
     SDL_Delay(1500);
     interact("continue_game");
+    int fades_before_door = -1;
     if (wait_for_team_menu() &&
         wait_for_interactable("seat_card_0", 5000)) {
       SDL_Delay(500);
+      // #237: the seat editor is a door on the OPEN Base Camp — a nested
+      // run_menu_screen entry, which never fades. (Base Camp's own entry
+      // from the main menu is the context switch, and that one does.)
+      fades_before_door = count_fade_between_traces();
       interact("seat_card_0");
     }
     if (wait_for_interactable("seat_settings_back", 5000)) {
       SDL_Delay(1500);
+      if (fades_before_door >= 0) {
+        state->fades_added_by_nested_door =
+            count_fade_between_traces() - fades_before_door;
+      }
       state->captures += capture_frame("seat_settings");
       interact("seat_settings_back");
     }
@@ -428,6 +457,9 @@ TEST(UxShots, b2_seat_settings) {
   g_picker_max_mainmenu_calls = 0;
   ASSERT_TRUE(state.finished);
   ASSERT_EQ(1, state.captures);
+  EXPECT_EQ(0, state.fades_added_by_nested_door)
+      << "#237: a door opened from the open Base Camp is a nested entry — it "
+         "must add no fade";
 }
 
 // --- 3. name entry ----------------------------------------------------------
@@ -1071,13 +1103,29 @@ struct ShotRect {
 constexpr ShotRect kViewScenarioButtonRects[] = {
     {10, 170, 44, 20}, {220, 170, 40, 20}, {270, 170, 40, 20}};
 
+bool in_rect_with_pulse(const ShotRect &r, int x, int y) {
+  return x >= r.x - kHighlightPulse && x <= r.x + r.w + kHighlightPulse &&
+         y >= r.y - kHighlightPulse && y <= r.y + r.h + kHighlightPulse;
+}
+
 bool in_view_scenario_button(int x, int y) {
   for (const ShotRect &r : kViewScenarioButtonRects) {
-    if (x >= r.x - kHighlightPulse && x <= r.x + r.w + kHighlightPulse &&
-        y >= r.y - kHighlightPulse && y <= r.y + r.h + kHighlightPulse)
+    if (in_rect_with_pulse(r, x, y))
       return true;
   }
   return false;
+}
+
+// The SCENARIO screen's own BACK face. The cross-screen comparison below
+// straddles two screens, so it has to skip the button chrome of BOTH: the
+// hover ring draw_buttons paints at yloc-1 and the focus box draw_highlight
+// pulses up to 3 px outside the rect land in the same rows as the backdrop
+// bands, at different x on each screen.
+constexpr ShotRect kScenarioBackRect = {30, 170, 60, 20};
+
+bool in_cross_screen_button(int x, int y) {
+  return in_view_scenario_button(x, y) ||
+         in_rect_with_pulse(kScenarioBackRect, x, y);
 }
 
 // Rows that carry nothing but backdrop on BOTH the SCENARIO screen and the
@@ -1089,13 +1137,15 @@ bool in_view_scenario_button(int x, int y) {
 // frame-to-frame half.
 constexpr int kBackdropOnlyBands[][2] = {{161, 170}, {190, 200}};
 
-// Differing pixels between two frames over rows [y0, y1).
+// Differing pixels between two frames over rows [y0, y1). `skip` (optional)
+// names the button chrome to leave out of the comparison.
+using PixelSkip = bool (*)(int, int);
 std::size_t frame_diff_count(const FramePixels &a, const FramePixels &b, int y0,
-                             int y1, bool skip_button_rects) {
+                             int y1, PixelSkip skip) {
   std::size_t differing = 0;
   for (int y = y0; y < y1; ++y) {
     for (int x = 0; x < 320; ++x) {
-      if (skip_button_rects && in_view_scenario_button(x, y))
+      if (skip != nullptr && skip(x, y))
         continue;
       const std::size_t i =
           (static_cast<std::size_t>(y) * 320 + static_cast<std::size_t>(x)) * 3;
@@ -1179,10 +1229,18 @@ bool check_view_level_staged_band(const FramePixels &rgb) {
     fprintf(stderr, "  [uxshot] no pre-viewer frame to compare against\n");
     return false;
   }
+  // The bands skip both screens' button chrome, but a keyboard-navigated
+  // highlight would move the focus box onto a DIFFERENT row than the mouse
+  // cadence this flow uses. State the assumption instead of inheriting it.
+  if (pks().menu_nav_enabled) {
+    fprintf(stderr, "  [uxshot] menu nav is enabled: the backdrop bands would "
+                    "carry a keyboard focus ring\n");
+    return false;
+  }
   for (const auto &band : kBackdropOnlyBands) {
     const std::size_t moved =
         frame_diff_count(g_menu_before_viewer_frame, rgb, band[0], band[1],
-                         /*skip_button_rects=*/false);
+                         &in_cross_screen_button);
     if (moved != 0) {
       fprintf(stderr,
               "  [uxshot] backdrop rows %d..%d differ from the pre-viewer "
@@ -1195,6 +1253,13 @@ bool check_view_level_staged_band(const FramePixels &rgb) {
   return true;
 }
 
+// Set when the ONLY thing wrong with a candidate frame is that it landed on
+// the same pan phase as the reference. The pan is a triangle wave and the
+// frame the wait observed is not the frame the capture handshake freezes, so
+// an apex between the two can hand back an identical band; that draw is worth
+// retrying. Every other failure below is a real one and must not be retried.
+std::atomic<bool> g_view_level_pan_phase_collided{false};
+
 // #251, the second half of the intra-screen camera pin. draw_backdrop() paints
 // the four menu quadrants THROUGH viewob[0] at the top of the same hook that
 // then lends the view to the staged preview, so a camera left behind on the
@@ -1204,6 +1269,7 @@ bool check_view_level_staged_band(const FramePixels &rgb) {
 // backdrop still between two pan phases; check_view_level_staged_band holds it
 // against the pre-viewer menu.
 bool check_view_level_staged_panned(const FramePixels &rgb) {
+  g_view_level_pan_phase_collided = false;
   if (!staged_band_is_populated(rgb))
     return false;
   if (g_view_level_first_frame.size() != rgb.size()) {
@@ -1212,11 +1278,10 @@ bool check_view_level_staged_panned(const FramePixels &rgb) {
   }
   const std::size_t backdrop_diff =
       frame_diff_count(g_view_level_first_frame, rgb, kBackdropStripTopY, 200,
-                       /*skip_button_rects=*/true);
+                       &in_view_scenario_button);
   const std::size_t band_diff = frame_diff_count(
       g_view_level_first_frame, rgb, kViewScenarioPreviewBandY,
-      kViewScenarioPreviewBandY + kViewScenarioPreviewBandH,
-      /*skip_button_rects=*/false);
+      kViewScenarioPreviewBandY + kViewScenarioPreviewBandH, nullptr);
   if (backdrop_diff != 0) {
     fprintf(stderr,
             "  [uxshot] backdrop strip moved between staged frames: %zu px\n",
@@ -1227,6 +1292,7 @@ bool check_view_level_staged_panned(const FramePixels &rgb) {
   // a frozen screen.
   if (band_diff == 0) {
     fprintf(stderr, "  [uxshot] preview band never panned between frames\n");
+    g_view_level_pan_phase_collided = true;
     return false;
   }
   fprintf(stderr,
@@ -1299,10 +1365,28 @@ int view_level_staged_injector(void *data) {
             capture_frame("view_level_staged", &check_view_level_staged_band);
         // #251: a second frame from further along the same pan, so the
         // backdrop can be judged against a frame that is unquestionably a
-        // different pan phase.
-        if (wait_for_preview_band_pan(g_view_level_first_frame, 8000)) {
-          state->captures += capture_frame("view_level_staged_panned",
-                                           &check_view_level_staged_panned);
+        // different pan phase. The wait and the capture freeze two different
+        // frames, so the triangle wave can turn back between them and hand
+        // the check a frame at the reference offset; that collision alone is
+        // retried (bounded, each attempt waiting on the live band again — no
+        // flat delay), and any other failure stands.
+        for (int attempt = 0; attempt < 3; ++attempt) {
+          if (!wait_for_preview_band_pan(g_view_level_first_frame, 8000))
+            break;
+          if (capture_frame("view_level_staged_panned",
+                            &check_view_level_staged_panned)) {
+            state->captures += 1;
+            break;
+          }
+          if (!g_view_level_pan_phase_collided.load()) {
+            fprintf(stderr, "  [uxshot] panned capture failed for a reason "
+                            "other than pan phase; not retrying\n");
+            break;
+          }
+          fprintf(stderr,
+                  "  [uxshot] panned capture landed on the reference pan "
+                  "phase; retrying (attempt %d)\n",
+                  attempt + 1);
         }
         SDL_Delay(200);
         interact("back");
@@ -1346,6 +1430,7 @@ TEST(UxShots, n_view_level_staged) {
   trace_clear();
   g_view_level_first_frame.clear();
   g_menu_before_viewer_frame.clear();
+  g_view_level_pan_phase_collided = false;
   CompanySlotCleanup cleanup{{"save0"}};
   {
     SaveData sd;
@@ -1597,17 +1682,11 @@ void help_park_pointer() {
 std::atomic<int> g_help_fades_at_door{-1};
 std::atomic<int> g_help_fades_after_return{-1};
 
-int count_fade_between_traces() {
-  std::lock_guard<std::mutex> lock(g_trace_mutex);
-  int fades = 0;
-  for (const TraceEntry &entry : g_trace_buffer) {
-    if (entry.category == "video" &&
-        entry.message.find("FadeBetween") != std::string::npos) {
-      ++fades;
-    }
-  }
-  return fades;
-}
+// One context-switch entry (see count_fade_between_traces above) = one fadeblack(0) + one fadeblack(1), and under
+// TESTING each traces exactly one FadeBetween line
+// (menu_screen_runner.cpp run_menu_screen). Measured against the main menu,
+// whose entry is the only context switch in the HELP flow below.
+constexpr int kMainMenuEntryFades = 2;
 
 int help_screen_injector(void *data) {
   og::runtime::ensure_thread_session();
@@ -1657,6 +1736,10 @@ int help_screen_injector(void *data) {
 TEST(UxShots, n_help_screen) {
   trace_clear();
   reap_all_companies();
+  // File-scope atomics: re-arm them here so a --gtest_repeat iteration cannot
+  // inherit the previous one's counts.
+  g_help_fades_at_door = -1;
+  g_help_fades_after_return = -1;
   ShotState state;
   SDL_Thread *thread =
       SDL_CreateThread(help_screen_injector, "ux_help", &state);
@@ -1669,9 +1752,14 @@ TEST(UxShots, n_help_screen) {
   g_picker_max_mainmenu_calls = 0;
   ASSERT_TRUE(state.finished);
   ASSERT_EQ(5, state.captures);
-  ASSERT_GE(g_help_fades_at_door.load(), 0);
-  ASSERT_GE(g_help_fades_after_return.load(), 0);
-  EXPECT_EQ(g_help_fades_at_door.load(), g_help_fades_after_return.load())
+  // Exact, not relative: the trace buffer was cleared at the top of this
+  // test, so everything counted here belongs to this run. kMainMenuEntryFades
+  // is the main menu's own entry — the one context switch in the flow — and
+  // the HELP door and the way back add nothing to it.
+  ASSERT_EQ(kMainMenuEntryFades, g_help_fades_at_door.load())
+      << "#237: entering the main menu is a context switch and must fade "
+         "exactly once (fade-out + fade-in)";
+  ASSERT_EQ(kMainMenuEntryFades, g_help_fades_after_return.load())
       << "#237: the HELP door and the return to the main menu are peer "
          "transitions — the round-trip must add zero fades";
 }

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -795,6 +795,46 @@ TEST(UxShots, g_basecamp_solo) {
   run_basecamp_shot(shot, &basecamp_shot_injector);
 }
 
+// #243: the phone shape — a single-seat device hides [+] and draws no
+// ghosts; the lone seat card opens flush on the panel's left rail.
+int basecamp_phone_shot_injector(void *data) {
+  og::runtime::ensure_thread_session();
+  NamedShot *shot = static_cast<NamedShot *>(data);
+  wait_for_interactable("continue_game", 10000);
+  SDL_Delay(1500);  // menu-entry settle
+  interact("continue_game");
+  if (wait_for_interactable("hire_troops", kTeamMenuTimeoutMs)) {
+    SDL_Delay(1500);
+    shot->state.captures += capture_frame(shot->name);
+    SDL_Delay(200);
+    interact("back");
+  }
+  if (wait_for_interactable("begin_new_game", 10000)) {
+    SDL_Delay(750);
+    interact("quit");
+  }
+  shot->state.finished = true;
+  return 0;
+}
+
+// Restores the desktop device class even when an ASSERT unwinds the test.
+struct SingleSeatDeviceGuard {
+  SingleSeatDeviceGuard() { og::input::set_single_seat_device(true); }
+  ~SingleSeatDeviceGuard() { og::input::set_single_seat_device(false); }
+};
+
+TEST(UxShots, g2_basecamp_phone_single_seat) {
+  trace_clear();
+  CompanySlotCleanup cleanup{{"save0"}};
+  ASSERT_TRUE(seed_company_with_roster("save0", "IRON KETTLE BAND", 1700259200,
+                                       playtest_roster()));
+  ASSERT_TRUE(og::data::set_active_company_slot("save0"));
+  SingleSeatDeviceGuard phone;
+  NamedShot shot;
+  shot.name = "basecamp_phone_single_seat";
+  run_basecamp_shot(shot, &basecamp_phone_shot_injector);
+}
+
 TEST(UxShots, h_basecamp_empty) {
   trace_clear();
   CompanySlotCleanup cleanup{{"save0"}};

--- a/tests/integration/test_uxshots_probe.cpp
+++ b/tests/integration/test_uxshots_probe.cpp
@@ -295,6 +295,12 @@ int count_fade_between_traces() {
   return fades;
 }
 
+// One main-menu-boundary crossing = one fadeblack(0) + one fadeblack(1), and
+// under TESTING each traces exactly one FadeBetween line
+// (menu_screen_runner.cpp run_menu_screen).
+constexpr int kFadesPerCrossing = 2;
+constexpr int kMainMenuEntryFades = kFadesPerCrossing;
+
 // --- 1. main menu, no companies --------------------------------------------
 
 int mainmenu_no_company_injector(void *data) {
@@ -363,17 +369,31 @@ TEST(UxShots, b_mainmenu_with_company) {
 // The global CONTROLS capture retired with that screen: per-player controls
 // are shot from the seat-settings probe below.
 
+// #237 symmetry pin, the second main-menu door driven end to end (HELP is the
+// other): GAME SETTINGS must fade on the way in and on the way back. On
+// master it entered instantly and faded only on the return — the reported bug.
+std::atomic<int> g_settings_fades_at_door{-1};
+std::atomic<int> g_settings_fades_inside_settings{-1};
+std::atomic<int> g_settings_fades_after_return{-1};
+
 int game_settings_injector(void *data) {
   og::runtime::ensure_thread_session();
   ShotState *state = static_cast<ShotState *>(data);
   if (wait_for_interactable("options", 5000)) {
     SDL_Delay(1500);
+    g_settings_fades_at_door = count_fade_between_traces();
     interact("options");
     if (wait_for_interactable("options_back", 5000)) {
       SDL_Delay(1500);
+      g_settings_fades_inside_settings = count_fade_between_traces();
       state->captures += capture_frame("game_settings");
       SDL_Delay(300);
       interact("options_back");
+    }
+    if (wait_for_interactable("begin_new_game", 10000)) {
+      SDL_Delay(750);
+      g_settings_fades_after_return = count_fade_between_traces();
+      interact("quit");
     }
   }
   state->finished = true;
@@ -383,18 +403,31 @@ int game_settings_injector(void *data) {
 TEST(UxShots, b1_game_settings) {
   trace_clear();
   reap_all_companies();
+  g_settings_fades_at_door = -1;
+  g_settings_fades_inside_settings = -1;
+  g_settings_fades_after_return = -1;
   ShotState state;
   SDL_Thread *thread =
       SDL_CreateThread(game_settings_injector, "ux_settings", &state);
   ASSERT_TRUE(thread != nullptr);
   g_picker_mainmenu_calls = 0;
-  g_picker_max_mainmenu_calls = 1;
+  // Two: the SETTINGS round trip re-presents the main menu, and the return
+  // fade is half of what this test pins.
+  g_picker_max_mainmenu_calls = 2;
   picker_main(0, nullptr);
   SDL_WaitThread(thread, nullptr);
   cleanup_picker_state();
   g_picker_max_mainmenu_calls = 0;
   ASSERT_TRUE(state.finished);
   ASSERT_EQ(1, state.captures);
+  ASSERT_EQ(kMainMenuEntryFades, g_settings_fades_at_door.load())
+      << "#237: the main menu's own entry fades once";
+  ASSERT_EQ(kFadesPerCrossing, g_settings_fades_inside_settings.load() -
+                                   g_settings_fades_at_door.load())
+      << "#237: the GAME SETTINGS door must fade on the way IN";
+  ASSERT_EQ(kFadesPerCrossing, g_settings_fades_after_return.load() -
+                                   g_settings_fades_inside_settings.load())
+      << "#237: and exactly as much on the way BACK";
 }
 
 // --- 2b. per-seat settings --------------------------------------------------
@@ -414,7 +447,7 @@ int seat_settings_injector(void *data) {
       SDL_Delay(500);
       // #237: the seat editor is a door on the OPEN Base Camp — a nested
       // run_menu_screen entry, which never fades. (Base Camp's own entry
-      // from the main menu is the context switch, and that one does.)
+      // from the main menu is the boundary crossing, and that one does.)
       fades_before_door = count_fade_between_traces();
       interact("seat_card_0");
     }
@@ -1717,16 +1750,12 @@ void help_park_pointer() {
   SDL_Delay(200);
 }
 
-// #237 wiring pin: the HELP door and the way back are lateral menu-cluster
-// moves (peer transitions) — the round-trip must add zero fades.
+// #237 symmetry pin: HELP is a main-menu door, so it fades on the way in AND
+// on the way back. The round trip is three crossings — the main menu's own
+// entry, the HELP door, and the main menu's re-entry behind BACK.
 std::atomic<int> g_help_fades_at_door{-1};
+std::atomic<int> g_help_fades_inside_help{-1};
 std::atomic<int> g_help_fades_after_return{-1};
-
-// One context-switch entry (see count_fade_between_traces above) = one fadeblack(0) + one fadeblack(1), and under
-// TESTING each traces exactly one FadeBetween line
-// (menu_screen_runner.cpp run_menu_screen). Measured against the main menu,
-// whose entry is the only context switch in the HELP flow below.
-constexpr int kMainMenuEntryFades = 2;
 
 int help_screen_injector(void *data) {
   og::runtime::ensure_thread_session();
@@ -1737,6 +1766,7 @@ int help_screen_injector(void *data) {
   interact("help");
   if (wait_for_interactable("help_tab_classes", 5000)) {
     SDL_Delay(500);
+    g_help_fades_inside_help = count_fade_between_traces();
     state->captures +=
         capture_frame("help_controls", &check_help_controls_merged);
     if (wait_for_interactable("help_page_next", 2000)) {
@@ -1779,6 +1809,7 @@ TEST(UxShots, n_help_screen) {
   // File-scope atomics: re-arm them here so a --gtest_repeat iteration cannot
   // inherit the previous one's counts.
   g_help_fades_at_door = -1;
+  g_help_fades_inside_help = -1;
   g_help_fades_after_return = -1;
   ShotState state;
   SDL_Thread *thread =
@@ -1793,15 +1824,22 @@ TEST(UxShots, n_help_screen) {
   ASSERT_TRUE(state.finished);
   ASSERT_EQ(5, state.captures);
   // Exact, not relative: the trace buffer was cleared at the top of this
-  // test, so everything counted here belongs to this run. kMainMenuEntryFades
-  // is the main menu's own entry — the one context switch in the flow — and
-  // the HELP door and the way back add nothing to it.
+  // test, so everything counted here belongs to this run. Three crossings:
+  // the main menu's own entry, the HELP door, and the main menu's re-entry.
   ASSERT_EQ(kMainMenuEntryFades, g_help_fades_at_door.load())
-      << "#237: entering the main menu is a context switch and must fade "
+      << "#237: entering the main menu is a boundary crossing and must fade "
          "exactly once (fade-out + fade-in)";
-  ASSERT_EQ(kMainMenuEntryFades, g_help_fades_after_return.load())
-      << "#237: the HELP door and the return to the main menu are peer "
-         "transitions — the round-trip must add zero fades";
+  ASSERT_EQ(3 * kFadesPerCrossing, g_help_fades_after_return.load())
+      << "#237: the HELP door and the way back are BOTH main-menu crossings "
+         "— the round trip adds two fades, symmetrically";
+  // The symmetry invariant itself, as two measured deltas.
+  ASSERT_EQ(kFadesPerCrossing,
+            g_help_fades_inside_help.load() - g_help_fades_at_door.load())
+      << "#237: the HELP door must fade on the way IN";
+  ASSERT_EQ(kFadesPerCrossing,
+            g_help_fades_after_return.load() - g_help_fades_inside_help.load())
+      << "#237: and exactly as much on the way BACK — the asymmetry this "
+         "rule exists to kill";
 }
 
 TEST(UxShots, i_basecamp_paged) {

--- a/tests/integration/test_video_fade.cpp
+++ b/tests/integration/test_video_fade.cpp
@@ -1,4 +1,5 @@
 #include <openglad/interface/screen.h>
+#include <openglad/interface/input.h>
 #include <openglad/platform/video_sdl.h>
 #include <gtest/gtest.h>
 #include <SDL3/SDL.h>
@@ -52,6 +53,27 @@ TEST(VideoFade, video_fadeblack_out_then_in_tracks_the_window)
     ASSERT_TRUE(scr->window_is_black());
     ASSERT_EQ(1, scr->fadeblack(true)) << "fade-from-black completes";
     ASSERT_FALSE(scr->window_is_black()) << "the fade-in's present clears the flag";
+}
+
+// A fade's key-press abort means a press DURING the fade, never one left over
+// from the screen that just exited: the tap that dismissed the campaign intro
+// (Backspace/Esc) used to end the scroller's own fade-out on its first frame.
+// FadeBetween clears the sticky press flag when the fade starts (the same
+// path both branches take), so a pending press is spent, not inherited.
+TEST(VideoFade, video_fade_start_spends_a_pending_key_press)
+{
+    screen* const scr = og::runtime::current_session->myscreen_;
+    scr->buffer_to_screen(0, 0, 320, 200);
+    clear_key_press_event();
+    input_key_press_event_ref() = 1;  // the dismissal tap, still remembered
+    ASSERT_EQ(1, scr->fadeblack(false)) << "the fade-out runs";
+    ASSERT_EQ(0, query_key_press_event())
+        << "starting a fade clears the stale press so the animation cannot "
+           "abort on a key the previous screen already consumed";
+    ASSERT_TRUE(scr->window_is_black());
+    input_key_press_event_ref() = 1;
+    ASSERT_EQ(1, scr->fadeblack(true)) << "the fade-in runs";
+    ASSERT_EQ(0, query_key_press_event()) << "the fade-in clears it too";
 }
 
 // The "never presented" invariant holds a present to the rect it DECLARED: a

--- a/tests/integration/test_video_fade.cpp
+++ b/tests/integration/test_video_fade.cpp
@@ -31,12 +31,22 @@ static SurfacePtr make_surface_masks(int w, int h, int depth,
 }
 } // namespace
 
-TEST(VideoFade, video_fadeblack_smoke_in_and_out)
+TEST(VideoFade, video_fadeblack_out_then_in_tracks_the_window)
 {
-    // In TESTING, FadeBetween skips animation but still exercises surface checks + blits.
-    int r1 = og::runtime::current_session->myscreen_->fadeblack(true);
-    int r2 = og::runtime::current_session->myscreen_->fadeblack(false);
-    ASSERT_TRUE(r1 >= 0 && r2 >= 0) << "fadeblack should return non-negative status";
+    // In TESTING, FadeBetween skips animation but still exercises surface
+    // checks + blits. The order is the ownership rule's: the frame on the
+    // window (the test boundary presents every canvas) fades OUT, then the
+    // buffer fades IN over the black that left; a fade-in first would be the
+    // "fade-in without a fade-out" violation the listener fails tests on.
+    screen* const scr = og::runtime::current_session->myscreen_;
+    ASSERT_FALSE(scr->window_is_black()) << "the test boundary presents a frame";
+    ASSERT_EQ(1, scr->fadeblack(false)) << "fade-to-black completes";
+    ASSERT_TRUE(scr->window_is_black()) << "a completed fade-out blackens the window";
+    ASSERT_EQ(0, scr->fadeblack(false))
+        << "a second fade-out is a no-op on a black window (returns 0, no fade)";
+    ASSERT_TRUE(scr->window_is_black());
+    ASSERT_EQ(1, scr->fadeblack(true)) << "fade-from-black completes";
+    ASSERT_FALSE(scr->window_is_black()) << "the fade-in's present clears the flag";
 }
 
 

--- a/tests/integration/test_video_fade.cpp
+++ b/tests/integration/test_video_fade.cpp
@@ -1,9 +1,11 @@
 #include <openglad/interface/screen.h>
+#include <openglad/platform/video_sdl.h>
 #include <gtest/gtest.h>
 #include <SDL3/SDL.h>
 
 #include <cstring>
 #include <memory>
+#include <string>
 #include <vector>
 
 // myscreen is now a macro defined in base.h (via game_session.h)
@@ -34,12 +36,15 @@ static SurfacePtr make_surface_masks(int w, int h, int depth,
 TEST(VideoFade, video_fadeblack_out_then_in_tracks_the_window)
 {
     // In TESTING, FadeBetween skips animation but still exercises surface
-    // checks + blits. The order is the ownership rule's: the frame on the
-    // window (the test boundary presents every canvas) fades OUT, then the
-    // buffer fades IN over the black that left; a fade-in first would be the
-    // "fade-in without a fade-out" violation the listener fails tests on.
+    // checks + blits. The order is the ownership rule's: a presented frame
+    // fades OUT, then the buffer fades IN over the black that left; a fade-in
+    // first would be the "fade-in without a fade-out" violation the listener
+    // fails tests on.
     screen* const scr = og::runtime::current_session->myscreen_;
-    ASSERT_FALSE(scr->window_is_black()) << "the test boundary presents a frame";
+    ASSERT_TRUE(scr->window_is_black())
+        << "the test boundary leaves the window black, as an exit fade does";
+    scr->buffer_to_screen(0, 0, 320, 200);
+    ASSERT_FALSE(scr->window_is_black()) << "a present clears the flag";
     ASSERT_EQ(1, scr->fadeblack(false)) << "fade-to-black completes";
     ASSERT_TRUE(scr->window_is_black()) << "a completed fade-out blackens the window";
     ASSERT_EQ(0, scr->fadeblack(false))
@@ -47,6 +52,58 @@ TEST(VideoFade, video_fadeblack_out_then_in_tracks_the_window)
     ASSERT_TRUE(scr->window_is_black());
     ASSERT_EQ(1, scr->fadeblack(true)) << "fade-from-black completes";
     ASSERT_FALSE(scr->window_is_black()) << "the fade-in's present clears the flag";
+}
+
+// The "never presented" invariant holds a present to the rect it DECLARED: a
+// partial-rect present (a pressed button face, the help scroller's dialog
+// rect) vouches for nothing outside it, so a draw outside that rect is still
+// unpresented at the next fade-out. (The nearest present path happens to
+// upload the whole surface; the SAI/Eagle path refreshes only the rect of
+// its scaled scratch. The declared rect is the honest lower bound.)
+TEST(VideoFade, video_fadeblack_out_after_a_draw_outside_the_presented_rect_is_a_violation)
+{
+    screen* const scr = og::runtime::current_session->myscreen_;
+    ASSERT_EQ(0, og::video_testing::g_fade_violations.load());
+
+    // A full-frame present: everything on the window matches the buffer.
+    scr->clearbuffer();
+    scr->fastbox(0, 0, 320, 200, 40);
+    scr->buffer_to_screen(0, 0, 320, 200);
+    ASSERT_FALSE(scr->window_is_black());
+
+    // Control: a draw inside a rect, presented by that rect, then a fade-out
+    // — the fade reads exactly what the window shows. No violation.
+    scr->fastbox(100, 50, 40, 20, 90);
+    scr->buffer_to_screen(100, 50, 40, 20);
+    ASSERT_EQ(1, scr->fadeblack(false)) << "fade-out completes";
+    EXPECT_EQ(0, og::video_testing::g_fade_violations.load())
+        << "a draw covered by its own partial present is presented";
+    ASSERT_TRUE(scr->window_is_black());
+
+    // Bring a frame back the honest way (fade-in from the buffer), then the
+    // shape under test: a partial present of one rect, a draw OUTSIDE it,
+    // and a fade-out. The window never showed that draw.
+    ASSERT_EQ(1, scr->fadeblack(true));
+    scr->fastbox(100, 50, 40, 20, 120);
+    scr->buffer_to_screen(100, 50, 40, 20);
+    scr->fastbox(200, 150, 30, 30, 200);  // outside the presented rect
+    ASSERT_EQ(1, scr->fadeblack(false))
+        << "production still fades — the violation is a TESTING report";
+    EXPECT_EQ(1, og::video_testing::g_fade_violations.load())
+        << "a draw outside every present's rect is a fade from a frame the "
+           "window never showed";
+    const std::vector<std::string> violations =
+        og::video_testing::fade_violation_messages();
+    ASSERT_EQ(1u, violations.size());
+    EXPECT_NE(std::string::npos,
+              violations.front().find("fade-out from a frame that was never presented"))
+        << violations.front();
+    EXPECT_NE(std::string::npos,
+              violations.front().find("x 200..229, y 150..179 of 320x200"))
+        << "the report names the culprit draw's bounding box: "
+        << violations.front();
+    // Triggered on purpose; the listener would otherwise fail this test.
+    og::video_testing::reset_fade_violations();
 }
 
 

--- a/tests/integration/test_video_fade.cpp
+++ b/tests/integration/test_video_fade.cpp
@@ -1,5 +1,6 @@
 #include <openglad/interface/screen.h>
 #include <openglad/interface/input.h>
+#include "test_input_helpers.h"
 #include <openglad/platform/video_sdl.h>
 #include <gtest/gtest.h>
 #include <SDL3/SDL.h>
@@ -55,25 +56,37 @@ TEST(VideoFade, video_fadeblack_out_then_in_tracks_the_window)
     ASSERT_FALSE(scr->window_is_black()) << "the fade-in's present clears the flag";
 }
 
-// A fade's key-press abort means a press DURING the fade, never one left over
-// from the screen that just exited: the tap that dismissed the campaign intro
-// (Backspace/Esc) used to end the scroller's own fade-out on its first frame.
-// FadeBetween clears the sticky press flag when the fade starts (the same
-// path both branches take), so a pending press is spent, not inherited.
-TEST(VideoFade, video_fade_start_spends_a_pending_key_press)
+// A fade's key-press abort means a press DURING the fade — an edge on the
+// press serial — never the latch left over from the screen that just exited:
+// the tap that dismissed the campaign intro (Backspace/Esc) used to end the
+// scroller's own fade-out on its first frame. The latch itself is untouched
+// by a fade: the intro's pages read it to abort, and a fade must not spend
+// it for them.
+TEST(VideoFade, video_fade_leaves_the_key_latch_alone_and_counts_presses)
 {
     screen* const scr = og::runtime::current_session->myscreen_;
     scr->buffer_to_screen(0, 0, 320, 200);
     clear_key_press_event();
-    input_key_press_event_ref() = 1;  // the dismissal tap, still remembered
+    input_key_press_event_ref() = 1;  // the dismissal tap, still latched
+    const unsigned serial_before = query_key_press_serial();
     ASSERT_EQ(1, scr->fadeblack(false)) << "the fade-out runs";
-    ASSERT_EQ(0, query_key_press_event())
-        << "starting a fade clears the stale press so the animation cannot "
-           "abort on a key the previous screen already consumed";
+    ASSERT_EQ(1, query_key_press_event())
+        << "a fade never clears the latch — the intro's abort reads it";
+    ASSERT_EQ(serial_before, query_key_press_serial())
+        << "no key was pressed during the fade, so the serial is unchanged";
     ASSERT_TRUE(scr->window_is_black());
-    input_key_press_event_ref() = 1;
     ASSERT_EQ(1, scr->fadeblack(true)) << "the fade-in runs";
-    ASSERT_EQ(0, query_key_press_event()) << "the fade-in clears it too";
+    ASSERT_EQ(1, query_key_press_event()) << "still latched after the fade-in";
+
+    // A real press advances the serial (the edge the animation aborts on).
+    clear_key_press_event();
+    inject_key_down(SDLK_SPACE);
+    get_input_events(POLL);
+    ASSERT_EQ(1, query_key_press_event()) << "the press latched";
+    ASSERT_EQ(serial_before + 1, query_key_press_serial())
+        << "and advanced the serial exactly once";
+    clear_key_press_event();
+    clear_events();
 }
 
 // The "never presented" invariant holds a present to the rect it DECLARED: a

--- a/tests/integration/test_view_team.cpp
+++ b/tests/integration/test_view_team.cpp
@@ -579,7 +579,7 @@ static int base_camp_row_train_injector(void* data)
         inject_key_press(SDLK_ESCAPE, 10);
         return 0;
     }
-    SDL_Delay(750);  // FadeAroundEntry eats early clicks
+    SDL_Delay(750);  // entry settle (fades are instant under TESTING)
     // Tap the rendered name itself, not the center of the wide row hit zone.
     // Round 6 places NAME at x=88; row 1 remains y=59..68.
     const auto [mapped_x, mapped_y] =
@@ -737,7 +737,7 @@ static int base_camp_scenario_line_injector(void* data)
         inject_key_press(SDLK_ESCAPE, 10);
         return 0;
     }
-    SDL_Delay(750);  // FadeAroundEntry eats early clicks
+    SDL_Delay(750);  // entry settle (fades are instant under TESTING)
     const auto [mapped_x, mapped_y] =
         ui_canvas_to_window(30.0f, 19.0f);
     inject_click(static_cast<int>(mapped_x), static_cast<int>(mapped_y), 100);
@@ -4129,7 +4129,7 @@ static int base_camp_train_rename_injector(void* data)
         inject_key_press(SDLK_ESCAPE, 10);
         return 0;
     }
-    SDL_Delay(750);  // FadeAroundEntry eats early clicks
+    SDL_Delay(750);  // entry settle (fades are instant under TESTING)
     interact("roster_row_1");
 
     if (!wait_for_interactable("rename", 10000)) {

--- a/tests/integration/test_view_team.cpp
+++ b/tests/integration/test_view_team.cpp
@@ -31,6 +31,7 @@
 #include <openglad/core/util.h>
 #include <atomic>
 #include <cstdint>
+#include <cstdlib>
 #include <format>
 #include <functional>
 #include <list>
@@ -112,6 +113,8 @@ namespace og::ui {
 void picker_testing_draw_menu_highlight(const MenuScreenSpec& spec,
                                         const button* buttons,
                                         int highlighted_button);
+void picker_testing_apply_row_states(const MenuScreenSpec& spec,
+                                     button* buttons, int num_buttons);
 }
 #endif
 
@@ -2311,9 +2314,12 @@ TEST(ViewTeam, base_camp_add_player_slot_claims_a_seat_through_a_real_click)
         << "slot one must read ADD PLAYER beside a single claimed seat";
     EXPECT_TRUE(state.slot_became_a_card)
         << "the click must claim a seat, not just repaint";
-    EXPECT_EQ("P2 ", state.slot_one_label_after.substr(0, 3))
-        << "the new seat lands in the slot that was clicked, as P2: '"
-        << state.slot_one_label_after << "'";
+    // Exact, not a prefix: ensure_unique_seat_mapping lands the second seat
+    // on the arrow profile, so the whole face is known — "P2 " + the arrow
+    // glyphs + the load-bearing chip-clearance pad.
+    EXPECT_EQ(std::format("P2 {} ", og::input::kArrowGlyphs),
+              state.slot_one_label_after)
+        << "the new seat lands in the slot that was clicked, as P2";
     EXPECT_TRUE(trace_contains("basecamp", "seat_add local_count=2"))
         << "the slot runs the add path itself, gates included";
     EXPECT_EQ(2, static_cast<int>(save.numplayers));
@@ -3138,11 +3144,147 @@ TEST(ViewTeam, base_camp_seat_rail_draws_labelled_placeholders_and_the_chip)
         << "the ADD PLAYER glyphs must actually be painted on the slot";
     EXPECT_NE(blank_face, empty_recess)
         << "and even bare, the slot is a raised button, not the old recess";
+    // And specifically the LAST glyph. "ADD PLAYER" is ten characters with no
+    // trailing pad, so vdisplay centers it from x+6 and the final "R" occupies
+    // x+60..x+64 — the very columns a card's chip clearance cuts away. The
+    // focus-ring probe below is only meaningful because this ink is there.
+    constexpr int kLastGlyphFirstCol = 60;
+    constexpr int kLastGlyphCols = 5;
+    const auto last_glyph_columns = [&](const std::vector<Uint32>& block) {
+        std::vector<Uint32> ink;
+        for (int row = 0; row < 10; ++row) {
+            for (int col = 0; col < kLastGlyphCols; ++col) {
+                ink.push_back(block[static_cast<std::size_t>(
+                    row * 70 + kLastGlyphFirstCol + col)]);
+            }
+        }
+        return ink;
+    };
+    EXPECT_NE(last_glyph_columns(blank_face), last_glyph_columns(slot_two))
+        << "the final glyph of ADD PLAYER lands in the card's chip columns";
 
-    // A FULL LOBBY dims the same face. Mirror the engine's one-line gate rule
-    // (menu_screen_runner apply_row_states: Disabled => live->color = GREY)
-    // off the row's own state_override, so the paint and the state can never
-    // drift apart here.
+    // KEYBOARD FOCUS on a bare slot. A card's ring is cut back ten pixels so
+    // it cannot paint over the numbered team chip; a placeholder has no chip
+    // and a pad-less ten-glyph label, so it takes the FULL face ring. Sample
+    // the pulse until both extremes have been seen and hold the rule at each:
+    // the ring is yellow, it stays inside the slot, it hugs the full 70px face
+    // symmetrically, and it never touches that last glyph.
+    output->fastbox(0, 0, 4, 4, YELLOW);
+    Uint8 yellow_r = 0;
+    Uint8 yellow_g = 0;
+    Uint8 yellow_b = 0;
+    output->get_pixel(1, 1, &yellow_r, &yellow_g, &yellow_b);
+    const Uint32 kYellow = (static_cast<Uint32>(yellow_r) << 16) |
+        (static_cast<Uint32>(yellow_g) << 8) |
+        static_cast<Uint32>(yellow_b);
+
+    // The whole rail band, so a ring that escaped onto a neighbour or the
+    // panel bevel is caught rather than sampled around.
+    constexpr int kRailLeft = 8;
+    constexpr int kRailTop = 162;
+    constexpr int kRailWidth = 313 - kRailLeft + 1;
+    constexpr int kRailHeight = 176 - kRailTop + 1;
+    const auto probe_placeholder_focus = [&](int slot, const char* what) {
+        const button& face = buttons[kBaseCampSeatCardBase + slot];
+        const int face_x = face.x;
+        const int face_y = face.y;
+        render();
+        const std::vector<Uint32> baseline =
+            capture_block(kRailLeft, kRailTop, kRailWidth, kRailHeight);
+        // The pulse insets by 0..3px. Both ends must be observed: the widest
+        // ring is the one a chip clearance would visibly cut, and the tightest
+        // proves the probe is reading a live pulse rather than a still frame.
+        // (The extremes are sampled as bands — sinf lands EXACTLY on +/-1 for
+        // a vanishing slice of the period, so pinning inset == 0 would be a
+        // coin flip.)
+        bool saw_wide_ring = false;
+        bool saw_tight_ring = false;
+        for (int sample = 0;
+             sample < 500 && !(saw_wide_ring && saw_tight_ring); ++sample)
+        {
+            render();
+            pks().menu_nav_enabled = true;
+            og::ui::picker_testing_draw_menu_highlight(
+                spec, buttons, kBaseCampSeatCardBase + slot);
+            const std::vector<Uint32> focused =
+                capture_block(kRailLeft, kRailTop, kRailWidth, kRailHeight);
+
+            int min_x = kRailLeft + kRailWidth;
+            int max_x = kRailLeft - 1;
+            int min_y = kRailTop + kRailHeight;
+            int max_y = kRailTop - 1;
+            for (int y = 0; y < kRailHeight; ++y) {
+                for (int x = 0; x < kRailWidth; ++x) {
+                    const std::size_t at =
+                        static_cast<std::size_t>(y * kRailWidth + x);
+                    if (focused[at] == baseline[at])
+                        continue;
+                    const int px = kRailLeft + x;
+                    const int py = kRailTop + y;
+                    ASSERT_EQ(kYellow, focused[at])
+                        << what << ": focus painted something that is not the "
+                                   "ring at (" << px << "," << py << ")";
+                    // The interior ring's own convention: draw_highlight_
+                    // interior boxes x..x+sizex inclusive, so the outermost
+                    // pulse lands one past the face's last column (the same
+                    // edge the move-up column's ring uses).
+                    ASSERT_GE(px, face_x) << what;
+                    ASSERT_LE(px, face_x + face.sizex) << what;
+                    ASSERT_GE(py, face_y) << what;
+                    ASSERT_LE(py, face_y + face.sizey) << what;
+                    min_x = std::min(min_x, px);
+                    max_x = std::max(max_x, px);
+                    min_y = std::min(min_y, py);
+                    max_y = std::max(max_y, py);
+                }
+            }
+            ASSERT_LE(min_x, max_x) << what << ": no focus ring was drawn";
+
+            // THE RULE. Both insets are measured against the FULL 70px face.
+            // A chip clearance here would push the right inset out to ten and
+            // strand the ring inside the label.
+            const int left_inset = min_x - face_x;
+            const int right_inset = face_x + face.sizex - max_x;
+            EXPECT_LE(left_inset, 3) << what;
+            EXPECT_LE(right_inset, 3)
+                << what << ": the ring must hug the bare slot's full face, "
+                           "not a card's chip-cleared one";
+            EXPECT_LE(std::abs(left_inset - right_inset), 1)
+                << what << ": the pulse insets both edges by the same step "
+                           "(float truncation allows one pixel)";
+
+            // The last glyph survives. Only the ring's two horizontal runs
+            // (min_y / max_y) may cross the label at all.
+            for (int py = min_y + 1; py < max_y; ++py) {
+                for (int col = 0; col < kLastGlyphCols; ++col) {
+                    const int px = face_x + kLastGlyphFirstCol + col;
+                    const std::size_t at = static_cast<std::size_t>(
+                        (py - kRailTop) * kRailWidth + px - kRailLeft);
+                    ASSERT_EQ(baseline[at], focused[at])
+                        << what << ": the ring struck through the label's "
+                                   "last glyph at (" << px << "," << py << ")";
+                }
+            }
+
+            if (right_inset <= 1)
+                saw_wide_ring = true;
+            if (right_inset >= 3)
+                saw_tight_ring = true;
+            SDL_Delay(5);
+        }
+        EXPECT_TRUE(saw_wide_ring)
+            << what << ": never observed the ring near its outermost, where a "
+                       "chip clearance would show";
+        EXPECT_TRUE(saw_tight_ring)
+            << what << ": never observed the ring at its innermost";
+        pks().menu_nav_enabled = false;
+    };
+    probe_placeholder_focus(1, "ADD PLAYER");
+
+    // A FULL LOBBY dims the same face — and the dim comes from the ENGINE'S
+    // gate pass (menu_screen_runner apply_row_states: Disabled =>
+    // live->color = GREY), driven here exactly as the loop drives it, so a
+    // test that painted grey by hand can never stand in for it.
     for (int i = 0; i < 15; ++i)
     {
         lobby.players.push_back(make_foreign_lobby_player(
@@ -3156,19 +3298,19 @@ TEST(ViewTeam, base_camp_seat_rail_draws_labelled_placeholders_and_the_chip)
               spec.rows[kBaseCampSeatCardBase + 1].state_override(
                   og::ui::MenuLabelContext{}));
     EXPECT_EQ("LOBBY FULL", buttons[kBaseCampSeatCardBase + 1].label);
+    og::ui::picker_testing_apply_row_states(spec, buttons, count);
     for (int slot = 1; slot < kBaseCampSeatCardsPerPage; ++slot)
     {
         const int ordinal = kBaseCampSeatCardBase + slot;
-        if (spec.rows[ordinal].state_override(og::ui::MenuLabelContext{}) ==
-            og::ui::RowState::Disabled)
-        {
-            vbutton* const live =
-                og::runtime::current_session
-                    ->allbuttons_[static_cast<std::size_t>(ordinal)];
-            ASSERT_NE(nullptr, live);
-            live->color = GREY;
-            live->label = buttons[ordinal].label;
-        }
+        vbutton* const live =
+            og::runtime::current_session
+                ->allbuttons_[static_cast<std::size_t>(ordinal)];
+        ASSERT_NE(nullptr, live);
+        EXPECT_EQ(GREY, live->color)
+            << "slot " << slot << ": the gate pass dims a Disabled slot";
+        EXPECT_EQ(0, live->myfunc)
+            << "slot " << slot << ": and makes it inert";
+        EXPECT_EQ("LOBBY FULL", live->label) << "slot " << slot;
     }
     render();
     const std::vector<Uint32> dimmed =
@@ -3177,6 +3319,9 @@ TEST(ViewTeam, base_camp_seat_rail_draws_labelled_placeholders_and_the_chip)
         << "a slot the lobby cannot fill must not look like one it can";
     EXPECT_EQ(dimmed, capture_block(kSlotTwoX, card.y, 70, 10))
         << "every dimmed slot wears the same face";
+    // LOBBY FULL is Disabled but still navigable, so keyboard focus lands on
+    // it too — and its ten pad-less glyphs need the same clearance-free ring.
+    probe_placeholder_focus(1, "LOBBY FULL");
 
     save.reset();
 }

--- a/tests/integration/test_view_team.cpp
+++ b/tests/integration/test_view_team.cpp
@@ -1690,8 +1690,6 @@ TEST(ViewTeam, base_camp_seat_card_focus_preserves_neighbors_and_team_chip)
         });
     }
     state.local_seat_indices = {0, 1};
-    state.seat_page =
-        og::ui::PageModel::make(5, kBaseCampSeatCardsPerPage);
     og::ui::install_base_camp_state_for_screen(&state);
 
     const og::ui::MenuScreenSpec& spec =
@@ -1706,14 +1704,17 @@ TEST(ViewTeam, base_camp_seat_card_focus_preserves_neighbors_and_team_chip)
     int highlighted = kBaseCampSeatCardBase + 1;
     spec.nav.rewire(buttons, count, highlighted);
     ASSERT_EQ(kBaseCampSeatCardBase + 1, highlighted);
-    ASSERT_FALSE(buttons[kBaseCampSeatPagePrevIndex].hidden);
-    ASSERT_FALSE(buttons[kBaseCampSeatPageNextIndex].hidden);
+    // Two of this machine's seats and two ADD PLAYER placeholders: the three
+    // remote seats are counted on the header line, never in the rail.
+    for (int slot = 0; slot < kBaseCampSeatCardsPerPage; ++slot)
+        ASSERT_FALSE(buttons[kBaseCampSeatCardBase + slot].hidden) << slot;
 
     constexpr int kCanvasWidth = 320;
     constexpr int kCanvasHeight = 200;
-    // The whole rail, from the '+' at the panel's left edge to the '>' on
-    // its right rail. The selected card's rect comes off the live button so
-    // a re-spaced rail (#236) cannot silently aim this probe at a gutter.
+    // The whole rail, from the first slot on the panel's left edge to the
+    // last on its right rail. The selected card's rect comes off the live
+    // button so a re-gridded rail cannot silently aim this probe at a
+    // gutter.
     constexpr int kRailLeft = 8;
     constexpr int kRailTop = 162;
     constexpr int kRailRight = 313;
@@ -1722,9 +1723,9 @@ TEST(ViewTeam, base_camp_seat_card_focus_preserves_neighbors_and_team_chip)
     constexpr int kRailHeight = kRailBottom - kRailTop + 1;
     const int kSelectedCardX = buttons[kBaseCampSeatCardBase + 1].x;
     const int kSelectedCardY = buttons[kBaseCampSeatCardBase + 1].y;
-    const int kLabelFocusRight = kSelectedCardX + 47;
+    const int kLabelFocusRight = kSelectedCardX + 60;
     const int kFocusBottom = kSelectedCardY + 10;
-    const int kChipX = kSelectedCardX + 48;
+    const int kChipX = kSelectedCardX + 61;
     const int kChipY = kSelectedCardY + 1;
     constexpr int kChipSize = 8;
 
@@ -2207,7 +2208,176 @@ og::sim::LobbyPlayer make_foreign_lobby_player(std::uint8_t player_index,
     return player;
 }
 
+// --- The placeholder paths, end to end through the REAL click dispatch ----
+//
+// The direct on_spec_row drives above pin the rule; these pin that a finger
+// on the rail reaches it. A bare slot is an ordinary button, so it goes
+// through leftmouse -> vbutton::leftclick -> MenuSpecRow like every other
+// row, and a full lobby's slot is an ordinary DISABLED button, which the
+// engine makes inert before the handler ever sees it.
+
+struct SlotClickFlowState
+{
+    bool finished = false;
+    bool saw_rail = false;
+    bool slot_offered_a_seat = false;
+    bool slot_became_a_card = false;
+    std::string slot_one_label_after;
+};
+
+int add_player_slot_injector(void* data)
+{
+    og::runtime::ensure_thread_session();
+    auto* state = static_cast<SlotClickFlowState*>(data);
+    if (!wait_for_interactable("seat_card_1", 10000)) {
+        state->finished = true;
+        inject_key_press(SDLK_ESCAPE, 10);
+        return 0;
+    }
+    state->saw_rail = true;
+    state->slot_offered_a_seat =
+        wait_for_interactable_label("seat_card_1", "ADD PLAYER", 5000);
+    SDL_Delay(300);
+    interact("seat_card_1");
+    // Wait on the SEAT, not on a clock: the slot stops offering a seat only
+    // once the lobby has actually published one.
+    state->slot_became_a_card =
+        wait_for_interactable_label_change("seat_card_1", "ADD PLAYER", 5000);
+    state->slot_one_label_after = interactable_label("seat_card_1");
+    SDL_Delay(300);
+    interact("back");
+    state->finished = true;
+    return 0;
+}
+
+int lobby_full_slot_injector(void* data)
+{
+    og::runtime::ensure_thread_session();
+    auto* state = static_cast<SlotClickFlowState*>(data);
+    if (!wait_for_interactable("seat_card_1", 10000)) {
+        state->finished = true;
+        inject_key_press(SDLK_ESCAPE, 10);
+        return 0;
+    }
+    state->saw_rail = true;
+    state->slot_offered_a_seat =
+        wait_for_interactable_label("seat_card_1", "LOBBY FULL", 5000);
+    SDL_Delay(300);
+    interact("seat_card_1");
+    SDL_Delay(500);
+    state->slot_one_label_after = interactable_label("seat_card_1");
+    interact("back");
+    state->finished = true;
+    return 0;
+}
+
 } // namespace
+
+// ADD PLAYER SUCCESS. A click on the bare slot beside the card claims a seat
+// and the slot becomes that seat's card — the placeholder is the door, and
+// the door is the same one the retired [+] opened.
+TEST(ViewTeam, base_camp_add_player_slot_claims_a_seat_through_a_real_click)
+{
+#if defined(DISABLE_MULTIPLAYER) || defined(USE_TOUCH_INPUT)
+    GTEST_SKIP() << "this build seats one local player";
+#else
+    trace_clear();
+    FactoryMappingGuard mapping_guard;
+
+    SaveData& save = og::runtime::current_session->myscreen_->save_data;
+    save.reset();
+    save.numplayers = 1;
+    save.current_campaign = "gladiator";
+    save.scen_num = 1;
+    save.save_name = "IRON KETTLE BAND";
+    auto hero = std::make_unique<guy>(FAMILY_SOLDIER);
+    hero->name = "GORT";
+    save.team_list[0] = std::move(hero);
+    save.team_size = 1;
+
+    SlotClickFlowState state;
+    SDL_Thread* thread =
+        SDL_CreateThread(add_player_slot_injector, "add_player_slot", &state);
+    ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
+
+    pks().selected_menu_item = nullptr;
+    (void)create_team_menu(0);
+    SDL_WaitThread(thread, nullptr);
+    cleanup_picker_state();
+
+    ASSERT_TRUE(state.finished) << "the injector should unwind";
+    ASSERT_TRUE(state.saw_rail) << "flow must reach the seat rail";
+    EXPECT_TRUE(state.slot_offered_a_seat)
+        << "slot one must read ADD PLAYER beside a single claimed seat";
+    EXPECT_TRUE(state.slot_became_a_card)
+        << "the click must claim a seat, not just repaint";
+    EXPECT_EQ("P2 ", state.slot_one_label_after.substr(0, 3))
+        << "the new seat lands in the slot that was clicked, as P2: '"
+        << state.slot_one_label_after << "'";
+    EXPECT_TRUE(trace_contains("basecamp", "seat_add local_count=2"))
+        << "the slot runs the add path itself, gates included";
+    EXPECT_EQ(2, static_cast<int>(save.numplayers));
+    save.reset();
+#endif
+}
+
+// LOBBY FULL. Sixteen seats in the lobby and one of them this machine's: the
+// three slots this machine could otherwise fill go DIMMED, and a click on one
+// is eaten by the engine's Disabled gate — no add, no popup, no seat.
+TEST(ViewTeam, base_camp_lobby_full_slot_is_inert_under_a_real_click)
+{
+#if defined(DISABLE_MULTIPLAYER) || defined(USE_TOUCH_INPUT)
+    GTEST_SKIP() << "this build seats one local player";
+#else
+    trace_clear();
+    FactoryMappingGuard mapping_guard;
+
+    SaveData& save = og::runtime::current_session->myscreen_->save_data;
+    save.reset();
+    save.numplayers = 1;
+    save.current_campaign = "gladiator";
+    save.scen_num = 1;
+    save.save_name = "IRON KETTLE BAND";
+
+    NetworkedRosterLobbyClient lobby;
+    lobby.host = false;
+    lobby.active_local_count = 1u;
+    for (std::uint8_t index = 0;
+         index < static_cast<std::uint8_t>(og::sim::kMaxGlobalPlayers);
+         ++index)
+    {
+        lobby.players.push_back(make_foreign_lobby_player(
+            index, "net-crowd", index == 0 ? "IRON KETTLE BAND" : "OTHERS",
+            0, 0));
+    }
+    lobby.local_indices = {0};
+    ActivePickerLobbyClientGuard client_guard(&lobby);
+
+    SlotClickFlowState state;
+    SDL_Thread* thread =
+        SDL_CreateThread(lobby_full_slot_injector, "lobby_full_slot", &state);
+    ASSERT_TRUE(thread != nullptr) << "failed to create injector thread";
+
+    pks().selected_menu_item = nullptr;
+    (void)create_team_menu(0);
+    SDL_WaitThread(thread, nullptr);
+    cleanup_picker_state();
+
+    ASSERT_TRUE(state.finished) << "the injector should unwind";
+    ASSERT_TRUE(state.saw_rail) << "flow must reach the seat rail";
+    EXPECT_TRUE(state.slot_offered_a_seat)
+        << "a slot the lobby cannot fill must say so, not vanish";
+    EXPECT_EQ("LOBBY FULL", state.slot_one_label_after)
+        << "and it must still say so after the click";
+    EXPECT_TRUE(
+        trace_contains("menu_engine", "disabled_row_click seat_card_1"))
+        << "the click landed on the dimmed slot";
+    EXPECT_EQ(0, lobby.add_seat_calls)
+        << "a dimmed slot must never reach the add path";
+    EXPECT_FALSE(trace_contains("basecamp", "seat_add"));
+    save.reset();
+#endif
+}
 
 TEST(ViewTeam, stable_seat_token_rejects_reindexed_display_handle)
 {
@@ -2391,7 +2561,11 @@ TEST(ViewTeam, base_camp_mp_columns_gate_foreign_rows_and_cap_deploys)
     save.reset();
 }
 
-TEST(ViewTeam, base_camp_seat_rail_targets_owned_global_seat_and_clamps_page)
+// The rail is THIS MACHINE'S seats. A five-seat lobby in which this client
+// owns exactly one (global P5) shows ONE card and three ADD PLAYER slots —
+// the four remote seats are counted on the header line and listed in VIEW
+// LEVEL's SEATS report, and no rail slot ever names another company.
+TEST(ViewTeam, base_camp_seat_rail_shows_only_this_machines_seats)
 {
     trace_clear();
     FactoryMappingGuard mapping_guard;
@@ -2429,7 +2603,7 @@ TEST(ViewTeam, base_camp_seat_rail_targets_owned_global_seat_and_clamps_page)
     og::ui::BaseCampScreenState state;
     og::ui::base_camp_refresh_rows(state);
     ASSERT_EQ(5u, state.seats.size());
-    ASSERT_EQ(2, state.seat_page.page_count());
+    ASSERT_EQ(1u, state.local_seat_indices.size());
     for (int i = 0; i < 5; ++i)
         EXPECT_EQ(i, state.seats[static_cast<std::size_t>(i)].player_index);
 
@@ -2443,33 +2617,26 @@ TEST(ViewTeam, base_camp_seat_rail_targets_owned_global_seat_and_clamps_page)
     const int count = picker_createmenu_button_count();
     int highlighted = kBaseCampSeatCardBase;
     base_spec.nav.rewire(buttons, count, highlighted);
-    EXPECT_FALSE(buttons[kBaseCampSeatPagePrevIndex].hidden);
-    EXPECT_FALSE(buttons[kBaseCampSeatPageNextIndex].hidden);
-    EXPECT_EQ("P1 IRO ", buttons[kBaseCampSeatCardBase].label);
-    EXPECT_EQ("P4 IRO ", buttons[kBaseCampSeatCardBase + 3].label);
-
-    // A foreign card is informational only and names the full company.
-    trace_clear();
-    EXPECT_EQ(MENU_OK,
-              base_spec.on_spec_row(kBaseCampSeatCardBase, &state));
-    EXPECT_TRUE(trace_contains("popup", "Iron Host"));
-    EXPECT_TRUE(lobby.seat_team_calls.empty());
-
-    // Page 2 contains only P5, which this client owns.
-    EXPECT_EQ(MENU_OK,
-              base_spec.on_spec_row(kBaseCampSeatPageNextIndex, &state));
-    EXPECT_EQ(1, state.seat_page.page);
-    // Stepping beyond the final page is a no-op.
-    EXPECT_EQ(MENU_OK,
-              base_spec.on_spec_row(kBaseCampSeatPageNextIndex, &state));
-    EXPECT_EQ(1, state.seat_page.page);
-    buttons = picker_createmenu_buttons();
-    base_spec.nav.rewire(buttons, count, highlighted);
     // The owned card names this machine's FIRST local profile (design §2.3):
-    // global P5, local slot 0, factory WASD.
+    // global P5, local slot 0, factory WASD. Slot zero, not slot four — the
+    // rail indexes local slots, so a machine that owns one seat shows it
+    // first however high its global P# runs.
     EXPECT_EQ("P5 WASD ", buttons[kBaseCampSeatCardBase].label);
-    for (int card = 1; card < kBaseCampSeatCardsPerPage; ++card)
-        EXPECT_TRUE(buttons[kBaseCampSeatCardBase + card].hidden);
+    for (int slot = 1; slot < kBaseCampSeatCardsPerPage; ++slot)
+    {
+        EXPECT_FALSE(buttons[kBaseCampSeatCardBase + slot].hidden) << slot;
+        EXPECT_EQ("ADD PLAYER", buttons[kBaseCampSeatCardBase + slot].label)
+            << slot;
+    }
+    // The four remote seats are on the header line's census, never in the
+    // rail: "Iron Host" appears on no slot face.
+    for (int slot = 0; slot < kBaseCampSeatCardsPerPage; ++slot)
+    {
+        EXPECT_EQ(std::string::npos,
+                  buttons[kBaseCampSeatCardBase + slot].label.find("IRO"))
+            << "slot " << slot << " names a foreign company";
+    }
+    EXPECT_TRUE(lobby.seat_team_calls.empty());
 
     // Clicking that card opens the stable-token editor in production. Drive
     // its TEAM row directly here so the test never depends on a blocking
@@ -2534,8 +2701,6 @@ TEST(ViewTeam, base_camp_seat_rail_targets_owned_global_seat_and_clamps_page)
     save.ctf_team_count = 2;
     local->team = 1;
     og::ui::base_camp_refresh_rows(state);
-    ASSERT_EQ(1, state.seat_page.page)
-        << "refresh preserves a still-valid page";
     EXPECT_EQ(MENU_OK,
               editor_spec.on_spec_row(
                   kSeatSettingsTeamIndex, &editor_state));
@@ -2607,8 +2772,8 @@ TEST(ViewTeam, base_camp_seat_rail_targets_owned_global_seat_and_clamps_page)
     world.type = old_world_type;
     set_mounted_campaign_for_testing(old_mounted_campaign);
 
-    // Disconnect/shrink while parked on page two clamps to page one and
-    // removes both pager arrows.
+    // Dropping this machine's only seat while four remote ones remain leaves
+    // a rail of four ADD PLAYER slots — never a rail of other people's seats.
     lobby.players.erase(
         std::remove_if(
             lobby.players.begin(), lobby.players.end(),
@@ -2616,13 +2781,18 @@ TEST(ViewTeam, base_camp_seat_rail_targets_owned_global_seat_and_clamps_page)
                 return player.player_index == 4;
             }),
         lobby.players.end());
+    lobby.local_indices.clear();
     og::ui::base_camp_refresh_rows(state);
-    EXPECT_EQ(0, state.seat_page.page);
-    EXPECT_EQ(1, state.seat_page.page_count());
+    EXPECT_EQ(4u, state.seats.size());
+    EXPECT_TRUE(state.local_seat_indices.empty());
     buttons = picker_createmenu_buttons();
     base_spec.nav.rewire(buttons, count, highlighted);
-    EXPECT_TRUE(buttons[kBaseCampSeatPagePrevIndex].hidden);
-    EXPECT_TRUE(buttons[kBaseCampSeatPageNextIndex].hidden);
+    for (int slot = 0; slot < kBaseCampSeatCardsPerPage; ++slot)
+    {
+        EXPECT_FALSE(buttons[kBaseCampSeatCardBase + slot].hidden) << slot;
+        EXPECT_EQ("ADD PLAYER", buttons[kBaseCampSeatCardBase + slot].label)
+            << slot;
+    }
 
     og::ui::install_seat_settings_state_for_screen(nullptr);
     og::ui::install_base_camp_state_for_screen(nullptr);
@@ -2682,21 +2852,18 @@ TEST(ViewTeam, base_camp_seat_chip_pointer_click_cycles_team_in_place)
     ASSERT_NE(nullptr, spec.on_spec_row);
     ASSERT_NE(nullptr, spec.nav.rewire);
     button* buttons = picker_createmenu_buttons();
-    // #243: the rail lays itself out per frame, so the chip zone has to be
-    // read off the LIVE card, not the static table. One local seat on an
-    // ordinary desktop fills the grid with three ghost slots, which justifies
-    // the row and pulls the lone card left of the full-rail slot at 46 — the
-    // discriminating shape for "does the chip follow the card".
+    // The rail lays itself out per frame, so the chip zone has to be read off
+    // the LIVE card, not the static table. One local seat on an ordinary
+    // desktop puts that card in slot zero with three ADD PLAYER slots beside
+    // it; the chip zone is the face's last nine pixels plus 2px of grace.
     int highlighted = kBaseCampSeatCardBase;
     spec.nav.rewire(buttons, picker_createmenu_button_count(), highlighted);
     const button& card = buttons[kBaseCampSeatCardBase];
-    ASSERT_EQ(57, card.sizex) << "card face width is the chip zone's anchor";
-    ASSERT_EQ(38, card.x) << "one seat + three ghosts justifies the rail";
-    ASSERT_EQ(8, buttons[kBaseCampAddSeatIndex].x)
-        << "the '+' keeps the panel's left rail";
+    ASSERT_EQ(70, card.sizex) << "card face width is the chip zone's anchor";
+    ASSERT_EQ(8, card.x) << "the rail's first slot opens on the left rail";
 
-    // Chip-body click (the drawn 8x8 chip starts at card_x+48).
-    pks().menu_click_x = card.x + 52;
+    // Chip-body click (the drawn 8x8 chip starts at card_x+61).
+    pks().menu_click_x = card.x + 65;
     pks().menu_click_y = card.y + 5;
     lobby.ready_state = true;
     EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
@@ -2711,8 +2878,8 @@ TEST(ViewTeam, base_camp_seat_chip_pointer_click_cycles_team_in_place)
     EXPECT_EQ(1, state.seats[0].team)
         << "the handler re-collects seats so this frame's chip digit is new";
 
-    // Zone left boundary: card_x+46 (2px grace before the drawn chip).
-    pks().menu_click_x = card.x + 46;
+    // Zone left boundary: card_x+59 (2px grace before the drawn chip).
+    pks().menu_click_x = card.x + 59;
     EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
     ASSERT_EQ(2u, lobby.seat_team_calls.size());
     EXPECT_EQ(2, lobby.seat_team_calls.back().second);
@@ -2727,7 +2894,7 @@ TEST(ViewTeam, base_camp_seat_chip_pointer_click_cycles_team_in_place)
 
     // The wrap: classic team 4 advances back to team 1 — the seat editor's
     // exact sequence (its own test pins the same wrap).
-    pks().menu_click_x = card.x + 52;
+    pks().menu_click_x = card.x + 65;
     EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
     ASSERT_EQ(4u, lobby.seat_team_calls.size());
     EXPECT_EQ(0, lobby.seat_team_calls.back().second);
@@ -2749,11 +2916,12 @@ TEST(ViewTeam, base_camp_seat_chip_pointer_click_cycles_team_in_place)
 }
 
 // ---------------------------------------------------------------------------
-// #202 gating: the chip zone obeys the card's ownership gates. A foreign
-// (networked, non-editable) seat's chip click names the owning company and
-// mutates nothing; a spectator machine's chip click points at + instead.
+// #202 gating, redesigned: the chip zone can no longer reach a foreign seat
+// because no rail slot ever holds one. The rail is this machine's seats, so a
+// chip-region click on a slot this machine has not claimed lands on the ADD
+// PLAYER door instead — never on someone else's team.
 // ---------------------------------------------------------------------------
-TEST(ViewTeam, base_camp_seat_chip_click_foreign_seat_stays_inert)
+TEST(ViewTeam, base_camp_seat_chip_click_never_reaches_a_foreign_seat)
 {
     trace_clear();
     FactoryMappingGuard mapping_guard;
@@ -2781,43 +2949,57 @@ TEST(ViewTeam, base_camp_seat_chip_click_foreign_seat_stays_inert)
     const og::ui::MenuScreenSpec& spec =
         *og::ui::menu_screen_host(og::ui::MenuScreenId::TeamBuild).spec;
     ASSERT_NE(nullptr, spec.nav.rewire);
+    ASSERT_NE(nullptr, spec.on_spec_row);
     button* buttons = picker_createmenu_buttons();
-    // The chip zone rides the live rail (#243), so lay the rail out first.
     int highlighted = kBaseCampSeatCardBase;
     spec.nav.rewire(buttons, picker_createmenu_button_count(), highlighted);
-    const button& card = buttons[kBaseCampSeatCardBase];
 
-    // Card 0 is Iron Host's seat: its chip is read-only for this machine.
-    pks().menu_click_x = card.x + 52;
-    pks().menu_click_y = card.y + 5;
-    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
-    EXPECT_TRUE(trace_contains("popup", "Iron Host"));
-    EXPECT_TRUE(lobby.seat_team_calls.empty())
-        << "a foreign chip click must never issue a team change";
+    // Slot zero is THIS machine's seat (global P2), not the host's P1 — the
+    // remote seat is on the header line's census and in VIEW LEVEL's SEATS
+    // report, and nowhere on this row.
+    EXPECT_EQ("P2 WASD ", buttons[kBaseCampSeatCardBase].label);
+    for (int slot = 1; slot < kBaseCampSeatCardsPerPage; ++slot)
+    {
+        EXPECT_EQ("ADD PLAYER", buttons[kBaseCampSeatCardBase + slot].label)
+            << slot;
+    }
 
-    // Spectator machine (an owned wire seat lingering at zero active local
-    // seats): the chip is inert there too.
-    lobby.active_local_count = 0;
-    og::ui::base_camp_refresh_rows(state);
+    // A chip-region click on slot ONE (a placeholder) runs the add door, not
+    // a team cycle: there is no seat under it whose team could change.
+    const button& placeholder = buttons[kBaseCampSeatCardBase + 1];
+    pks().menu_click_x = placeholder.x + 65;
+    pks().menu_click_y = placeholder.y + 5;
     trace_clear();
-    const button& own_card = buttons[kBaseCampSeatCardBase + 1];
-    pks().menu_click_x = own_card.x + 52;
-    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase + 1, &state));
-    EXPECT_TRUE(trace_contains("popup", "PRESS + TO ADD A PLAYER"))
-        << "a spectator chip click pops, never mutates";
-    EXPECT_TRUE(lobby.seat_team_calls.empty());
+    EXPECT_EQ(MENU_OK,
+              spec.on_spec_row(kBaseCampSeatCardBase + 1, &state));
+    EXPECT_TRUE(lobby.seat_team_calls.empty())
+        << "a placeholder's chip region must never issue a team change";
+    EXPECT_FALSE(trace_contains("popup", "Iron Host"))
+        << "no rail slot may name another company";
+
+    // The owned slot's chip still cycles: the gate is ownership of the SLOT,
+    // and this machine owns slot zero.
+    const button& own_card = buttons[kBaseCampSeatCardBase];
+    pks().menu_click_x = own_card.x + 65;
+    pks().menu_click_y = own_card.y + 5;
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
+    ASSERT_EQ(1u, lobby.seat_team_calls.size());
+    EXPECT_EQ(1, lobby.seat_team_calls.back().first)
+        << "the chip targets the seat's GLOBAL player index";
 
     og::ui::install_base_camp_state_for_screen(nullptr);
     save.reset();
 }
 
 // ---------------------------------------------------------------------------
-// #243 ink: with one seat claimed on an ordinary desktop the rail draws three
-// GHOST slots, and the card — with its team chip — moves off the full-rail
-// coordinates the static table carries. The sibling test above proves the
-// click zone follows; this one proves the drawn overlay does, in pixels.
+// The rail's ink. A bare slot used to be a GHOST — an empty recess drawn by
+// the content pass, unclickable chrome. It is a real labelled button now, so
+// this pins that the ADD PLAYER ink lands on the slot's own grid x, that a
+// placeholder is a raised button rather than the old recess, that a full
+// lobby dims the same face, and that the team chip moved with the widened
+// card.
 // ---------------------------------------------------------------------------
-TEST(ViewTeam, base_camp_seat_rail_draws_ghost_slots_and_moves_the_chip)
+TEST(ViewTeam, base_camp_seat_rail_draws_labelled_placeholders_and_the_chip)
 {
     struct ScreenStateGuard {
         ~ScreenStateGuard()
@@ -2861,22 +3043,28 @@ TEST(ViewTeam, base_camp_seat_rail_draws_ghost_slots_and_moves_the_chip)
     int highlighted = kBaseCampSeatCardBase;
     spec.nav.rewire(buttons, count, highlighted);
 
-    // One card, three ghosts, the '+' on the left rail: the justified shape
-    // the pure layout pins in the picker_common units.
+    // One card and three ADD PLAYER slots on the fixed grid.
     const button& card = buttons[kBaseCampSeatCardBase];
-    ASSERT_EQ(38, card.x);
+    ASSERT_EQ(8, card.x);
     ASSERT_EQ(164, card.y);
-    ASSERT_EQ(57, card.sizex);
-    ASSERT_TRUE(buttons[kBaseCampSeatCardBase + 1].hidden)
-        << "a ghost is chrome, never a button";
-    constexpr int kGhostSlotX = 111;
-    constexpr int kStaleCardX = 46;  // where the static table puts card 0
+    ASSERT_EQ(70, card.sizex);
+    for (int slot = 1; slot < kBaseCampSeatCardsPerPage; ++slot)
+    {
+        const button& face = buttons[kBaseCampSeatCardBase + slot];
+        ASSERT_FALSE(face.hidden) << "a placeholder is a real button now";
+        ASSERT_EQ(8 + 78 * slot, face.x) << "slot " << slot;
+        ASSERT_EQ("ADD PLAYER", face.label) << "slot " << slot;
+    }
+    constexpr int kSlotOneX = 86;
+    constexpr int kSlotTwoX = 164;
+    constexpr int kStaleCardX = 46;  // where the retired rail put card 0
 
-    output->fastbox(0, 0, 320, 200, PURE_BLACK);
-    spec.draw_background(&state);
-    draw_buttons(buttons, count);
-    spec.draw_content(&state);
-
+    const auto render = [&]() {
+        output->fastbox(0, 0, 320, 200, PURE_BLACK);
+        spec.draw_background(&state);
+        draw_buttons(buttons, count);
+        spec.draw_content(&state);
+    };
     const auto capture_block = [&](int x0, int y0, int w, int h) {
         std::vector<Uint32> block;
         block.reserve(static_cast<std::size_t>(w * h));
@@ -2894,9 +3082,11 @@ TEST(ViewTeam, base_camp_seat_rail_draws_ghost_slots_and_moves_the_chip)
         return block;
     };
 
-    // The chip's 8x8 black surround sits at card_x + 48. Its whole top row
-    // is one solid PURE_BLACK run, which the backdrop and the card face
-    // never produce — so the run is the chip's signature.
+    render();
+
+    // The chip's 8x8 black surround sits at card_x + 61 now (the face's last
+    // nine pixels). Its whole top row is one solid PURE_BLACK run, which the
+    // backdrop and the card face never produce — so the run is its signature.
     const auto solid_black_run = [&](int x0, int y) {
         Uint8 red = 0;
         Uint8 green = 0;
@@ -2908,27 +3098,85 @@ TEST(ViewTeam, base_camp_seat_rail_draws_ghost_slots_and_moves_the_chip)
         return std::all_of(run.begin(), run.end(),
                            [black](Uint32 pixel) { return pixel == black; });
     };
-    // (0,0) is still the PURE_BLACK the frame was cleared to: the menu
-    // backdrop starts below the title band.
-    EXPECT_TRUE(solid_black_run(card.x + 48, card.y + 1))
+    EXPECT_TRUE(solid_black_run(card.x + 61, card.y + 1))
         << "the team chip draws on the card the rail actually placed";
     EXPECT_FALSE(solid_black_run(kStaleCardX + 48, card.y + 1))
-        << "nothing is left behind at the static table's card slot";
+        << "nothing is left behind at the retired rail's card slot";
 
-    // Each ghost slot is a recessed empty bevel of exactly the card's size.
-    // Compare against one drawn on the spot: byte-equal or the rail is
-    // drawing something else, somewhere else.
-    const std::vector<Uint32> ghost = capture_block(kGhostSlotX, card.y, 57, 10);
-    const std::vector<Uint32> ghost_two =
-        capture_block(kGhostSlotX + 72, card.y, 57, 10);
+    // The two ADD PLAYER slots paint the same face and the same ink, on the
+    // grid, and neither is the empty recess a ghost used to be.
+    const std::vector<Uint32> slot_one =
+        capture_block(kSlotOneX, card.y, 70, 10);
+    const std::vector<Uint32> slot_two =
+        capture_block(kSlotTwoX, card.y, 70, 10);
     const std::vector<Uint32> offset_by_one =
-        capture_block(kGhostSlotX - 1, card.y, 57, 10);
-    output->draw_button_inverted(8, 100, 57, 10);
-    const std::vector<Uint32> reference = capture_block(8, 100, 57, 10);
-    EXPECT_EQ(reference, ghost) << "ghost slot 1 is an empty recessed bevel";
-    EXPECT_EQ(reference, ghost_two) << "ghost slot 2 is the same bevel";
-    EXPECT_NE(reference, offset_by_one)
+        capture_block(kSlotOneX - 1, card.y, 70, 10);
+    EXPECT_EQ(slot_one, slot_two)
+        << "the two ADD PLAYER slots are the same button on the same grid";
+    EXPECT_NE(slot_one, offset_by_one)
         << "the probe would pass one pixel off, so the match above is real";
+    output->draw_button_inverted(8, 100, 70, 10);
+    const std::vector<Uint32> empty_recess = capture_block(8, 100, 70, 10);
+    EXPECT_NE(empty_recess, slot_one)
+        << "a placeholder is a labelled button, not the retired ghost recess";
+    // ...and it is not a blank raised face either: the ADD PLAYER INK is on
+    // it. Blank slot two's label, redraw, and compare the two faces — same
+    // rect, same bevel, same button, differing only by the glyphs. An empty
+    // or unwritten label would make these identical.
+    vbutton* const slot_two_live =
+        og::runtime::current_session
+            ->allbuttons_[static_cast<std::size_t>(kBaseCampSeatCardBase + 2)];
+    ASSERT_NE(nullptr, slot_two_live);
+    const std::string kept_label = slot_two_live->label;
+    slot_two_live->label = "";
+    render();
+    const std::vector<Uint32> blank_face =
+        capture_block(kSlotTwoX, card.y, 70, 10);
+    slot_two_live->label = kept_label;
+    render();
+    EXPECT_NE(blank_face, slot_two)
+        << "the ADD PLAYER glyphs must actually be painted on the slot";
+    EXPECT_NE(blank_face, empty_recess)
+        << "and even bare, the slot is a raised button, not the old recess";
+
+    // A FULL LOBBY dims the same face. Mirror the engine's one-line gate rule
+    // (menu_screen_runner apply_row_states: Disabled => live->color = GREY)
+    // off the row's own state_override, so the paint and the state can never
+    // drift apart here.
+    for (int i = 0; i < 15; ++i)
+    {
+        lobby.players.push_back(make_foreign_lobby_player(
+            static_cast<std::uint8_t>(i + 1), "net-x", "OTHER", 0, 0));
+    }
+    og::ui::base_camp_refresh_rows(state);
+    spec.nav.rewire(buttons, count, highlighted);
+    ASSERT_NE(nullptr,
+              spec.rows[kBaseCampSeatCardBase + 1].state_override);
+    EXPECT_EQ(og::ui::RowState::Disabled,
+              spec.rows[kBaseCampSeatCardBase + 1].state_override(
+                  og::ui::MenuLabelContext{}));
+    EXPECT_EQ("LOBBY FULL", buttons[kBaseCampSeatCardBase + 1].label);
+    for (int slot = 1; slot < kBaseCampSeatCardsPerPage; ++slot)
+    {
+        const int ordinal = kBaseCampSeatCardBase + slot;
+        if (spec.rows[ordinal].state_override(og::ui::MenuLabelContext{}) ==
+            og::ui::RowState::Disabled)
+        {
+            vbutton* const live =
+                og::runtime::current_session
+                    ->allbuttons_[static_cast<std::size_t>(ordinal)];
+            ASSERT_NE(nullptr, live);
+            live->color = GREY;
+            live->label = buttons[ordinal].label;
+        }
+    }
+    render();
+    const std::vector<Uint32> dimmed =
+        capture_block(kSlotOneX, card.y, 70, 10);
+    EXPECT_NE(slot_one, dimmed)
+        << "a slot the lobby cannot fill must not look like one it can";
+    EXPECT_EQ(dimmed, capture_block(kSlotTwoX, card.y, 70, 10))
+        << "every dimmed slot wears the same face";
 
     save.reset();
 }
@@ -3304,9 +3552,11 @@ TEST(ViewTeam, seat_settings_remove_uses_exact_token_and_compacts_profiles)
             1, static_cast<int>(ControlDirectionMode::FourDirection),
             KEY_UP));
 
-    // Drive the real Base Camp [+] boundary. Authority appends the
-    // replacement to this machine's local-seat order, so it must resolve to
-    // the freed tail profile (WASD), not clone the surviving arrow profile.
+    // Drive the real Base Camp ADD PLAYER boundary through the first BARE
+    // slot (this machine holds one seat, so slot one is the door). Authority
+    // appends the replacement to this machine's local-seat order, so it must
+    // resolve to the freed tail profile (WASD), not clone the surviving arrow
+    // profile.
     og::ui::install_seat_settings_state_for_screen(nullptr);
     lobby.seat_to_publish_on_add =
         make_foreign_lobby_player(
@@ -3320,7 +3570,7 @@ TEST(ViewTeam, seat_settings_remove_uses_exact_token_and_compacts_profiles)
     ASSERT_NE(nullptr, base_spec.on_spec_row);
     EXPECT_EQ(
         MENU_OK,
-        base_spec.on_spec_row(kBaseCampAddSeatIndex, &base_state));
+        base_spec.on_spec_row(kBaseCampSeatCardBase + 1, &base_state));
     ASSERT_TRUE(lobby.active_local_count.has_value());
     EXPECT_EQ(2u, *lobby.active_local_count);
     EXPECT_EQ(
@@ -3381,7 +3631,7 @@ TEST(ViewTeam, seat_settings_remove_uses_exact_token_and_compacts_profiles)
 #endif
 }
 
-TEST(ViewTeam, base_camp_zero_seat_state_activates_only_through_plus)
+TEST(ViewTeam, base_camp_zero_seat_state_activates_through_the_first_slot)
 {
     FactoryMappingGuard mapping_guard;
     SaveData& save = og::runtime::current_session->myscreen_->save_data;
@@ -3404,7 +3654,8 @@ TEST(ViewTeam, base_camp_zero_seat_state_activates_only_through_plus)
     // Local sessions own every synthetic seat, including the one retained
     // for a zero-player spectator. They do not need a network ownership list.
     // The old Player Settings right-click painted a separate SPECTATOR status;
-    // Base Camp now makes that state actionable in-place as SPEC + [+].
+    // Base Camp makes that state actionable in place — the seat reads SPEC and
+    // the slot beside it is the ADD PLAYER door.
     lobby.networked = false;
     lobby.local_indices.clear();
     {
@@ -3421,24 +3672,26 @@ TEST(ViewTeam, base_camp_zero_seat_state_activates_only_through_plus)
             buttons, picker_createmenu_button_count(), highlighted);
         EXPECT_FALSE(buttons[kBaseCampSeatCardBase].hidden);
         EXPECT_EQ("P7 SPEC ", buttons[kBaseCampSeatCardBase].label);
-        EXPECT_FALSE(buttons[kBaseCampAddSeatIndex].hidden);
+        // The door out of the spectator state is the slot beside the SPEC
+        // card, not a [+] somewhere else on the row.
+        EXPECT_FALSE(buttons[kBaseCampSeatCardBase + 1].hidden);
+        EXPECT_EQ("ADD PLAYER", buttons[kBaseCampSeatCardBase + 1].label);
         ASSERT_NE(nullptr,
-                  spec.rows[kBaseCampAddSeatIndex].state_override);
+                  spec.rows[kBaseCampSeatCardBase + 1].state_override);
         EXPECT_EQ(
             og::ui::RowState::Visible,
-            spec.rows[kBaseCampAddSeatIndex].state_override(
+            spec.rows[kBaseCampSeatCardBase + 1].state_override(
                 og::ui::MenuLabelContext{}));
-        trace_clear();
-        EXPECT_EQ(MENU_OK,
-                  spec.on_spec_row(kBaseCampSeatCardBase, &state));
-        EXPECT_TRUE(trace_contains("popup", "PRESS + TO ADD A PLAYER"));
+        // The SPEC card itself opens its own editor rather than popping a
+        // note about a button that no longer exists.
         EXPECT_TRUE(lobby.seat_team_calls.empty());
         og::ui::install_base_camp_state_for_screen(nullptr);
     }
 
     // A current network spectator publishes no owned placeholder at all:
     // the dormant reconnect token is server-private, so the client sees zero
-    // cards and cannot READY. [+] asks authority to activate and publish P1.
+    // cards and cannot READY. The first slot asks authority to activate and
+    // publish P1.
     lobby.networked = true;
     lobby.players.clear();
     lobby.local_indices.clear();
@@ -3453,25 +3706,34 @@ TEST(ViewTeam, base_camp_zero_seat_state_activates_only_through_plus)
 
         og::ui::install_base_camp_state_for_screen(&state);
         button* buttons = picker_createmenu_buttons();
-        int highlighted = kBaseCampAddSeatIndex;
+        int highlighted = kBaseCampSeatCardBase;
         spec.nav.rewire(
             buttons, picker_createmenu_button_count(), highlighted);
-        EXPECT_TRUE(buttons[kBaseCampSeatCardBase].hidden);
-        EXPECT_FALSE(buttons[kBaseCampAddSeatIndex].hidden);
+        // Four ADD PLAYER slots and no card at all: the rail of a machine
+        // sitting in a lobby with nobody of its own in it.
+        for (int slot = 0; slot < kBaseCampSeatCardsPerPage; ++slot)
+        {
+            EXPECT_FALSE(buttons[kBaseCampSeatCardBase + slot].hidden)
+                << slot;
+            EXPECT_EQ("ADD PLAYER",
+                      buttons[kBaseCampSeatCardBase + slot].label)
+                << slot;
+        }
         EXPECT_TRUE(buttons[kCreateMenuReadyIndex].hidden);
         ASSERT_NE(nullptr,
-                  spec.rows[kBaseCampAddSeatIndex].state_override);
+                  spec.rows[kBaseCampSeatCardBase].state_override);
         EXPECT_EQ(
             og::ui::RowState::Visible,
-            spec.rows[kBaseCampAddSeatIndex].state_override(
+            spec.rows[kBaseCampSeatCardBase].state_override(
                 og::ui::MenuLabelContext{}));
         EXPECT_TRUE(lobby.seat_team_calls.empty());
 
-        // [+] activates the authority's dormant token and publishes its new
-        // active seat. One touch-collapsed duplicate is debounced.
+        // Activating slot zero asks authority to activate the dormant token
+        // and publish its new active seat. One touch-collapsed duplicate is
+        // debounced.
         trace_clear();
         EXPECT_EQ(MENU_OK,
-                  spec.on_spec_row(kBaseCampAddSeatIndex, &state));
+                  spec.on_spec_row(kBaseCampSeatCardBase, &state));
         ASSERT_EQ(1, lobby.add_seat_calls);
         ASSERT_TRUE(lobby.active_local_count.has_value());
         EXPECT_EQ(1u, *lobby.active_local_count);
@@ -3479,8 +3741,10 @@ TEST(ViewTeam, base_camp_zero_seat_state_activates_only_through_plus)
         spec.nav.rewire(
             buttons, picker_createmenu_button_count(), highlighted);
         EXPECT_EQ("P1 WASD ", buttons[kBaseCampSeatCardBase].label);
+        // The seat landed in slot zero, so the SECOND slot is the door now —
+        // and the debounce is on the DOOR, not on the ordinal.
         EXPECT_EQ(MENU_OK,
-                  spec.on_spec_row(kBaseCampAddSeatIndex, &state));
+                  spec.on_spec_row(kBaseCampSeatCardBase + 1, &state));
         EXPECT_EQ(1, lobby.add_seat_calls);
         EXPECT_TRUE(trace_contains("basecamp", "seat_add_debounced"));
         og::ui::install_base_camp_state_for_screen(nullptr);
@@ -3491,10 +3755,11 @@ TEST(ViewTeam, base_camp_zero_seat_state_activates_only_through_plus)
 
 // #249: a phone is a single-seat device — its touchscreen is the only
 // controller it has. The card names the SCREEN (naming a keyboard mapping
-// would name keys the device does not have), [+] goes inert while nothing
-// else is attached, and a seat the player cycled onto a real pad keeps
+// would name keys the device does not have), the rail shrinks to ONE slot
+// while nothing else is attached (an offer the hardware cannot accept is
+// worse than no offer), and a seat the player cycled onto a real pad keeps
 // naming that pad.
-TEST(ViewTeam, base_camp_single_seat_device_names_screen_and_closes_plus)
+TEST(ViewTeam, base_camp_single_seat_device_names_screen_and_closes_the_rail)
 {
     FactoryMappingGuard mapping_guard;
     SaveData& save = og::runtime::current_session->myscreen_->save_data;
@@ -3520,7 +3785,7 @@ TEST(ViewTeam, base_camp_single_seat_device_names_screen_and_closes_plus)
         *og::ui::menu_screen_host(og::ui::MenuScreenId::TeamBuild).spec;
     ASSERT_NE(nullptr, spec.nav.rewire);
     ASSERT_NE(nullptr, spec.on_spec_row);
-    ASSERT_NE(nullptr, spec.rows[kBaseCampAddSeatIndex].state_override);
+    ASSERT_NE(nullptr, spec.rows[kBaseCampSeatCardBase + 1].state_override);
 
     og::ui::BaseCampScreenState state;
     og::ui::base_camp_refresh_rows(state);
@@ -3531,43 +3796,46 @@ TEST(ViewTeam, base_camp_single_seat_device_names_screen_and_closes_plus)
     int highlighted = kBaseCampSeatCardBase;
     button* buttons = picker_createmenu_buttons();
     spec.nav.rewire(buttons, picker_createmenu_button_count(), highlighted);
-    // Desktop: the card names the seat's keyboard mapping, [+] is live.
+    // Desktop: the card names the seat's keyboard mapping, and three ADD
+    // PLAYER slots stand beside it on the fixed grid.
     EXPECT_EQ("P1 WASD ", buttons[kBaseCampSeatCardBase].label);
     EXPECT_EQ(og::ui::RowState::Visible,
-              spec.rows[kBaseCampAddSeatIndex].state_override(
+              spec.rows[kBaseCampSeatCardBase + 1].state_override(
                   og::ui::MenuLabelContext{}));
-    // #243: three more seats are claimable here, so three ghost slots fill
-    // the grid and the row justifies with the '+' on the left rail.
-    EXPECT_EQ(8, buttons[kBaseCampAddSeatIndex].x);
-    EXPECT_EQ(38, buttons[kBaseCampSeatCardBase].x);
+    EXPECT_EQ(8, buttons[kBaseCampSeatCardBase].x);
+    EXPECT_EQ(86, buttons[kBaseCampSeatCardBase + 1].x);
+    EXPECT_EQ("ADD PLAYER", buttons[kBaseCampSeatCardBase + 1].label);
 
     input_hardware_state().single_seat_device = true;
     buttons = picker_createmenu_buttons();
     spec.nav.rewire(buttons, picker_createmenu_button_count(), highlighted);
     EXPECT_EQ("P1 SCRN ", buttons[kBaseCampSeatCardBase].label);
-    // The phone's rail is one card and nothing else: no '+' to open the row,
-    // and no ghost slots, because no seat on this device can be claimed. So
-    // the lone card starts where every other left-aligned control does
-    // instead of floating 38px in from the panel's edge.
-    EXPECT_TRUE(buttons[kBaseCampAddSeatIndex].hidden)
-        << "the rewire mirrors the device-capped [+] gate";
+    // The phone's rail is ONE card and nothing else: no slot on this device
+    // can be claimed, so no slot is offered. The lone card starts where every
+    // other left-aligned control does.
     EXPECT_EQ(8, buttons[kBaseCampSeatCardBase].x);
     EXPECT_EQ(buttons[kCreateMenuBackIndex].x,
               buttons[kBaseCampSeatCardBase].x)
         << "the lone card opens on BACK's left edge";
-    EXPECT_TRUE(buttons[kBaseCampSeatCardBase + 1].hidden)
-        << "no ghost slot claims a card ordinal";
+    for (int slot = 1; slot < kBaseCampSeatCardsPerPage; ++slot)
+    {
+        EXPECT_TRUE(buttons[kBaseCampSeatCardBase + slot].hidden)
+            << "slot " << slot << " must not offer a seat the phone cannot "
+                                  "seat";
+        EXPECT_EQ(og::ui::RowState::Hidden,
+                  spec.rows[kBaseCampSeatCardBase + slot].state_override(
+                      og::ui::MenuLabelContext{}))
+            << "slot " << slot;
+    }
     EXPECT_LE(buttons[kBaseCampSeatCardBase].label.size(),
               static_cast<std::size_t>(kBaseCampSeatCardLabelBudget));
     EXPECT_EQ(' ', buttons[kBaseCampSeatCardBase].label.back())
         << "the team-chip clearance pad is load-bearing";
-    // Nothing else is attached, so this machine is full at one seat, and
-    // the device-capped rail hides [+] outright (pause-menu consistency).
-    EXPECT_EQ(og::ui::RowState::Hidden,
-              spec.rows[kBaseCampAddSeatIndex].state_override(
-                  og::ui::MenuLabelContext{}));
+    // A slot the device cap hides is still the add DOOR if something drives
+    // it anyway (a stale click, a scripted dispatch): the gate lives in the
+    // handler, so it answers with the hardware instruction, not a seat.
     trace_clear();
-    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampAddSeatIndex, &state));
+    EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase + 1, &state));
     EXPECT_TRUE(trace_contains("popup", "ATTACH A GAMEPAD TO ADD SEATS"));
     EXPECT_EQ(0, lobby.add_seat_calls);
 

--- a/tests/integration/test_view_team.cpp
+++ b/tests/integration/test_view_team.cpp
@@ -2680,9 +2680,20 @@ TEST(ViewTeam, base_camp_seat_chip_pointer_click_cycles_team_in_place)
     const og::ui::MenuScreenSpec& spec =
         *og::ui::menu_screen_host(og::ui::MenuScreenId::TeamBuild).spec;
     ASSERT_NE(nullptr, spec.on_spec_row);
+    ASSERT_NE(nullptr, spec.nav.rewire);
     button* buttons = picker_createmenu_buttons();
+    // #243: the rail lays itself out per frame, so the chip zone has to be
+    // read off the LIVE card, not the static table. One local seat on an
+    // ordinary desktop fills the grid with three ghost slots, which justifies
+    // the row and pulls the lone card left of the full-rail slot at 46 — the
+    // discriminating shape for "does the chip follow the card".
+    int highlighted = kBaseCampSeatCardBase;
+    spec.nav.rewire(buttons, picker_createmenu_button_count(), highlighted);
     const button& card = buttons[kBaseCampSeatCardBase];
     ASSERT_EQ(57, card.sizex) << "card face width is the chip zone's anchor";
+    ASSERT_EQ(38, card.x) << "one seat + three ghosts justifies the rail";
+    ASSERT_EQ(8, buttons[kBaseCampAddSeatIndex].x)
+        << "the '+' keeps the panel's left rail";
 
     // Chip-body click (the drawn 8x8 chip starts at card_x+48).
     pks().menu_click_x = card.x + 52;
@@ -2769,7 +2780,11 @@ TEST(ViewTeam, base_camp_seat_chip_click_foreign_seat_stays_inert)
 
     const og::ui::MenuScreenSpec& spec =
         *og::ui::menu_screen_host(og::ui::MenuScreenId::TeamBuild).spec;
+    ASSERT_NE(nullptr, spec.nav.rewire);
     button* buttons = picker_createmenu_buttons();
+    // The chip zone rides the live rail (#243), so lay the rail out first.
+    int highlighted = kBaseCampSeatCardBase;
+    spec.nav.rewire(buttons, picker_createmenu_button_count(), highlighted);
     const button& card = buttons[kBaseCampSeatCardBase];
 
     // Card 0 is Iron Host's seat: its chip is read-only for this machine.
@@ -2793,6 +2808,128 @@ TEST(ViewTeam, base_camp_seat_chip_click_foreign_seat_stays_inert)
     EXPECT_TRUE(lobby.seat_team_calls.empty());
 
     og::ui::install_base_camp_state_for_screen(nullptr);
+    save.reset();
+}
+
+// ---------------------------------------------------------------------------
+// #243 ink: with one seat claimed on an ordinary desktop the rail draws three
+// GHOST slots, and the card — with its team chip — moves off the full-rail
+// coordinates the static table carries. The sibling test above proves the
+// click zone follows; this one proves the drawn overlay does, in pixels.
+// ---------------------------------------------------------------------------
+TEST(ViewTeam, base_camp_seat_rail_draws_ghost_slots_and_moves_the_chip)
+{
+    struct ScreenStateGuard {
+        ~ScreenStateGuard()
+        {
+            og::ui::install_base_camp_state_for_screen(nullptr);
+            clear_allbuttons();
+            pks().menu_nav_enabled = false;
+            og::runtime::current_session->myscreen_->save_data.reset();
+        }
+    } guard;
+    FactoryMappingGuard mapping_guard;
+
+    screen* const output = og::runtime::current_session->myscreen_;
+    SaveData& save = output->save_data;
+    save.reset();
+    save.numplayers = 1;
+    save.current_campaign = "gladiator";
+    save.save_name = "MY COMPANY";
+
+    NetworkedRosterLobbyClient lobby;
+    lobby.local_indices = {0};
+    lobby.players.push_back(
+        make_foreign_lobby_player(0, "net-me", "MY COMPANY", 0, 0));
+    lobby.players.front().team = 0;
+    ActivePickerLobbyClientGuard client_guard(&lobby);
+
+    og::ui::BaseCampScreenState state;
+    og::ui::base_camp_refresh_rows(state);
+    ASSERT_EQ(1u, state.seats.size());
+    og::ui::install_base_camp_state_for_screen(&state);
+
+    const og::ui::MenuScreenSpec& spec =
+        *og::ui::menu_screen_host(og::ui::MenuScreenId::TeamBuild).spec;
+    ASSERT_NE(nullptr, spec.nav.rewire);
+    ASSERT_NE(nullptr, spec.draw_background);
+    ASSERT_NE(nullptr, spec.draw_content);
+
+    button* const buttons = picker_createmenu_buttons();
+    const int count = picker_createmenu_button_count();
+    init_buttons(buttons, count);
+    int highlighted = kBaseCampSeatCardBase;
+    spec.nav.rewire(buttons, count, highlighted);
+
+    // One card, three ghosts, the '+' on the left rail: the justified shape
+    // the pure layout pins in the picker_common units.
+    const button& card = buttons[kBaseCampSeatCardBase];
+    ASSERT_EQ(38, card.x);
+    ASSERT_EQ(164, card.y);
+    ASSERT_EQ(57, card.sizex);
+    ASSERT_TRUE(buttons[kBaseCampSeatCardBase + 1].hidden)
+        << "a ghost is chrome, never a button";
+    constexpr int kGhostSlotX = 111;
+    constexpr int kStaleCardX = 46;  // where the static table puts card 0
+
+    output->fastbox(0, 0, 320, 200, PURE_BLACK);
+    spec.draw_background(&state);
+    draw_buttons(buttons, count);
+    spec.draw_content(&state);
+
+    const auto capture_block = [&](int x0, int y0, int w, int h) {
+        std::vector<Uint32> block;
+        block.reserve(static_cast<std::size_t>(w * h));
+        for (int y = y0; y < y0 + h; ++y) {
+            for (int x = x0; x < x0 + w; ++x) {
+                Uint8 red = 0;
+                Uint8 green = 0;
+                Uint8 blue = 0;
+                output->get_pixel(x, y, &red, &green, &blue);
+                block.push_back((static_cast<Uint32>(red) << 16) |
+                                (static_cast<Uint32>(green) << 8) |
+                                static_cast<Uint32>(blue));
+            }
+        }
+        return block;
+    };
+
+    // The chip's 8x8 black surround sits at card_x + 48. Its whole top row
+    // is one solid PURE_BLACK run, which the backdrop and the card face
+    // never produce — so the run is the chip's signature.
+    const auto solid_black_run = [&](int x0, int y) {
+        Uint8 red = 0;
+        Uint8 green = 0;
+        Uint8 blue = 0;
+        output->get_pixel(0, 0, &red, &green, &blue);
+        const Uint32 black = (static_cast<Uint32>(red) << 16) |
+            (static_cast<Uint32>(green) << 8) | static_cast<Uint32>(blue);
+        const std::vector<Uint32> run = capture_block(x0, y, 8, 1);
+        return std::all_of(run.begin(), run.end(),
+                           [black](Uint32 pixel) { return pixel == black; });
+    };
+    // (0,0) is still the PURE_BLACK the frame was cleared to: the menu
+    // backdrop starts below the title band.
+    EXPECT_TRUE(solid_black_run(card.x + 48, card.y + 1))
+        << "the team chip draws on the card the rail actually placed";
+    EXPECT_FALSE(solid_black_run(kStaleCardX + 48, card.y + 1))
+        << "nothing is left behind at the static table's card slot";
+
+    // Each ghost slot is a recessed empty bevel of exactly the card's size.
+    // Compare against one drawn on the spot: byte-equal or the rail is
+    // drawing something else, somewhere else.
+    const std::vector<Uint32> ghost = capture_block(kGhostSlotX, card.y, 57, 10);
+    const std::vector<Uint32> ghost_two =
+        capture_block(kGhostSlotX + 72, card.y, 57, 10);
+    const std::vector<Uint32> offset_by_one =
+        capture_block(kGhostSlotX - 1, card.y, 57, 10);
+    output->draw_button_inverted(8, 100, 57, 10);
+    const std::vector<Uint32> reference = capture_block(8, 100, 57, 10);
+    EXPECT_EQ(reference, ghost) << "ghost slot 1 is an empty recessed bevel";
+    EXPECT_EQ(reference, ghost_two) << "ghost slot 2 is the same bevel";
+    EXPECT_NE(reference, offset_by_one)
+        << "the probe would pass one pixel off, so the match above is real";
+
     save.reset();
 }
 
@@ -3399,11 +3536,27 @@ TEST(ViewTeam, base_camp_single_seat_device_names_screen_and_closes_plus)
     EXPECT_EQ(og::ui::RowState::Visible,
               spec.rows[kBaseCampAddSeatIndex].state_override(
                   og::ui::MenuLabelContext{}));
+    // #243: three more seats are claimable here, so three ghost slots fill
+    // the grid and the row justifies with the '+' on the left rail.
+    EXPECT_EQ(8, buttons[kBaseCampAddSeatIndex].x);
+    EXPECT_EQ(38, buttons[kBaseCampSeatCardBase].x);
 
     input_hardware_state().single_seat_device = true;
     buttons = picker_createmenu_buttons();
     spec.nav.rewire(buttons, picker_createmenu_button_count(), highlighted);
     EXPECT_EQ("P1 SCRN ", buttons[kBaseCampSeatCardBase].label);
+    // The phone's rail is one card and nothing else: no '+' to open the row,
+    // and no ghost slots, because no seat on this device can be claimed. So
+    // the lone card starts where every other left-aligned control does
+    // instead of floating 38px in from the panel's edge.
+    EXPECT_TRUE(buttons[kBaseCampAddSeatIndex].hidden)
+        << "the rewire mirrors the device-capped [+] gate";
+    EXPECT_EQ(8, buttons[kBaseCampSeatCardBase].x);
+    EXPECT_EQ(buttons[kCreateMenuBackIndex].x,
+              buttons[kBaseCampSeatCardBase].x)
+        << "the lone card opens on BACK's left edge";
+    EXPECT_TRUE(buttons[kBaseCampSeatCardBase + 1].hidden)
+        << "no ghost slot claims a card ordinal";
     EXPECT_LE(buttons[kBaseCampSeatCardBase].label.size(),
               static_cast<std::size_t>(kBaseCampSeatCardLabelBudget));
     EXPECT_EQ(' ', buttons[kBaseCampSeatCardBase].label.back())

--- a/tests/integration/test_view_team.cpp
+++ b/tests/integration/test_view_team.cpp
@@ -1726,9 +1726,9 @@ TEST(ViewTeam, base_camp_seat_card_focus_preserves_neighbors_and_team_chip)
     constexpr int kRailHeight = kRailBottom - kRailTop + 1;
     const int kSelectedCardX = buttons[kBaseCampSeatCardBase + 1].x;
     const int kSelectedCardY = buttons[kBaseCampSeatCardBase + 1].y;
-    const int kLabelFocusRight = kSelectedCardX + 60;
+    const int kLabelFocusRight = kSelectedCardX + 59;
     const int kFocusBottom = kSelectedCardY + 10;
-    const int kChipX = kSelectedCardX + 61;
+    const int kChipX = kSelectedCardX + 60;
     const int kChipY = kSelectedCardY + 1;
     constexpr int kChipSize = 8;
 
@@ -2316,8 +2316,8 @@ TEST(ViewTeam, base_camp_add_player_slot_claims_a_seat_through_a_real_click)
         << "the click must claim a seat, not just repaint";
     // Exact, not a prefix: ensure_unique_seat_mapping lands the second seat
     // on the arrow profile, so the whole face is known — "P2 " + the arrow
-    // glyphs + the load-bearing chip-clearance pad.
-    EXPECT_EQ(std::format("P2 {} ", og::input::kArrowGlyphs),
+    // glyphs + the two load-bearing chip-clearance pads.
+    EXPECT_EQ(std::format("P2 {}  ", og::input::kArrowGlyphs),
               state.slot_one_label_after)
         << "the new seat lands in the slot that was clicked, as P2";
     EXPECT_TRUE(trace_contains("basecamp", "seat_add local_count=2"))
@@ -2627,7 +2627,7 @@ TEST(ViewTeam, base_camp_seat_rail_shows_only_this_machines_seats)
     // global P5, local slot 0, factory WASD. Slot zero, not slot four — the
     // rail indexes local slots, so a machine that owns one seat shows it
     // first however high its global P# runs.
-    EXPECT_EQ("P5 WASD ", buttons[kBaseCampSeatCardBase].label);
+    EXPECT_EQ("P5 WASD  ", buttons[kBaseCampSeatCardBase].label);
     for (int slot = 1; slot < kBaseCampSeatCardsPerPage; ++slot)
     {
         EXPECT_FALSE(buttons[kBaseCampSeatCardBase + slot].hidden) << slot;
@@ -2861,14 +2861,14 @@ TEST(ViewTeam, base_camp_seat_chip_pointer_click_cycles_team_in_place)
     // The rail lays itself out per frame, so the chip zone has to be read off
     // the LIVE card, not the static table. One local seat on an ordinary
     // desktop puts that card in slot zero with three ADD PLAYER slots beside
-    // it; the chip zone is the face's last nine pixels plus 2px of grace.
+    // it; the chip zone is the face's last ten pixels plus 2px of grace.
     int highlighted = kBaseCampSeatCardBase;
     spec.nav.rewire(buttons, picker_createmenu_button_count(), highlighted);
     const button& card = buttons[kBaseCampSeatCardBase];
     ASSERT_EQ(70, card.sizex) << "card face width is the chip zone's anchor";
     ASSERT_EQ(8, card.x) << "the rail's first slot opens on the left rail";
 
-    // Chip-body click (the drawn 8x8 chip starts at card_x+61).
+    // Chip-body click (the drawn 8x8 chip starts at card_x+60).
     pks().menu_click_x = card.x + 65;
     pks().menu_click_y = card.y + 5;
     lobby.ready_state = true;
@@ -2884,8 +2884,8 @@ TEST(ViewTeam, base_camp_seat_chip_pointer_click_cycles_team_in_place)
     EXPECT_EQ(1, state.seats[0].team)
         << "the handler re-collects seats so this frame's chip digit is new";
 
-    // Zone left boundary: card_x+59 (2px grace before the drawn chip).
-    pks().menu_click_x = card.x + 59;
+    // Zone left boundary: card_x+58 (2px grace before the drawn chip).
+    pks().menu_click_x = card.x + 58;
     EXPECT_EQ(MENU_OK, spec.on_spec_row(kBaseCampSeatCardBase, &state));
     ASSERT_EQ(2u, lobby.seat_team_calls.size());
     EXPECT_EQ(2, lobby.seat_team_calls.back().second);
@@ -2963,7 +2963,7 @@ TEST(ViewTeam, base_camp_seat_chip_click_never_reaches_a_foreign_seat)
     // Slot zero is THIS machine's seat (global P2), not the host's P1 — the
     // remote seat is on the header line's census and in VIEW LEVEL's SEATS
     // report, and nowhere on this row.
-    EXPECT_EQ("P2 WASD ", buttons[kBaseCampSeatCardBase].label);
+    EXPECT_EQ("P2 WASD  ", buttons[kBaseCampSeatCardBase].label);
     for (int slot = 1; slot < kBaseCampSeatCardsPerPage; ++slot)
     {
         EXPECT_EQ("ADD PLAYER", buttons[kBaseCampSeatCardBase + slot].label)
@@ -3090,8 +3090,9 @@ TEST(ViewTeam, base_camp_seat_rail_draws_labelled_placeholders_and_the_chip)
 
     render();
 
-    // The chip's 8x8 black surround sits at card_x + 61 now (the face's last
-    // nine pixels). Its whole top row is one solid PURE_BLACK run, which the
+    // The chip's 8x8 black surround sits at card_x + 60 now (the face's last
+    // ten pixels, one of which stays face so the chip is not nipped by the
+    // right bevel). Its whole top row is one solid PURE_BLACK run, which the
     // backdrop and the card face never produce — so the run is its signature.
     const auto solid_black_run = [&](int x0, int y) {
         Uint8 red = 0;
@@ -3104,7 +3105,7 @@ TEST(ViewTeam, base_camp_seat_rail_draws_labelled_placeholders_and_the_chip)
         return std::all_of(run.begin(), run.end(),
                            [black](Uint32 pixel) { return pixel == black; });
     };
-    EXPECT_TRUE(solid_black_run(card.x + 61, card.y + 1))
+    EXPECT_TRUE(solid_black_run(card.x + 60, card.y + 1))
         << "the team chip draws on the card the rail actually placed";
     EXPECT_FALSE(solid_black_run(kStaleCardX + 48, card.y + 1))
         << "nothing is left behind at the retired rail's card slot";
@@ -3816,7 +3817,7 @@ TEST(ViewTeam, base_camp_zero_seat_state_activates_through_the_first_slot)
         spec.nav.rewire(
             buttons, picker_createmenu_button_count(), highlighted);
         EXPECT_FALSE(buttons[kBaseCampSeatCardBase].hidden);
-        EXPECT_EQ("P7 SPEC ", buttons[kBaseCampSeatCardBase].label);
+        EXPECT_EQ("P7 SPEC  ", buttons[kBaseCampSeatCardBase].label);
         // The door out of the spectator state is the slot beside the SPEC
         // card, not a [+] somewhere else on the row.
         EXPECT_FALSE(buttons[kBaseCampSeatCardBase + 1].hidden);
@@ -3885,7 +3886,7 @@ TEST(ViewTeam, base_camp_zero_seat_state_activates_through_the_first_slot)
         buttons = picker_createmenu_buttons();
         spec.nav.rewire(
             buttons, picker_createmenu_button_count(), highlighted);
-        EXPECT_EQ("P1 WASD ", buttons[kBaseCampSeatCardBase].label);
+        EXPECT_EQ("P1 WASD  ", buttons[kBaseCampSeatCardBase].label);
         // The seat landed in slot zero, so the SECOND slot is the door now —
         // and the debounce is on the DOOR, not on the ordinal.
         EXPECT_EQ(MENU_OK,
@@ -3943,7 +3944,7 @@ TEST(ViewTeam, base_camp_single_seat_device_names_screen_and_closes_the_rail)
     spec.nav.rewire(buttons, picker_createmenu_button_count(), highlighted);
     // Desktop: the card names the seat's keyboard mapping, and three ADD
     // PLAYER slots stand beside it on the fixed grid.
-    EXPECT_EQ("P1 WASD ", buttons[kBaseCampSeatCardBase].label);
+    EXPECT_EQ("P1 WASD  ", buttons[kBaseCampSeatCardBase].label);
     EXPECT_EQ(og::ui::RowState::Visible,
               spec.rows[kBaseCampSeatCardBase + 1].state_override(
                   og::ui::MenuLabelContext{}));
@@ -3954,7 +3955,7 @@ TEST(ViewTeam, base_camp_single_seat_device_names_screen_and_closes_the_rail)
     input_hardware_state().single_seat_device = true;
     buttons = picker_createmenu_buttons();
     spec.nav.rewire(buttons, picker_createmenu_button_count(), highlighted);
-    EXPECT_EQ("P1 SCRN ", buttons[kBaseCampSeatCardBase].label);
+    EXPECT_EQ("P1 SCRN  ", buttons[kBaseCampSeatCardBase].label);
     // The phone's rail is ONE card and nothing else: no slot on this device
     // can be claimed, so no slot is offered. The lone card starts where every
     // other left-aligned control does.
@@ -3988,7 +3989,7 @@ TEST(ViewTeam, base_camp_single_seat_device_names_screen_and_closes_the_rail)
     player_joy[0].index = 0;
     buttons = picker_createmenu_buttons();
     spec.nav.rewire(buttons, picker_createmenu_button_count(), highlighted);
-    EXPECT_EQ("P1 JOY1 ", buttons[kBaseCampSeatCardBase].label);
+    EXPECT_EQ("P1 JOY1  ", buttons[kBaseCampSeatCardBase].label);
 
     og::ui::install_base_camp_state_for_screen(nullptr);
     save.reset();

--- a/tests/test_interact.h
+++ b/tests/test_interact.h
@@ -25,16 +25,21 @@ std::mutex& get_allbuttons_mutex();
 // digest, and the label sync.
 //
 // Only engine-hosted screens (run_menu_screen) pump; a task posted while no
-// menu loop is running waits out its timeout and is discarded between tests.
+// menu loop is running waits out its timeout and is CANCELLED there and then.
 // All three are defined in integration_main.cpp.
 using MainThreadTaskTicket = std::uint64_t;
 MainThreadTaskTicket post_main_thread_task(std::function<void()> task);
-// Blocks until the posted task has finished running. Returns false on timeout
-// (the menu loop never got a frame in); the ceiling is generous on purpose.
+// Blocks until the posted task has finished running. Returns true only when
+// the task actually ran on the menu thread; the ceiling is generous on
+// purpose. On timeout the ticket is cancelled before this returns — a task
+// that missed its window never runs afterwards, so a lambda may capture the
+// caller's locals by reference — and the return is false. False also comes
+// back for a task the between-tests drain threw away unrun; a discarded task
+// is never reported as a success.
 bool wait_for_main_thread_task(MainThreadTaskTicket ticket,
                                int timeout_ms = 15000);
-// Discards every queued-but-unrun task and releases waiters. Runs between
-// tests so a task left behind by a timed-out injector can never execute
+// Discards every queued-but-unrun task and releases its waiters with false.
+// Runs between tests so a task left behind by an injector can never execute
 // inside the next test's menu loop.
 void drain_main_thread_tasks();
 

--- a/tests/test_interact.h
+++ b/tests/test_interact.h
@@ -5,6 +5,8 @@
 #include <openglad/interface/input.h>
 #include <openglad/platform/game_session.h>
 #include "test_input_helpers.h"
+#include <cstdint>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -12,6 +14,37 @@
 // Mutex to synchronize access to allbuttons[] between injector threads
 // and the main thread during menu transitions. Defined in integration_main.cpp.
 std::mutex& get_allbuttons_mutex();
+
+// Main-thread task queue (issue #257). An injector thread that mutates state
+// the menu loop reads every frame (save_data, cfg, the hire session, the live
+// roster) must NOT write it directly: SaveData::completed_levels and cfg are
+// node-based maps, and one concurrent insert dangles an iterator the main
+// thread is walking. Post the mutation instead — the menu runner drains the
+// queue at the top of each frame (og::ui::g_picker_main_thread_pump), so the
+// write lands between frames, ordered against the lobby poll, the stage
+// digest, and the label sync.
+//
+// Only engine-hosted screens (run_menu_screen) pump; a task posted while no
+// menu loop is running waits out its timeout and is discarded between tests.
+// All three are defined in integration_main.cpp.
+using MainThreadTaskTicket = std::uint64_t;
+MainThreadTaskTicket post_main_thread_task(std::function<void()> task);
+// Blocks until the posted task has finished running. Returns false on timeout
+// (the menu loop never got a frame in); the ceiling is generous on purpose.
+bool wait_for_main_thread_task(MainThreadTaskTicket ticket,
+                               int timeout_ms = 15000);
+// Discards every queued-but-unrun task and releases waiters. Runs between
+// tests so a task left behind by a timed-out injector can never execute
+// inside the next test's menu loop.
+void drain_main_thread_tasks();
+
+// Post + wait in one call, the shape nearly every injector wants.
+inline bool run_on_main_thread(std::function<void()> task,
+                               int timeout_ms = 15000)
+{
+    return wait_for_main_thread_task(post_main_thread_task(std::move(task)),
+                                     timeout_ms);
+}
 
 struct AllButtonsLock final
 {

--- a/tests/test_interact.h
+++ b/tests/test_interact.h
@@ -137,6 +137,69 @@ inline bool wait_for_interactable(const std::string& id, int timeout_ms = 5000)
     return false;
 }
 
+// The live label of a visible interactable, or "" when it is absent/hidden.
+// Base Camp's seat slots are one ordinal wearing two faces (a seat card or an
+// ADD PLAYER door), so presence alone no longer tells an injector what a slot
+// IS — the label does.
+inline std::string interactable_label(const std::string& id)
+{
+    og::runtime::ensure_thread_session();
+    AllButtonsLock lock;
+    for (int i = 0; i < MAX_BUTTONS; i++) {
+        vbutton* const live =
+            og::runtime::current_session->allbuttons_[static_cast<std::size_t>(i)];
+        if (live == nullptr || live->id != id || live->hidden)
+            continue;
+        return live->label;
+    }
+    return {};
+}
+
+// Block until a visible interactable carries an exact label. The wait-on-
+// condition form of "the click landed": a slot that became a seat card names
+// its controller, and one that did not still says ADD PLAYER.
+inline bool wait_for_interactable_label(const std::string& id,
+                                        const std::string& label,
+                                        int timeout_ms = 5000)
+{
+    int elapsed = 0;
+    const int poll_interval = 50;
+    while (elapsed < timeout_ms) {
+        if (interactable_label(id) == label)
+            return true;
+        SDL_Delay(static_cast<Uint32>(poll_interval));
+        elapsed += poll_interval;
+    }
+    fprintf(stderr,
+            "  [interact] TIMEOUT waiting for '%s' to read '%s' (%d ms; now "
+            "'%s')\n",
+            id.c_str(), label.c_str(), timeout_ms,
+            interactable_label(id).c_str());
+    return false;
+}
+
+// Block until a visible interactable STOPS carrying a label — the "this slot
+// changed identity" wait, for cases where the new text is not known up front.
+inline bool wait_for_interactable_label_change(const std::string& id,
+                                               const std::string& old_label,
+                                               int timeout_ms = 5000)
+{
+    int elapsed = 0;
+    const int poll_interval = 50;
+    while (elapsed < timeout_ms) {
+        const std::string now = interactable_label(id);
+        if (!now.empty() && now != old_label)
+            return true;
+        SDL_Delay(static_cast<Uint32>(poll_interval));
+        elapsed += poll_interval;
+    }
+    fprintf(stderr,
+            "  [interact] TIMEOUT waiting for '%s' to stop reading '%s' "
+            "(%d ms)\n",
+            id.c_str(), old_label.c_str(), timeout_ms);
+    return false;
+}
+
 // Click an interactable by ID. Finds the button, computes center in game coords,
 // converts to window coords, injects SDL click event.
 inline void interact(const std::string& id)

--- a/tests/test_interact.h
+++ b/tests/test_interact.h
@@ -186,7 +186,7 @@ inline bool accept_generated_company_name(int timeout_ms = 5000)
 {
     if (!wait_for_interactable("company_name_accept", timeout_ms))
         return false;
-    SDL_Delay(750);  // FadeAroundEntry settle (fadeblack eats events)
+    SDL_Delay(750);  // menu-entry settle (fades are instant under TESTING)
     fprintf(stderr, "  [test] accepting generated company name\n");
     interact("company_name_accept");
     return true;

--- a/tests/unit/test_device_seats.cpp
+++ b/tests/unit/test_device_seats.cpp
@@ -70,8 +70,9 @@ TEST(DeviceSeats, screen_owner_token_covers_the_keyboard_seat_only)
 
 TEST(DeviceSeats, screen_owner_label_fits_the_seat_card_face)
 {
-    // The seat card face is nine characters including "P{n} " and the
-    // load-bearing trailing pad (picker_sdl_defs.h), so the token owns four.
+    // The seat card face is eleven characters including "P{n} " and the
+    // load-bearing trailing pad (picker_sdl_defs.h), and a two-digit lobby-
+    // wide P# eats one more, so the token stays inside four.
     EXPECT_EQ(4u, std::strlen(og::input::kScreenSeatOwnerLabel));
     EXPECT_STREQ("SCRN", og::input::kScreenSeatOwnerLabel);
 }

--- a/tests/unit/test_input_mappings.cpp
+++ b/tests/unit/test_input_mappings.cpp
@@ -215,8 +215,9 @@ TEST(InputMappings, unspellable_clusters_fall_back_to_custom)
 TEST(InputMappings, short_names_fit_the_base_camp_seat_card)
 {
     // ARROWS renders as the font's arrow glyphs (up/left/down/right) on
-    // every SDL display surface; "P2 \x01\x03\x02\x04 " is eight of the eleven
-    // characters the 70px seat-slot face holds.
+    // every SDL display surface; "P2 \x01\x03\x02\x04  " is nine of the eleven
+    // characters the 70px seat-slot face holds (three of them the P# prefix,
+    // two the trailing pads that center the ink over the chip-free zone).
     ASSERT_EQ(og::input::kArrowGlyphs, mapping_short_name("ARROWS"));
     ASSERT_EQ("\x01\x03\x02\x04", mapping_short_name("ARROWS"));
     ASSERT_EQ("WASD", mapping_short_name("WASD"));

--- a/tests/unit/test_input_mappings.cpp
+++ b/tests/unit/test_input_mappings.cpp
@@ -215,8 +215,8 @@ TEST(InputMappings, unspellable_clusters_fall_back_to_custom)
 TEST(InputMappings, short_names_fit_the_base_camp_seat_card)
 {
     // ARROWS renders as the font's arrow glyphs (up/left/down/right) on
-    // every SDL display surface; "P2 \x01\x03\x02\x04 " is eight of the nine
-    // characters the 57px card face holds.
+    // every SDL display surface; "P2 \x01\x03\x02\x04 " is eight of the eleven
+    // characters the 70px seat-slot face holds.
     ASSERT_EQ(og::input::kArrowGlyphs, mapping_short_name("ARROWS"));
     ASSERT_EQ("\x01\x03\x02\x04", mapping_short_name("ARROWS"));
     ASSERT_EQ("WASD", mapping_short_name("WASD"));

--- a/tests/unit/test_picker_common.cpp
+++ b/tests/unit/test_picker_common.cpp
@@ -4608,16 +4608,39 @@ TEST(BaseCampMpDisplay, session_status_degrades_by_shape_not_by_byte_cut)
         make_lobby_seat(0, "net-h", "IRON KETTLE BAND", true, false, 1, 0,
                         1)};
     // Each rung is taken whole while it fits and abandoned whole when it
-    // does not — never a prefix of the rung above.
-    EXPECT_EQ("IN GLAD-7Q2F: 1 PLAYERS / 1 MACHINES",
+    // does not — never a prefix of the rung above. ONE IS ONE: a lobby of one
+    // says PLAYER / MACHINE / PC, never the "1 PLAYERS" that told the reader
+    // the line could not count. The singular is always the shorter spelling,
+    // so it can never push a rung off a band it used to fit — here it makes
+    // the widest rung 34 characters instead of 38.
+    EXPECT_EQ("IN GLAD-7Q2F: 1 PLAYER / 1 MACHINE",
               og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
                                                       kettle, 36));
-    EXPECT_EQ("IN GLAD-7Q2F: 1 PLAYERS/1 PCS",
+    EXPECT_EQ(std::size_t{34},
               og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
-                                                      kettle, 35));
+                                                      kettle, 34).size());
+    EXPECT_EQ("IN GLAD-7Q2F: 1 PLAYER / 1 MACHINE",
+              og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
+                                                      kettle, 34))
+        << "the singular rung fits a band the plural one would have missed";
+    EXPECT_EQ("IN GLAD-7Q2F: 1 PLAYER/1 PC",
+              og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
+                                                      kettle, 33));
     EXPECT_EQ("IN GLAD-7Q2F: 1P/1M",
               og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
-                                                      kettle, 28));
+                                                      kettle, 26));
+    // A machine with two seats in it: the players half pluralizes on its own
+    // count, the machines half does not.
+    const std::vector<og::sim::LobbyPlayer> two_on_one = {
+        make_lobby_seat(0, "net-h", "IRON KETTLE BAND", true, false, 1, 0, 1),
+        make_lobby_seat(1, "net-h2", "IRON KETTLE BAND", false, false, 1, 0,
+                        1)};
+    EXPECT_EQ("IN GLAD-7Q2F: 2 PLAYERS / 1 MACHINE",
+              og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
+                                                      two_on_one, 40));
+    EXPECT_EQ("IN GLAD-7Q2F: 2 PLAYERS/1 PC",
+              og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
+                                                      two_on_one, 34));
     EXPECT_EQ("JOINED: 1P/1M",
               og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
                                                       kettle, 18));
@@ -4645,7 +4668,7 @@ TEST(BaseCampMpDisplay, line_b_gives_the_alert_slot_and_color_precedence)
         std::nullopt, true, "GLAD-7Q2F", players,
         og::ui::kBaseCampLineBCharsHireHidden);
     EXPECT_FALSE(healthy.alert);
-    EXPECT_EQ("HOSTING GLAD-7Q2F: 1 PLAYERS / 1 MACHINES", healthy.text);
+    EXPECT_EQ("HOSTING GLAD-7Q2F: 1 PLAYER / 1 MACHINE", healthy.text);
 
     // Degraded: the alert takes the slot AND the color (§9.12 precedence —
     // the ORANGE mapping rides the alert flag).

--- a/tests/unit/test_picker_common.cpp
+++ b/tests/unit/test_picker_common.cpp
@@ -4458,31 +4458,6 @@ TEST(BaseCampMpDisplay, session_census_counts_machines_and_players)
     EXPECT_EQ(5, census.players);
 }
 
-TEST(BaseCampMpDisplay, host_display_name_prefers_company_over_wire_name)
-{
-    // §9.12: player names are machine-generated "net-<hex>" wire ids, so
-    // the joiner's HOST: display uses the host machine's company (the
-    // format_go_blockers naming convention), 16-char COMPANY clip.
-    const std::vector<og::sim::LobbyPlayer> players = {
-        make_lobby_seat(0, "net-h", "A COMPANY NAME PAST SIXTEEN", true,
-                        false, 1, 0),
-        make_lobby_seat(1, "net-j", "JOIN CO", false, false, 1, 0),
-    };
-    EXPECT_EQ("A COMPANY NAME P",
-              og::ui::base_camp_host_display_name(players));
-
-    // Empty company falls back to the seat's display name. It is presentation
-    // only; the server-issued machine ID remains the grouping authority.
-    const std::vector<og::sim::LobbyPlayer> bare = {
-        make_lobby_seat(0, "net-h#2", "", true, false, 1, 0)};
-    EXPECT_EQ("net-h#2", og::ui::base_camp_host_display_name(bare));
-
-    // No host seat yet (pre-election): empty.
-    const std::vector<og::sim::LobbyPlayer> unelected = {
-        make_lobby_seat(1, "net-j", "JOIN CO", false, false, 1, 0)};
-    EXPECT_EQ("", og::ui::base_camp_host_display_name(unelected));
-}
-
 TEST(BaseCampMpDisplay, session_status_shapes_hold_the_line_b_budget)
 {
     const std::vector<og::sim::LobbyPlayer> players = {
@@ -4514,55 +4489,65 @@ TEST(BaseCampMpDisplay, session_status_shapes_hold_the_line_b_budget)
     EXPECT_GT(ink_right_edge(kWide + 1), og::ui::kBaseCampLineBPagerWallX)
         << "the wide budget must be the WIDEST that clears the pagers";
 
-    // §9.12 host shape on the wide band: role + room + census. "MACH /
-    // PLYR" is the recorded budget latitude (spelled-out overruns at
-    // double digits).
-    EXPECT_EQ("HOSTING GLAD-7Q2F - 2 MACH / 3 PLYR",
+    // The rail shows THIS machine's seats only, so line B is where the size
+    // of the lobby lives — players first, machines second. Every rung below
+    // is a whole spelling; the ladder falls between them and never cuts one.
+    //
+    // WIDE band, everyday counts: the spelled-out rung lands on exactly 41.
+    EXPECT_EQ("HOSTING GLAD-7Q2F: 3 PLAYERS / 2 MACHINES",
               og::ui::format_base_camp_session_status(true, "GLAD-7Q2F",
                                                       players, kWide));
-    // Relay-less (LAN) host: the census alone.
-    EXPECT_EQ("HOSTING 2 MACH / 3 PLYR",
+    EXPECT_EQ(static_cast<std::size_t>(kWide),
+              og::ui::format_base_camp_session_status(true, "GLAD-7Q2F",
+                                                      players, kWide).size())
+        << "the widest rung is sized to the widest band";
+    // Relay-less (LAN) host: no room code to carry.
+    EXPECT_EQ("HOSTING: 3 PLAYERS / 2 MACHINES",
               og::ui::format_base_camp_session_status(true, "", players,
                                                       kWide));
 
-    // §9.12 joiner shape: room + the host machine's company.
-    EXPECT_EQ("IN GLAD-7Q2F - HOST: IRON KETTLE BAND",
+    // The joiner's line carries the same census. "HOST: <company>" is gone:
+    // the host's company is on every one of its roster rows, and the count
+    // of everyone in the lobby is on none of them.
+    EXPECT_EQ("IN GLAD-7Q2F: 3 PLAYERS / 2 MACHINES",
               og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
                                                       players, kWide));
     // Direct (LAN) joiner: no room code.
-    EXPECT_EQ("JOINED - HOST: IRON KETTLE BAND",
+    EXPECT_EQ("JOINED: 3 PLAYERS / 2 MACHINES",
               og::ui::format_base_camp_session_status(false, "", players,
                                                       kWide));
-    // Host not yet known (pre-election on a dedicated server).
-    EXPECT_EQ("IN GLAD-7Q2F",
+    // Pre-first-state: an empty roster still answers honestly.
+    EXPECT_EQ("IN GLAD-7Q2F: 0 PLAYERS / 0 MACHINES",
               og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
                                                       {}, kWide));
-    EXPECT_EQ("JOINED",
+    EXPECT_EQ("JOINED: 0 PLAYERS / 0 MACHINES",
               og::ui::format_base_camp_session_status(false, "", {}, kWide));
 
-    // The NARROW band (the shape every shipped campaign renders today —
-    // the default composition shows HIRE): the everyday host line is 35,
-    // one character over, so the census takes its compact spelling rather
-    // than losing "PLYR" to a byte cut. The joiner drops the "HOST: "
-    // label instead of the company that names the lobby.
-    EXPECT_EQ("HOSTING GLAD-7Q2F - 2M / 3P",
+    // The NARROW band (the shape every shipped campaign renders today — the
+    // default composition shows HIRE): "MACHINES" costs six characters more
+    // than the room code is worth, so the second rung says PCS and lands on
+    // exactly 34.
+    EXPECT_EQ("HOSTING GLAD-7Q2F: 3 PLAYERS/2 PCS",
               og::ui::format_base_camp_session_status(true, "GLAD-7Q2F",
                                                       players, kNarrow));
-    EXPECT_EQ("HOSTING 2 MACH / 3 PLYR",
+    EXPECT_EQ(static_cast<std::size_t>(kNarrow),
+              og::ui::format_base_camp_session_status(
+                  true, "GLAD-7Q2F", players, kNarrow).size())
+        << "the everyday rung is sized to the everyday band";
+    EXPECT_EQ("HOSTING: 3 PLAYERS / 2 MACHINES",
               og::ui::format_base_camp_session_status(true, "", players,
                                                       kNarrow))
         << "a shape that already fits keeps the spelled-out census";
-    EXPECT_EQ("IN GLAD-7Q2F - IRON KETTLE BAND",
+    EXPECT_EQ("IN GLAD-7Q2F: 3 PLAYERS/2 PCS",
               og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
                                                       players, kNarrow));
-    EXPECT_EQ("JOINED - HOST: IRON KETTLE BAND",
+    EXPECT_EQ("JOINED: 3 PLAYERS / 2 MACHINES",
               og::ui::format_base_camp_session_status(false, "", players,
-                                                      kNarrow))
-        << "the LAN joiner shape fits as-is and keeps its label";
+                                                      kNarrow));
 
-    // Budget pins: the absolute worst shapes fit BOTH bands — host at the
-    // 16-seat global cap, joiner at the full 16-char company clip; a
-    // pathological room code display-clips at 12.
+    // Budget pins: the absolute worst shapes fit BOTH bands — the 16-seat
+    // global cap on 16 machines, and a pathological room code that display-
+    // clips at 12.
     std::vector<og::sim::LobbyPlayer> sixteen;
     for (int i = 0; i < 16; ++i) {
         sixteen.push_back(make_lobby_seat(
@@ -4570,42 +4555,36 @@ TEST(BaseCampMpDisplay, session_status_shapes_hold_the_line_b_budget)
             std::format("net-{:02}", i).c_str(), "C", i == 0, false, 1, 0,
             static_cast<og::sim::LobbyMachineId>(i + 1)));
     }
-    const std::vector<og::sim::LobbyPlayer> long_company = {
-        make_lobby_seat(0, "net-h", "A COMPANY NAME PAST SIXTEEN", true,
-                        false, 1, 0, 1)};
     for (const int budget : {kNarrow, kWide}) {
         EXPECT_LE(og::ui::format_base_camp_session_status(
                       true, "GLAD-XXXX", sixteen, budget).size(),
                   static_cast<std::size_t>(budget))
             << "16-seat host at budget " << budget;
         EXPECT_LE(og::ui::format_base_camp_session_status(
-                      false, "GLAD-XXXX", players, budget).size(),
+                      false, "GLAD-XXXX", sixteen, budget).size(),
                   static_cast<std::size_t>(budget))
-            << "joiner at budget " << budget;
+            << "16-seat joiner at budget " << budget;
         EXPECT_LE(og::ui::format_base_camp_session_status(
                       true, "GLAD-TOO-LONG-CODE", sixteen, budget).size(),
                   static_cast<std::size_t>(budget))
             << "pathological room code at budget " << budget;
-        EXPECT_LE(og::ui::format_base_camp_session_status(
-                      false, "GLAD-TOO-LONG-CODE", long_company, budget)
-                      .size(),
-                  static_cast<std::size_t>(budget))
-            << "pathological room code + company at budget " << budget;
     }
-    EXPECT_EQ("HOSTING GLAD-XXXX - 16 MACH / 16 PLYR",
+    // Two-digit counts push the spelled-out rung past even the wide band, so
+    // the ladder drops a whole rung at a time.
+    EXPECT_EQ("HOSTING GLAD-XXXX: 16 PLAYERS/16 PCS",
               og::ui::format_base_camp_session_status(true, "GLAD-XXXX",
                                                       sixteen, kWide));
-    EXPECT_EQ("HOSTING GLAD-XXXX - 16M / 16P",
+    EXPECT_EQ("HOSTING GLAD-XXXX: 16P/16M",
               og::ui::format_base_camp_session_status(true, "GLAD-XXXX",
                                                       sixteen, kNarrow));
-    // Room 12 + company 16 is the joiner's exact-fit worst case at 34.
-    EXPECT_EQ("IN GLAD-TOO-LON - A COMPANY NAME P",
+    // Room 12 + two-digit counts is the joiner's exact-fit worst case at 34.
+    EXPECT_EQ("IN GLAD-TOO-LON: 16 PLAYERS/16 PCS",
               og::ui::format_base_camp_session_status(
-                  false, "GLAD-TOO-LONG-CODE", long_company, kNarrow));
+                  false, "GLAD-TOO-LONG-CODE", sixteen, kNarrow));
 }
 
 // The composer's budget is a parameter, not a constant: narrower callers
-// (and any future band) shed the room code and whole words rather than
+// (and any future band) drop a whole rung, then the room code, rather than
 // emitting a byte-cut line.
 TEST(BaseCampMpDisplay, session_status_degrades_by_shape_not_by_byte_cut)
 {
@@ -4618,29 +4597,30 @@ TEST(BaseCampMpDisplay, session_status_degrades_by_shape_not_by_byte_cut)
     }
     // Too narrow even for the compact census beside a room code: the room
     // half goes (the NETWORKING screen keeps the authoritative code).
-    EXPECT_EQ("HOSTING 16M / 16P",
+    EXPECT_EQ("HOSTING: 16P/16M",
               og::ui::format_base_camp_session_status(true, "GLAD-7Q2F",
+                                                      sixteen, 20));
+    EXPECT_EQ("JOINED: 16P/16M",
+              og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
                                                       sixteen, 20));
 
     const std::vector<og::sim::LobbyPlayer> kettle = {
         make_lobby_seat(0, "net-h", "IRON KETTLE BAND", true, false, 1, 0,
                         1)};
-    // The company sheds a whole word when one survives past half the
-    // remaining budget...
-    EXPECT_EQ("IN GLAD-7Q2F - IRON KETTLE",
+    // Each rung is taken whole while it fits and abandoned whole when it
+    // does not — never a prefix of the rung above.
+    EXPECT_EQ("IN GLAD-7Q2F: 1 PLAYERS / 1 MACHINES",
               og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
-                                                      kettle, 26));
-    EXPECT_EQ("IN GLAD-7Q2F - IRON",
+                                                      kettle, 36));
+    EXPECT_EQ("IN GLAD-7Q2F: 1 PLAYERS/1 PCS",
               og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
-                                                      kettle, 20));
-    // ...and takes the bytes when the whole-word remainder would say less
-    // than they do.
-    const std::vector<og::sim::LobbyPlayer> lopsided = {
-        make_lobby_seat(0, "net-h", "A VERYLONGNAMEHERE", true, false, 1, 0,
-                        1)};
-    EXPECT_EQ("IN GLAD-7Q2F - A VERYLONGN",
+                                                      kettle, 35));
+    EXPECT_EQ("IN GLAD-7Q2F: 1P/1M",
               og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
-                                                      lopsided, 26));
+                                                      kettle, 28));
+    EXPECT_EQ("JOINED: 1P/1M",
+              og::ui::format_base_camp_session_status(false, "GLAD-7Q2F",
+                                                      kettle, 18));
     // The hard floor: every shape still honors the budget.
     for (int budget = 1; budget <= 45; ++budget) {
         EXPECT_LE(og::ui::format_base_camp_session_status(
@@ -4665,7 +4645,7 @@ TEST(BaseCampMpDisplay, line_b_gives_the_alert_slot_and_color_precedence)
         std::nullopt, true, "GLAD-7Q2F", players,
         og::ui::kBaseCampLineBCharsHireHidden);
     EXPECT_FALSE(healthy.alert);
-    EXPECT_EQ("HOSTING GLAD-7Q2F - 1 MACH / 1 PLYR", healthy.text);
+    EXPECT_EQ("HOSTING GLAD-7Q2F: 1 PLAYERS / 1 MACHINES", healthy.text);
 
     // Degraded: the alert takes the slot AND the color (§9.12 precedence —
     // the ORANGE mapping rides the alert flag).
@@ -5461,265 +5441,167 @@ TEST(LevelPickerLayout, status_labels_match_the_progress_report)
 }
 
 // ---------------------------------------------------------------------------
-// #243: the Base Camp seat rail's per-frame geometry. The rail used to be a
-// static seven-control row, so every shape that hid a control left a hole —
-// a 24px gap where '<' would be, a right margin that stopped wherever the
-// last card happened to end, and on a phone a 38px void to the LEFT of the
-// only card on screen. These pin the replacement rule.
+// The Base Camp seat rail. It used to window the whole lobby behind a [+]
+// and two pagers, so its geometry changed with the number of players and a
+// card could slide sideways under a finger already on its way down. The rail
+// is THIS MACHINE'S four seats now, on a grid that never moves; these pin the
+// grid and the rule that decides what each slot is.
 
-namespace {
-
-// The rail's live elements, left to right, as (x, width) pairs.
-std::vector<std::pair<int, int>> seat_rail_elements(
-    const og::ui::SeatRailLayout& rail)
+TEST(SeatRailLayout, the_four_slots_are_a_fixed_grid_across_the_panel)
 {
-    std::vector<std::pair<int, int>> out;
-    if (rail.add_visible)
-        out.emplace_back(rail.add_x, og::ui::kSeatRailAddWidth);
-    if (rail.pagers_visible)
-        out.emplace_back(rail.prev_x, og::ui::kSeatRailPagerWidth);
-    for (int slot = 0; slot < rail.slot_count(); ++slot)
-        out.emplace_back(rail.slot_x[static_cast<std::size_t>(slot)],
-                         rail.card_w);
-    if (rail.pagers_visible)
-        out.emplace_back(rail.next_x, og::ui::kSeatRailPagerWidth);
-    return out;
-}
-
-} // namespace
-
-TEST(SeatRailLayout, the_full_rail_is_the_shape_the_static_table_carries)
-{
-    // Everything visible: '+', both arrows and four cards, at exactly the
-    // coordinates menu_screen_specs.cpp's constants produce. This is the one
-    // shape the exact-rect table in test_menu_layout pins, and it must not
-    // move by a pixel.
+    // Four 70px faces, 8px gutters, opening on BACK's left edge and closing
+    // on the panel's right rail with no remainder. Every one of these numbers
+    // is also written into the static spec table (test_menu_layout pins the
+    // rects); they must not move by a pixel.
     const og::ui::SeatRailLayout rail =
-        og::ui::base_camp_seat_rail_layout(true, true, 4, 0);
-    EXPECT_EQ(8, rail.add_x);
-    EXPECT_EQ(29, rail.prev_x);
-    EXPECT_EQ(46, rail.slot_x[0]);
-    EXPECT_EQ(110, rail.slot_x[1]);
-    EXPECT_EQ(174, rail.slot_x[2]);
-    EXPECT_EQ(238, rail.slot_x[3]);
-    EXPECT_EQ(302, rail.next_x);
-    EXPECT_EQ(57, rail.card_w);
-    EXPECT_EQ(312, rail.next_x + og::ui::kSeatRailPagerWidth);
-    // Six gutters of exactly the packed width: the justified rail and the
-    // packed rail agree here, which is why the shape is byte-identical.
-    const auto elements = seat_rail_elements(rail);
-    ASSERT_EQ(7u, elements.size());
-    for (std::size_t i = 1; i < elements.size(); ++i)
-    {
-        EXPECT_EQ(og::ui::kSeatRailGap,
-                  elements[i].first - (elements[i - 1].first +
-                                       elements[i - 1].second))
-            << "gutter " << i;
-    }
-}
-
-TEST(SeatRailLayout, a_ghost_filled_desktop_row_justifies_between_both_rails)
-{
-    // Two claimed seats on an ordinary desktop: two cards plus two ghosts
-    // fill the grid, so the row spans 8..312 with gutters that differ by at
-    // most the one odd pixel the leftmost gutters absorb.
-    const og::ui::SeatRailLayout rail =
-        og::ui::base_camp_seat_rail_layout(true, false, 2, 2);
-    EXPECT_EQ(2, rail.shown_cards);
-    EXPECT_EQ(2, rail.ghost_count);
-    EXPECT_EQ(8, rail.add_x);
-    EXPECT_EQ(38, rail.slot_x[0]);
-    EXPECT_EQ(111, rail.slot_x[1]);
-    EXPECT_EQ(183, rail.slot_x[2]);
-    EXPECT_EQ(255, rail.slot_x[3]);
-    EXPECT_EQ(312, rail.slot_x[3] + rail.card_w);
-}
-
-TEST(SeatRailLayout, an_under_full_row_packs_left_at_the_uniform_gutter)
-{
-    // A device that caps at two seats with one claimed: one card, one ghost,
-    // no arrows. Nothing stretches — a two-control row spread across the
-    // whole panel reads as broken, so it packs from the left rail.
-    const og::ui::SeatRailLayout rail =
-        og::ui::base_camp_seat_rail_layout(true, false, 1, 1);
-    EXPECT_EQ(8, rail.add_x);
-    EXPECT_EQ(29, rail.slot_x[0]);
-    EXPECT_EQ(93, rail.slot_x[1]);
-    EXPECT_EQ(2, rail.slot_count());
-}
-
-TEST(SeatRailLayout, a_phone_puts_its_lone_card_on_the_left_rail)
-{
-    // Single-seat device: no '+', no arrows, no ghosts (nothing is
-    // claimable), so the only control on the row starts where every other
-    // left-aligned control on the screen starts.
-    const og::ui::SeatRailLayout rail =
-        og::ui::base_camp_seat_rail_layout(false, false, 1, 0);
-    EXPECT_EQ(og::ui::kSeatRailX0, rail.slot_x[0]);
+        og::ui::base_camp_seat_rail_layout(4, 0);
     EXPECT_EQ(8, rail.slot_x[0]);
-    EXPECT_EQ(1, rail.slot_count());
-    EXPECT_FALSE(rail.add_visible);
+    EXPECT_EQ(86, rail.slot_x[1]);
+    EXPECT_EQ(164, rail.slot_x[2]);
+    EXPECT_EQ(242, rail.slot_x[3]);
+    EXPECT_EQ(70, rail.card_w);
+    EXPECT_EQ(og::ui::kSeatRailX0, rail.slot_x[0]);
+    EXPECT_EQ(og::ui::kSeatRailRightX, rail.slot_x[3] + rail.card_w);
+    for (int slot = 1; slot < og::ui::kSeatRailSlots; ++slot) {
+        EXPECT_EQ(og::ui::kSeatRailGap,
+                  rail.slot_x[static_cast<std::size_t>(slot)] -
+                      (rail.slot_x[static_cast<std::size_t>(slot - 1)] +
+                       rail.card_w))
+            << "gutter " << slot;
+    }
+    // The face IS the label budget: 70/6 = 11 characters, which is what makes
+    // "ADD PLAYER" and "LOBBY FULL" (10 each) fit a bare slot.
+    EXPECT_EQ(11, og::ui::kSeatRailCardWidth / 6);
+    EXPECT_LE(std::string_view("ADD PLAYER").size() * 6,
+              static_cast<std::size_t>(og::ui::kSeatRailCardWidth));
+    EXPECT_LE(std::string_view("LOBBY FULL").size() * 6,
+              static_cast<std::size_t>(og::ui::kSeatRailCardWidth));
 }
 
-TEST(SeatRailLayout, a_short_last_page_packs_left_under_an_anchored_pager)
+TEST(SeatRailLayout, a_slot_keeps_its_x_however_many_neighbours_are_live)
 {
-    // A 5-seat lobby's last page with nothing claimable (4 local seats at
-    // the build cap): one card, no ghosts, both arrows up. The run packs
-    // left at the uniform gutter and the '>' alone holds the right rail —
-    // never three controls stretched across 71px voids.
-    const og::ui::SeatRailLayout rail =
-        og::ui::base_camp_seat_rail_layout(/*add_visible=*/true,
-                                           /*pagers_visible=*/true,
-                                           /*visible_cards=*/1,
-                                           /*ghost_count=*/0);
-    EXPECT_EQ(8, rail.add_x);
-    EXPECT_EQ(29, rail.prev_x);
-    EXPECT_EQ(46, rail.slot_x[0]);
-    EXPECT_EQ(og::ui::kSeatRailRightX - og::ui::kSeatRailPagerWidth,
-              rail.next_x);
-}
-
-TEST(SeatRailLayout, every_shape_keeps_the_rail_ordered_and_inside_the_panel)
-{
+    // The whole point of the fixed grid: slot 2 is at 164 whether it is the
+    // last card, the first placeholder, or hidden behind a device cap. The
+    // old rail justified and packed, so claiming a seat moved every card on
+    // the row out from under the pointer that claimed it.
+    const og::ui::SeatRailLayout full =
+        og::ui::base_camp_seat_rail_layout(4, 0);
     int checked = 0;
-    for (int add = 0; add < 2; ++add)
-    {
-        for (int pagers = 0; pagers < 2; ++pagers)
-        {
-            for (int cards = 0; cards <= og::ui::kSeatRailSlots; ++cards)
-            {
-                for (int ghosts = 0;
-                     ghosts <= og::ui::kSeatRailSlots - cards; ++ghosts)
-                {
-                    const og::ui::SeatRailLayout rail =
-                        og::ui::base_camp_seat_rail_layout(
-                            add != 0, pagers != 0, cards, ghosts);
-                    const auto elements = seat_rail_elements(rail);
-                    if (elements.empty())
-                        continue;
-                    ++checked;
-                    const std::string shape =
-                        std::format("add={} pagers={} cards={} ghosts={}",
-                                    add, pagers, cards, ghosts);
-
-                    // The row always opens on the panel's left rail.
-                    EXPECT_EQ(og::ui::kSeatRailX0, elements.front().first)
-                        << shape;
-                    // Monotone, never overlapping, always on screen.
-                    std::vector<int> gutters;
-                    for (std::size_t i = 1; i < elements.size(); ++i)
-                    {
-                        const int gutter =
-                            elements[i].first -
-                            (elements[i - 1].first + elements[i - 1].second);
-                        EXPECT_GE(gutter, og::ui::kSeatRailGap)
-                            << shape << " gutter " << i;
-                        gutters.push_back(gutter);
-                    }
-                    // The gutter before an anchored '>' absorbs a short
-                    // row's slack; every gutter within the run itself stays
-                    // even (the leftmost take the odd pixel).
-                    const std::size_t run_gutter_count = gutters.size() -
-                        (rail.pagers_visible && !gutters.empty() ? 1 : 0);
-                    for (std::size_t i = 1; i < run_gutter_count; ++i)
-                    {
-                        EXPECT_LE(std::abs(gutters[i] - gutters[i - 1]), 1)
-                            << shape << " neighbouring gutters " << i;
-                    }
-                    const auto& last = elements.back();
-                    EXPECT_LE(last.first + last.second,
-                              og::ui::kSeatRailRightX)
-                        << shape;
-
-                    // A full row justifies to the right rail; a paged rail's
-                    // anchored '>' closes on it in every shape. Anything
-                    // else packs at the uniform gutter and stops.
-                    const bool justified =
-                        rail.slot_count() == og::ui::kSeatRailSlots;
-                    if ((justified || rail.pagers_visible) &&
-                        elements.size() > 1)
-                    {
-                        EXPECT_EQ(og::ui::kSeatRailRightX,
-                                  last.first + last.second)
-                            << shape << " must close on the right rail";
-                    }
-                    if (!justified)
-                    {
-                        for (std::size_t i = 0; i < run_gutter_count; ++i)
-                            EXPECT_EQ(og::ui::kSeatRailGap, gutters[i])
-                                << shape << " packed gutter " << i;
-                    }
-
-                    // Cards never change width: the nine-character label
-                    // budget and the chip offset both depend on 57.
-                    EXPECT_EQ(og::ui::kSeatRailCardWidth, rail.card_w)
-                        << shape;
-                }
-            }
+    for (int cards = 0; cards <= og::ui::kSeatRailSlots; ++cards) {
+        for (int placeholders = 0;
+             placeholders <= og::ui::kSeatRailSlots; ++placeholders) {
+            const og::ui::SeatRailLayout rail =
+                og::ui::base_camp_seat_rail_layout(cards, placeholders);
+            ++checked;
+            const std::string shape = std::format(
+                "cards={} placeholders={}", cards, placeholders);
+            EXPECT_EQ(full.slot_x, rail.slot_x) << shape;
+            EXPECT_EQ(70, rail.card_w) << shape;
+            EXPECT_EQ(cards, rail.shown_cards) << shape;
+            // A slot is a card or a placeholder, never both, and the row
+            // never grows a fifth.
+            EXPECT_EQ(std::min(placeholders, og::ui::kSeatRailSlots - cards),
+                      rail.placeholder_count)
+                << shape;
+            EXPECT_LE(rail.slot_count(), og::ui::kSeatRailSlots) << shape;
+            EXPECT_GE(rail.slot_count(), cards) << shape;
         }
     }
-    EXPECT_EQ(59, checked) << "every non-empty rail shape was exercised";
+    EXPECT_EQ(25, checked) << "every card/placeholder pairing was exercised";
+
+    // A phone's lone slot opens on the left rail, where BACK and every other
+    // left-aligned control on the screen opens (#249).
+    const og::ui::SeatRailLayout phone =
+        og::ui::base_camp_seat_rail_layout(1, 0);
+    EXPECT_EQ(og::ui::kSeatRailX0, phone.slot_x[0]);
+    EXPECT_EQ(1, phone.slot_count());
 }
 
-TEST(SeatRailGhosts, ghosts_appear_only_where_a_seat_can_actually_be_claimed)
+TEST(SeatRailSlots, the_device_decides_how_many_slots_the_rail_has)
 {
-    using og::ui::base_camp_seat_rail_ghost_count;
+    using og::ui::base_camp_seat_rail_slot_cap;
     using og::ui::SeatClaimability;
 
-    const SeatClaimability desktop_two{.local_count = 2, .global_count = 2};
-    EXPECT_EQ(2, og::ui::seats_still_claimable(desktop_two));
-    EXPECT_EQ(2, base_camp_seat_rail_ghost_count(
-                     {.claim = desktop_two, .visible_cards = 2}));
+    // Desktop: the build limit.
+    EXPECT_EQ(4, base_camp_seat_rail_slot_cap(SeatClaimability{}));
+    // Phone with nothing attached, then one pad, then two, then plenty.
+    EXPECT_EQ(1, base_camp_seat_rail_slot_cap(
+                     SeatClaimability{.local_seat_cap = 1}));
+    EXPECT_EQ(2, base_camp_seat_rail_slot_cap(
+                     SeatClaimability{.local_seat_cap = 2}));
+    EXPECT_EQ(3, base_camp_seat_rail_slot_cap(
+                     SeatClaimability{.local_seat_cap = 3}));
+    EXPECT_EQ(4, base_camp_seat_rail_slot_cap(
+                     SeatClaimability{.local_seat_cap = 9}))
+        << "the rail has four slots however many pads are plugged in";
+    // A build with no multiplayer has one seat and no door to a second.
+    EXPECT_EQ(1, base_camp_seat_rail_slot_cap(
+                     SeatClaimability{.multiplayer_enabled = false}));
+    // The LOBBY the machine is in never removes a slot — that is the dimmed
+    // face's job, not the grid's.
+    EXPECT_EQ(4, base_camp_seat_rail_slot_cap(
+                     SeatClaimability{.local_count = 1, .global_count = 16}));
+}
 
-    // Four local seats: the machine is full, the [+] is dimmed, and the rail
-    // promises nothing.
-    const SeatClaimability desktop_full{.local_count = 4, .global_count = 4};
-    EXPECT_EQ(0, og::ui::seats_still_claimable(desktop_full));
-    EXPECT_EQ(0, base_camp_seat_rail_ghost_count(
-                     {.claim = desktop_full, .visible_cards = 4}));
+TEST(SeatRailSlots, placeholders_fill_every_slot_the_device_can_still_seat)
+{
+    using og::ui::base_camp_seat_rail_placeholder_count;
+    using og::ui::SeatClaimability;
 
-    // A phone with nothing attached caps at one seat.
-    const SeatClaimability phone{
-        .local_count = 1, .local_seat_cap = 1, .global_count = 1};
-    EXPECT_EQ(0, base_camp_seat_rail_ghost_count(
-                     {.claim = phone, .visible_cards = 1}));
+    // Desktop, one seat claimed: three bare slots.
+    EXPECT_EQ(3, base_camp_seat_rail_placeholder_count(
+                     SeatClaimability{.local_count = 1, .global_count = 1}));
+    // Two claimed, two bare.
+    EXPECT_EQ(2, base_camp_seat_rail_placeholder_count(
+                     SeatClaimability{.local_count = 2, .global_count = 2}));
+    // Four claimed: the rail is full and offers nothing.
+    EXPECT_EQ(0, base_camp_seat_rail_placeholder_count(
+                     SeatClaimability{.local_count = 4, .global_count = 4}));
+    // A phone with nothing attached: one card and NO bare slot — an offer
+    // the hardware cannot accept is worse than no offer (#249).
+    EXPECT_EQ(0, base_camp_seat_rail_placeholder_count(SeatClaimability{
+                     .local_count = 1, .local_seat_cap = 1,
+                     .global_count = 1}));
+    // A pad opens exactly one more.
+    EXPECT_EQ(1, base_camp_seat_rail_placeholder_count(SeatClaimability{
+                     .local_count = 1, .local_seat_cap = 2,
+                     .global_count = 1}));
+    // A DISABLE_MULTIPLAYER build: one seat, nothing beside it.
+    EXPECT_EQ(0, base_camp_seat_rail_placeholder_count(SeatClaimability{
+                     .multiplayer_enabled = false, .local_count = 1}));
+    // THE FULL LOBBY STILL SHOWS ITS SLOTS. The rail is this machine's
+    // hardware; a full lobby dims the face (LOBBY FULL) rather than deleting
+    // a seat the player can see they own the room for.
+    EXPECT_EQ(3, base_camp_seat_rail_placeholder_count(
+                     SeatClaimability{.local_count = 1, .global_count = 16}));
+    EXPECT_EQ(0, og::ui::seats_still_claimable(
+                     SeatClaimability{.local_count = 1, .global_count = 16}))
+        << "which is exactly what the dimmed face says";
+    // Nothing claimed yet (a connected spectator): four bare slots.
+    EXPECT_EQ(4, base_camp_seat_rail_placeholder_count(
+                     SeatClaimability{.global_count = 3}));
+    // A seat that outlived its cap (a pad unplugged under a live seat) never
+    // produces a negative count.
+    EXPECT_EQ(0, base_camp_seat_rail_placeholder_count(SeatClaimability{
+                     .local_count = 3, .local_seat_cap = 1,
+                     .global_count = 3}));
+}
 
-    // A DISABLE_MULTIPLAYER build has no second seat to offer at all.
-    const SeatClaimability no_multiplayer{.multiplayer_enabled = false};
-    EXPECT_EQ(0, og::ui::seats_still_claimable(no_multiplayer));
-    EXPECT_EQ(0, base_camp_seat_rail_ghost_count(
-                     {.claim = no_multiplayer, .visible_cards = 1}));
+TEST(SeatRailSlots, claimability_answers_the_dimmed_face_question)
+{
+    using og::ui::SeatClaimability;
+    using og::ui::seats_still_claimable;
 
-    // A two-seat device with one seat claimed offers exactly one more.
-    const SeatClaimability pad_phone{
-        .local_count = 1, .local_seat_cap = 2, .global_count = 1};
-    EXPECT_EQ(1, base_camp_seat_rail_ghost_count(
-                     {.claim = pad_phone, .visible_cards = 1}));
-
+    EXPECT_EQ(2, seats_still_claimable(
+                     SeatClaimability{.local_count = 2, .global_count = 2}));
+    EXPECT_EQ(0, seats_still_claimable(
+                     SeatClaimability{.local_count = 4, .global_count = 4}));
     // The lobby ceiling binds before the local cap does.
-    const SeatClaimability crowded_lobby{
-        .local_count = 1, .global_count = 14};
-    EXPECT_EQ(2, og::ui::seats_still_claimable(crowded_lobby));
-    EXPECT_EQ(2, base_camp_seat_rail_ghost_count(
-                     {.claim = crowded_lobby, .visible_cards = 1}));
-    const SeatClaimability full_lobby{.local_count = 1, .global_count = 16};
-    EXPECT_EQ(0, base_camp_seat_rail_ghost_count(
-                     {.claim = full_lobby, .visible_cards = 1}));
-
-    // While the rail is paged, ghosts belong on the last page only — that is
-    // where a newly claimed seat would appear.
-    const SeatClaimability roomy{.local_count = 1, .global_count = 5};
-    EXPECT_EQ(0, base_camp_seat_rail_ghost_count({.claim = roomy,
-                                                  .visible_cards = 4,
-                                                  .on_last_page = false}));
-    EXPECT_EQ(0, base_camp_seat_rail_ghost_count({.claim = roomy,
-                                                  .visible_cards = 1,
-                                                  .on_last_page = false}));
-    EXPECT_EQ(3, base_camp_seat_rail_ghost_count({.claim = roomy,
-                                                  .visible_cards = 1,
-                                                  .on_last_page = true}));
-
-    // A full page never grows a fifth slot.
-    EXPECT_EQ(0, base_camp_seat_rail_ghost_count(
-                     {.claim = roomy, .visible_cards = 4}));
+    EXPECT_EQ(2, seats_still_claimable(
+                     SeatClaimability{.local_count = 1, .global_count = 14}));
+    EXPECT_EQ(0, seats_still_claimable(
+                     SeatClaimability{.local_count = 1, .global_count = 16}));
+    // A DISABLE_MULTIPLAYER build has no second seat to offer at all.
+    EXPECT_EQ(0, seats_still_claimable(
+                     SeatClaimability{.multiplayer_enabled = false}));
 }

--- a/tests/unit/test_picker_common.cpp
+++ b/tests/unit/test_picker_common.cpp
@@ -5561,6 +5561,24 @@ TEST(SeatRailLayout, a_phone_puts_its_lone_card_on_the_left_rail)
     EXPECT_FALSE(rail.add_visible);
 }
 
+TEST(SeatRailLayout, a_short_last_page_packs_left_under_an_anchored_pager)
+{
+    // A 5-seat lobby's last page with nothing claimable (4 local seats at
+    // the build cap): one card, no ghosts, both arrows up. The run packs
+    // left at the uniform gutter and the '>' alone holds the right rail —
+    // never three controls stretched across 71px voids.
+    const og::ui::SeatRailLayout rail =
+        og::ui::base_camp_seat_rail_layout(/*add_visible=*/true,
+                                           /*pagers_visible=*/true,
+                                           /*visible_cards=*/1,
+                                           /*ghost_count=*/0);
+    EXPECT_EQ(8, rail.add_x);
+    EXPECT_EQ(29, rail.prev_x);
+    EXPECT_EQ(46, rail.slot_x[0]);
+    EXPECT_EQ(og::ui::kSeatRailRightX - og::ui::kSeatRailPagerWidth,
+              rail.next_x);
+}
+
 TEST(SeatRailLayout, every_shape_keeps_the_rail_ordered_and_inside_the_panel)
 {
     int checked = 0;
@@ -5598,7 +5616,12 @@ TEST(SeatRailLayout, every_shape_keeps_the_rail_ordered_and_inside_the_panel)
                             << shape << " gutter " << i;
                         gutters.push_back(gutter);
                     }
-                    for (std::size_t i = 1; i < gutters.size(); ++i)
+                    // The gutter before an anchored '>' absorbs a short
+                    // row's slack; every gutter within the run itself stays
+                    // even (the leftmost take the odd pixel).
+                    const std::size_t run_gutter_count = gutters.size() -
+                        (rail.pagers_visible && !gutters.empty() ? 1 : 0);
+                    for (std::size_t i = 1; i < run_gutter_count; ++i)
                     {
                         EXPECT_LE(std::abs(gutters[i] - gutters[i - 1]), 1)
                             << shape << " neighbouring gutters " << i;
@@ -5608,21 +5631,23 @@ TEST(SeatRailLayout, every_shape_keeps_the_rail_ordered_and_inside_the_panel)
                               og::ui::kSeatRailRightX)
                         << shape;
 
-                    // Justified shapes close on the right rail; packed ones
-                    // stop at the uniform gutter.
+                    // A full row justifies to the right rail; a paged rail's
+                    // anchored '>' closes on it in every shape. Anything
+                    // else packs at the uniform gutter and stops.
                     const bool justified =
-                        rail.slot_count() == og::ui::kSeatRailSlots ||
-                        rail.pagers_visible;
-                    if (justified && elements.size() > 1)
+                        rail.slot_count() == og::ui::kSeatRailSlots;
+                    if ((justified || rail.pagers_visible) &&
+                        elements.size() > 1)
                     {
                         EXPECT_EQ(og::ui::kSeatRailRightX,
                                   last.first + last.second)
                             << shape << " must close on the right rail";
                     }
-                    else
+                    if (!justified)
                     {
-                        for (const int gutter : gutters)
-                            EXPECT_EQ(og::ui::kSeatRailGap, gutter) << shape;
+                        for (std::size_t i = 0; i < run_gutter_count; ++i)
+                            EXPECT_EQ(og::ui::kSeatRailGap, gutters[i])
+                                << shape << " packed gutter " << i;
                     }
 
                     // Cards never change width: the nine-character label

--- a/tests/unit/test_picker_common.cpp
+++ b/tests/unit/test_picker_common.cpp
@@ -31,6 +31,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -5457,4 +5458,243 @@ TEST(LevelPickerLayout, status_labels_match_the_progress_report)
     EXPECT_STREQ("CLEARED", og::ui::level_row_status_label(true, true));
     EXPECT_STREQ("CURRENT", og::ui::level_row_status_label(false, true));
     EXPECT_STREQ("", og::ui::level_row_status_label(false, false));
+}
+
+// ---------------------------------------------------------------------------
+// #243: the Base Camp seat rail's per-frame geometry. The rail used to be a
+// static seven-control row, so every shape that hid a control left a hole —
+// a 24px gap where '<' would be, a right margin that stopped wherever the
+// last card happened to end, and on a phone a 38px void to the LEFT of the
+// only card on screen. These pin the replacement rule.
+
+namespace {
+
+// The rail's live elements, left to right, as (x, width) pairs.
+std::vector<std::pair<int, int>> seat_rail_elements(
+    const og::ui::SeatRailLayout& rail)
+{
+    std::vector<std::pair<int, int>> out;
+    if (rail.add_visible)
+        out.emplace_back(rail.add_x, og::ui::kSeatRailAddWidth);
+    if (rail.pagers_visible)
+        out.emplace_back(rail.prev_x, og::ui::kSeatRailPagerWidth);
+    for (int slot = 0; slot < rail.slot_count(); ++slot)
+        out.emplace_back(rail.slot_x[static_cast<std::size_t>(slot)],
+                         rail.card_w);
+    if (rail.pagers_visible)
+        out.emplace_back(rail.next_x, og::ui::kSeatRailPagerWidth);
+    return out;
+}
+
+} // namespace
+
+TEST(SeatRailLayout, the_full_rail_is_the_shape_the_static_table_carries)
+{
+    // Everything visible: '+', both arrows and four cards, at exactly the
+    // coordinates menu_screen_specs.cpp's constants produce. This is the one
+    // shape the exact-rect table in test_menu_layout pins, and it must not
+    // move by a pixel.
+    const og::ui::SeatRailLayout rail =
+        og::ui::base_camp_seat_rail_layout(true, true, 4, 0);
+    EXPECT_EQ(8, rail.add_x);
+    EXPECT_EQ(29, rail.prev_x);
+    EXPECT_EQ(46, rail.slot_x[0]);
+    EXPECT_EQ(110, rail.slot_x[1]);
+    EXPECT_EQ(174, rail.slot_x[2]);
+    EXPECT_EQ(238, rail.slot_x[3]);
+    EXPECT_EQ(302, rail.next_x);
+    EXPECT_EQ(57, rail.card_w);
+    EXPECT_EQ(312, rail.next_x + og::ui::kSeatRailPagerWidth);
+    // Six gutters of exactly the packed width: the justified rail and the
+    // packed rail agree here, which is why the shape is byte-identical.
+    const auto elements = seat_rail_elements(rail);
+    ASSERT_EQ(7u, elements.size());
+    for (std::size_t i = 1; i < elements.size(); ++i)
+    {
+        EXPECT_EQ(og::ui::kSeatRailGap,
+                  elements[i].first - (elements[i - 1].first +
+                                       elements[i - 1].second))
+            << "gutter " << i;
+    }
+}
+
+TEST(SeatRailLayout, a_ghost_filled_desktop_row_justifies_between_both_rails)
+{
+    // Two claimed seats on an ordinary desktop: two cards plus two ghosts
+    // fill the grid, so the row spans 8..312 with gutters that differ by at
+    // most the one odd pixel the leftmost gutters absorb.
+    const og::ui::SeatRailLayout rail =
+        og::ui::base_camp_seat_rail_layout(true, false, 2, 2);
+    EXPECT_EQ(2, rail.shown_cards);
+    EXPECT_EQ(2, rail.ghost_count);
+    EXPECT_EQ(8, rail.add_x);
+    EXPECT_EQ(38, rail.slot_x[0]);
+    EXPECT_EQ(111, rail.slot_x[1]);
+    EXPECT_EQ(183, rail.slot_x[2]);
+    EXPECT_EQ(255, rail.slot_x[3]);
+    EXPECT_EQ(312, rail.slot_x[3] + rail.card_w);
+}
+
+TEST(SeatRailLayout, an_under_full_row_packs_left_at_the_uniform_gutter)
+{
+    // A device that caps at two seats with one claimed: one card, one ghost,
+    // no arrows. Nothing stretches — a two-control row spread across the
+    // whole panel reads as broken, so it packs from the left rail.
+    const og::ui::SeatRailLayout rail =
+        og::ui::base_camp_seat_rail_layout(true, false, 1, 1);
+    EXPECT_EQ(8, rail.add_x);
+    EXPECT_EQ(29, rail.slot_x[0]);
+    EXPECT_EQ(93, rail.slot_x[1]);
+    EXPECT_EQ(2, rail.slot_count());
+}
+
+TEST(SeatRailLayout, a_phone_puts_its_lone_card_on_the_left_rail)
+{
+    // Single-seat device: no '+', no arrows, no ghosts (nothing is
+    // claimable), so the only control on the row starts where every other
+    // left-aligned control on the screen starts.
+    const og::ui::SeatRailLayout rail =
+        og::ui::base_camp_seat_rail_layout(false, false, 1, 0);
+    EXPECT_EQ(og::ui::kSeatRailX0, rail.slot_x[0]);
+    EXPECT_EQ(8, rail.slot_x[0]);
+    EXPECT_EQ(1, rail.slot_count());
+    EXPECT_FALSE(rail.add_visible);
+}
+
+TEST(SeatRailLayout, every_shape_keeps_the_rail_ordered_and_inside_the_panel)
+{
+    int checked = 0;
+    for (int add = 0; add < 2; ++add)
+    {
+        for (int pagers = 0; pagers < 2; ++pagers)
+        {
+            for (int cards = 0; cards <= og::ui::kSeatRailSlots; ++cards)
+            {
+                for (int ghosts = 0;
+                     ghosts <= og::ui::kSeatRailSlots - cards; ++ghosts)
+                {
+                    const og::ui::SeatRailLayout rail =
+                        og::ui::base_camp_seat_rail_layout(
+                            add != 0, pagers != 0, cards, ghosts);
+                    const auto elements = seat_rail_elements(rail);
+                    if (elements.empty())
+                        continue;
+                    ++checked;
+                    const std::string shape =
+                        std::format("add={} pagers={} cards={} ghosts={}",
+                                    add, pagers, cards, ghosts);
+
+                    // The row always opens on the panel's left rail.
+                    EXPECT_EQ(og::ui::kSeatRailX0, elements.front().first)
+                        << shape;
+                    // Monotone, never overlapping, always on screen.
+                    std::vector<int> gutters;
+                    for (std::size_t i = 1; i < elements.size(); ++i)
+                    {
+                        const int gutter =
+                            elements[i].first -
+                            (elements[i - 1].first + elements[i - 1].second);
+                        EXPECT_GE(gutter, og::ui::kSeatRailGap)
+                            << shape << " gutter " << i;
+                        gutters.push_back(gutter);
+                    }
+                    for (std::size_t i = 1; i < gutters.size(); ++i)
+                    {
+                        EXPECT_LE(std::abs(gutters[i] - gutters[i - 1]), 1)
+                            << shape << " neighbouring gutters " << i;
+                    }
+                    const auto& last = elements.back();
+                    EXPECT_LE(last.first + last.second,
+                              og::ui::kSeatRailRightX)
+                        << shape;
+
+                    // Justified shapes close on the right rail; packed ones
+                    // stop at the uniform gutter.
+                    const bool justified =
+                        rail.slot_count() == og::ui::kSeatRailSlots ||
+                        rail.pagers_visible;
+                    if (justified && elements.size() > 1)
+                    {
+                        EXPECT_EQ(og::ui::kSeatRailRightX,
+                                  last.first + last.second)
+                            << shape << " must close on the right rail";
+                    }
+                    else
+                    {
+                        for (const int gutter : gutters)
+                            EXPECT_EQ(og::ui::kSeatRailGap, gutter) << shape;
+                    }
+
+                    // Cards never change width: the nine-character label
+                    // budget and the chip offset both depend on 57.
+                    EXPECT_EQ(og::ui::kSeatRailCardWidth, rail.card_w)
+                        << shape;
+                }
+            }
+        }
+    }
+    EXPECT_EQ(59, checked) << "every non-empty rail shape was exercised";
+}
+
+TEST(SeatRailGhosts, ghosts_appear_only_where_a_seat_can_actually_be_claimed)
+{
+    using og::ui::base_camp_seat_rail_ghost_count;
+    using og::ui::SeatClaimability;
+
+    const SeatClaimability desktop_two{.local_count = 2, .global_count = 2};
+    EXPECT_EQ(2, og::ui::seats_still_claimable(desktop_two));
+    EXPECT_EQ(2, base_camp_seat_rail_ghost_count(
+                     {.claim = desktop_two, .visible_cards = 2}));
+
+    // Four local seats: the machine is full, the [+] is dimmed, and the rail
+    // promises nothing.
+    const SeatClaimability desktop_full{.local_count = 4, .global_count = 4};
+    EXPECT_EQ(0, og::ui::seats_still_claimable(desktop_full));
+    EXPECT_EQ(0, base_camp_seat_rail_ghost_count(
+                     {.claim = desktop_full, .visible_cards = 4}));
+
+    // A phone with nothing attached caps at one seat.
+    const SeatClaimability phone{
+        .local_count = 1, .local_seat_cap = 1, .global_count = 1};
+    EXPECT_EQ(0, base_camp_seat_rail_ghost_count(
+                     {.claim = phone, .visible_cards = 1}));
+
+    // A DISABLE_MULTIPLAYER build has no second seat to offer at all.
+    const SeatClaimability no_multiplayer{.multiplayer_enabled = false};
+    EXPECT_EQ(0, og::ui::seats_still_claimable(no_multiplayer));
+    EXPECT_EQ(0, base_camp_seat_rail_ghost_count(
+                     {.claim = no_multiplayer, .visible_cards = 1}));
+
+    // A two-seat device with one seat claimed offers exactly one more.
+    const SeatClaimability pad_phone{
+        .local_count = 1, .local_seat_cap = 2, .global_count = 1};
+    EXPECT_EQ(1, base_camp_seat_rail_ghost_count(
+                     {.claim = pad_phone, .visible_cards = 1}));
+
+    // The lobby ceiling binds before the local cap does.
+    const SeatClaimability crowded_lobby{
+        .local_count = 1, .global_count = 14};
+    EXPECT_EQ(2, og::ui::seats_still_claimable(crowded_lobby));
+    EXPECT_EQ(2, base_camp_seat_rail_ghost_count(
+                     {.claim = crowded_lobby, .visible_cards = 1}));
+    const SeatClaimability full_lobby{.local_count = 1, .global_count = 16};
+    EXPECT_EQ(0, base_camp_seat_rail_ghost_count(
+                     {.claim = full_lobby, .visible_cards = 1}));
+
+    // While the rail is paged, ghosts belong on the last page only — that is
+    // where a newly claimed seat would appear.
+    const SeatClaimability roomy{.local_count = 1, .global_count = 5};
+    EXPECT_EQ(0, base_camp_seat_rail_ghost_count({.claim = roomy,
+                                                  .visible_cards = 4,
+                                                  .on_last_page = false}));
+    EXPECT_EQ(0, base_camp_seat_rail_ghost_count({.claim = roomy,
+                                                  .visible_cards = 1,
+                                                  .on_last_page = false}));
+    EXPECT_EQ(3, base_camp_seat_rail_ghost_count({.claim = roomy,
+                                                  .visible_cards = 1,
+                                                  .on_last_page = true}));
+
+    // A full page never grows a fifth slot.
+    EXPECT_EQ(0, base_camp_seat_rail_ghost_count(
+                     {.claim = roomy, .visible_cards = 4}));
 }


### PR DESCRIPTION
Menu UI polish cluster: the seat rail lays itself out, fades follow one rule, VIEW LEVEL's camera is pinned, and the injector UAF class is gone.

Closes #243. Closes #237. Closes #251. Closes #257.

## #243 — Seat rail v2: this machine's four seats, ADD PLAYER placeholders

The first cut (ghost slots + `[+]` + `< >` pagers) made `[+]` redundant and paged remote seats through a rail nobody could act on. The rail is now **always this machine's four local seat slots**, in every mode:

- No `[+]`, no pagers. An unfilled slot is a real **ADD PLAYER** button — the same add path as the old `[+]` (device-cap gate, lobby-cap gate, 250ms debounce, mapping de-dup, phone pad auto-claim), one implementation.
- Four 70px slots at x = 8 / 86 / 164 / 242 with 8px gutters: slot 0 opens on BACK's left edge, slot 3 closes on GO's right edge, exactly (4·70 + 3·8 = 304). The card label budget grows from 9 to 11 characters. The rail band is a black readability strip so the title backdrop never sits in a gutter.
- Device cap: a phone with no pad shows its one card flush left and nothing else (slots past the cap are absent, not promised). A full 16-player lobby shows greyed **LOBBY FULL** placeholders.
- Networked: remote seats are **not** in the rail. The header line carries the count (`HOSTING GLAD-7Q2F: 7 PLAYERS/4 PCS`, or `IN …` for a joiner — players first, a pixel-honest ladder that fits both line-B budgets), every remote character shows its company on its roster row, and VIEW LEVEL's SEATS report lists everyone. The joiner line drops `HOST: {company}` (the host's company is on every roster row).
- Slot k *is* local controller profile k, which retires a P#-vs-local-slot hazard; `seat_page` and the paging machinery are deleted.

Pinned by a 20-shape slot-state matrix ({0..4 local} × {desktop, phone} × {lobby open, full}) with BFS nav reachability per variant, exact-x unit pins, pixel probes for the ADD PLAYER ink, the dimmed LOBBY FULL face, the chip position and the focus ring, injector flows through the real click dispatch (ADD PLAYER claims a seat; LOBBY FULL is inert; the device-cap denial goes through a slot), and every header rung pinned exactly at both budgets.

## #237 — One fade rule: the main-menu boundary, symmetric

`EnterTransition` (hand-declared per screen, 5 fade / 17 don't, no rule) is gone. The rule, derived in `run_menu_screen`: a transition fades exactly when it **crosses the main-menu boundary** or is a flow context switch — and it fades **symmetrically**, the way in and the way back. The bug class this kills is the asymmetry master shipped: GAME SETTINGS and HELP faded on the way *back* to the main menu but not on the way in; NETWORKING faded back to Base Camp but not in.

- **Every main-menu door fades both ways**: GAME SETTINGS, HELP, LOAD, CLOUD SAVES, LEVEL EDITOR, BEGIN NEW GAME (name entry), CONTINUE (Base Camp), and the return to the main menu from each.
- **Everything deeper is instant both ways**: Base Camp's strip/roster doors (HIRE, TRAIN, DIFFICULTY, SCENARIO, VIEW LEVEL, seats, zone pages, SET CAMPAIGN), settings' own subscreens, the company list's BACKUPS. **NETWORKING is a Base Camp strip door** and stays instant like its siblings (its old fade-back-only was one of the asymmetries).
- Pause-family overlays never fade. Flow context switches (menu↔gameplay, intro, campaign select, results) keep fading; the cold-start black-to-black fade is gone.

Mechanism: depth-1 entries fade naturally. Two door shapes the depth rule can't see take a one-shot override (`note_menu_entry_fade`, swallowed by every entry so it can't leak): CLOUD SAVES and the LEVEL EDITOR run *nested* inside the still-open main menu, so a shared `run_nested_menu_door` bracket fades them in and, on the way back, leaves a black note the parent loop turns into a fade-in; NETWORKING's legacy screen runs at depth 0 after Base Camp exits, so it notes `Instant` both ways. A review pass also removed HELP's stray `clearbuffer()` calls, which made its production fade black-to-black (invisible to the trace pins — caught by the Fable reviewer's code trace).

**Checked, not assumed**: a per-transition symmetry audit traced every door in both directions, and each main-menu door now carries an exact fade-count pin on *both* legs (SETTINGS 2/2, HELP 2/2, LOAD 2/2, CLOUD 2/2, editor 2/2, name entry 2/2), each nested door a 0/0 pin (BACKUPS, seat editor, NETWORKING), plus engine-level override/bracket tests. Three plant-a-break checks (an Instant note on SETTINGS; dropping CLOUD's return fade; dropping NETWORKING's return suppression) each failed exactly the pin that owns them. The wasm e2e settle budgets were raised for the two new web-side fades (Asyncify fades block for 500ms each); accepted unpinned legs: campaign-select cancel, Base Camp BACK, and the sanctioned NETWORKING-hookup→Base Camp exception.

## #237 (cont.) — Fade ownership: fade-in-without-fade-out is now structurally impossible

Two more regressions of one class were reported after the rule landed: a hard cut to black followed by a fade-in after naming a new company (ACCEPT) and after dismissing the campaign intro. Root cause, confirmed by tracing both flows: `fadeblack(0)` blends *from the mutable render buffer*, and the fade-out was executed later by the *incoming* screen — so any `clear()` between the outgoing screen's last present and that deferred fade-out (there was one in each flow, and in HELP before that) made the fade-out black-to-black. Patching those lines was not the deliverable; the design that permitted them is gone.

**The video layer owns "the window is black."** One `Screen` flag, cleared at the single `SDL_RenderPresent` choke point and set when a fade-out completes. `fadeblack(0)` on a black window is a no-op (this also retired the 500ms black-to-black at every cold start). The black-note plumbing is deleted.

**Whoever fades in fades out, at its own exit, while its frame is still the buffer.** `run_menu_screen` holds an RAII scope: the same boolean owns the entry fade-in and the exit fade-out, on every return path. Legacy presenters (campaign browser, results, level editor, networking, the campaign-intro scroller) use an equivalent RAII `LegacyMenuFade`. Door-site fade-outs and the "clear after a nested screen returns" calls are deleted; the window between last-present and fade-out is zero by construction. NETWORKING's hookup exit and the results panel fade their own frames out instead of leaning on the next entry.

**Three guards, so it cannot come back quietly:**
1. Under TESTING the video layer snapshots every presented rect and, at the fade itself, flags three violations that fail the running test through the gtest listener: a fade-out from a frame that was never presented (a clear or redraw since the last present), a fade-in when the window is not black, and an entry that finds an unfaded window (the previous surface exited without its fade-out — the deferred fallback is now a reported defect, not a silent rescue). Every flow test in the tree is an oracle.
2. `scripts/check_fadeblack_sites.sh` runs as a build dependency of `og_interface` and `og_platform_sdl`: every `fadeblack(` call site is keyed by enclosing function **with a count**; an unlisted site, a changed count, or a stale key fails the build.
3. The TESTING short-circuit that hid the campaign-intro leg from every test is gone (auto-accept/auto-dismiss hooks); a new end-to-end BEGIN NEW GAME pin counts all four legs at 2/2/2/2 with zero violations.

**Teeth, run and recorded:** removing the exit scope's fade turns `FadeOwnership` and `UxShots.n_help_screen` red with named-screen violations (`…exited without its fade-out (help)`, `(mainmenu)`, `(name_entry)`, `(campaign select)`); planting `clearbuffer(); fadeblack(0);` inside an allowlisted function fails the build (`go_menu: found 2 fadeblack() call(s), allowlist says 1`); a draw outside a partially-presented rect followed by a fade-out reports the never-presented violation.

## #251 — VIEW LEVEL pan: verified fixed, now pinned

The leak was fixed on master by d6c04f40 (`ScopedBorrowedView`, PR #245), which landed ~9h before the issue was filed — the report almost certainly came from an older web preview. This PR adds what was missing: an **intra-screen** regression pin (two captures while the pane pans; the backdrop rows must be pixel-identical while the preview band must differ — both halves plant-a-break verified), plus hardening: the borrow guard now restores the view's rect as well as its camera, replacing the heavier `relayout_views()` call. Evidence below: the pitch pans between the two frames; the chrome and backdrop do not move a pixel.

## #257 — Injector-thread UAF class eliminated

The degrade injector's 17k ledger inserts raced the host stage digest's set iteration (ASan heap-use-after-free, the og_test_matchup flake root cause). Fix: a null-by-default main-thread pump hook at the top of the menu frame loop; test injectors post their save/cfg/session mutations — and their reads of the same containers — as tasks the menu thread drains between frames. The queue cancels timed-out tasks (they can never fire later against dead stack captures) and reports drained tasks as not-run. The sweep converted every offender in the tree (options menu cfg races included — the likely og_test_menu_ui ASan flake co-culprit). Teeth: shrinking the ledger to 100 makes the test fail; ASan runs of og_test_matchup (×3), og_test_menu_ui, og_test_game_core are clean. A pre-existing SIGSEGV in og_test_menu_engine (guard teardown walking a destroyed lobby double) was found and fixed along the way — 13 previously-unreached tests now run.

## Phantom click after the level editor — pointer-baseline ownership

Reported mid-review: exiting the LEVEL EDITOR and hovering BEGIN NEW GAME during the fade activated it with no click. Root cause: the web collapsed-tap queue mints a *coordinate-less* pending click on any mouse-up whose press was never observed via `query_mouse()` — and the editor (plus the native results screen and the editor's text prompts) pumps its own events without ever acknowledging presses, so every click inside it minted one. The next menu's click detector then paired the stale entry with the live pointer.

Fix, symmetric with the fade-ownership rule: **a surface owns its pointer state**. The offenders acknowledge their presses each frame (`acknowledge_mouse_presses()` — the observed-press bookkeeping without a poll); `run_menu_screen` resets click tracking at entry and exit and `run_nested_menu_door` after its body returns, so no screen can spend a click minted on another surface; the campaign/level pickers gate their level-triggered click on having seen the button released once (their click-through sibling); the intro's closing-fade leak and a cross-test pending-click leak in the harness are closed. Contract documented beside the fade contract.

Red-then-green: the regression test drives the reporter's exact scenario (real File→Exit clicks in the editor, then a hover-only motion onto BEGIN NEW GAME) and failed on the unfixed tree with the phantom activation; an engine-level nested-door pin and a mint/acknowledge/reset unit triangle back it; removing only the door reset turns the repro red again.

## Process

Built with multi-agent workflows: read-only recon per issue → design with two maintainer decisions (slot-grid ghosts; depth rule) → sequential implementation → 7-agent adversarial verification (26 findings, all fixed or ruled) → screenshot review pass. Local gate: full `ctest --preset ci-test` green (64/64 + standard emscripten skip); targeted ASan groups clean; og_test_menu_ui timing adjudicated against its real 420s ceiling (the 180s in comments was stale prose — not bumped, just read).

## Screenshots

### #243 — the rail, v2 (solo / two / three / four local seats / phone / net host / net join / lobby full, 4x band crops)
![rail shapes](https://raw.githubusercontent.com/openglad/openglad-screenshots/d4d98165e2e1caa39b4bf48738a1034935d55542/pr-258/rail-v2/rails_stacked.png)

Solo — one seat + three ADD PLAYER slots on the rail's black ground, opening on BACK's edge and closing on GO's:
![solo](https://raw.githubusercontent.com/openglad/openglad-screenshots/d4d98165e2e1caa39b4bf48738a1034935d55542/pr-258/rail-v2/basecamp_solo.png)

**Phone (single-seat device) — the lone card flush left, nothing else:**
![phone](https://raw.githubusercontent.com/openglad/openglad-screenshots/d4d98165e2e1caa39b4bf48738a1034935d55542/pr-258/rail-v2/basecamp_phone_single_seat.png)

Lobby full — greyed LOBBY FULL placeholders (all four bevels kept):
![lobby full](https://raw.githubusercontent.com/openglad/openglad-screenshots/d4d98165e2e1caa39b4bf48738a1034935d55542/pr-258/rail-v2/basecamp_lobby_full.png)

Keyboard focus on a placeholder — the ring spans the full face (no chip to clear):
![placeholder focus](https://raw.githubusercontent.com/openglad/openglad-screenshots/d4d98165e2e1caa39b4bf48738a1034935d55542/pr-258/rail-v2/basecamp_placeholder_focus_rail.png)

Networked host and joiner — remote seats absent from the rail; the header line carries the count:
![net screens](https://raw.githubusercontent.com/openglad/openglad-screenshots/d4d98165e2e1caa39b4bf48738a1034935d55542/pr-258/rail-v2/net_screens_stacked.png)

### #251 — the pane pans, the menu does not (two frames ~1s apart)
![frame 1](https://raw.githubusercontent.com/openglad/openglad-screenshots/0ab18988899ec20134a5958b8f809cff7e916970/pr-258/view_level_staged.png)
![frame 2](https://raw.githubusercontent.com/openglad/openglad-screenshots/0ab18988899ec20134a5958b8f809cff7e916970/pr-258/view_level_staged_panned.png)


🤖 Generated with [Claude Code](https://claude.com/claude-code)




