### PR TITLE
Web: opt-in window.__opengladPersistNamespace for isolated browser persistence

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -163,6 +163,40 @@ cd dist && python3 -m http.server 8080
 # Open http://localhost:8080/index.html
 ```
 
+### Embedding / hosting for multiple users
+
+The web build persists each player's companies, config and campaigns to the
+browser's IndexedDB, in a store scoped to the **page origin**. If you serve
+OpenGlad to more than one person from a single origin (an embed, a portal, a
+kiosk), they will share one set of companies unless you give each a separate
+persistence namespace.
+
+Set `window.__opengladPersistNamespace` to an opaque, caller-chosen token
+**before `play.js` loads** — for example, an inline `<script>` in the shell
+`<head>`:
+
+```html
+<script>
+  // One isolated persistence store per token.
+  window.__opengladPersistNamespace = "u_9f83c1a4e2b7";
+</script>
+```
+
+- **Allowed:** 1–64 characters of `A–Z a–z 0–9 _ -`. A hash or base64url digest
+  of your own user identifier is a good choice.
+- **Absent, empty, or invalid:** OpenGlad uses the default shared store — exactly
+  as with no embedding. An invalid value is ignored (with one console warning);
+  passing a valid token, or nothing, is the caller's responsibility.
+- The virtual filesystem layout (`save/`, `cfg/`, `campaigns/`, …) is identical
+  inside each namespace; only the browser-side backing store is separated.
+- The token is **not authentication and not a secret** — it is the name of a
+  persistence store, visible in browser dev-tools. It selects *where* data is
+  stored; it grants nothing. Deriving it from a stable per-user value keeps a
+  user's companies across their sessions on that browser.
+- A host that switches an existing shared deployment to namespaces starts each
+  user with a fresh per-namespace store; migrating prior shared data is out of
+  scope for OpenGlad.
+
 ### Pull Request Previews
 
 After the required WASM Playwright tests pass, CI deploys same-repository pull

--- a/src/resources/platform_io.cpp
+++ b/src/resources/platform_io.cpp
@@ -98,6 +98,57 @@ int rwops_write_handler(void *data, unsigned char *buffer, size_t size)
     return 1;
 }
 
+#ifdef __EMSCRIPTEN__
+// stringToNewUTF8 is a JS library symbol; declare the dependency explicitly
+// (same as the relay test hook in picker_lobby_network_client.cpp).
+EM_JS_DEPS(og_persist_namespace_dep, "$stringToNewUTF8");
+
+namespace {
+
+// Web embedding hook, following the __openglad* window-var convention: a host
+// that serves the browser build to more than one person from a single origin
+// can set window.__opengladPersistNamespace to an opaque token before play.js
+// loads. Unset or empty keeps the single shared "/persist" store unchanged.
+EM_JS(char*, openglad_persist_namespace_js, (), {
+    const value = (typeof window !== 'undefined' &&
+                   typeof window.__opengladPersistNamespace === 'string')
+        ? window.__opengladPersistNamespace
+        : "";
+    return stringToNewUTF8(value);
+});
+
+// IDBFS mount point for the browser build: "/persist" by default, or
+// "/persist_<token>" when the embedding host supplied a namespace. A valid
+// token is 1..64 characters of [A-Za-z0-9_-]; empty, over-length or otherwise
+// invalid falls back to "/persist" (a non-empty invalid value also logs one
+// warning). The token only selects where data is stored -- it is not
+// authentication and not a secret. Resolved once per run.
+const std::string& web_persist_root()
+{
+    static const std::string root = [] {
+        const std::string fallback = "/persist";
+        const std::unique_ptr<char, decltype(&std::free)> raw(
+            openglad_persist_namespace_js(), &std::free);
+        const std::string token = raw ? std::string(raw.get()) : std::string();
+        if (token.empty())
+            return fallback;
+        if (token.size() > 64 ||
+            token.find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                    "abcdefghijklmnopqrstuvwxyz"
+                                    "0123456789_-") != std::string::npos)
+        {
+            LogWarn("Ignoring window.__opengladPersistNamespace: expected 1-64 "
+                    "characters of [A-Za-z0-9_-]; using the default store\n");
+            return fallback;
+        }
+        return fallback + "_" + token;
+    }();
+    return root;
+}
+
+}  // namespace
+#endif // __EMSCRIPTEN__
+
 std::string get_user_path()
 {
     auto normalize_dir = [](std::string path) {
@@ -120,8 +171,9 @@ std::string get_user_path()
     }
 
 #ifdef __EMSCRIPTEN__
-    // Use IDBFS mount point for persistent storage in browser
-    return "/persist/";
+    // IDBFS mount point for browser persistence -- "/persist/" unless the
+    // embedding host selected a namespace (see web_persist_root()).
+    return web_persist_root() + "/";
 #elif defined(ANDROID)
     std::string path = SDL_GetAndroidInternalStoragePath();
     return path + "/";
@@ -287,16 +339,23 @@ void io_init(int argc, char* argv[])
     Log("Setting up IDBFS for persistent storage...\n");
     idbfs_sync_done.store(false, std::memory_order_release);
 
+    // web_persist_root() is "/persist" unless the embedding host selected a
+    // namespace via window.__opengladPersistNamespace.
+// EM_ASM's $-placeholders are lexed as C++ identifiers; silence that here.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
     EM_ASM({
+        const mount = UTF8ToString($0);
+
         // Create mount point
         try {
-            FS.mkdir('/persist');
+            FS.mkdir(mount);
         } catch(e) {
             // Directory may already exist
         }
 
         // Mount IDBFS
-        FS.mount(IDBFS, {}, '/persist');
+        FS.mount(IDBFS, {}, mount);
 
         // Sync FROM IndexedDB to populate the virtual filesystem
         FS.syncfs(true, function(err) {
@@ -308,7 +367,8 @@ void io_init(int argc, char* argv[])
             // Signal that sync is done
             Module._on_idbfs_sync_done();
         });
-    });
+    }, web_persist_root().c_str());
+#pragma clang diagnostic pop
 
     // Wait for sync to complete (ASYNCIFY allows this)
     Log("Waiting for IDBFS sync...\n");

--- a/tests/e2e/wasm-persist-namespace.spec.js
+++ b/tests/e2e/wasm-persist-namespace.spec.js
@@ -1,0 +1,180 @@
+// @ts-check
+//
+// Web persistence namespace: window.__opengladPersistNamespace
+//
+// The Emscripten build persists to IDBFS mounted at /persist, in an IndexedDB
+// store scoped to the page origin, so several players served from one origin
+// share a single set of companies. An embedding host can set
+// window.__opengladPersistNamespace to an opaque token before play.js loads to
+// give each token its own store. Absent, empty or invalid keeps the shared
+// /persist behavior exactly as before.
+//
+// These specs assert what a host can observe at the JS boundary:
+//   1. a default boot is unchanged and emits no namespace warning
+//   2. an invalid token warns exactly once and falls back without aborting
+//   3. each valid namespace gets its own persistence store, those stores
+//      coexist, and using one namespace never disturbs another
+//
+// They deliberately do NOT assert the IndexedDB database name (an Emscripten
+// IDBFS implementation detail). The behavioral gate is: distinct namespaces
+// produce distinct, coexisting, reload-surviving stores.
+const { test, expect } = require('@playwright/test');
+const { waitForGameLoad, waitForPickerReady } = require('./wasm_helpers');
+
+const NAMESPACE_WARNING = /__opengladPersistNamespace/;
+// Blank/near-blank canvas captures compress well under this; real frames do not
+// (same heuristic as wasm-game.spec.js / wasm-contextloss.spec.js).
+const MIN_NON_TRIVIAL_PNG_BYTES = 2_000;
+
+// The namespace (and whether to seed a company) for the next /play.html load is
+// carried in localStorage, so one addInitScript can vary it across reloads
+// inside a single browser context -- IndexedDB coexistence is only observable
+// within one context.
+async function primeContext(page) {
+  await page.goto('/');
+  await page.addInitScript(() => {
+    try {
+      const ns = window.localStorage.getItem('__pwPersistNs');
+      if (ns) {
+        window.__opengladPersistNamespace = ns;
+      }
+      if (window.localStorage.getItem('__pwSeed') === '1') {
+        window.__opengladSeedSinglePlayerTeam = true;
+      }
+      window.__opengladSkipIntroForTests = true;
+    } catch (err) {
+      // First navigation: nothing stored yet.
+    }
+  });
+}
+
+async function loadPlay(page, { ns, seed = false } = {}) {
+  await page.evaluate(
+    ({ ns, seed }) => {
+      if (ns === undefined) {
+        window.localStorage.removeItem('__pwPersistNs');
+      } else {
+        window.localStorage.setItem('__pwPersistNs', ns);
+      }
+      window.localStorage.setItem('__pwSeed', seed ? '1' : '0');
+    },
+    { ns, seed },
+  );
+  await page.goto('/play.html');
+  await waitForGameLoad(page);
+}
+
+async function inspectStores(page) {
+  return await page.evaluate(async () => {
+    if (!window.indexedDB || typeof indexedDB.databases !== 'function') {
+      return null;
+    }
+    const dbs = await indexedDB.databases();
+    return {
+      count: dbs.length,
+      // A token can never introduce a path separator or a traversal segment.
+      unsafe: dbs.some((db) => /[\\/\s]|\.\./.test(db.name || '')),
+    };
+  });
+}
+
+async function canvasBytes(page) {
+  return (await page.locator('#canvas').screenshot()).length;
+}
+
+test.describe('Web persistence namespace', () => {
+  test('no namespace: default persistence, no warning, no unsafe store name', async ({
+    page,
+  }) => {
+    const warnings = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'warning' && NAMESPACE_WARNING.test(msg.text())) {
+        warnings.push(msg.text());
+      }
+    });
+
+    await primeContext(page);
+    await loadPlay(page, { ns: undefined });
+
+    expect(warnings).toEqual([]);
+    expect(await canvasBytes(page)).toBeGreaterThan(MIN_NON_TRIVIAL_PNG_BYTES);
+    const stores = await inspectStores(page);
+    if (stores) {
+      expect(stores.unsafe).toBe(false);
+    }
+  });
+
+  for (const { token, label } of [
+    { token: 'bad/token', label: 'contains a slash' },
+    { token: '../evil', label: 'is a traversal' },
+    { token: 'x'.repeat(65), label: 'is over 64 chars' },
+  ]) {
+    test(`invalid namespace (${label}): warns once, no abort, default store`, async ({
+      page,
+    }) => {
+      const warnings = [];
+      const errors = [];
+      page.on('console', (msg) => {
+        if (msg.type() === 'warning' && NAMESPACE_WARNING.test(msg.text())) {
+          warnings.push(msg.text());
+        }
+        if (msg.type() === 'error') {
+          errors.push(msg.text());
+        }
+      });
+      page.on('pageerror', (err) => errors.push(err.message));
+
+      await primeContext(page);
+      await loadPlay(page, { ns: token });
+
+      expect(warnings.length).toBe(1);
+      expect(errors.join('\n')).not.toMatch(/Aborted/);
+      expect(await canvasBytes(page)).toBeGreaterThan(MIN_NON_TRIVIAL_PNG_BYTES);
+    });
+  }
+
+  test('valid namespaces get separate, coexisting, reload-surviving stores', async ({
+    page,
+  }) => {
+    // Boots /play.html five times.
+    test.setTimeout(240_000);
+    const errors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push(msg.text());
+      }
+    });
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    await primeContext(page);
+
+    // ns-alpha, seeded: the seed writes save0 and syncs it to this namespace's
+    // own store.
+    await loadPlay(page, { ns: 'ns-alpha', seed: true });
+    await waitForPickerReady(page);
+    const afterAlpha = await inspectStores(page);
+    if (afterAlpha) {
+      expect(afterAlpha.count).toBeGreaterThanOrEqual(1);
+      expect(afterAlpha.unsafe).toBe(false);
+    }
+
+    // ns-alpha again, no seed: the store survived the reload and the game boots.
+    await loadPlay(page, { ns: 'ns-alpha' });
+    expect(await canvasBytes(page)).toBeGreaterThan(MIN_NON_TRIVIAL_PNG_BYTES);
+
+    // ns-beta: a different token gets its own store, alongside ns-alpha's.
+    await loadPlay(page, { ns: 'ns-beta' });
+    expect(await canvasBytes(page)).toBeGreaterThan(MIN_NON_TRIVIAL_PNG_BYTES);
+    const afterBeta = await inspectStores(page);
+    if (afterAlpha && afterBeta) {
+      expect(afterBeta.count).toBeGreaterThan(afterAlpha.count);
+      expect(afterBeta.unsafe).toBe(false);
+    }
+
+    // Back to ns-alpha: exercising ns-beta left ns-alpha's store intact.
+    await loadPlay(page, { ns: 'ns-alpha' });
+    expect(await canvasBytes(page)).toBeGreaterThan(MIN_NON_TRIVIAL_PNG_BYTES);
+
+    expect(errors.join('\n')).not.toMatch(/Aborted/);
+  });
+});


### PR DESCRIPTION
Closes #281 — you asked for a PR there.

## The problem

The Emscripten build persists companies, config and campaigns to IDBFS mounted
at `/persist`, in an IndexedDB store scoped to the page **origin**. An
application that serves OpenGlad to more than one person from a single origin —
an embed, a community portal, a kiosk — has every user share one set of
companies: whoever plays second inherits the first player's roster. Today the
only way around it is a separate origin per user.

## The change

An optional, caller-set global, read once at startup before `play.js` loads:

```html
<script>window.__opengladPersistNamespace = "<opaque token>";</script>
```

- **Valid token** (1–64 characters of `[A-Za-z0-9_-]`): OpenGlad mounts IDBFS at
  `/persist_<token>` and returns `/persist_<token>/` from `get_user_path()` —
  the virtual filesystem layout is unchanged, just re-parented, and each token
  gets its own IndexedDB-backed store.
- **Absent / empty / invalid:** unchanged behaviour (`/persist`); a non-empty
  invalid value is ignored with one `console.warn`.

It follows the existing `window.__openglad*` convention (same shape as
`__opengladRelayBaseUrlForTests`), relies only on the documented property that a
distinct IDBFS mount point is a distinct backing store, and does not depend on
the IndexedDB database name, touch save / autosave / cloud-save /
`sync_filesystem()` semantics, or affect native builds — the change is entirely
under `#ifdef __EMSCRIPTEN__` (the only text a native compiler sees differ is one
blank line).

Migrating a host's pre-existing shared `/persist` data into a namespace is
intentionally out of scope; a host that switches namespaces on starts each user
with a fresh store.

## Contents

* `src/resources/platform_io.cpp` — read the token before the IDBFS mount; mount
  at `/persist_<token>` and root `get_user_path()` there; reject an invalid
  token (→ default `/persist`, one console warning)
* `tests/e2e/wasm-persist-namespace.spec.js` — default boot stays silent and
  unchanged; an invalid token warns exactly once without aborting; distinct
  namespaces produce distinct, coexisting, reload-surviving stores (asserts
  behavioural separation, not the database name)
* `docs/INSTALL.md` — "Embedding / hosting for multiple users" under Web Build
  (Emscripten)

## Deployed

This is running in production: it's integrated into L33TEST, a
gaming-community / BBS project, where callers launch OpenGlad through the web
side of the BBS and each user's data has to stay isolated on the shared hosted
instance. Small player base so far, but a real integration rather than a
hypothetical one. (Context from #281.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArHrjQ7XUMdKc4cExxmiDs
